### PR TITLE
feat: add /pr command for pull request review workflow

### DIFF
--- a/koan/app/pr_review.py
+++ b/koan/app/pr_review.py
@@ -1,0 +1,687 @@
+#!/usr/bin/env python3
+"""
+Koan -- Pull Request review and update workflow.
+
+Multi-step pipeline for /pr command:
+1. Fetch PR context from GitHub
+2. Checkout and rebase onto target branch
+3. Run Claude Code to address review feedback
+4. Run refactor pass (if skill available)
+5. Run quality review pass (if skill available)
+6. Confirm tests pass
+7. Force-push and comment on PR
+"""
+
+import json
+import os
+import re
+import subprocess
+from pathlib import Path
+from typing import Optional, Tuple, List
+
+from app.utils import get_model_config, build_claude_flags
+
+# Matches skill names like `atoomic.refactor` or my.review (with or without backticks)
+_SKILL_RE = re.compile(r'`?([a-zA-Z0-9_-]+\.(?:refactor|review))\b`?')
+
+
+def parse_pr_url(url: str) -> Tuple[str, str, str]:
+    """Extract owner, repo, and PR number from a GitHub PR URL.
+
+    Accepts formats:
+        https://github.com/owner/repo/pull/123
+        https://github.com/owner/repo/pull/123#...
+
+    Returns:
+        (owner, repo, pr_number) as strings.
+
+    Raises:
+        ValueError: If the URL doesn't match expected format.
+    """
+    match = re.match(
+        r"https?://github\.com/([^/]+)/([^/]+)/pull/(\d+)",
+        url.strip(),
+    )
+    if not match:
+        raise ValueError(f"Invalid PR URL: {url}")
+    return match.group(1), match.group(2), match.group(3)
+
+
+def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
+    """Fetch PR details, diff, and review comments via gh CLI.
+
+    Returns a dict with keys: title, body, branch, base, diff, reviews,
+    comments, issue_comments, state, author, url.
+    """
+    full_repo = f"{owner}/{repo}"
+
+    # Fetch PR metadata
+    pr_json = _gh(
+        ["gh", "pr", "view", pr_number, "--repo", full_repo, "--json",
+         "title,body,headRefName,baseRefName,state,author,url"]
+    )
+
+    # Fetch PR diff
+    diff = _gh(
+        ["gh", "pr", "diff", pr_number, "--repo", full_repo]
+    )
+
+    # Fetch review comments (inline code comments)
+    comments_json = _gh(
+        ["gh", "api", f"repos/{full_repo}/pulls/{pr_number}/comments",
+         "--paginate", "--jq",
+         r'.[] | "[\(.path):\(.line // .original_line)] @\(.user.login): \(.body)"']
+    )
+
+    # Fetch PR-level review comments (top-level reviews)
+    reviews_json = _gh(
+        ["gh", "api", f"repos/{full_repo}/pulls/{pr_number}/reviews",
+         "--paginate", "--jq",
+         r'.[] | select(.body != "") | "@\(.user.login) (\(.state)): \(.body)"']
+    )
+
+    # Fetch issue-level comments (conversation thread)
+    issue_comments = _gh(
+        ["gh", "api", f"repos/{full_repo}/issues/{pr_number}/comments",
+         "--paginate", "--jq",
+         r'.[] | "@\(.user.login): \(.body)"']
+    )
+
+    try:
+        metadata = json.loads(pr_json)
+    except (json.JSONDecodeError, TypeError):
+        metadata = {}
+
+    return {
+        "title": metadata.get("title", ""),
+        "body": metadata.get("body", ""),
+        "branch": metadata.get("headRefName", ""),
+        "base": metadata.get("baseRefName", "main"),
+        "state": metadata.get("state", ""),
+        "author": metadata.get("author", {}).get("login", ""),
+        "url": metadata.get("url", ""),
+        "diff": _truncate(diff, 8000),
+        "review_comments": _truncate(comments_json, 4000),
+        "reviews": _truncate(reviews_json, 3000),
+        "issue_comments": _truncate(issue_comments, 3000),
+    }
+
+
+def _load_prompt(name: str, **kwargs) -> str:
+    """Lazy-load a system prompt template by name."""
+    from app.prompts import load_prompt
+    return load_prompt(name, **kwargs)
+
+
+def build_pr_prompt(context: dict) -> str:
+    """Build a prompt for Claude to address PR review feedback."""
+    return _load_prompt(
+        "pr-review",
+        TITLE=context["title"],
+        BODY=context["body"],
+        BRANCH=context["branch"],
+        BASE=context["base"],
+        DIFF=context["diff"],
+        REVIEW_COMMENTS=context["review_comments"],
+        REVIEWS=context["reviews"],
+        ISSUE_COMMENTS=context["issue_comments"],
+    )
+
+
+def build_refactor_prompt(project_path: str, skill_name: str = "") -> str:
+    """Build a prompt for the refactor pass on recent changes."""
+    prompt = _load_prompt("pr-refactor", PROJECT_PATH=project_path)
+    if skill_name:
+        prompt += (
+            f"\n\n## Skill Invocation\n\n"
+            f"Invoke the `{skill_name}` skill using the Skill tool before "
+            f"doing any manual refactoring:\n"
+            f'`skill: "{skill_name}"`'
+        )
+    return prompt
+
+
+def build_quality_review_prompt(project_path: str, skill_name: str = "") -> str:
+    """Build a prompt for the quality review pass on recent changes."""
+    prompt = _load_prompt("pr-quality-review", PROJECT_PATH=project_path)
+    if skill_name:
+        prompt += (
+            f"\n\n## Skill Invocation\n\n"
+            f"Invoke the `{skill_name}` skill using the Skill tool before "
+            f"doing any manual review:\n"
+            f'`skill: "{skill_name}"`'
+        )
+    return prompt
+
+
+def detect_test_command(project_path: str) -> Optional[str]:
+    """Detect the test command for a project by examining common files.
+
+    Returns:
+        Shell command string to run tests, or None if not detected.
+    """
+    p = Path(project_path)
+
+    # Makefile with 'test' target
+    makefile = p / "Makefile"
+    if makefile.exists():
+        content = makefile.read_text()
+        if re.search(r'^test\s*:', content, re.MULTILINE):
+            return "make test"
+
+    # Python: pytest
+    if (p / "pytest.ini").exists() or (p / "pyproject.toml").exists() or (p / "setup.py").exists():
+        # Check if there's a tests directory
+        if (p / "tests").is_dir() or (p / "koan" / "tests").is_dir():
+            return "make test" if makefile.exists() else "pytest"
+
+    # Node.js
+    pkg_json = p / "package.json"
+    if pkg_json.exists():
+        try:
+            pkg = json.loads(pkg_json.read_text())
+            if "test" in pkg.get("scripts", {}):
+                return "npm test"
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    return None
+
+
+def detect_skills(project_path: str = "") -> Tuple[Optional[str], Optional[str]]:
+    """Detect available refactor and review skills.
+
+    Searches for skill names matching *.refactor and *.review patterns in:
+    1. CLAUDE.md at the project path (closest to runtime skill registry)
+    2. soul.md in the instance directory
+    3. Falls back to generic "refactor"/"review" if skill mentions exist
+
+    Args:
+        project_path: Optional path to project root for CLAUDE.md lookup.
+
+    Returns:
+        (refactor_skill, review_skill) — skill names or None if unavailable.
+    """
+    refactor_skill = None
+    review_skill = None
+
+    # Collect text sources to scan for skill references
+    sources: List[str] = []
+
+    # 1. Check CLAUDE.md at project path (highest priority — project-specific skills)
+    if project_path:
+        claude_md = Path(project_path) / "CLAUDE.md"
+        if claude_md.exists():
+            sources.append(claude_md.read_text())
+
+    # 2. Check soul.md in instance directory
+    instance_dir = Path(os.environ.get("KOAN_ROOT", "")) / "instance"
+    soul_path = instance_dir / "soul.md"
+    if soul_path.exists():
+        sources.append(soul_path.read_text())
+
+    # Scan all sources for skill name patterns
+    for text in sources:
+        if refactor_skill and review_skill:
+            break
+
+        for match in _SKILL_RE.finditer(text):
+            name = match.group(1)
+            if name.endswith(".refactor") and not refactor_skill:
+                refactor_skill = name
+            elif name.endswith(".review") and not review_skill:
+                review_skill = name
+
+        # Fallback: generic mentions of "refactor/review" + "skill"
+        if not refactor_skill and "refactor" in text.lower() and "skill" in text.lower():
+            refactor_skill = "refactor"
+        if not review_skill and "review" in text.lower() and "skill" in text.lower():
+            review_skill = "review"
+
+    return refactor_skill, review_skill
+
+
+def run_pr_review(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    project_path: str,
+    notify_fn=None,
+) -> Tuple[bool, str]:
+    """Execute the full PR review pipeline.
+
+    Steps:
+        1. Fetch PR context from GitHub
+        2. Checkout the PR branch and rebase onto target branch
+        3. Run Claude Code to address review feedback (commit changes)
+        4. Run refactor skill if available (separate commit)
+        5. Run review skill if available (separate commit)
+        6. Run tests — fix if broken
+        7. Force-push the branch
+        8. Comment on PR with summary of all actions
+
+    Args:
+        owner: GitHub owner
+        repo: GitHub repo name
+        pr_number: PR number as string
+        project_path: Local path to the project
+        notify_fn: Optional callback for progress notifications.
+                   Defaults to send_telegram.
+
+    Returns:
+        (success, summary) tuple.
+    """
+    if notify_fn is None:
+        from app.notify import send_telegram
+        notify_fn = send_telegram
+
+    full_repo = f"{owner}/{repo}"
+    actions_log: List[str] = []
+
+    # ── Step 1: Fetch PR context ──────────────────────────────────────
+    notify_fn(f"Reading PR #{pr_number}...")
+    try:
+        context = fetch_pr_context(owner, repo, pr_number)
+    except Exception as e:
+        return False, f"Failed to fetch PR context: {e}"
+
+    if not context["branch"]:
+        return False, "Could not determine PR branch name."
+
+    branch = context["branch"]
+    base = context["base"]
+
+    # ── Step 2: Checkout and rebase onto target branch ────────────────
+    notify_fn(f"Rebasing `{branch}` onto `{base}`...")
+    try:
+        _run_git(["git", "fetch", "origin", branch], cwd=project_path)
+        _run_git(["git", "checkout", branch], cwd=project_path)
+        _run_git(["git", "pull", "origin", branch, "--rebase"], cwd=project_path)
+    except Exception as e:
+        return False, f"Failed to checkout branch {branch}: {e}"
+
+    # Rebase onto the upstream target branch (tries origin, then upstream)
+    rebase_remote = _rebase_onto_target(base, project_path)
+    if rebase_remote:
+        actions_log.append(f"Rebased `{branch}` onto `{rebase_remote}/{base}`")
+    else:
+        return False, f"Rebase conflict on {base} (tried origin and upstream)"
+
+    # ── Step 3: Address review feedback via Claude Code ───────────────
+    has_review_feedback = bool(
+        context["review_comments"].strip()
+        or context["reviews"].strip()
+        or context["issue_comments"].strip()
+    )
+
+    if has_review_feedback:
+        notify_fn(f"Addressing review comments on `{branch}`...")
+        _run_claude_step(
+            prompt=build_pr_prompt(context),
+            project_path=project_path,
+            commit_msg=f"pr-review: address feedback on #{pr_number}",
+            success_label="Addressed reviewer feedback",
+            failure_label="Review feedback step failed",
+            actions_log=actions_log,
+            max_turns=30,
+        )
+
+    # ── Step 4: Refactor pass ─────────────────────────────────────────
+    refactor_skill, review_skill = detect_skills(project_path)
+
+    if refactor_skill:
+        notify_fn(f"Running refactor pass ({refactor_skill})...")
+        _run_claude_step(
+            prompt=build_refactor_prompt(project_path, refactor_skill),
+            project_path=project_path,
+            commit_msg=f"refactor: apply refactoring pass on #{pr_number}",
+            success_label=f"Applied refactoring via `{refactor_skill}`",
+            failure_label="Refactor step skipped",
+            actions_log=actions_log,
+            use_skill=True,
+        )
+
+    # ── Step 5: Quality review pass ───────────────────────────────────
+    if review_skill:
+        notify_fn(f"Running quality review pass ({review_skill})...")
+        _run_claude_step(
+            prompt=build_quality_review_prompt(project_path, review_skill),
+            project_path=project_path,
+            commit_msg=f"review: apply quality improvements on #{pr_number}",
+            success_label=f"Applied quality review via `{review_skill}`",
+            failure_label="Quality review step skipped",
+            actions_log=actions_log,
+            use_skill=True,
+        )
+
+    # ── Step 6: Run tests ─────────────────────────────────────────────
+    test_cmd = detect_test_command(project_path)
+    if test_cmd:
+        notify_fn("Running tests...")
+        test_result = _run_tests(test_cmd, project_path)
+        if test_result["passed"]:
+            actions_log.append(
+                f"Tests passing ({test_result.get('details', 'OK')})"
+            )
+        else:
+            # Try to fix failing tests via Claude
+            notify_fn("Tests failing — attempting fix...")
+            fix_prompt = (
+                f"The test suite is failing after PR changes. "
+                f"Test command: `{test_cmd}`\n\n"
+                f"Test output:\n```\n{test_result.get('output', '')[:3000]}\n```\n\n"
+                f"Fix the failing tests. Only modify what's necessary."
+            )
+            _run_claude_step(
+                prompt=fix_prompt,
+                project_path=project_path,
+                commit_msg=f"fix: repair tests after PR #{pr_number} changes",
+                success_label="",  # handled below via retest
+                failure_label="",
+                actions_log=[],  # discard — we log based on retest below
+                max_turns=15,
+                timeout=300,
+            )
+
+            # Re-run tests to confirm
+            retest = _run_tests(test_cmd, project_path)
+            if retest["passed"]:
+                actions_log.append("Tests fixed and passing")
+            else:
+                actions_log.append(
+                    f"Tests still failing: {retest.get('details', 'unknown')}"
+                )
+
+    # ── Step 7: Force-push ────────────────────────────────────────────
+    notify_fn(f"Pushing `{branch}`...")
+    try:
+        _run_git(
+            ["git", "push", "origin", branch, "--force-with-lease"],
+            cwd=project_path,
+        )
+        actions_log.append(f"Force-pushed `{branch}`")
+    except Exception as e:
+        return False, f"Push failed: {e}\n\nActions completed before failure:\n" + "\n".join(
+            f"- {a}" for a in actions_log
+        )
+
+    # ── Step 8: Comment on PR ─────────────────────────────────────────
+    comment_body = _build_pr_comment(
+        pr_number, branch, base, actions_log, context
+    )
+
+    try:
+        _gh([
+            "gh", "pr", "comment", pr_number,
+            "--repo", full_repo,
+            "--body", comment_body,
+        ])
+        actions_log.append("Commented on PR")
+    except Exception as e:
+        # Non-fatal
+        notify_fn(f"Changes pushed but failed to comment on PR: {e}")
+
+    summary = f"PR #{pr_number} updated.\n" + "\n".join(
+        f"- {a}" for a in actions_log
+    )
+    return True, summary
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _run_claude_step(
+    prompt: str,
+    project_path: str,
+    commit_msg: str,
+    success_label: str,
+    failure_label: str,
+    actions_log: List[str],
+    max_turns: int = 20,
+    timeout: int = 600,
+    use_skill: bool = False,
+) -> bool:
+    """Run a Claude Code step: invoke CLI, commit changes, log result.
+
+    Args:
+        use_skill: If True, include the Skill tool in allowed tools
+                   so Claude can invoke registered skills (e.g. /refactor).
+
+    Returns True if the step produced a commit.
+    """
+    models = get_model_config()
+    flags = build_claude_flags(
+        model=models["mission"], fallback=models["fallback"]
+    )
+
+    tools = "Bash,Read,Write,Glob,Grep,Edit"
+    if use_skill:
+        tools += ",Skill"
+
+    cmd = (
+        ["claude", "-p", prompt,
+         "--allowedTools", tools,
+         "--max-turns", str(max_turns)]
+        + flags
+    )
+
+    result = _run_claude(cmd, project_path, timeout=timeout)
+    if result["success"]:
+        committed = _commit_if_changes(project_path, commit_msg)
+        if committed and success_label:
+            actions_log.append(success_label)
+            return True
+    elif failure_label:
+        actions_log.append(f"{failure_label}: {result['error'][:200]}")
+    return False
+
+
+def _rebase_onto_target(base: str, project_path: str) -> Optional[str]:
+    """Rebase onto target branch, trying origin then upstream.
+
+    Returns:
+        Remote name used (e.g. "origin" or "upstream") on success, None on failure.
+    """
+    for remote in ("origin", "upstream"):
+        try:
+            _run_git(["git", "fetch", remote, base], cwd=project_path)
+            _run_git(
+                ["git", "rebase", "--autostash", f"{remote}/{base}"],
+                cwd=project_path,
+            )
+            return remote
+        except Exception:
+            subprocess.run(
+                ["git", "rebase", "--abort"],
+                capture_output=True, cwd=project_path,
+            )
+    return None
+
+
+def _run_claude(
+    cmd: list, cwd: str, timeout: int = 600
+) -> dict:
+    """Run a Claude Code CLI command.
+
+    Returns:
+        Dict with keys: success (bool), output (str), error (str).
+    """
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True, text=True,
+            timeout=timeout, cwd=cwd,
+        )
+        if result.returncode != 0:
+            stderr_snippet = result.stderr[-500:] if result.stderr else "no stderr"
+            return {
+                "success": False,
+                "output": result.stdout.strip(),
+                "error": f"Exit code {result.returncode}: {stderr_snippet}",
+            }
+        return {
+            "success": True,
+            "output": result.stdout.strip(),
+            "error": "",
+        }
+    except subprocess.TimeoutExpired:
+        return {
+            "success": False,
+            "output": "",
+            "error": f"Timeout ({timeout}s)",
+        }
+
+
+def _commit_if_changes(project_path: str, message: str) -> bool:
+    """Stage all changes and commit if there are any.
+
+    Returns True if a commit was created.
+    """
+    status = subprocess.run(
+        ["git", "status", "--porcelain"],
+        capture_output=True, text=True, cwd=project_path,
+    )
+    if not status.stdout.strip():
+        return False
+
+    _run_git(["git", "add", "-u"], cwd=project_path)
+    _run_git(["git", "commit", "-m", message], cwd=project_path)
+    return True
+
+
+def _run_tests(test_cmd: str, project_path: str) -> dict:
+    """Run the test suite and return results.
+
+    Returns:
+        Dict with keys: passed (bool), output (str), details (str).
+    """
+    try:
+        result = subprocess.run(
+            test_cmd,
+            shell=True,
+            capture_output=True, text=True,
+            timeout=300, cwd=project_path,
+        )
+        output = result.stdout + result.stderr
+        passed = result.returncode == 0
+
+        # Try to extract test count from output
+        details = "OK" if passed else "FAILED"
+        count_match = re.search(
+            r'(\d+)\s+(?:tests?|passed)', output, re.IGNORECASE
+        )
+        if count_match:
+            details = count_match.group(0)
+
+        return {"passed": passed, "output": output[-3000:], "details": details}
+    except subprocess.TimeoutExpired:
+        return {"passed": False, "output": "", "details": "timeout (300s)"}
+    except Exception as e:
+        return {"passed": False, "output": str(e), "details": str(e)[:100]}
+
+
+def _build_pr_comment(
+    pr_number: str,
+    branch: str,
+    base: str,
+    actions_log: List[str],
+    context: dict,
+) -> str:
+    """Build a markdown-formatted comment for the PR.
+
+    Format:
+        ## Description title
+        Summary paragraph
+        ### Changes
+        - bullet list of actions
+        ### Status & Next Steps
+        Quick message about current state
+    """
+    # Build a descriptive title from the PR context
+    title = context.get("title", f"PR #{pr_number}")
+
+    # Count meaningful changes
+    change_count = sum(
+        1 for a in actions_log
+        if not a.startswith("Tests") and "Force-pushed" not in a
+    )
+
+    # Summary paragraph
+    if change_count == 0:
+        summary = (
+            f"Automated pipeline ran on `{branch}`. "
+            f"The branch has been rebased on `{base}` and force-pushed."
+        )
+    else:
+        summary = (
+            f"Automated pipeline ran {len(actions_log)} steps on `{branch}`: "
+            f"rebased onto `{base}`, applied {change_count} change(s), "
+            f"and force-pushed the result."
+        )
+
+    # Actions as bullet list
+    actions_md = "\n".join(f"- {a}" for a in actions_log) if actions_log else "- No changes needed"
+
+    # Status and next steps
+    has_failures = any(
+        "failing" in a.lower() or "failed" in a.lower() or "skipped" in a.lower()
+        for a in actions_log
+    )
+
+    if has_failures:
+        status_msg = (
+            "Some steps encountered issues. "
+            "Please review the changes and verify the failing items. "
+            "You may want to run the test suite locally before merging."
+        )
+    else:
+        status_msg = (
+            "All steps completed successfully. "
+            "The branch is rebased, tests are passing, and the PR is ready for re-review."
+        )
+
+    return (
+        f"## {title}\n\n"
+        f"{summary}\n\n"
+        f"### Changes\n\n"
+        f"{actions_md}\n\n"
+        f"### Status & Next Steps\n\n"
+        f"{status_msg}\n\n"
+        f"---\n"
+        f"_Automated by Kōan_"
+    )
+
+
+def _gh(cmd: list, timeout: int = 30) -> str:
+    """Run a gh CLI command and return stdout."""
+    result = subprocess.run(
+        cmd,
+        capture_output=True, text=True, timeout=timeout,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"gh command failed: {' '.join(cmd[:4])}... — {result.stderr[:200]}"
+        )
+    return result.stdout.strip()
+
+
+def _run_git(cmd: list, cwd: str = None, timeout: int = 60) -> str:
+    """Run a git command, raise on failure."""
+    result = subprocess.run(
+        cmd,
+        capture_output=True, text=True,
+        timeout=timeout, cwd=cwd,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git failed: {' '.join(cmd)} — {result.stderr[:200]}"
+        )
+    return result.stdout.strip()
+
+
+def _truncate(text: str, max_chars: int) -> str:
+    """Truncate text with indicator."""
+    if len(text) <= max_chars:
+        return text
+    return text[:max_chars] + "\n...(truncated)"

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -214,6 +214,7 @@ def get_interval_seconds() -> int:
     """
     config = load_config()
     return int(config.get("interval_seconds", 300))
+
 def get_fast_reply_model() -> str:
     """Get model to use for fast replies (command handlers like /usage, /sparring).
 
