### PR TITLE
Add test suite (37 tests)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: setup awake run clean say migrate
+.PHONY: setup awake run clean say migrate test
 
 VENV := .venv
 PYTHON := $(VENV)/bin/python3
@@ -22,6 +22,10 @@ run:
 say:
 	@test -n "$(m)" || (echo "Usage: make say m=\"your message\"" && exit 1)
 	@cd koan && $(PYTHON) -c "from awake import handle_message; handle_message('$(m)')"
+
+test: setup
+	$(VENV)/bin/pip install -q pytest 2>/dev/null
+	cd koan && ../$(PYTHON) -m pytest -v
 
 migrate: setup
 	$(PYTHON) koan/migrate_memory.py

--- a/koan/conftest.py
+++ b/koan/conftest.py
@@ -1,0 +1,36 @@
+"""Shared fixtures for koan tests."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_env(tmp_path, monkeypatch):
+    """Ensure tests don't touch real instance/ or send real Telegram messages."""
+    monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "fake-token")
+    monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "123456")
+    monkeypatch.delenv("KOAN_PROJECT_PATH", raising=False)
+    monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+
+
+@pytest.fixture
+def instance_dir(tmp_path):
+    """Create a minimal instance directory structure."""
+    inst = tmp_path / "instance"
+    inst.mkdir()
+    (inst / "soul.md").write_text("# Test Soul")
+    (inst / "memory").mkdir()
+    (inst / "memory" / "summary.md").write_text("Test summary.")
+    (inst / "journal").mkdir()
+    (inst / "outbox.md").write_text("")
+    missions = inst / "missions.md"
+    missions.write_text(
+        "# Missions\n\n"
+        "## En attente\n\n"
+        "(aucune)\n\n"
+        "## En cours\n\n"
+        "## Terminées\n\n"
+    )
+    return inst

