### PR TITLE
feat: add /priority command to reorder mission queue

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -233,3 +233,170 @@ def find_section_boundaries(lines: List[str]) -> Dict[str, Tuple[int, int]]:
         boundaries[key] = (start, end)
 
     return boundaries
+
+
+def format_queue(content: str) -> str:
+    """Build a full numbered queue of pending and in-progress missions.
+
+    Returns a formatted string showing all missions with position numbers,
+    grouped as in-progress first then pending. Project tags are stripped
+    from display but project name is shown inline.
+    """
+    sections = parse_sections(content)
+    in_progress = sections.get("in_progress", [])
+    pending = sections.get("pending", [])
+
+    if not in_progress and not pending:
+        return "Queue is empty. Nothing in progress."
+
+    lines = ["📋 Mission Queue\n"]
+
+    if in_progress:
+        lines.append("▶️ In progress:")
+        for item in in_progress:
+            project = extract_project_tag(item)
+            display = _strip_project_tag(item)
+            tag = f" [{project}]" if project != "default" else ""
+            lines.append(f"  → {display}{tag}")
+
+    if pending:
+        lines.append(f"\n⏳ Pending ({len(pending)}):")
+        for i, item in enumerate(pending, 1):
+            project = extract_project_tag(item)
+            display = _strip_project_tag(item)
+            tag = f" [{project}]" if project != "default" else ""
+            lines.append(f"  {i}. {display}{tag}")
+
+    return "\n".join(lines)
+
+
+def _strip_project_tag(item: str) -> str:
+    """Remove [project:X] / [projet:X] tag and leading '- ' from a mission line."""
+    # Take first line only (for multi-line blocks)
+    first_line = item.split("\n")[0]
+    # Remove leading "- "
+    if first_line.startswith("- "):
+        first_line = first_line[2:]
+    # Remove project tag
+    first_line = re.sub(r'\[projec?t:[a-zA-Z0-9_-]+\]\s*', '', first_line)
+    return first_line.strip()
+
+
+def reorder_mission(content: str, position: int, target: int = 1) -> Tuple[str, str]:
+    """Move a pending mission from one position to another.
+
+    Args:
+        content: Full missions.md content.
+        position: 1-indexed position of the mission to move (in pending list).
+        target: 1-indexed target position (default 1 = top of queue).
+
+    Returns:
+        (new_content, moved_text) where moved_text is the mission that was moved.
+
+    Raises:
+        ValueError: If position is invalid or no pending missions.
+    """
+    lines = content.splitlines()
+    boundaries = find_section_boundaries(lines)
+
+    if "pending" not in boundaries:
+        raise ValueError("No pending section found.")
+
+    start, end = boundaries["pending"]
+
+    # Collect pending items as (start_line_idx, end_line_idx, text) tuples
+    items = []
+    i = start + 1  # Skip the ## header line
+    while i < end:
+        stripped = lines[i].strip()
+        if stripped.startswith("- "):
+            item_start = i
+            i += 1
+            # Include continuation lines (indented, not a new item or header)
+            while i < end:
+                next_stripped = lines[i].strip()
+                if (next_stripped.startswith("- ") or
+                        next_stripped.startswith("## ") or
+                        next_stripped.startswith("### ") or
+                        next_stripped == ""):
+                    break
+                i += 1
+            items.append((item_start, i, "\n".join(lines[item_start:i])))
+        else:
+            i += 1
+
+    if not items:
+        raise ValueError("No pending missions to reorder.")
+
+    if position < 1 or position > len(items):
+        raise ValueError(
+            f"Invalid position: {position}. Queue has {len(items)} pending mission(s)."
+        )
+
+    if target < 1 or target > len(items):
+        raise ValueError(
+            f"Invalid target: {target}. Queue has {len(items)} pending mission(s)."
+        )
+
+    if position == target:
+        raise ValueError(f"Mission #{position} is already at position {target}.")
+
+    # Extract the item to move
+    moved_start, moved_end, moved_text = items[position - 1]
+
+    # Remove the moved item's lines
+    new_lines = lines[:moved_start] + lines[moved_end:]
+
+    # Recalculate target insertion point after removal
+    new_boundaries = find_section_boundaries(new_lines)
+    new_start, new_end = new_boundaries["pending"]
+
+    new_items = []
+    j = new_start + 1
+    while j < new_end:
+        s = new_lines[j].strip()
+        if s.startswith("- "):
+            item_start_j = j
+            j += 1
+            while j < new_end:
+                ns = new_lines[j].strip()
+                if (ns.startswith("- ") or
+                        ns.startswith("## ") or
+                        ns.startswith("### ") or
+                        ns == ""):
+                    break
+                j += 1
+            new_items.append(item_start_j)
+        else:
+            j += 1
+
+    # Determine insertion line index
+    if target == 1:
+        insert_idx = new_start + 1
+        while insert_idx < new_end and new_lines[insert_idx].strip() == "":
+            insert_idx += 1
+    elif target - 1 < len(new_items):
+        insert_idx = new_items[target - 1]
+    else:
+        if new_items:
+            last_start = new_items[-1]
+            insert_idx = last_start + 1
+            while insert_idx < new_end:
+                ns = new_lines[insert_idx].strip()
+                if (ns.startswith("- ") or
+                        ns.startswith("## ") or
+                        ns.startswith("### ") or
+                        ns == ""):
+                    break
+                insert_idx += 1
+        else:
+            insert_idx = new_start + 1
+
+    # Insert the moved lines
+    moved_lines = moved_text.splitlines()
+    result_lines = new_lines[:insert_idx] + moved_lines + new_lines[insert_idx:]
+
+    first_line = moved_text.split("\n")[0]
+    display = _strip_project_tag(first_line)
+
+    return "\n".join(result_lines), display


### PR DESCRIPTION
## Summary
- `/priority N` bumps mission #N to top of queue
- `/priority N M` moves mission #N to position M
- `reorder_mission()` in missions.py with file-locked read-modify-write
- 23 new tests (13 missions + 10 awake)

Rebased on upstream/main as isolated single-commit branch.

🤖 Generated with Kōan