@@ -604,6 +605,30 @@ def compact_telegram_history(history_file: Path, topics_file: Path, min_messages
     count = len(messages)
     print(f"[utils] Compacted {count} messages → {topics_file.name}")
     return count
+
+
+def get_known_projects() -> list:
+    """Return sorted list of (name, path) tuples from KOAN_PROJECTS env var.
+
+    Format: name:path;name2:path2
+    Falls back to KOAN_PROJECT_PATH with name "default" for single-project mode.
+    Returns empty list if neither is set.
+    """
+    projects_str = os.environ.get("KOAN_PROJECTS", "")
+    if projects_str:
+        result = []
+        for pair in projects_str.split(";"):
+            pair = pair.strip()
+            if ":" in pair:
+                name, path = pair.split(":", 1)
+                result.append((name.strip(), path.strip()))
+        return sorted(result, key=lambda x: x[0].lower())
+
+    single_path = os.environ.get("KOAN_PROJECT_PATH", "")
+    if single_path:
+        return [("default", single_path)]
+
+    return []
 
 
 def append_to_outbox(outbox_path: Path, content: str):

--- a/koan/system-prompts/pr-quality-review.md
+++ b/koan/system-prompts/pr-quality-review.md
@@ -1,0 +1,20 @@
+# Quality Review Pass — PR Improvements
+
+You are performing a quality review on recently changed files in this project.
+
+Working directory: `{PROJECT_PATH}`
+
+## Your Task
+
+1. Run `git diff HEAD~3..HEAD --name-only` to identify files changed in recent commits.
+2. Read each changed file and check for:
+   - Security issues (injection, XSS, unsafe deserialization, hardcoded secrets)
+   - Error handling gaps (missing try/catch, unhandled edge cases)
+   - Logic bugs or race conditions
+   - Test coverage gaps for new code
+   - API consistency issues
+3. **Fix issues you find** — don't just report them.
+4. For each fix, ensure it's minimal and doesn't change unrelated code.
+5. If you find issues but the fix would be too invasive, note them as comments in the code.
+
+Output a brief summary of what you found and fixed.

--- a/koan/system-prompts/pr-refactor.md
+++ b/koan/system-prompts/pr-refactor.md
@@ -1,0 +1,21 @@
+# Refactor Pass — PR Code Quality
+
+You are performing a refactoring pass on recently changed files in this project.
+
+Working directory: `{PROJECT_PATH}`
+
+## Your Task
+
+1. Run `git diff HEAD~3..HEAD --name-only` to identify files changed in recent commits.
+2. Read each changed file and look for:
+   - Duplicated code that can be factored out
+   - Overly complex functions that can be simplified
+   - Dead code or unused imports
+   - Naming inconsistencies
+   - Missing or incorrect type hints (if the project uses them)
+3. Apply **minimal, focused refactoring** — each change should be clearly an improvement.
+4. Do NOT change behavior, only structure and clarity.
+5. Do NOT add new features, comments, or docstrings unless fixing something broken.
+6. Prefer small, obvious improvements over ambitious restructuring.
+
+Output a brief summary of what you refactored.

--- a/koan/system-prompts/pr-review.md
+++ b/koan/system-prompts/pr-review.md
@@ -1,0 +1,48 @@
+# PR Review — Address Feedback
+
+You are reviewing a pull request and implementing the changes requested by reviewers.
+
+## Pull Request: {TITLE}
+
+**Branch**: `{BRANCH}` → `{BASE}`
+
+### PR Description
+
+{BODY}
+
+---
+
+## Current Diff
+
+```diff
+{DIFF}
+```
+
+---
+
+## Review Comments (inline on code)
+
+{REVIEW_COMMENTS}
+
+## Reviews (top-level)
+
+{REVIEWS}
+
+## Conversation Thread
+
+{ISSUE_COMMENTS}
+
+---
+
+## Your Task
+
+1. **Read the review comments carefully.** Understand what changes are being requested.
+2. **Implement the requested changes.** Edit the code to address each review comment.
+   - If a comment is a question or discussion (not a change request), skip it.
+   - If a comment requests a change that would break functionality, note it but still implement it.
+3. **Run the test suite** to make sure your changes don't break anything.
+   - Look for a Makefile, package.json, or similar to find the test command.
+   - If tests fail, fix them.
+4. **Be thorough but focused.** Only change what reviewers asked for — no drive-by refactoring.
+
+When you're done, output a concise summary of what you changed and why.

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -21,7 +21,9 @@ from app.awake import (
     _clean_chat_response,
     _build_status,
     _handle_help,
+    _handle_pr,
     _handle_usage,
+    _resolve_project_path,
     _run_in_worker,
     get_updates,
     check_config,
@@ -1154,3 +1156,96 @@ class TestPauseAwareness:
 
         # Prompt should mention running status
         assert "RUNNING" in prompt or "▶️" in prompt
+
+
+# ---------------------------------------------------------------------------
+# _resolve_project_path
+# ---------------------------------------------------------------------------
+
+class TestResolveProjectPath:
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "")
+    def test_exact_match(self, mock_projects):
+        mock_projects.return_value = [("koan", "/home/user/koan"), ("web", "/home/user/web")]
+        assert _resolve_project_path("koan") == "/home/user/koan"
+
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "")
+    def test_case_insensitive(self, mock_projects):
+        mock_projects.return_value = [("Koan", "/home/user/koan")]
+        assert _resolve_project_path("koan") == "/home/user/koan"
+
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "")
+    def test_basename_match(self, mock_projects):
+        mock_projects.return_value = [("myproject", "/home/user/koan")]
+        assert _resolve_project_path("koan") == "/home/user/koan"
+
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "")
+    def test_single_project_fallback(self, mock_projects):
+        mock_projects.return_value = [("only", "/home/user/only")]
+        assert _resolve_project_path("unknown") == "/home/user/only"
+
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "/fallback/path")
+    def test_project_path_fallback(self, mock_projects):
+        mock_projects.return_value = [("a", "/a"), ("b", "/b")]
+        assert _resolve_project_path("unknown") == "/fallback/path"
+
+    @patch("app.awake.get_known_projects")
+    @patch("app.awake.PROJECT_PATH", "")
+    def test_no_match_returns_none(self, mock_projects):
+        mock_projects.return_value = [("a", "/a"), ("b", "/b")]
+        assert _resolve_project_path("unknown") is None
+
+
+# ---------------------------------------------------------------------------
+# /pr command
+# ---------------------------------------------------------------------------
+
+class TestHandlePr:
+    @patch("app.awake.send_telegram")
+    def test_no_args_shows_usage(self, mock_send):
+        _handle_pr("")
+        mock_send.assert_called_once()
+        assert "Usage" in mock_send.call_args[0][0]
+
+    @patch("app.awake.send_telegram")
+    def test_invalid_url_shows_error(self, mock_send):
+        _handle_pr("not a url")
+        mock_send.assert_called_once()
+        assert "No valid GitHub PR URL" in mock_send.call_args[0][0]
+
+    @patch("app.awake._run_in_worker")
+    @patch("app.awake._resolve_project_path", return_value="/home/user/koan")
+    @patch("app.awake.send_telegram")
+    def test_valid_url_starts_review(self, mock_send, mock_resolve, mock_worker):
+        _handle_pr("https://github.com/sukria/koan/pull/42")
+        mock_worker.assert_called_once()
+        mock_send.assert_called()
+        assert "Starting PR review" in mock_send.call_args_list[-1][0][0]
+
+    @patch("app.awake.get_known_projects", return_value=[])
+    @patch("app.awake._resolve_project_path", return_value=None)
+    @patch("app.awake.send_telegram")
+    def test_no_matching_project(self, mock_send, mock_resolve, mock_projects):
+        _handle_pr("https://github.com/sukria/unknown-repo/pull/1")
+        mock_send.assert_called()
+        assert "Could not find local project" in mock_send.call_args[0][0]
+
+    @patch("app.awake._handle_pr")
+    def test_handle_command_routes_pr(self, mock_pr):
+        handle_command("/pr https://github.com/sukria/koan/pull/1")
+        mock_pr.assert_called_once_with("https://github.com/sukria/koan/pull/1")
+
+    @patch("app.awake._handle_pr")
+    def test_handle_command_routes_pr_no_args(self, mock_pr):
+        handle_command("/pr")
+        mock_pr.assert_called_once_with("")
+
+    @patch("app.awake.send_telegram")
+    def test_help_includes_pr(self, mock_send):
+        _handle_help()
+        msg = mock_send.call_args[0][0]
+        assert "/pr" in msg

