### PR TITLE
feat: implement fast_reply config for command handlers

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -8,6 +8,11 @@ pilot_repo: "/path/to/koan"            # This repo
 max_runs_per_day: 20
 interval_seconds: 300  # 5 minutes between runs
 
+# Fast reply mode — use lightweight model (Haiku) for command handlers
+# When true, /usage, /sparring, and similar commands use Haiku instead of default model
+# Faster response, lower cost, but simpler answers
+fast_reply: false
+
 # Telegram
 telegram:
   bot_token: "YOUR_BOT_TOKEN"  # From @BotFather

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -39,6 +39,7 @@ from app.utils import (
     get_tools_description,
     get_model_config,
     build_claude_flags,
+    get_fast_reply_model,
 )
 
 load_dotenv()
@@ -302,8 +303,13 @@ def _handle_usage():
     )
 
     try:
+        # Use fast_reply model (lightweight/Haiku) if configured
+        fast_model = get_fast_reply_model()
+        cmd = ["claude", "-p", prompt, "--max-turns", "1"]
+        if fast_model:
+            cmd.extend(["--model", fast_model])
         result = subprocess.run(
-            ["claude", "-p", prompt, "--max-turns", "1"],
+            cmd,
             capture_output=True, text=True, timeout=60,
         )
         if result.returncode == 0 and result.stdout.strip():
@@ -405,8 +411,13 @@ def _handle_sparring():
     )
 
     try:
+        # Use fast_reply model (lightweight/Haiku) if configured
+        fast_model = get_fast_reply_model()
+        cmd = ["claude", "-p", prompt, "--max-turns", "1"]
+        if fast_model:
+            cmd.extend(["--model", fast_model])
         result = subprocess.run(
-            ["claude", "-p", prompt, "--max-turns", "1"],
+            cmd,
             capture_output=True, text=True, timeout=60,
         )
         if result.returncode == 0 and result.stdout.strip():

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -187,6 +187,23 @@ def get_model_config() -> dict:
     return {k: models.get(k, v) for k, v in defaults.items()}
 
 
+def get_fast_reply_model() -> str:
+    """Get model to use for fast replies (command handlers like /usage, /sparring).
+
+    When config.fast_reply is True, returns the lightweight model (usually Haiku)
+    for faster, cheaper responses. When False, returns empty string (use default).
+
+    Returns:
+        Model name string (e.g., "haiku") or empty string for default model.
+    """
+    config = load_config()
+    fast_reply = config.get("fast_reply", False)
+    if fast_reply:
+        models = get_model_config()
+        return models["lightweight"]
+    return ""
+
+
 def build_claude_flags(
     model: str = "",
     fallback: str = "",

--- a/koan/tests/test_cli_coverage.py
+++ b/koan/tests/test_cli_coverage.py
@@ -404,6 +404,38 @@ class TestModelConfig:
             flags = get_claude_flags_for_role("unknown_role")
         assert flags == ""
 
+    def test_get_fast_reply_model_enabled(self):
+        """fast_reply=true returns lightweight model."""
+        from app.utils import get_fast_reply_model
+        config = {"fast_reply": True, "models": {"lightweight": "haiku"}}
+        with patch("app.utils.load_config", return_value=config):
+            model = get_fast_reply_model()
+        assert model == "haiku"
+
+    def test_get_fast_reply_model_disabled(self):
+        """fast_reply=false returns empty string (use default)."""
+        from app.utils import get_fast_reply_model
+        config = {"fast_reply": False, "models": {"lightweight": "haiku"}}
+        with patch("app.utils.load_config", return_value=config):
+            model = get_fast_reply_model()
+        assert model == ""
+
+    def test_get_fast_reply_model_missing(self):
+        """Missing fast_reply key defaults to false."""
+        from app.utils import get_fast_reply_model
+        config = {"models": {"lightweight": "haiku"}}
+        with patch("app.utils.load_config", return_value=config):
+            model = get_fast_reply_model()
+        assert model == ""
+
+    def test_get_fast_reply_model_custom_lightweight(self):
+        """fast_reply uses custom lightweight model from config."""
+        from app.utils import get_fast_reply_model
+        config = {"fast_reply": True, "models": {"lightweight": "sonnet"}}
+        with patch("app.utils.load_config", return_value=config):
+            model = get_fast_reply_model()
+        assert model == "sonnet"
+
 
 class TestUtilsConversationHistory:
     """Cover save/load/format conversation history edge cases."""


### PR DESCRIPTION
When config.fast_reply is true, /usage and /sparring handlers use the lightweight model (Haiku by default) for faster, cheaper responses.

- Add get_fast_reply_model() to utils.py
- Use it in _handle_usage() and _handle_sparring() in awake.py
- Document fast_reply in instance.example/config.yaml
- Add 4 tests (654 total)