### PR TITLE
feat: add /projects command and get_known_projects() utility

### DIFF
--- a/koan/skills/core/projects/SKILL.md
+++ b/koan/skills/core/projects/SKILL.md
@@ -1,0 +1,12 @@
+---
+name: projects
+scope: core
+description: List configured projects
+version: 1.0.0
+commands:
+  - name: projects
+    description: List configured projects
+    usage: /projects
+    aliases: [proj]
+handler: handler.py
+---

--- a/koan/skills/core/projects/handler.py
+++ b/koan/skills/core/projects/handler.py
@@ -1,0 +1,16 @@
+"""Koan projects skill — list configured projects."""
+
+
+def handle(ctx):
+    """Handle /projects command."""
+    from app.utils import get_known_projects
+
+    projects = get_known_projects()
+
+    if not projects:
+        return "No projects configured."
+
+    lines = ["Configured projects:"]
+    for name, path in projects:
+        lines.append(f"  - {name} ({path})")
+    return "\n".join(lines)

--- a/koan/tests/test_projects_skill.py
+++ b/koan/tests/test_projects_skill.py
@@ -1,0 +1,148 @@
+"""Tests for the /projects core skill — list configured projects."""
+
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.skills import SkillContext
+
+
+# ---------------------------------------------------------------------------
+# Handler tests (direct handler invocation)
+# ---------------------------------------------------------------------------
+
+class TestProjectsHandler:
+    """Test the projects skill handler directly."""
+
+    def _make_ctx(self, tmp_path, args=""):
+        """Create a SkillContext for /projects."""
+        instance_dir = tmp_path / "instance"
+        instance_dir.mkdir(exist_ok=True)
+        return SkillContext(
+            koan_root=tmp_path,
+            instance_dir=instance_dir,
+            command_name="projects",
+            args=args,
+        )
+
+    @patch("app.utils.get_known_projects", return_value=[])
+    def test_no_projects(self, mock_projects, tmp_path):
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path)
+        result = handle(ctx)
+        assert "No projects configured" in result
+
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("koan", "/home/user/koan"), ("webapp", "/home/user/webapp")],
+    )
+    def test_multiple_projects(self, mock_projects, tmp_path):
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path)
+        result = handle(ctx)
+        assert "Configured projects:" in result
+        assert "koan" in result
+        assert "webapp" in result
+        assert "/home/user/koan" in result
+        assert "/home/user/webapp" in result
+
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("myproject", "/path/to/project")],
+    )
+    def test_single_project(self, mock_projects, tmp_path):
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path)
+        result = handle(ctx)
+        assert "Configured projects:" in result
+        assert "myproject" in result
+        assert "/path/to/project" in result
+
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("alpha", "/a"), ("beta", "/b"), ("gamma", "/g")],
+    )
+    def test_bullet_format(self, mock_projects, tmp_path):
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path)
+        result = handle(ctx)
+        lines = result.strip().split("\n")
+        assert lines[0] == "Configured projects:"
+        assert lines[1].strip().startswith("- alpha")
+        assert lines[2].strip().startswith("- beta")
+        assert lines[3].strip().startswith("- gamma")
+
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("koan", "/home/koan")],
+    )
+    def test_shows_path_in_parens(self, mock_projects, tmp_path):
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path)
+        result = handle(ctx)
+        assert "koan (/home/koan)" in result
+
+    @patch("app.utils.get_known_projects", return_value=[])
+    def test_args_ignored(self, mock_projects, tmp_path):
+        """Extra args don't break the handler."""
+        from skills.core.projects.handler import handle
+
+        ctx = self._make_ctx(tmp_path, args="extra stuff")
+        result = handle(ctx)
+        assert "No projects configured" in result
+
+
+# ---------------------------------------------------------------------------
+# Integration: command routing via awake.py
+# ---------------------------------------------------------------------------
+
+class TestProjectsCommandRouting:
+    """Test that /projects and /proj route to the skill via awake."""
+
+    @patch("app.awake.send_telegram")
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("koan", "/home/koan")],
+    )
+    def test_projects_routes_via_skill(self, mock_projects, mock_send, tmp_path):
+        from app.awake import handle_command
+
+        with patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.INSTANCE_DIR", tmp_path):
+            handle_command("/projects")
+        mock_send.assert_called_once()
+        output = mock_send.call_args[0][0]
+        assert "koan" in output
+
+    @patch("app.awake.send_telegram")
+    @patch(
+        "app.utils.get_known_projects",
+        return_value=[("koan", "/home/koan")],
+    )
+    def test_proj_alias_routes(self, mock_projects, mock_send, tmp_path):
+        from app.awake import handle_command
+
+        with patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.INSTANCE_DIR", tmp_path):
+            handle_command("/proj")
+        mock_send.assert_called_once()
+        output = mock_send.call_args[0][0]
+        assert "koan" in output
+
+    @patch("app.awake.send_telegram")
+    def test_projects_appears_in_help(self, mock_send, tmp_path):
+        """Verify /projects is included in /help output via skill discovery."""
+        from app.awake import handle_command
+
+        with patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.INSTANCE_DIR", tmp_path):
+            handle_command("/help")
+        mock_send.assert_called_once()
+        help_text = mock_send.call_args[0][0]
+        assert "/projects" in help_text


### PR DESCRIPTION
- Add get_known_projects() to utils.py — parses KOAN_PROJECTS env var
  (name:path;name2:path2), falls back to KOAN_PROJECT_PATH, sorted alpha
- Add /projects command handler in awake.py — sends bullet list of projects
- Add /projects to /help listing
- Fix /reflect missing return (fell through to handle_chat)
- 11 new tests (6 utils + 5 awake), 697 total passing

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