--- a/koan/tests/test_pr_review.py
+++ b/koan/tests/test_pr_review.py
@@ -1,0 +1,770 @@
+"""Tests for pr_review.py — PR URL parsing, context fetching, prompt building, pipeline."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import patch, MagicMock, call
+
+import pytest
+
+from app.pr_review import (
+    parse_pr_url,
+    fetch_pr_context,
+    build_pr_prompt,
+    build_refactor_prompt,
+    build_quality_review_prompt,
+    detect_test_command,
+    detect_skills,
+    run_pr_review,
+    _build_pr_comment,
+    _commit_if_changes,
+    _rebase_onto_target,
+    _run_claude,
+    _run_claude_step,
+    _run_tests,
+    _gh,
+    _run_git,
+    _truncate,
+)
+
+
+# ---------------------------------------------------------------------------
+# parse_pr_url
+# ---------------------------------------------------------------------------
+
+class TestParsePrUrl:
+    def test_standard_url(self):
+        owner, repo, num = parse_pr_url("https://github.com/sukria/koan/pull/29")
+        assert owner == "sukria"
+        assert repo == "koan"
+        assert num == "29"
+
+    def test_url_with_fragment(self):
+        owner, repo, num = parse_pr_url(
+            "https://github.com/sukria/koan/pull/29#pullrequestreview-123"
+        )
+        assert owner == "sukria"
+        assert repo == "koan"
+        assert num == "29"
+
+    def test_url_with_trailing_whitespace(self):
+        owner, repo, num = parse_pr_url("  https://github.com/foo/bar/pull/1  ")
+        assert owner == "foo"
+        assert repo == "bar"
+        assert num == "1"
+
+    def test_http_url(self):
+        owner, repo, num = parse_pr_url("http://github.com/a/b/pull/99")
+        assert owner == "a"
+        assert repo == "b"
+        assert num == "99"
+
+    def test_invalid_url_raises(self):
+        with pytest.raises(ValueError, match="Invalid PR URL"):
+            parse_pr_url("https://github.com/sukria/koan/issues/29")
+
+    def test_not_github_raises(self):
+        with pytest.raises(ValueError, match="Invalid PR URL"):
+            parse_pr_url("https://gitlab.com/sukria/koan/pull/29")
+
+    def test_empty_string_raises(self):
+        with pytest.raises(ValueError, match="Invalid PR URL"):
+            parse_pr_url("")
+
+    def test_no_pr_number_raises(self):
+        with pytest.raises(ValueError, match="Invalid PR URL"):
+            parse_pr_url("https://github.com/sukria/koan/pull/")
+
+
+# ---------------------------------------------------------------------------
+# _truncate
+# ---------------------------------------------------------------------------
+
+class TestTruncate:
+    def test_short_text_unchanged(self):
+        assert _truncate("hello", 100) == "hello"
+
+    def test_exact_length_unchanged(self):
+        assert _truncate("12345", 5) == "12345"
+
+    def test_long_text_truncated(self):
+        result = _truncate("a" * 20, 10)
+        assert len(result) < 30
+        assert "truncated" in result
+
+    def test_empty_string(self):
+        assert _truncate("", 100) == ""
+
+
+# ---------------------------------------------------------------------------
+# _gh
+# ---------------------------------------------------------------------------
+
+class TestGh:
+    @patch("app.pr_review.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="output\n")
+        result = _gh(["gh", "pr", "view", "1"])
+        assert result == "output"
+
+    @patch("app.pr_review.subprocess.run")
+    def test_failure_raises(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stderr="not found")
+        with pytest.raises(RuntimeError, match="gh command failed"):
+            _gh(["gh", "pr", "view", "999"])
+
+
+# ---------------------------------------------------------------------------
+# _run_git
+# ---------------------------------------------------------------------------
+
+class TestRunGit:
+    @patch("app.pr_review.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok\n")
+        result = _run_git(["git", "status"])
+        assert result == "ok"
+
+    @patch("app.pr_review.subprocess.run")
+    def test_failure_raises(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=1, stderr="error")
+        with pytest.raises(RuntimeError, match="git failed"):
+            _run_git(["git", "checkout", "nope"])
+
+    @patch("app.pr_review.subprocess.run")
+    def test_cwd_passed(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        _run_git(["git", "status"], cwd="/tmp/test")
+        mock_run.assert_called_once()
+        assert mock_run.call_args.kwargs["cwd"] == "/tmp/test"
+
+
+# ---------------------------------------------------------------------------
+# _build_pr_comment
+# ---------------------------------------------------------------------------
+
+class TestBuildPrComment:
+    def test_basic_comment(self):
+        actions = ["Rebased onto main", "Tests passing"]
+        ctx = {"title": "Fix bug", "body": "desc", "branch": "fix", "base": "main"}
+        comment = _build_pr_comment("1", "fix", "main", actions, ctx)
+        assert "## Fix bug" in comment
+        assert "### Changes" in comment
+        assert "Rebased onto main" in comment
+        assert "Tests passing" in comment
+        assert "Automated by Kōan" in comment
+        assert "### Status & Next Steps" in comment
+        assert "successfully" in comment
+
+    def test_comment_with_failures(self):
+        actions = ["Rebased onto main", "Tests still failing: 3 errors"]
+        ctx = {"title": "Fix", "body": "", "branch": "b", "base": "main"}
+        comment = _build_pr_comment("1", "b", "main", actions, ctx)
+        assert "issues" in comment.lower() or "review" in comment.lower()
+
+    def test_comment_with_skipped_step(self):
+        actions = ["Rebased onto main", "Refactor step skipped: timeout"]
+        ctx = {"title": "Add feature", "body": "", "branch": "b", "base": "main"}
+        comment = _build_pr_comment("1", "b", "main", actions, ctx)
+        assert "issues" in comment.lower() or "verify" in comment.lower()
+
+    def test_empty_actions(self):
+        ctx = {"title": "", "body": "", "branch": "b", "base": "main"}
+        comment = _build_pr_comment("1", "b", "main", [], ctx)
+        assert "No changes needed" in comment
+
+    def test_summary_paragraph_present(self):
+        actions = ["Rebased onto main", "Applied refactoring", "Force-pushed `b`"]
+        ctx = {"title": "Improve auth", "body": "", "branch": "b", "base": "main"}
+        comment = _build_pr_comment("1", "b", "main", actions, ctx)
+        # Summary should mention the step count and pipeline
+        assert "pipeline" in comment.lower() or "steps" in comment.lower()
+
+
+# ---------------------------------------------------------------------------
+# _run_claude_step
+# ---------------------------------------------------------------------------
+
+class TestRunClaudeStep:
+    @patch("app.pr_review._commit_if_changes", return_value=True)
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review.build_claude_flags", return_value=[])
+    @patch("app.pr_review.get_model_config", return_value={"mission": "", "fallback": "sonnet"})
+    def test_success_with_commit(self, mock_models, mock_flags, mock_claude, mock_commit):
+        mock_claude.return_value = {"success": True, "output": "Done", "error": ""}
+        actions = []
+        result = _run_claude_step(
+            prompt="test", project_path="/tmp",
+            commit_msg="test commit", success_label="Step done",
+            failure_label="Step failed", actions_log=actions,
+        )
+        assert result is True
+        assert "Step done" in actions
+
+    @patch("app.pr_review._commit_if_changes", return_value=False)
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review.build_claude_flags", return_value=[])
+    @patch("app.pr_review.get_model_config", return_value={"mission": "", "fallback": "sonnet"})
+    def test_success_no_changes(self, mock_models, mock_flags, mock_claude, mock_commit):
+        mock_claude.return_value = {"success": True, "output": "Done", "error": ""}
+        actions = []
+        result = _run_claude_step(
+            prompt="test", project_path="/tmp",
+            commit_msg="msg", success_label="OK",
+            failure_label="FAIL", actions_log=actions,
+        )
+        assert result is False
+        assert len(actions) == 0
+
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review.build_claude_flags", return_value=[])
+    @patch("app.pr_review.get_model_config", return_value={"mission": "", "fallback": "sonnet"})
+    def test_failure_logs_error(self, mock_models, mock_flags, mock_claude):
+        mock_claude.return_value = {"success": False, "output": "", "error": "timeout"}
+        actions = []
+        result = _run_claude_step(
+            prompt="test", project_path="/tmp",
+            commit_msg="msg", success_label="OK",
+            failure_label="Step failed", actions_log=actions,
+        )
+        assert result is False
+        assert any("Step failed" in a for a in actions)
+
+    @patch("app.pr_review._commit_if_changes", return_value=True)
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review.build_claude_flags", return_value=[])
+    @patch("app.pr_review.get_model_config", return_value={"mission": "", "fallback": "sonnet"})
+    def test_use_skill_includes_skill_tool(self, mock_models, mock_flags, mock_claude, mock_commit):
+        """When use_skill=True, the Skill tool should be in allowedTools."""
+        mock_claude.return_value = {"success": True, "output": "Done", "error": ""}
+        _run_claude_step(
+            prompt="test", project_path="/tmp",
+            commit_msg="msg", success_label="OK",
+            failure_label="FAIL", actions_log=[],
+            use_skill=True,
+        )
+        cmd = mock_claude.call_args[0][0]
+        tools_idx = cmd.index("--allowedTools") + 1
+        assert "Skill" in cmd[tools_idx]
+
+    @patch("app.pr_review._commit_if_changes", return_value=True)
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review.build_claude_flags", return_value=[])
+    @patch("app.pr_review.get_model_config", return_value={"mission": "", "fallback": "sonnet"})
+    def test_default_no_skill_tool(self, mock_models, mock_flags, mock_claude, mock_commit):
+        """By default, Skill tool should NOT be in allowedTools."""
+        mock_claude.return_value = {"success": True, "output": "Done", "error": ""}
+        _run_claude_step(
+            prompt="test", project_path="/tmp",
+            commit_msg="msg", success_label="OK",
+            failure_label="FAIL", actions_log=[],
+        )
+        cmd = mock_claude.call_args[0][0]
+        tools_idx = cmd.index("--allowedTools") + 1
+        assert "Skill" not in cmd[tools_idx]
+
+
+# ---------------------------------------------------------------------------
+# _commit_if_changes
+# ---------------------------------------------------------------------------
+
+class TestCommitIfChanges:
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review.subprocess.run")
+    def test_commits_when_changes(self, mock_run, mock_git):
+        mock_run.return_value = MagicMock(returncode=0, stdout="M file.py\n")
+        result = _commit_if_changes("/tmp/p", "test commit")
+        assert result is True
+        assert mock_git.call_count == 2  # git add + git commit
+
+    @patch("app.pr_review.subprocess.run")
+    def test_no_commit_when_clean(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="")
+        result = _commit_if_changes("/tmp/p", "test commit")
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# _run_claude
+# ---------------------------------------------------------------------------
+
+class TestRunClaude:
+    @patch("app.pr_review.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="Done", stderr=""
+        )
+        result = _run_claude(["claude", "-p", "test"], "/tmp")
+        assert result["success"] is True
+        assert result["output"] == "Done"
+
+    @patch("app.pr_review.subprocess.run")
+    def test_failure(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error"
+        )
+        result = _run_claude(["claude", "-p", "test"], "/tmp")
+        assert result["success"] is False
+        assert "Exit code 1" in result["error"]
+
+    @patch("app.pr_review.subprocess.run")
+    def test_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=10)
+        result = _run_claude(["claude", "-p", "test"], "/tmp", timeout=10)
+        assert result["success"] is False
+        assert "Timeout" in result["error"]
+
+
+# ---------------------------------------------------------------------------
+# _rebase_onto_target
+# ---------------------------------------------------------------------------
+
+class TestRebaseOntoTarget:
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review.subprocess.run")
+    def test_success_returns_remote_name(self, mock_subproc, mock_git):
+        result = _rebase_onto_target("main", "/tmp/p")
+        assert result == "origin"
+        assert mock_git.call_count == 2  # fetch + rebase
+
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review.subprocess.run")
+    def test_falls_back_to_upstream(self, mock_subproc, mock_git):
+        """When origin rebase fails, tries upstream."""
+        call_count = 0
+        def selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # First two calls are origin fetch+rebase — fail the rebase
+            if call_count == 2:
+                raise RuntimeError("conflict on origin")
+            return ""
+        mock_git.side_effect = selective_fail
+        result = _rebase_onto_target("main", "/tmp/p")
+        assert result == "upstream"
+
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review.subprocess.run")
+    def test_all_remotes_fail_returns_none(self, mock_subproc, mock_git):
+        mock_git.side_effect = RuntimeError("conflict")
+        result = _rebase_onto_target("main", "/tmp/p")
+        assert result is None
+        # Should have called rebase --abort twice (once per remote)
+        assert mock_subproc.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# _run_tests
+# ---------------------------------------------------------------------------
+
+class TestRunTests:
+    @patch("app.pr_review.subprocess.run")
+    def test_passing(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="42 tests passed", stderr=""
+        )
+        result = _run_tests("make test", "/tmp/p")
+        assert result["passed"] is True
+        assert "42" in result["details"]
+
+    @patch("app.pr_review.subprocess.run")
+    def test_failing(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="3 failed", stderr=""
+        )
+        result = _run_tests("make test", "/tmp/p")
+        assert result["passed"] is False
+
+    @patch("app.pr_review.subprocess.run")
+    def test_timeout(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="make", timeout=300)
+        result = _run_tests("make test", "/tmp/p")
+        assert result["passed"] is False
+        assert "timeout" in result["details"]
+
+
+# ---------------------------------------------------------------------------
+# detect_test_command
+# ---------------------------------------------------------------------------
+
+class TestDetectTestCommand:
+    def test_makefile_with_test_target(self, tmp_path):
+        (tmp_path / "Makefile").write_text("test:\n\tpytest\n")
+        assert detect_test_command(str(tmp_path)) == "make test"
+
+    def test_makefile_without_test_target(self, tmp_path):
+        (tmp_path / "Makefile").write_text("build:\n\tgcc main.c\n")
+        assert detect_test_command(str(tmp_path)) is None
+
+    def test_python_project(self, tmp_path):
+        (tmp_path / "pyproject.toml").write_text("[tool.pytest]\n")
+        (tmp_path / "tests").mkdir()
+        assert detect_test_command(str(tmp_path)) == "pytest"
+
+    def test_python_with_makefile(self, tmp_path):
+        (tmp_path / "Makefile").write_text("test:\n\tpytest\n")
+        (tmp_path / "pyproject.toml").write_text("[tool.pytest]\n")
+        (tmp_path / "tests").mkdir()
+        assert detect_test_command(str(tmp_path)) == "make test"
+
+    def test_nodejs_project(self, tmp_path):
+        pkg = {"scripts": {"test": "jest"}}
+        (tmp_path / "package.json").write_text(json.dumps(pkg))
+        assert detect_test_command(str(tmp_path)) == "npm test"
+
+    def test_empty_directory(self, tmp_path):
+        assert detect_test_command(str(tmp_path)) is None
+
+
+# ---------------------------------------------------------------------------
+# detect_skills
+# ---------------------------------------------------------------------------
+
+class TestDetectSkills:
+    def test_with_soul_mentioning_skills(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "soul.md").write_text(
+            "Skills: `atoomic.refactor` and `atoomic.review` are available."
+        )
+        refactor, review = detect_skills()
+        assert refactor == "atoomic.refactor"
+        assert review == "atoomic.review"
+
+    def test_without_soul(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        (tmp_path / "instance").mkdir()
+        refactor, review = detect_skills()
+        assert refactor is None
+        assert review is None
+
+    def test_generic_skill_mentions(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "soul.md").write_text(
+            "You have access to refactor skill and review skill tools."
+        )
+        refactor, review = detect_skills()
+        assert refactor == "refactor"
+        assert review == "review"
+
+    def test_unquoted_skill_names(self, tmp_path, monkeypatch):
+        """Skills detected without backtick quoting."""
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "soul.md").write_text(
+            "Use atoomic.refactor and atoomic.review for code quality."
+        )
+        refactor, review = detect_skills()
+        assert refactor == "atoomic.refactor"
+        assert review == "atoomic.review"
+
+    def test_claude_md_at_project_path(self, tmp_path, monkeypatch):
+        """Skills detected from CLAUDE.md at project path (highest priority)."""
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        (tmp_path / "instance").mkdir()
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "CLAUDE.md").write_text(
+            "Use `myapp.refactor` and `myapp.review` skills when appropriate."
+        )
+        refactor, review = detect_skills(str(project))
+        assert refactor == "myapp.refactor"
+        assert review == "myapp.review"
+
+    def test_claude_md_takes_priority_over_soul(self, tmp_path, monkeypatch):
+        """CLAUDE.md skills take priority over soul.md skills."""
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "soul.md").write_text(
+            "Skills: `atoomic.refactor` and `atoomic.review` are available."
+        )
+        project = tmp_path / "project"
+        project.mkdir()
+        (project / "CLAUDE.md").write_text(
+            "Available: `custom.refactor` for code cleanup."
+        )
+        refactor, review = detect_skills(str(project))
+        assert refactor == "custom.refactor"
+        # review falls through to soul.md
+        assert review == "atoomic.review"
+
+    def test_no_project_path(self, tmp_path, monkeypatch):
+        """Works without project_path, falls back to soul.md only."""
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "soul.md").write_text(
+            "Skills: `atoomic.refactor` and `atoomic.review`."
+        )
+        refactor, review = detect_skills("")
+        assert refactor == "atoomic.refactor"
+        assert review == "atoomic.review"
+
+
+# ---------------------------------------------------------------------------
+# fetch_pr_context
+# ---------------------------------------------------------------------------
+
+class TestFetchPrContext:
+    @patch("app.pr_review._gh")
+    def test_fetches_all_data(self, mock_gh):
+        pr_meta = json.dumps({
+            "title": "Add feature",
+            "body": "Some description",
+            "headRefName": "koan/feature",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "author": {"login": "dev"},
+            "url": "https://github.com/o/r/pull/1",
+        })
+        mock_gh.side_effect = [
+            pr_meta,           # PR metadata
+            "diff content",    # diff
+            "comment1",        # review comments
+            "review1",         # reviews
+            "discussion1",     # issue comments
+        ]
+
+        ctx = fetch_pr_context("owner", "repo", "1")
+        assert ctx["title"] == "Add feature"
+        assert ctx["branch"] == "koan/feature"
+        assert ctx["base"] == "main"
+        assert ctx["diff"] == "diff content"
+        assert ctx["review_comments"] == "comment1"
+        assert ctx["reviews"] == "review1"
+        assert ctx["issue_comments"] == "discussion1"
+        assert mock_gh.call_count == 5
+
+    @patch("app.pr_review._gh")
+    def test_handles_invalid_json(self, mock_gh):
+        mock_gh.side_effect = ["not json", "", "", "", ""]
+        ctx = fetch_pr_context("o", "r", "1")
+        assert ctx["title"] == ""
+        assert ctx["branch"] == ""
+
+
+# ---------------------------------------------------------------------------
+# build_pr_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildPrPrompt:
+    def test_builds_prompt(self):
+        ctx = {
+            "title": "Test PR",
+            "body": "Description",
+            "branch": "fix-branch",
+            "base": "main",
+            "diff": "+some code",
+            "review_comments": "fix this",
+            "reviews": "needs work",
+            "issue_comments": "thread",
+        }
+        prompt = build_pr_prompt(ctx)
+        assert "Test PR" in prompt
+        assert "fix-branch" in prompt
+        assert "+some code" in prompt
+        assert "fix this" in prompt
+        assert "needs work" in prompt
+
+
+# ---------------------------------------------------------------------------
+# build_refactor_prompt / build_quality_review_prompt
+# ---------------------------------------------------------------------------
+
+class TestBuildRefactorPrompt:
+    def test_includes_project_path(self):
+        prompt = build_refactor_prompt("/tmp/project")
+        assert "/tmp/project" in prompt
+
+    def test_includes_skill_name(self):
+        prompt = build_refactor_prompt("/tmp/project", "atoomic.refactor")
+        assert "atoomic.refactor" in prompt
+
+    def test_empty_skill_name(self):
+        prompt = build_refactor_prompt("/tmp/project", "")
+        assert "/tmp/project" in prompt
+
+
+class TestBuildQualityReviewPrompt:
+    def test_includes_project_path(self):
+        prompt = build_quality_review_prompt("/tmp/project")
+        assert "/tmp/project" in prompt
+
+    def test_includes_skill_name(self):
+        prompt = build_quality_review_prompt("/tmp/project", "atoomic.review")
+        assert "atoomic.review" in prompt
+
+
+# ---------------------------------------------------------------------------
+# run_pr_review (integration-level with mocks)
+# ---------------------------------------------------------------------------
+
+class TestRunPrReview:
+    def _mock_pr_context(self):
+        return json.dumps({
+            "title": "Fix bug",
+            "body": "Fixes #10",
+            "headRefName": "koan/fix-bug",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "author": {"login": "dev"},
+            "url": "https://github.com/o/r/pull/1",
+        })
+
+    @patch("app.pr_review.detect_skills", return_value=(None, None))
+    @patch("app.pr_review.detect_test_command", return_value=None)
+    @patch("app.pr_review._gh")
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review._commit_if_changes")
+    @patch("app.pr_review.subprocess.run")
+    @patch("app.pr_review.get_model_config")
+    @patch("app.pr_review.build_claude_flags")
+    def test_basic_workflow(
+        self, mock_flags, mock_models, mock_subproc, mock_commit,
+        mock_claude, mock_git, mock_gh, mock_test_cmd, mock_skills
+    ):
+        mock_flags.return_value = []
+        mock_models.return_value = {"mission": "", "fallback": "sonnet"}
+
+        mock_gh.side_effect = [
+            self._mock_pr_context(), "diff", "reviewer comment", "reviews", "thread",
+            "",  # final comment
+        ]
+        mock_claude.return_value = {"success": True, "output": "Fixed", "error": ""}
+        mock_commit.return_value = True
+
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is True
+        assert "updated" in summary.lower() or "PR #1" in summary
+
+    @patch("app.pr_review.fetch_pr_context")
+    def test_no_branch_fails(self, mock_fetch):
+        mock_fetch.return_value = {
+            "title": "X", "body": "", "branch": "", "base": "main",
+            "state": "OPEN", "author": "", "url": "",
+            "diff": "", "review_comments": "", "reviews": "", "issue_comments": "",
+        }
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is False
+        assert "branch" in summary.lower()
+
+    @patch("app.pr_review.fetch_pr_context")
+    def test_fetch_error_fails(self, mock_fetch):
+        mock_fetch.side_effect = RuntimeError("API error")
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is False
+        assert "Failed to fetch" in summary
+
+    @patch("app.pr_review.detect_skills", return_value=("atoomic.refactor", "atoomic.review"))
+    @patch("app.pr_review.detect_test_command", return_value="make test")
+    @patch("app.pr_review._run_tests")
+    @patch("app.pr_review._gh")
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review._commit_if_changes")
+    @patch("app.pr_review.subprocess.run")
+    @patch("app.pr_review.get_model_config")
+    @patch("app.pr_review.build_claude_flags")
+    def test_full_pipeline_with_skills_and_tests(
+        self, mock_flags, mock_models, mock_subproc, mock_commit,
+        mock_claude, mock_git, mock_gh, mock_tests, mock_test_cmd, mock_skills
+    ):
+        mock_flags.return_value = []
+        mock_models.return_value = {"mission": "", "fallback": "sonnet"}
+
+        mock_gh.side_effect = [
+            self._mock_pr_context(), "diff", "comment", "review", "thread",
+            "",  # final comment
+        ]
+        # 3 Claude calls: review feedback, refactor, quality review
+        mock_claude.return_value = {"success": True, "output": "Done", "error": ""}
+        mock_commit.return_value = True
+        mock_tests.return_value = {"passed": True, "output": "", "details": "800 tests passed"}
+
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is True
+        # Should have called Claude 3 times (feedback + refactor + review)
+        assert mock_claude.call_count == 3
+        assert "refactoring" in summary.lower() or "quality" in summary.lower()
+
+    @patch("app.pr_review.detect_skills", return_value=(None, None))
+    @patch("app.pr_review.detect_test_command", return_value=None)
+    @patch("app.pr_review._gh")
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review._commit_if_changes")
+    @patch("app.pr_review.subprocess.run")
+    @patch("app.pr_review.get_model_config")
+    @patch("app.pr_review.build_claude_flags")
+    def test_no_review_feedback_skips_claude(
+        self, mock_flags, mock_models, mock_subproc, mock_commit,
+        mock_claude, mock_git, mock_gh, mock_test_cmd, mock_skills
+    ):
+        """When PR has no review comments, skip the Claude feedback step."""
+        mock_flags.return_value = []
+        mock_models.return_value = {"mission": "", "fallback": "sonnet"}
+
+        pr_meta = json.dumps({
+            "title": "Add feature",
+            "body": "Description",
+            "headRefName": "koan/feature",
+            "baseRefName": "main",
+            "state": "OPEN",
+            "author": {"login": "dev"},
+            "url": "https://github.com/o/r/pull/1",
+        })
+        # No comments/reviews
+        mock_gh.side_effect = [pr_meta, "diff", "", "", "", ""]
+        mock_commit.return_value = False
+
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is True
+        # Claude should NOT be called (no feedback to address, no skills)
+        assert mock_claude.call_count == 0
+
+    @patch("app.pr_review.detect_skills", return_value=(None, None))
+    @patch("app.pr_review.detect_test_command", return_value="make test")
+    @patch("app.pr_review._run_tests")
+    @patch("app.pr_review._gh")
+    @patch("app.pr_review._run_git")
+    @patch("app.pr_review._run_claude")
+    @patch("app.pr_review._commit_if_changes")
+    @patch("app.pr_review.subprocess.run")
+    @patch("app.pr_review.get_model_config")
+    @patch("app.pr_review.build_claude_flags")
+    def test_failing_tests_trigger_fix_attempt(
+        self, mock_flags, mock_models, mock_subproc, mock_commit,
+        mock_claude, mock_git, mock_gh, mock_tests, mock_test_cmd, mock_skills
+    ):
+        mock_flags.return_value = []
+        mock_models.return_value = {"mission": "", "fallback": "sonnet"}
+
+        mock_gh.side_effect = [
+            self._mock_pr_context(), "diff", "", "", "",
+            "",  # comment
+        ]
+        mock_claude.return_value = {"success": True, "output": "Fixed", "error": ""}
+        mock_commit.return_value = True
+
+        # First run fails, second (after fix) passes
+        mock_tests.side_effect = [
+            {"passed": False, "output": "AssertionError", "details": "1 failed"},
+            {"passed": True, "output": "OK", "details": "800 passed"},
+        ]
+
+        notify = MagicMock()
+        success, summary = run_pr_review("o", "r", "1", "/tmp/p", notify_fn=notify)
+        assert success is True
+        assert "fixed" in summary.lower() or "passing" in summary.lower()

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -521,3 +521,46 @@ class TestGetStartOnPause:
         # No config file at all
         from app.utils import get_start_on_pause
         assert get_start_on_pause() is False
+
+
+class TestGetKnownProjects:
+    def test_parses_koan_projects_env(self, monkeypatch):
+        monkeypatch.setenv("KOAN_PROJECTS", "koan:/home/koan;web:/home/web")
+        from app.utils import get_known_projects
+        result = get_known_projects()
+        assert len(result) == 2
+        assert result[0] == ("koan", "/home/koan")
+        assert result[1] == ("web", "/home/web")
+
+    def test_sorted_alphabetically(self, monkeypatch):
+        monkeypatch.setenv("KOAN_PROJECTS", "zebra:/z;alpha:/a")
+        from app.utils import get_known_projects
+        result = get_known_projects()
+        assert result[0][0] == "alpha"
+        assert result[1][0] == "zebra"
+
+    def test_fallback_to_project_path(self, monkeypatch):
+        monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+        monkeypatch.setenv("KOAN_PROJECT_PATH", "/single/path")
+        from app.utils import get_known_projects
+        result = get_known_projects()
+        assert result == [("default", "/single/path")]
+
+    def test_empty_when_no_config(self, monkeypatch):
+        monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+        monkeypatch.delenv("KOAN_PROJECT_PATH", raising=False)
+        from app.utils import get_known_projects
+        assert get_known_projects() == []
+
+    def test_handles_whitespace(self, monkeypatch):
+        monkeypatch.setenv("KOAN_PROJECTS", " koan : /home/koan ; web : /home/web ")
+        from app.utils import get_known_projects
+        result = get_known_projects()
+        assert len(result) == 2
+        assert result[0] == ("koan", "/home/koan")
+
+    def test_skips_malformed_entries(self, monkeypatch):
+        monkeypatch.setenv("KOAN_PROJECTS", "koan:/home/koan;badentry;web:/home/web")
+        from app.utils import get_known_projects
+        result = get_known_projects()
+        assert len(result) == 2


### PR DESCRIPTION
## Summary
- New `/pr <github-url>` command to review and update pull requests from Telegram
- `pr_review.py` module: fetch PR context, run Claude Code, commit, push, comment
- `_resolve_project_path()` matches repo names to local projects
- 41 new tests across test_pr_review.py and test_awake.py

Rebased on upstream/main as isolated single-commit branch.

🤖 Generated with Kōan