### PR TITLE
feat: add /queue command — full numbered mission queue

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -181,6 +181,10 @@ def handle_command(text: str):
     if cmd.startswith("/reflect "):
         _handle_reflect(text[9:].strip())
 
+    if cmd == "/queue":
+        _handle_queue()
+        return
+
     if cmd == "/help":
         _handle_help()
         return
@@ -239,13 +243,13 @@ def _build_status() -> str:
 
     return "\n".join(parts)
 
-
 def _handle_help():
     """Send the list of available commands."""
     help_text = (
         "Commandes disponibles :\n\n"
         "/help — cette aide\n"
         "/status — état rapide (missions, pause, loop)\n"
+        "/queue — file d'attente complète avec numéros\n"
         "/usage — status détaillé formaté par Claude (quota, missions, progression)\n"
         "/stop — arrêter Kōan après la mission en cours\n"
         "/pause — mettre en pause (pas de nouvelles missions)\n"

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -1013,3 +1013,343 @@ class TestHandleUsage:
 
         prompt_arg = mock_run.call_args[0][0][2]
         assert "fix auth" in prompt_arg
+
+# ---------------------------------------------------------------------------
+# Recurring mission commands (/daily, /hourly, /weekly, /recurring)
+# ---------------------------------------------------------------------------
+
+class TestHandleRecurringAdd:
+    @patch("app.awake.send_telegram")
+    def test_daily_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "check unread emails")
+        mock_send.assert_called_once()
+        msg = mock_send.call_args[0][0]
+        assert "daily" in msg
+        assert "check unread emails" in msg
+        assert (instance / "recurring.json").exists()
+
+    @patch("app.awake.send_telegram")
+    def test_hourly_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("hourly", "check open PRs")
+        msg = mock_send.call_args[0][0]
+        assert "hourly" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_weekly_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("weekly", "security audit")
+        msg = mock_send.call_args[0][0]
+        assert "weekly" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_add_with_project(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "[project:koan] check logs")
+        msg = mock_send.call_args[0][0]
+        assert "project:koan" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_add_empty_body(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "")
+        msg = mock_send.call_args[0][0]
+        assert "Usage" in msg
+
+
+class TestHandleRecurringList:
+    @patch("app.awake.send_telegram")
+    def test_empty_list(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_list()
+        msg = mock_send.call_args[0][0]
+        assert "No recurring" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_shows_missions(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_list()
+        msg = mock_send.call_args[0][0]
+        assert "check emails" in msg
+        assert "[daily]" in msg
+
+
+class TestHandleCancelRecurring:
+    @patch("app.awake.send_telegram")
+    def test_cancel_empty_shows_help(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("")
+        msg = mock_send.call_args[0][0]
+        assert "No recurring" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_cancel_by_number(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("1")
+        msg = mock_send.call_args[0][0]
+        assert "removed" in msg.lower() or "Recurring mission removed" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_cancel_invalid(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("99")
+        msg = mock_send.call_args[0][0]
+        assert "Invalid" in msg
+
+
+class TestHandleCommandRecurring:
+    """Test that handle_command routes recurring commands correctly."""
+
+    @patch("app.awake._handle_recurring_add")
+    def test_daily_route(self, mock_add):
+        handle_command("/daily check emails")
+        mock_add.assert_called_once_with("daily", "check emails")
+
+    @patch("app.awake._handle_recurring_add")
+    def test_hourly_route(self, mock_add):
+        handle_command("/hourly check PRs")
+        mock_add.assert_called_once_with("hourly", "check PRs")
+
+    @patch("app.awake._handle_recurring_add")
+    def test_weekly_route(self, mock_add):
+        handle_command("/weekly audit security")
+        mock_add.assert_called_once_with("weekly", "audit security")
+
+    @patch("app.awake._handle_recurring_list")
+    def test_recurring_list_route(self, mock_list):
+        handle_command("/recurring")
+        mock_list.assert_called_once()
+
+    @patch("app.awake._handle_cancel_recurring")
+    def test_cancel_recurring_route(self, mock_cancel):
+        handle_command("/cancel-recurring 1")
+        mock_cancel.assert_called_once_with("1")
+
+
+# ---------------------------------------------------------------------------
+# Recurring mission commands (/daily, /hourly, /weekly, /recurring)
+# ---------------------------------------------------------------------------
+
+class TestHandleRecurringAdd:
+    @patch("app.awake.send_telegram")
+    def test_daily_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "check unread emails")
+        mock_send.assert_called_once()
+        msg = mock_send.call_args[0][0]
+        assert "daily" in msg
+        assert "check unread emails" in msg
+        assert (instance / "recurring.json").exists()
+
+    @patch("app.awake.send_telegram")
+    def test_hourly_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("hourly", "check open PRs")
+        msg = mock_send.call_args[0][0]
+        assert "hourly" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_weekly_add(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("weekly", "security audit")
+        msg = mock_send.call_args[0][0]
+        assert "weekly" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_add_with_project(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "[project:koan] check logs")
+        msg = mock_send.call_args[0][0]
+        assert "project:koan" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_add_empty_body(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_add("daily", "")
+        msg = mock_send.call_args[0][0]
+        assert "Usage" in msg
+
+
+class TestHandleRecurringList:
+    @patch("app.awake.send_telegram")
+    def test_empty_list(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_list()
+        msg = mock_send.call_args[0][0]
+        assert "No recurring" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_shows_missions(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_recurring_list()
+        msg = mock_send.call_args[0][0]
+        assert "check emails" in msg
+        assert "[daily]" in msg
+
+
+class TestHandleCancelRecurring:
+    @patch("app.awake.send_telegram")
+    def test_cancel_empty_shows_help(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("")
+        msg = mock_send.call_args[0][0]
+        assert "No recurring" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_cancel_by_number(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("1")
+        msg = mock_send.call_args[0][0]
+        assert "removed" in msg.lower() or "Recurring mission removed" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_cancel_invalid(self, mock_send, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        from app.recurring import add_recurring
+        add_recurring(instance / "recurring.json", "daily", "check emails")
+        with patch("app.awake.INSTANCE_DIR", instance):
+            _handle_cancel_recurring("99")
+        msg = mock_send.call_args[0][0]
+        assert "Invalid" in msg
+
+
+class TestHandleCommandRecurring:
+    """Test that handle_command routes recurring commands correctly."""
+
+    @patch("app.awake._handle_recurring_add")
+    def test_daily_route(self, mock_add):
+        handle_command("/daily check emails")
+        mock_add.assert_called_once_with("daily", "check emails")
+
+    @patch("app.awake._handle_recurring_add")
+    def test_hourly_route(self, mock_add):
+        handle_command("/hourly check PRs")
+        mock_add.assert_called_once_with("hourly", "check PRs")
+
+    @patch("app.awake._handle_recurring_add")
+    def test_weekly_route(self, mock_add):
+        handle_command("/weekly audit security")
+        mock_add.assert_called_once_with("weekly", "audit security")
+
+    @patch("app.awake._handle_recurring_list")
+    def test_recurring_list_route(self, mock_list):
+        handle_command("/recurring")
+        mock_list.assert_called_once()
+
+    @patch("app.awake._handle_cancel_recurring")
+    def test_cancel_recurring_route(self, mock_cancel):
+        handle_command("/cancel-recurring 1")
+        mock_cancel.assert_called_once_with("1")
+
+
+# ---------------------------------------------------------------------------
+# /queue
+# ---------------------------------------------------------------------------
+
+class TestHandleQueue:
+    @patch("app.awake.send_telegram")
+    def test_queue_with_missions(self, mock_send, tmp_path):
+        """Shows full numbered queue."""
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            "# Missions\n\n"
+            "## En attente\n\n"
+            "- [project:koan] add tests\n"
+            "- fix bug\n"
+            "- refactor auth\n\n"
+            "## En cours\n\n"
+            "- [project:koan] doing stuff\n\n"
+            "## Terminées\n"
+        )
+        with patch("app.awake.MISSIONS_FILE", missions_file):
+            _handle_queue()
+        msg = mock_send.call_args[0][0]
+        assert "Mission Queue" in msg
+        assert "In progress" in msg
+        assert "doing stuff" in msg
+        assert "1." in msg
+        assert "2." in msg
+        assert "3." in msg
+        assert "Pending (3)" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_queue_empty(self, mock_send, tmp_path):
+        """Empty queue shows appropriate message."""
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text("# Missions\n\n## En attente\n\n## En cours\n\n## Terminées\n")
+        with patch("app.awake.MISSIONS_FILE", missions_file):
+            _handle_queue()
+        msg = mock_send.call_args[0][0]
+        assert "vide" in msg.lower()
+
+    @patch("app.awake.send_telegram")
+    def test_queue_no_file(self, mock_send, tmp_path):
+        """Missing missions.md shows empty message."""
+        with patch("app.awake.MISSIONS_FILE", tmp_path / "nonexistent.md"):
+            _handle_queue()
+        msg = mock_send.call_args[0][0]
+        assert "vide" in msg.lower()
+
+    @patch("app.awake._handle_queue")
+    def test_handle_command_routes_queue(self, mock_queue):
+        """handle_command routes /queue to _handle_queue."""
+        handle_command("/queue")
+        mock_queue.assert_called_once()
+
+    @patch("app.awake.send_telegram")
+    def test_help_mentions_queue(self, mock_send):
+        """/help output includes /queue."""
+        _handle_help()
+        msg = mock_send.call_args[0][0]
+        assert "/queue" in msg
+


### PR DESCRIPTION
format_queue() in missions.py builds a numbered display of all
pending and in-progress missions. _handle_queue() in awake.py
serves it via /queue. Unlike /status (truncated to 2-3 items),
/queue shows every mission with its position number and project tag.

12 new tests, 799 total.

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>