--- a/koan/test_awake.py
+++ b/koan/test_awake.py
@@ -1,0 +1,184 @@
+"""Tests for awake.py — message classification, mission handling, project parsing."""
+
+import re
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from awake import (
+    is_mission,
+    is_command,
+    parse_project,
+    handle_mission,
+    _build_status,
+    MISSIONS_FILE,
+)
+
+
+# ---------------------------------------------------------------------------
+# is_mission
+# ---------------------------------------------------------------------------
+
+class TestIsMission:
+    """Test mission detection heuristics."""
+
+    def test_explicit_mission_prefix(self):
+        assert is_mission("mission: audit the backend") is True
+
+    def test_explicit_mission_prefix_with_space(self):
+        assert is_mission("mission : fix the login bug") is True
+
+    def test_imperative_verb_start(self):
+        assert is_mission("implement dark mode") is True
+        assert is_mission("fix the authentication bug") is True
+        assert is_mission("audit the security layer") is True
+        assert is_mission("create a new endpoint") is True
+        assert is_mission("add tests for awake.py") is True
+        assert is_mission("review the PR") is True
+        assert is_mission("analyze the logs") is True
+        assert is_mission("explore the codebase") is True
+        assert is_mission("build the dashboard") is True
+        assert is_mission("write a migration script") is True
+        assert is_mission("run the test suite") is True
+        assert is_mission("deploy to staging") is True
+        assert is_mission("test the new feature") is True
+        assert is_mission("refactor the auth module") is True
+
+    def test_long_message_with_verb(self):
+        long_text = "implement " + "x " * 150  # >200 chars
+        assert is_mission(long_text) is True
+
+    def test_short_question_not_mission(self):
+        assert is_mission("how are you?") is False
+        assert is_mission("what's the status?") is False
+
+    def test_greeting_not_mission(self):
+        assert is_mission("hello") is False
+        assert is_mission("good morning") is False
+
+    def test_case_insensitive(self):
+        assert is_mission("Implement dark mode") is True
+        assert is_mission("MISSION: do something") is True
+
+    def test_empty_string(self):
+        assert is_mission("") is False
+
+
+# ---------------------------------------------------------------------------
+# is_command
+# ---------------------------------------------------------------------------
+
+class TestIsCommand:
+    def test_slash_commands(self):
+        assert is_command("/stop") is True
+        assert is_command("/status") is True
+        assert is_command("/resume") is True
+
+    def test_non_commands(self):
+        assert is_command("hello") is False
+        assert is_command("fix the bug") is False
+        assert is_command("") is False
+
+
+# ---------------------------------------------------------------------------
+# parse_project
+# ---------------------------------------------------------------------------
+
+class TestParseProject:
+    def test_with_project_tag(self):
+        project, text = parse_project("[project:anantys] fix the login")
+        assert project == "anantys"
+        assert text == "fix the login"
+
+    def test_without_project_tag(self):
+        project, text = parse_project("fix the login")
+        assert project is None
+        assert text == "fix the login"
+
+    def test_project_tag_with_hyphen(self):
+        project, text = parse_project("[project:anantys-back] deploy")
+        assert project == "anantys-back"
+        assert text == "deploy"
+
+    def test_project_tag_with_underscore(self):
+        project, text = parse_project("[project:my_project] test")
+        assert project == "my_project"
+        assert text == "test"
+
+    def test_project_tag_in_middle(self):
+        project, text = parse_project("fix [project:koan] the bug")
+        assert project == "koan"
+        assert text == "fix the bug"
+
+
+# ---------------------------------------------------------------------------
+# handle_mission (integration with filesystem)
+# ---------------------------------------------------------------------------
+
+class TestHandleMission:
+    @patch("awake.send_telegram")
+    @patch("awake.MISSIONS_FILE")
+    @patch("awake.INSTANCE_DIR")
+    def test_mission_appended_to_pending(self, mock_inst, mock_file, mock_send, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n## En attente\n\n(aucune)\n\n## En cours\n\n## Terminées\n"
+        )
+        mock_file.__class__ = type(missions_file)
+        # Directly test the file manipulation logic
+        with patch("awake.MISSIONS_FILE", missions_file):
+            handle_mission("mission: audit security")
+
+        content = missions_file.read_text()
+        assert "- audit security" in content
+        mock_send.assert_called_once()
+
+    @patch("awake.send_telegram")
+    def test_mission_with_project_tag(self, mock_send, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n## En attente\n\n(aucune)\n\n## En cours\n\n"
+        )
+        with patch("awake.MISSIONS_FILE", missions_file):
+            handle_mission("[project:koan] add tests")
+
+        content = missions_file.read_text()
+        assert "- [project:koan] add tests" in content
+
+
+# ---------------------------------------------------------------------------
+# _build_status
+# ---------------------------------------------------------------------------
+
+class TestBuildStatus:
+    @patch("awake.MISSIONS_FILE")
+    def test_status_with_pending(self, mock_file, tmp_path):
+        """Note: _build_status checks for English 'pending'/'in_progress' sections."""
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- [project:koan] add tests\n"
+            "- fix bug\n\n"
+            "## In Progress\n\n"
+            "- [project:koan] doing stuff\n\n"
+        )
+        with patch("awake.MISSIONS_FILE", missions_file), \
+             patch("awake.KOAN_ROOT", tmp_path):
+            status = _build_status()
+
+        assert "Kōan Status" in status
+        # Missions split by project: koan gets 1 pending + 1 in_progress, default gets 1 pending
+        assert "**koan**" in status
+        assert "**default**" in status
+        assert "In progress: 1" in status
+
+    @patch("awake.MISSIONS_FILE")
+    def test_status_empty(self, mock_file, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text("# Missions\n\n## En attente\n\n## En cours\n\n")
+        with patch("awake.MISSIONS_FILE", missions_file), \
+             patch("awake.KOAN_ROOT", tmp_path):
+            status = _build_status()
+
+        assert "Kōan Status" in status

--- a/koan/test_daily_report.py
+++ b/koan/test_daily_report.py
@@ -1,0 +1,172 @@
+"""Tests for daily_report.py — report generation, mission parsing, time logic."""
+
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from daily_report import (
+    should_send_report,
+    _read_journal,
+    _parse_completed_missions,
+    _count_pending_missions,
+    generate_report,
+)
+
+
+# ---------------------------------------------------------------------------
+# should_send_report
+# ---------------------------------------------------------------------------
+
+class TestShouldSendReport:
+    def test_morning_window(self, tmp_path):
+        morning = datetime(2026, 2, 1, 8, 0)
+        with patch("daily_report.datetime") as mock_dt, \
+             patch("daily_report.REPORT_MARKER", tmp_path / ".marker"):
+            mock_dt.now.return_value = morning
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            result = should_send_report()
+        assert result == "morning"
+
+    def test_outside_window(self, tmp_path):
+        noon = datetime(2026, 2, 1, 12, 0)
+        with patch("daily_report.datetime") as mock_dt, \
+             patch("daily_report.REPORT_MARKER", tmp_path / ".marker"):
+            mock_dt.now.return_value = noon
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            result = should_send_report()
+        assert result is None
+
+    def test_evening_with_quota(self, tmp_path):
+        evening = datetime(2026, 2, 1, 21, 0)
+        quota_file = tmp_path / ".koan-quota-reset"
+        quota_file.write_text("resets 7am")
+        with patch("daily_report.datetime") as mock_dt, \
+             patch("daily_report.REPORT_MARKER", tmp_path / ".marker"), \
+             patch("daily_report.KOAN_ROOT", tmp_path):
+            mock_dt.now.return_value = evening
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            result = should_send_report()
+        assert result == "evening"
+
+    def test_no_duplicate_report(self, tmp_path):
+        morning = datetime(2026, 2, 1, 8, 0)
+        marker = tmp_path / ".marker"
+        marker.write_text("2026-02-01")
+        with patch("daily_report.datetime") as mock_dt, \
+             patch("daily_report.REPORT_MARKER", marker):
+            mock_dt.now.return_value = morning
+            mock_dt.side_effect = lambda *a, **k: datetime(*a, **k)
+            result = should_send_report()
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _read_journal
+# ---------------------------------------------------------------------------
+
+class TestReadJournal:
+    def test_nested_journal(self, tmp_path):
+        with patch("daily_report.INSTANCE_DIR", tmp_path):
+            journal_dir = tmp_path / "journal" / "2026-02-01"
+            journal_dir.mkdir(parents=True)
+            (journal_dir / "koan.md").write_text("## Session 28\nDid stuff.")
+            result = _read_journal(date(2026, 2, 1))
+        assert "Session 28" in result
+        assert "[koan]" in result
+
+    def test_missing_journal(self, tmp_path):
+        with patch("daily_report.INSTANCE_DIR", tmp_path):
+            result = _read_journal(date(2026, 2, 1))
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# _parse_completed_missions
+# ---------------------------------------------------------------------------
+
+class TestParseCompletedMissions:
+    def test_bold_entries(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n"
+            "## Terminées\n\n"
+            "- **Fix IDOR** (session 22)\n"
+            "- **Dunning emails** — session 20\n"
+            "- Old plain entry\n"
+        )
+        with patch("daily_report.MISSIONS_FILE", missions_file):
+            result = _parse_completed_missions()
+        assert len(result) == 2
+        assert "Fix IDOR" in result[0]
+        assert "Dunning emails" in result[1]
+
+    def test_empty_done_section(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text("# Missions\n\n## Terminées\n\n")
+        with patch("daily_report.MISSIONS_FILE", missions_file):
+            result = _parse_completed_missions()
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# _count_pending_missions
+# ---------------------------------------------------------------------------
+
+class TestCountPendingMissions:
+    def test_count(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n"
+            "## En attente\n\n"
+            "- task 1\n"
+            "- task 2\n\n"
+            "## En cours\n\n"
+        )
+        with patch("daily_report.MISSIONS_FILE", missions_file):
+            assert _count_pending_missions() == 2
+
+    def test_no_pending(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text("# Missions\n\n## En attente\n\n(aucune)\n\n## En cours\n\n")
+        with patch("daily_report.MISSIONS_FILE", missions_file):
+            assert _count_pending_missions() == 0
+
+
+# ---------------------------------------------------------------------------
+# generate_report
+# ---------------------------------------------------------------------------
+
+class TestGenerateReport:
+    def test_morning_report(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n"
+            "## En attente\n\n"
+            "- task 1\n\n"
+            "## En cours\n\n"
+            "### Big project (PRIO)\n"
+            "- sub-item\n\n"
+            "## Terminées\n\n"
+            "- **Done thing** (session 1)\n"
+        )
+        with patch("daily_report.MISSIONS_FILE", missions_file), \
+             patch("daily_report.INSTANCE_DIR", tmp_path):
+            report = generate_report("morning")
+
+        assert "Rapport du" in report
+        assert "Done thing" in report
+        assert "En attente: 1" in report
+        assert "Big project" in report
+        assert "-- Koan" in report
+
+    def test_evening_report(self, tmp_path):
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text("# Missions\n\n## En attente\n\n## En cours\n\n## Terminées\n\n")
+        with patch("daily_report.MISSIONS_FILE", missions_file), \
+             patch("daily_report.INSTANCE_DIR", tmp_path):
+            report = generate_report("evening")
+
+        assert "Bilan de la journee" in report
+        assert "-- Koan" in report

--- a/koan/test_notify.py
+++ b/koan/test_notify.py
@@ -1,0 +1,44 @@
+"""Tests for notify.py — message sending, chunking, error handling."""
+
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from notify import send_telegram
+
+
+class TestSendTelegram:
+    @patch("notify.requests.post")
+    def test_short_message(self, mock_post):
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        assert send_telegram("hello") is True
+        mock_post.assert_called_once()
+        call_kwargs = mock_post.call_args
+        assert call_kwargs[1]["json"]["text"] == "hello"
+
+    @patch("notify.requests.post")
+    def test_long_message_chunked(self, mock_post):
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        long_msg = "x" * 8500  # Should be split into 3 chunks (4000+4000+500)
+        assert send_telegram(long_msg) is True
+        assert mock_post.call_count == 3
+
+    @patch("notify.requests.post")
+    def test_api_error(self, mock_post):
+        mock_post.return_value = MagicMock(
+            json=lambda: {"ok": False, "description": "bad request"},
+            text='{"ok":false}',
+        )
+        assert send_telegram("test") is False
+
+    @patch("notify.requests.post", side_effect=Exception("network error"))
+    def test_network_error(self, mock_post):
+        assert send_telegram("test") is False
+
+    def test_no_token(self, monkeypatch):
+        monkeypatch.setattr("notify.BOT_TOKEN", "")
+        assert send_telegram("test") is False
+
+    def test_no_chat_id(self, monkeypatch):
+        monkeypatch.setattr("notify.CHAT_ID", "")
+        assert send_telegram("test") is False


### PR DESCRIPTION
## Summary
- 37 pytest tests covering awake.py, daily_report.py, and notify.py
- conftest.py with `isolate_env` and `instance_dir` fixtures
- `make test` target added
- **Stacked on**: koan/daily-report (includes daily_report.py which tests depend on)

## Test plan
- [ ] Run \`make test\` — all 37 tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)