### PR TITLE
feat: report branch/PR in conclusion messages

### DIFF
--- a/koan/system-prompts/agent.md
+++ b/koan/system-prompts/agent.md
@@ -228,8 +228,13 @@ When a mission or autonomous run completes, write **exactly one** message to
 - Start with 🏁 to clearly mark mission completion
 - A concise summary of what you did (2-5 lines max)
 - Key decisions or findings worth highlighting
+- **If you pushed a branch**: include the branch name (e.g. "Branch: koan/fix-xyz pushed")
+- **If you created a draft PR**: include the PR link (e.g. "PR: https://github.com/...")
 - The session kōan
 - If you learned something new, mention it briefly
+
+The branch/PR info is critical — it's how the human knows where to review your work.
+Keep it natural, not a template dump. Example: "Poussé sur koan/fix-auth. Draft PR: https://github.com/sukria/koan/pull/42"
 
 Do NOT write multiple messages to outbox.md. One mission = one conclusion.
 The outbox is flushed to Telegram — multiple writes cause repeated messages.

--- a/koan/tests/test_system_prompts.py
+++ b/koan/tests/test_system_prompts.py
@@ -42,6 +42,16 @@ def test_agent_prompt_has_all_required_placeholders():
         assert placeholder in agent_prompt, f"Missing placeholder: {placeholder}"
 
 
+def test_agent_prompt_has_branch_pr_notification_instructions():
+    """Conclusion message should instruct agent to report branch name and PR link."""
+    agent_prompt = (PROMPTS_DIR / "agent.md").read_text()
+
+    # Must mention branch notification in conclusion section
+    assert "pushed a branch" in agent_prompt
+    # Must mention PR link
+    assert "draft PR" in agent_prompt
+
+
 def test_all_prompts_exist():
     """All referenced prompt files should exist."""
     expected_prompts = [


### PR DESCRIPTION
## Summary
- Updated agent.md conclusion message section to instruct the agent to include branch name and PR link when a mission produces code
- Added test in test_system_prompts.py to verify these instructions exist
- 927 tests pass

## What changed
The "Conclusion message" section in `agent.md` now includes two new bullet points:
- **If you pushed a branch**: include the branch name
- **If you created a draft PR**: include the PR link

Plus an example to keep it natural: "Poussé sur koan/fix-auth. Draft PR: https://..."

## Test plan
- [x] New test `test_agent_prompt_has_branch_pr_notification_instructions` passes
- [x] Full suite: 927 tests pass

---
🤖 Generated by Kōan (session 40)