### PR TITLE
feat: add recurring missions with /daily /hourly /weekly commands

### DIFF
--- a/koan/app/recurring.py
+++ b/koan/app/recurring.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""
+Koan -- Recurring missions
+
+Manages recurring missions (hourly, daily, weekly) stored in instance/recurring.json.
+The scheduler checks which missions are due and inserts them into missions.md pending
+section for normal execution by the run loop.
+
+Storage format (recurring.json):
+[
+    {
+        "id": "rec_1706990000",
+        "frequency": "daily",
+        "text": "summarize unread emails",
+        "project": null,
+        "created": "2026-02-03T22:00:00",
+        "last_run": null,
+        "enabled": true
+    },
+    ...
+]
+"""
+
+import json
+import os
+import time
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from app.utils import atomic_write, insert_pending_mission
+
+
+FREQUENCIES = ("hourly", "daily", "weekly")
+
+
+def load_recurring(recurring_path: Path) -> List[Dict]:
+    """Load recurring missions from JSON file.
+
+    Returns empty list if file doesn't exist or is invalid.
+    """
+    if not recurring_path.exists():
+        return []
+    try:
+        data = json.loads(recurring_path.read_text(encoding="utf-8"))
+        if not isinstance(data, list):
+            return []
+        return data
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def save_recurring(recurring_path: Path, missions: List[Dict]):
+    """Save recurring missions to JSON file atomically."""
+    content = json.dumps(missions, ensure_ascii=False, indent=2) + "\n"
+    atomic_write(recurring_path, content)
+
+
+def add_recurring(
+    recurring_path: Path,
+    frequency: str,
+    text: str,
+    project: Optional[str] = None,
+) -> Dict:
+    """Add a new recurring mission.
+
+    Args:
+        recurring_path: Path to recurring.json
+        frequency: One of "hourly", "daily", "weekly"
+        text: Mission description
+        project: Optional project name
+
+    Returns:
+        The created mission dict
+
+    Raises:
+        ValueError: If frequency is invalid
+    """
+    if frequency not in FREQUENCIES:
+        raise ValueError(f"Invalid frequency: {frequency}. Must be one of {FREQUENCIES}")
+
+    missions = load_recurring(recurring_path)
+
+    mission = {
+        "id": f"rec_{int(time.time())}_{os.getpid()}_{len(missions)}",
+        "frequency": frequency,
+        "text": text.strip(),
+        "project": project,
+        "created": datetime.now().isoformat(timespec="seconds"),
+        "last_run": None,
+        "enabled": True,
+    }
+
+    missions.append(mission)
+    save_recurring(recurring_path, missions)
+    return mission
+
+
+def remove_recurring(recurring_path: Path, identifier: str) -> str:
+    """Remove a recurring mission by number (1-indexed) or keyword.
+
+    Args:
+        recurring_path: Path to recurring.json
+        identifier: Number (1-indexed) or keyword substring
+
+    Returns:
+        Description of the removed mission
+
+    Raises:
+        ValueError: If identifier doesn't match any mission
+    """
+    missions = load_recurring(recurring_path)
+    if not missions:
+        raise ValueError("No recurring missions configured.")
+
+    enabled = [m for m in missions if m.get("enabled", True)]
+    if not enabled:
+        raise ValueError("No active recurring missions.")
+
+    if identifier.isdigit():
+        idx = int(identifier) - 1
+        if idx < 0 or idx >= len(enabled):
+            raise ValueError(
+                f"Invalid number: {identifier}. "
+                f"Valid range: 1-{len(enabled)}"
+            )
+        target = enabled[idx]
+    else:
+        # Keyword match (case-insensitive substring)
+        matches = [
+            m for m in enabled
+            if identifier.lower() in m["text"].lower()
+        ]
+        if not matches:
+            raise ValueError(f"No recurring mission matching '{identifier}'.")
+        if len(matches) > 1:
+            raise ValueError(
+                f"Multiple matches for '{identifier}'. Be more specific or use a number."
+            )
+        target = matches[0]
+
+    # Remove from list
+    missions = [m for m in missions if m["id"] != target["id"]]
+    save_recurring(recurring_path, missions)
+    return f"[{target['frequency']}] {target['text']}"
+
+
+def list_recurring(recurring_path: Path) -> List[Dict]:
+    """List all enabled recurring missions.
+
+    Returns list of mission dicts, sorted by frequency (hourly, daily, weekly).
+    """
+    missions = load_recurring(recurring_path)
+    enabled = [m for m in missions if m.get("enabled", True)]
+    freq_order = {"hourly": 0, "daily": 1, "weekly": 2}
+    return sorted(enabled, key=lambda m: freq_order.get(m["frequency"], 99))
+
+
+def format_recurring_list(missions: List[Dict]) -> str:
+    """Format recurring missions for display.
+
+    Returns a human-readable string with numbered entries.
+    """
+    if not missions:
+        return "No recurring missions configured."
+
+    lines = ["Recurring missions:"]
+    for i, m in enumerate(missions, 1):
+        freq = m["frequency"]
+        text = m["text"]
+        project = m.get("project")
+        last_run = m.get("last_run")
+
+        entry = f"  {i}. [{freq}] {text}"
+        if project:
+            entry += f" (project: {project})"
+        if last_run:
+            # Show relative time
+            try:
+                last_dt = datetime.fromisoformat(last_run)
+                delta = datetime.now() - last_dt
+                if delta.total_seconds() < 3600:
+                    entry += f" — last: {int(delta.total_seconds() / 60)}min ago"
+                elif delta.total_seconds() < 86400:
+                    entry += f" — last: {int(delta.total_seconds() / 3600)}h ago"
+                else:
+                    entry += f" — last: {int(delta.days)}d ago"
+            except (ValueError, TypeError):
+                entry += f" — last: {last_run}"
+        else:
+            entry += " — never run"
+
+        lines.append(entry)
+
+    return "\n".join(lines)
+
+
+def is_due(mission: Dict, now: Optional[datetime] = None) -> bool:
+    """Check if a recurring mission is due for execution.
+
+    Rules:
+        - hourly: last_run is None or > 1 hour ago
+        - daily: last_run is None or last_run date != today
+        - weekly: last_run is None or > 7 days ago
+    """
+    if not mission.get("enabled", True):
+        return False
+
+    now = now or datetime.now()
+    last_run = mission.get("last_run")
+
+    if last_run is None:
+        return True
+
+    try:
+        last_dt = datetime.fromisoformat(last_run)
+    except (ValueError, TypeError):
+        return True  # Invalid date = treat as never run
+
+    frequency = mission["frequency"]
+
+    if frequency == "hourly":
+        return (now - last_dt) >= timedelta(hours=1)
+    elif frequency == "daily":
+        return last_dt.date() < now.date()
+    elif frequency == "weekly":
+        return (now - last_dt) >= timedelta(weeks=1)
+
+    return False
+
+
+def check_and_inject(
+    recurring_path: Path,
+    missions_path: Path,
+    now: Optional[datetime] = None,
+) -> List[str]:
+    """Check all recurring missions and inject due ones into missions.md.
+
+    This is the main scheduler entry point. Called from run.sh at the top
+    of each loop iteration.
+
+    Args:
+        recurring_path: Path to recurring.json
+        missions_path: Path to missions.md
+        now: Optional datetime for testing
+
+    Returns:
+        List of mission descriptions that were injected
+    """
+    missions = load_recurring(recurring_path)
+    if not missions:
+        return []
+
+    now = now or datetime.now()
+    injected = []
+
+    for mission in missions:
+        if not is_due(mission, now):
+            continue
+
+        text = mission["text"]
+        project = mission.get("project")
+        freq = mission["frequency"]
+
+        # Build mission entry for missions.md
+        tag = f"[{freq}] "
+        if project:
+            entry = f"- [project:{project}] {tag}{text}"
+        else:
+            entry = f"- {tag}{text}"
+
+        # Insert into pending section
+        insert_pending_mission(missions_path, entry)
+
+        # Update last_run
+        mission["last_run"] = now.isoformat(timespec="seconds")
+        injected.append(f"[{freq}] {text}")
+
+    # Save updated timestamps
+    if injected:
+        save_recurring(recurring_path, missions)
+
+    return injected

--- a/koan/app/recurring_scheduler.py
+++ b/koan/app/recurring_scheduler.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""
+Koan -- Recurring mission scheduler (CLI entry point)
+
+Called from run.sh at the top of each loop iteration to inject
+due recurring missions into the pending queue.
+
+Usage:
+    python3 recurring_scheduler.py <instance_dir>
+
+Output:
+    Prints each injected mission (for run.sh logging).
+    Exit code 0 always (errors are non-fatal).
+"""
+
+import sys
+from pathlib import Path
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: recurring_scheduler.py <instance_dir>", file=sys.stderr)
+        sys.exit(1)
+
+    instance_dir = Path(sys.argv[1])
+    recurring_path = instance_dir / "recurring.json"
+    missions_path = instance_dir / "missions.md"
+
+    if not recurring_path.exists():
+        sys.exit(0)
+
+    try:
+        from app.recurring import check_and_inject
+        injected = check_and_inject(recurring_path, missions_path)
+        for desc in injected:
+            print(f"[recurring] Injected: {desc}")
+    except Exception as e:
+        print(f"[recurring] Error: {e}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/run.sh
+++ b/koan/run.sh
@@ -382,6 +382,11 @@ while true; do
   echo "  Safety margin: 10% → Available: ${AVAILABLE_PCT}%"
   echo ""
 
+  # Check recurring missions — inject due ones into pending queue
+  "$PYTHON" "$APP_DIR/recurring_scheduler.py" "$INSTANCE" 2>/dev/null | while IFS= read -r line; do
+    log mission "$line"
+  done
+
   # Pick next mission using Claude-based intelligent picker
   LAST_PROJECT=$(cat "$KOAN_ROOT/.koan-project" 2>/dev/null || echo "")
   PICK_MISSION="$APP_DIR/pick_mission.py"

--- a/koan/skills/core/recurring/SKILL.md
+++ b/koan/skills/core/recurring/SKILL.md
@@ -1,0 +1,23 @@
+---
+name: recurring
+scope: core
+description: Manage recurring missions (hourly, daily, weekly)
+version: 1.0.0
+commands:
+  - name: daily
+    description: Add a daily recurring mission
+    usage: /daily <text> [project:<name>]
+  - name: hourly
+    description: Add an hourly recurring mission
+    usage: /hourly <text> [project:<name>]
+  - name: weekly
+    description: Add a weekly recurring mission
+    usage: /weekly <text> [project:<name>]
+  - name: recurring
+    description: List all recurring missions
+    usage: /recurring
+  - name: cancel-recurring
+    description: Cancel a recurring mission
+    usage: /cancel-recurring <n>, /cancel-recurring <keyword>
+handler: handler.py
+---

--- a/koan/skills/core/recurring/handler.py
+++ b/koan/skills/core/recurring/handler.py
@@ -1,0 +1,76 @@
+"""Koan recurring skill -- manage recurring missions (hourly, daily, weekly)."""
+
+
+def handle(ctx):
+    """Handle /daily, /hourly, /weekly, /recurring, /cancel-recurring commands.
+
+    /daily <text>           — add a daily recurring mission
+    /hourly <text>          — add an hourly recurring mission
+    /weekly <text>          — add a weekly recurring mission
+    /recurring              — list all recurring missions
+    /cancel-recurring [n]   — cancel a recurring mission by number or keyword
+    """
+    command = ctx.command_name
+
+    if command in ("daily", "hourly", "weekly"):
+        return _handle_add(ctx, command)
+    elif command == "recurring":
+        return _handle_list(ctx)
+    elif command == "cancel-recurring":
+        return _handle_cancel(ctx)
+
+    return None
+
+
+def _handle_add(ctx, frequency):
+    """Add a recurring mission with the given frequency."""
+    body = ctx.args.strip()
+    if not body:
+        return f"Usage: /{frequency} <description>\nEx: /{frequency} check open pull requests"
+
+    from app.utils import parse_project
+    from app.recurring import add_recurring
+
+    project, text = parse_project(body)
+    recurring_path = ctx.instance_dir / "recurring.json"
+
+    try:
+        add_recurring(recurring_path, frequency, text, project)
+        ack = f"Recurring mission added ({frequency})"
+        if project:
+            ack += f" [project:{project}]"
+        ack += f":\n\n{text}"
+        return ack
+    except ValueError as e:
+        return str(e)
+
+
+def _handle_list(ctx):
+    """List all recurring missions."""
+    from app.recurring import list_recurring, format_recurring_list
+
+    recurring_path = ctx.instance_dir / "recurring.json"
+    missions = list_recurring(recurring_path)
+    return format_recurring_list(missions)
+
+
+def _handle_cancel(ctx):
+    """Cancel a recurring mission by number or keyword."""
+    from app.recurring import list_recurring, format_recurring_list, remove_recurring
+
+    recurring_path = ctx.instance_dir / "recurring.json"
+    identifier = ctx.args.strip()
+
+    if not identifier:
+        missions = list_recurring(recurring_path)
+        if missions:
+            msg = format_recurring_list(missions)
+            msg += "\n\nUsage: /cancel-recurring <number or keyword>"
+            return msg
+        return "No recurring missions to cancel."
+
+    try:
+        removed = remove_recurring(recurring_path, identifier)
+        return f"Recurring mission removed: {removed}"
+    except ValueError as e:
+        return str(e)

--- a/koan/tests/test_recurring.py
+++ b/koan/tests/test_recurring.py
@@ -1,0 +1,373 @@
+"""Tests for recurring.py — recurring missions storage and scheduler."""
+
+import json
+import pytest
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from app.recurring import (
+    load_recurring,
+    save_recurring,
+    add_recurring,
+    remove_recurring,
+    list_recurring,
+    format_recurring_list,
+    is_due,
+    check_and_inject,
+    FREQUENCIES,
+)
+
+
+# --- load_recurring / save_recurring ---
+
+
+class TestLoadSave:
+    def test_load_nonexistent(self, tmp_path):
+        assert load_recurring(tmp_path / "nope.json") == []
+
+    def test_load_empty_file(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        f.write_text("")
+        assert load_recurring(f) == []
+
+    def test_load_invalid_json(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        f.write_text("{not json")
+        assert load_recurring(f) == []
+
+    def test_load_non_list(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        f.write_text('{"key": "value"}')
+        assert load_recurring(f) == []
+
+    def test_roundtrip(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        data = [{"id": "rec_1", "frequency": "daily", "text": "test"}]
+        save_recurring(f, data)
+        loaded = load_recurring(f)
+        assert loaded == data
+
+    def test_save_creates_file(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        save_recurring(f, [])
+        assert f.exists()
+        assert json.loads(f.read_text()) == []
+
+
+# --- add_recurring ---
+
+
+class TestAddRecurring:
+    def test_add_daily(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        m = add_recurring(f, "daily", "check emails")
+        assert m["frequency"] == "daily"
+        assert m["text"] == "check emails"
+        assert m["project"] is None
+        assert m["last_run"] is None
+        assert m["enabled"] is True
+        assert m["id"].startswith("rec_")
+
+    def test_add_with_project(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        m = add_recurring(f, "weekly", "audit security", project="koan")
+        assert m["project"] == "koan"
+
+    def test_add_invalid_frequency(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        with pytest.raises(ValueError, match="Invalid frequency"):
+            add_recurring(f, "monthly", "something")
+
+    def test_add_multiple(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "task 1")
+        add_recurring(f, "hourly", "task 2")
+        missions = load_recurring(f)
+        assert len(missions) == 2
+
+    def test_add_strips_whitespace(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        m = add_recurring(f, "daily", "  check emails  ")
+        assert m["text"] == "check emails"
+
+
+# --- remove_recurring ---
+
+
+class TestRemoveRecurring:
+    def _setup(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "check emails")
+        add_recurring(f, "weekly", "security audit")
+        add_recurring(f, "hourly", "check PRs")
+        return f
+
+    def test_remove_by_number(self, tmp_path):
+        f = self._setup(tmp_path)
+        removed = remove_recurring(f, "1")
+        assert "check emails" in removed
+        assert len(load_recurring(f)) == 2
+
+    def test_remove_by_keyword(self, tmp_path):
+        f = self._setup(tmp_path)
+        removed = remove_recurring(f, "security")
+        assert "security audit" in removed
+        assert len(load_recurring(f)) == 2
+
+    def test_remove_invalid_number(self, tmp_path):
+        f = self._setup(tmp_path)
+        with pytest.raises(ValueError, match="Invalid number"):
+            remove_recurring(f, "10")
+
+    def test_remove_no_match(self, tmp_path):
+        f = self._setup(tmp_path)
+        with pytest.raises(ValueError, match="No recurring mission matching"):
+            remove_recurring(f, "nonexistent")
+
+    def test_remove_empty_list(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        save_recurring(f, [])
+        with pytest.raises(ValueError, match="No recurring missions"):
+            remove_recurring(f, "1")
+
+    def test_remove_ambiguous(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "check emails morning")
+        add_recurring(f, "daily", "check emails evening")
+        with pytest.raises(ValueError, match="Multiple matches"):
+            remove_recurring(f, "check")
+
+
+# --- list_recurring ---
+
+
+class TestListRecurring:
+    def test_empty(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        assert list_recurring(f) == []
+
+    def test_sorts_by_frequency(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "weekly", "task W")
+        add_recurring(f, "hourly", "task H")
+        add_recurring(f, "daily", "task D")
+        result = list_recurring(f)
+        assert [m["frequency"] for m in result] == ["hourly", "daily", "weekly"]
+
+    def test_excludes_disabled(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        missions = [
+            {"id": "1", "frequency": "daily", "text": "active", "enabled": True},
+            {"id": "2", "frequency": "daily", "text": "disabled", "enabled": False},
+        ]
+        save_recurring(f, missions)
+        result = list_recurring(f)
+        assert len(result) == 1
+        assert result[0]["text"] == "active"
+
+
+# --- format_recurring_list ---
+
+
+class TestFormatRecurringList:
+    def test_empty(self):
+        assert "No recurring" in format_recurring_list([])
+
+    def test_basic_format(self):
+        missions = [
+            {"frequency": "daily", "text": "check emails", "project": None, "last_run": None},
+        ]
+        result = format_recurring_list(missions)
+        assert "[daily]" in result
+        assert "check emails" in result
+        assert "never run" in result
+
+    def test_with_project(self):
+        missions = [
+            {"frequency": "weekly", "text": "audit", "project": "koan", "last_run": None},
+        ]
+        result = format_recurring_list(missions)
+        assert "project: koan" in result
+
+    def test_with_last_run(self):
+        recent = (datetime.now() - timedelta(minutes=30)).isoformat()
+        missions = [
+            {"frequency": "hourly", "text": "check PRs", "project": None, "last_run": recent},
+        ]
+        result = format_recurring_list(missions)
+        assert "30min ago" in result
+
+
+# --- is_due ---
+
+
+class TestIsDue:
+    def test_never_run_is_due(self):
+        m = {"frequency": "daily", "last_run": None, "enabled": True}
+        assert is_due(m) is True
+
+    def test_disabled_not_due(self):
+        m = {"frequency": "daily", "last_run": None, "enabled": False}
+        assert is_due(m) is False
+
+    def test_hourly_within_hour(self):
+        now = datetime(2026, 2, 3, 14, 0)
+        m = {"frequency": "hourly", "last_run": (now - timedelta(minutes=30)).isoformat(), "enabled": True}
+        assert is_due(m, now) is False
+
+    def test_hourly_past_hour(self):
+        now = datetime(2026, 2, 3, 14, 0)
+        m = {"frequency": "hourly", "last_run": (now - timedelta(hours=1, minutes=1)).isoformat(), "enabled": True}
+        assert is_due(m, now) is True
+
+    def test_daily_same_day(self):
+        now = datetime(2026, 2, 3, 14, 0)
+        m = {"frequency": "daily", "last_run": datetime(2026, 2, 3, 8, 0).isoformat(), "enabled": True}
+        assert is_due(m, now) is False
+
+    def test_daily_next_day(self):
+        now = datetime(2026, 2, 4, 8, 0)
+        m = {"frequency": "daily", "last_run": datetime(2026, 2, 3, 22, 0).isoformat(), "enabled": True}
+        assert is_due(m, now) is True
+
+    def test_weekly_within_week(self):
+        now = datetime(2026, 2, 3, 14, 0)
+        m = {"frequency": "weekly", "last_run": (now - timedelta(days=3)).isoformat(), "enabled": True}
+        assert is_due(m, now) is False
+
+    def test_weekly_past_week(self):
+        now = datetime(2026, 2, 10, 14, 0)
+        m = {"frequency": "weekly", "last_run": datetime(2026, 2, 3, 8, 0).isoformat(), "enabled": True}
+        assert is_due(m, now) is True
+
+    def test_invalid_last_run_is_due(self):
+        m = {"frequency": "daily", "last_run": "not-a-date", "enabled": True}
+        assert is_due(m) is True
+
+
+# --- check_and_inject ---
+
+
+class TestCheckAndInject:
+    def _setup_missions(self, tmp_path):
+        missions_path = tmp_path / "missions.md"
+        missions_path.write_text(
+            "# Missions\n\n"
+            "## En attente\n\n"
+            "## En cours\n\n"
+            "## Terminées\n\n"
+        )
+        return missions_path
+
+    def test_no_recurring_file(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+        result = check_and_inject(recurring_path, missions_path)
+        assert result == []
+
+    def test_injects_due_mission(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+        add_recurring(recurring_path, "daily", "check emails")
+
+        now = datetime(2026, 2, 3, 8, 0)
+        result = check_and_inject(recurring_path, missions_path, now)
+
+        assert len(result) == 1
+        assert "check emails" in result[0]
+
+        # Verify mission was inserted into missions.md
+        content = missions_path.read_text()
+        assert "[daily] check emails" in content
+
+        # Verify last_run was updated
+        missions = load_recurring(recurring_path)
+        assert missions[0]["last_run"] is not None
+
+    def test_skips_not_due(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+
+        # Add and mark as recently run
+        now = datetime(2026, 2, 3, 14, 0)
+        missions_data = [{
+            "id": "rec_1",
+            "frequency": "daily",
+            "text": "check emails",
+            "project": None,
+            "created": "2026-02-03T08:00:00",
+            "last_run": now.isoformat(),
+            "enabled": True,
+        }]
+        save_recurring(recurring_path, missions_data)
+
+        result = check_and_inject(recurring_path, missions_path, now)
+        assert result == []
+
+    def test_injects_with_project_tag(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+        add_recurring(recurring_path, "weekly", "audit security", project="koan")
+
+        now = datetime(2026, 2, 3, 8, 0)
+        check_and_inject(recurring_path, missions_path, now)
+
+        content = missions_path.read_text()
+        assert "[project:koan]" in content
+        assert "[weekly] audit security" in content
+
+    def test_multiple_due(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+        add_recurring(recurring_path, "daily", "task 1")
+        add_recurring(recurring_path, "hourly", "task 2")
+
+        now = datetime(2026, 2, 3, 8, 0)
+        result = check_and_inject(recurring_path, missions_path, now)
+
+        assert len(result) == 2
+
+    def test_mixed_due_and_not_due(self, tmp_path):
+        missions_path = self._setup_missions(tmp_path)
+        recurring_path = tmp_path / "recurring.json"
+
+        now = datetime(2026, 2, 3, 14, 0)
+        missions_data = [
+            {
+                "id": "rec_1", "frequency": "daily", "text": "due task",
+                "project": None, "created": "2026-02-01", "last_run": None, "enabled": True,
+            },
+            {
+                "id": "rec_2", "frequency": "daily", "text": "not due",
+                "project": None, "created": "2026-02-01",
+                "last_run": now.isoformat(), "enabled": True,
+            },
+        ]
+        save_recurring(recurring_path, missions_data)
+
+        result = check_and_inject(recurring_path, missions_path, now)
+        assert len(result) == 1
+        assert "due task" in result[0]
+
+
+# --- CLI recurring_scheduler.py ---
+
+
+class TestRecurringSchedulerCLI:
+    def test_no_args(self):
+        import subprocess
+        result = subprocess.run(
+            ["python3", "-m", "app.recurring_scheduler"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 1
+
+    def test_no_recurring_file(self, tmp_path):
+        import subprocess
+        result = subprocess.run(
+            ["python3", "-m", "app.recurring_scheduler", str(tmp_path)],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 0

--- a/koan/tests/test_recurring_skill.py
+++ b/koan/tests/test_recurring_skill.py
@@ -1,0 +1,204 @@
+"""Tests for the /recurring core skill — manage recurring missions."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.skills import SkillContext
+
+
+def _load_handler():
+    """Import the recurring skill handler."""
+    import importlib.util
+    handler_path = str(
+        Path(__file__).parent.parent / "skills" / "core" / "recurring" / "handler.py"
+    )
+    spec = importlib.util.spec_from_file_location("recurring_handler", handler_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _ctx(tmp_path, command_name, args=""):
+    """Create a SkillContext for testing."""
+    instance_dir = tmp_path / "instance"
+    instance_dir.mkdir(exist_ok=True)
+    return SkillContext(
+        koan_root=tmp_path,
+        instance_dir=instance_dir,
+        command_name=command_name,
+        args=args,
+    )
+
+
+# ---------------------------------------------------------------------------
+# /daily, /hourly, /weekly — add recurring missions
+# ---------------------------------------------------------------------------
+
+
+class TestAddCommands:
+    def test_daily_adds_mission(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "daily", "check emails")
+        result = mod.handle(ctx)
+        assert "Recurring mission added (daily)" in result
+        assert "check emails" in result
+
+        recurring_path = tmp_path / "instance" / "recurring.json"
+        assert recurring_path.exists()
+        data = json.loads(recurring_path.read_text())
+        assert len(data) == 1
+        assert data[0]["frequency"] == "daily"
+
+    def test_hourly_adds_mission(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "hourly", "check PRs")
+        result = mod.handle(ctx)
+        assert "Recurring mission added (hourly)" in result
+
+    def test_weekly_adds_mission(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "weekly", "security audit")
+        result = mod.handle(ctx)
+        assert "Recurring mission added (weekly)" in result
+
+    def test_add_with_project_tag(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "daily", "[project:koan] check tests")
+        result = mod.handle(ctx)
+        assert "project:koan" in result
+
+        recurring_path = tmp_path / "instance" / "recurring.json"
+        data = json.loads(recurring_path.read_text())
+        assert data[0]["project"] == "koan"
+
+    def test_add_empty_shows_usage(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "daily", "")
+        result = mod.handle(ctx)
+        assert "Usage:" in result
+        assert "/daily" in result
+
+    def test_add_whitespace_only_shows_usage(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "hourly", "   ")
+        result = mod.handle(ctx)
+        assert "Usage:" in result
+
+
+# ---------------------------------------------------------------------------
+# /recurring — list recurring missions
+# ---------------------------------------------------------------------------
+
+
+class TestListCommand:
+    def test_list_empty(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "recurring")
+        result = mod.handle(ctx)
+        assert "No recurring" in result
+
+    def test_list_shows_missions(self, tmp_path):
+        mod = _load_handler()
+        # Add some missions first
+        from app.recurring import add_recurring
+        recurring_path = tmp_path / "instance" / "recurring.json"
+        (tmp_path / "instance").mkdir(exist_ok=True)
+        add_recurring(recurring_path, "daily", "check emails")
+        add_recurring(recurring_path, "weekly", "audit security")
+
+        ctx = _ctx(tmp_path, "recurring")
+        result = mod.handle(ctx)
+        assert "check emails" in result
+        assert "audit security" in result
+        assert "[daily]" in result
+        assert "[weekly]" in result
+
+
+# ---------------------------------------------------------------------------
+# /cancel-recurring — cancel recurring missions
+# ---------------------------------------------------------------------------
+
+
+class TestCancelRecurringCommand:
+    def _setup_recurring(self, tmp_path):
+        from app.recurring import add_recurring
+        (tmp_path / "instance").mkdir(exist_ok=True)
+        recurring_path = tmp_path / "instance" / "recurring.json"
+        add_recurring(recurring_path, "daily", "check emails")
+        add_recurring(recurring_path, "weekly", "security audit")
+        return recurring_path
+
+    def test_cancel_by_number(self, tmp_path):
+        mod = _load_handler()
+        self._setup_recurring(tmp_path)
+        ctx = _ctx(tmp_path, "cancel-recurring", "1")
+        result = mod.handle(ctx)
+        assert "Recurring mission removed" in result
+        assert "check emails" in result
+
+    def test_cancel_by_keyword(self, tmp_path):
+        mod = _load_handler()
+        self._setup_recurring(tmp_path)
+        ctx = _ctx(tmp_path, "cancel-recurring", "security")
+        result = mod.handle(ctx)
+        assert "Recurring mission removed" in result
+        assert "security audit" in result
+
+    def test_cancel_invalid_number(self, tmp_path):
+        mod = _load_handler()
+        self._setup_recurring(tmp_path)
+        ctx = _ctx(tmp_path, "cancel-recurring", "99")
+        result = mod.handle(ctx)
+        assert "Invalid number" in result
+
+    def test_cancel_no_match(self, tmp_path):
+        mod = _load_handler()
+        self._setup_recurring(tmp_path)
+        ctx = _ctx(tmp_path, "cancel-recurring", "nonexistent")
+        result = mod.handle(ctx)
+        assert "No recurring mission matching" in result
+
+    def test_cancel_empty_shows_list(self, tmp_path):
+        mod = _load_handler()
+        self._setup_recurring(tmp_path)
+        ctx = _ctx(tmp_path, "cancel-recurring", "")
+        result = mod.handle(ctx)
+        assert "check emails" in result
+        assert "/cancel-recurring" in result
+
+    def test_cancel_empty_no_missions(self, tmp_path):
+        mod = _load_handler()
+        ctx = _ctx(tmp_path, "cancel-recurring", "")
+        result = mod.handle(ctx)
+        assert "No recurring missions to cancel" in result
+
+
+# ---------------------------------------------------------------------------
+# Skill registration (SKILL.md)
+# ---------------------------------------------------------------------------
+
+
+class TestSkillRegistration:
+    def test_skill_md_exists(self):
+        skill_md = Path(__file__).parent.parent / "skills" / "core" / "recurring" / "SKILL.md"
+        assert skill_md.exists()
+
+    def test_skill_md_has_required_commands(self):
+        skill_md = Path(__file__).parent.parent / "skills" / "core" / "recurring" / "SKILL.md"
+        content = skill_md.read_text()
+        for cmd in ["daily", "hourly", "weekly", "recurring", "cancel-recurring"]:
+            assert cmd in content, f"Missing command '{cmd}' in SKILL.md"
+
+    def test_handler_exists(self):
+        handler = Path(__file__).parent.parent / "skills" / "core" / "recurring" / "handler.py"
+        assert handler.exists()
+
+    def test_registry_discovers_recurring(self):
+        from app.skills import build_registry
+        registry = build_registry()
+        for cmd in ["daily", "hourly", "weekly", "recurring", "cancel-recurring"]:
+            skill = registry.find_by_command(cmd)
+            assert skill is not None, f"Command '/{cmd}' not found in registry"
+            assert skill.name == "recurring"


### PR DESCRIPTION
New recurring mission system for scheduled task execution:
- recurring.py: storage (recurring.json), scheduler, CRUD operations
- recurring_scheduler.py: CLI entry point called from run.sh each loop
- awake.py: /daily, /hourly, /weekly, /recurring, /cancel-recurring commands
- run.sh: scheduler integration before mission picker

Scheduling logic: hourly (>1h since last), daily (different date), weekly (>7d since last). Due missions injected into missions.md pending section for normal execution flow.

56 new tests (787 total). All passing.