### PR TITLE
feat: /cost and /budget commands for per-mission token tracking

### DIFF
--- a/koan/app/cost_tracker.py
+++ b/koan/app/cost_tracker.py
@@ -1,0 +1,230 @@
+#!/usr/bin/env python3
+"""
+Kōan Cost Tracker — Per-mission token cost tracking.
+
+Records token usage for each mission run and provides summaries.
+Data stored in instance/cost_history.json.
+
+CLI usage (called from run.sh):
+    cost_tracker.py record <claude_json> <instance_dir> <project> [mission_title]
+
+Library usage (called from awake.py):
+    from app.cost_tracker import get_cost_summary
+    summary = get_cost_summary(instance_dir)
+"""
+
+import json
+import sys
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Optional, List, Dict
+
+# Add parent to path for imports
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from app.utils import atomic_write
+
+
+COST_FILE = "cost_history.json"
+MAX_HISTORY_DAYS = 30
+
+
+def _load_history(instance_dir: Path) -> List[Dict]:
+    cost_file = instance_dir / COST_FILE
+    if cost_file.exists():
+        try:
+            return json.loads(cost_file.read_text())
+        except (json.JSONDecodeError, OSError):
+            pass
+    return []
+
+
+def _save_history(instance_dir: Path, history: List[Dict]):
+    cost_file = instance_dir / COST_FILE
+    atomic_write(cost_file, json.dumps(history, indent=2) + "\n")
+
+
+def _prune_old_entries(history: List[Dict]) -> List[Dict]:
+    cutoff = (datetime.now() - timedelta(days=MAX_HISTORY_DAYS)).isoformat()
+    return [e for e in history if e.get("timestamp", "") >= cutoff]
+
+
+def _extract_tokens(claude_json_path: Path) -> Optional[Dict[str, int]]:
+    """Extract input/output tokens from Claude JSON output."""
+    try:
+        data = json.loads(claude_json_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+    # Try top-level fields
+    inp = data.get("input_tokens", 0)
+    out = data.get("output_tokens", 0)
+    if inp or out:
+        return {"input_tokens": inp, "output_tokens": out}
+
+    # Try nested usage object
+    usage = data.get("usage", {})
+    if isinstance(usage, dict):
+        inp = usage.get("input_tokens", 0)
+        out = usage.get("output_tokens", 0)
+        if inp or out:
+            return {"input_tokens": inp, "output_tokens": out}
+
+    # Try stats or metadata
+    for key in ("stats", "metadata", "session"):
+        sub = data.get(key, {})
+        if isinstance(sub, dict):
+            inp = sub.get("input_tokens", 0)
+            out = sub.get("output_tokens", 0)
+            if inp or out:
+                return {"input_tokens": inp, "output_tokens": out}
+
+    return None
+
+
+def record_mission_cost(
+    claude_json_path: Path,
+    instance_dir: Path,
+    project: str,
+    mission: str = "",
+):
+    """Record token cost for a mission run."""
+    tokens = _extract_tokens(claude_json_path)
+    if tokens is None:
+        return
+
+    entry = {
+        "timestamp": datetime.now().isoformat(),
+        "project": project,
+        "mission": mission or "(autonomous)",
+        "input_tokens": tokens["input_tokens"],
+        "output_tokens": tokens["output_tokens"],
+        "total_tokens": tokens["input_tokens"] + tokens["output_tokens"],
+    }
+
+    history = _load_history(instance_dir)
+    history.append(entry)
+    history = _prune_old_entries(history)
+    _save_history(instance_dir, history)
+
+
+def _format_tokens(n: int) -> str:
+    if n >= 1_000_000:
+        return f"{n / 1_000_000:.1f}M"
+    if n >= 1_000:
+        return f"{n / 1_000:.1f}k"
+    return str(n)
+
+
+def get_cost_summary(
+    instance_dir: Path,
+    project: Optional[str] = None,
+    days: int = 7,
+) -> str:
+    """Build a human-readable cost summary."""
+    history = _load_history(instance_dir)
+    if not history:
+        return "No cost data yet. Costs are tracked after each mission run."
+
+    now = datetime.now()
+    cutoff = (now - timedelta(days=days)).isoformat()
+    entries = [e for e in history if e.get("timestamp", "") >= cutoff]
+
+    if project:
+        entries = [e for e in entries if e.get("project") == project]
+
+    if not entries:
+        scope = f" for {project}" if project else ""
+        return f"No cost data{scope} in the last {days} days."
+
+    # Today's missions
+    today = now.strftime("%Y-%m-%d")
+    today_entries = [e for e in entries if e["timestamp"].startswith(today)]
+
+    # Per-project totals
+    by_project: Dict[str, int] = {}
+    total_tokens = 0
+    for e in entries:
+        proj = e.get("project", "unknown")
+        tokens = e.get("total_tokens", 0)
+        by_project[proj] = by_project.get(proj, 0) + tokens
+        total_tokens += tokens
+
+    # Build output
+    lines = []
+    scope = f" ({project})" if project else ""
+    lines.append(f"Token costs — last {days} days{scope}")
+    lines.append("")
+
+    # Today's breakdown
+    if today_entries:
+        lines.append(f"Today ({today}):")
+        for e in today_entries:
+            mission = e.get("mission", "?")
+            if len(mission) > 40:
+                mission = mission[:37] + "..."
+            total = _format_tokens(e["total_tokens"])
+            inp = _format_tokens(e["input_tokens"])
+            out = _format_tokens(e["output_tokens"])
+            proj = e.get("project", "?")
+            lines.append(f"  [{proj}] {mission}")
+            lines.append(f"    {total} total ({inp} in / {out} out)")
+        lines.append("")
+
+    # Previous days (grouped by date)
+    older = [e for e in entries if not e["timestamp"].startswith(today)]
+    if older:
+        by_date: Dict[str, list] = {}
+        for e in older:
+            day = e["timestamp"][:10]
+            by_date.setdefault(day, []).append(e)
+        for day in sorted(by_date, reverse=True):
+            day_entries = by_date[day]
+            day_total = sum(e.get("total_tokens", 0) for e in day_entries)
+            lines.append(f"{day}: {len(day_entries)} runs, {_format_tokens(day_total)}")
+            for e in day_entries:
+                mission = e.get("mission", "?")
+                if len(mission) > 40:
+                    mission = mission[:37] + "..."
+                proj = e.get("project", "?")
+                lines.append(f"  [{proj}] {mission} — {_format_tokens(e['total_tokens'])}")
+        lines.append("")
+
+    # Per-project summary
+    if len(by_project) > 1 or not today_entries:
+        lines.append("By project:")
+        for proj in sorted(by_project):
+            lines.append(f"  {proj}: {_format_tokens(by_project[proj])}")
+        lines.append("")
+
+    # Grand total
+    lines.append(f"Total: {_format_tokens(total_tokens)} tokens ({len(entries)} runs)")
+
+    return "\n".join(lines)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: cost_tracker.py record <claude_json> <instance_dir> <project> [mission]",
+              file=sys.stderr)
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    if command == "record":
+        if len(sys.argv) < 5:
+            print("Usage: cost_tracker.py record <claude_json> <instance_dir> <project> [mission]",
+                  file=sys.stderr)
+            sys.exit(1)
+        claude_json = Path(sys.argv[2])
+        instance_dir = Path(sys.argv[3])
+        project = sys.argv[4]
+        mission = sys.argv[5] if len(sys.argv) > 5 else ""
+        record_mission_cost(claude_json, instance_dir, project, mission)
+
+    else:
+        print(f"Unknown command: {command}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/run.sh
+++ b/koan/run.sh
@@ -23,6 +23,7 @@ SELF_REFLECTION="$APP_DIR/self_reflection.py"
 RITUALS="$APP_DIR/rituals.py"
 USAGE_TRACKER="$APP_DIR/usage_tracker.py"
 USAGE_ESTIMATOR="$APP_DIR/usage_estimator.py"
+COST_TRACKER="$APP_DIR/cost_tracker.py"
 USAGE_STATE="$INSTANCE/usage_state.json"
 
 if [ ! -d "$INSTANCE" ]; then
@@ -551,6 +552,9 @@ EOF
 
   # Update token usage state from JSON output
   "$PYTHON" "$USAGE_ESTIMATOR" update "$CLAUDE_OUT" "$USAGE_STATE" "$INSTANCE/usage.md" 2>/dev/null || true
+
+  # Record per-mission cost for /cost command
+  "$PYTHON" "$COST_TRACKER" record "$CLAUDE_OUT" "$INSTANCE" "$PROJECT_NAME" "$MISSION_TITLE" 2>/dev/null || true
 
   # Check for quota exhaustion (in both text output and stderr)
   CLAUDE_COMBINED="$(cat "$CLAUDE_ERR" 2>/dev/null; echo "$CLAUDE_TEXT")"

--- a/koan/tests/test_cost_tracker.py
+++ b/koan/tests/test_cost_tracker.py
@@ -1,0 +1,300 @@
+"""Tests for cost_tracker.py — Per-mission token cost tracking."""
+
+import json
+import pytest
+from datetime import datetime, timedelta
+from pathlib import Path
+from unittest.mock import patch
+
+from app.cost_tracker import (
+    _extract_tokens,
+    _format_tokens,
+    _load_history,
+    _prune_old_entries,
+    _save_history,
+    get_cost_summary,
+    record_mission_cost,
+    COST_FILE,
+    MAX_HISTORY_DAYS,
+)
+
+
+@pytest.fixture
+def instance_dir(tmp_path):
+    return tmp_path / "instance"
+
+
+@pytest.fixture
+def instance(instance_dir):
+    instance_dir.mkdir()
+    return instance_dir
+
+
+@pytest.fixture
+def claude_json(tmp_path):
+    f = tmp_path / "claude_out.json"
+    f.write_text(json.dumps({
+        "result": "Done.",
+        "input_tokens": 1500,
+        "output_tokens": 500,
+    }))
+    return f
+
+
+@pytest.fixture
+def claude_json_nested(tmp_path):
+    f = tmp_path / "claude_nested.json"
+    f.write_text(json.dumps({
+        "result": "Done.",
+        "usage": {"input_tokens": 3000, "output_tokens": 1000},
+    }))
+    return f
+
+
+@pytest.fixture
+def claude_json_no_tokens(tmp_path):
+    f = tmp_path / "claude_no_tokens.json"
+    f.write_text(json.dumps({"result": "Hello."}))
+    return f
+
+
+@pytest.fixture
+def claude_json_invalid(tmp_path):
+    f = tmp_path / "claude_bad.json"
+    f.write_text("not json at all")
+    return f
+
+
+class TestExtractTokens:
+    def test_top_level_fields(self, claude_json):
+        result = _extract_tokens(claude_json)
+        assert result == {"input_tokens": 1500, "output_tokens": 500}
+
+    def test_nested_usage(self, claude_json_nested):
+        result = _extract_tokens(claude_json_nested)
+        assert result == {"input_tokens": 3000, "output_tokens": 1000}
+
+    def test_stats_fallback(self, tmp_path):
+        f = tmp_path / "stats.json"
+        f.write_text(json.dumps({
+            "result": "ok",
+            "stats": {"input_tokens": 100, "output_tokens": 50},
+        }))
+        result = _extract_tokens(f)
+        assert result == {"input_tokens": 100, "output_tokens": 50}
+
+    def test_no_tokens(self, claude_json_no_tokens):
+        assert _extract_tokens(claude_json_no_tokens) is None
+
+    def test_invalid_json(self, claude_json_invalid):
+        assert _extract_tokens(claude_json_invalid) is None
+
+    def test_missing_file(self, tmp_path):
+        assert _extract_tokens(tmp_path / "nonexistent.json") is None
+
+
+class TestFormatTokens:
+    def test_small_number(self):
+        assert _format_tokens(500) == "500"
+
+    def test_thousands(self):
+        assert _format_tokens(1500) == "1.5k"
+
+    def test_exact_thousand(self):
+        assert _format_tokens(1000) == "1.0k"
+
+    def test_millions(self):
+        assert _format_tokens(2_500_000) == "2.5M"
+
+    def test_zero(self):
+        assert _format_tokens(0) == "0"
+
+
+class TestHistoryIO:
+    def test_load_empty(self, instance):
+        assert _load_history(instance) == []
+
+    def test_save_and_load(self, instance):
+        data = [{"timestamp": "2026-01-01T00:00:00", "project": "test", "total_tokens": 100}]
+        _save_history(instance, data)
+        assert _load_history(instance) == data
+
+    def test_load_corrupt_json(self, instance):
+        (instance / COST_FILE).write_text("not json")
+        assert _load_history(instance) == []
+
+    def test_prune_old(self):
+        old = (datetime.now() - timedelta(days=MAX_HISTORY_DAYS + 1)).isoformat()
+        recent = datetime.now().isoformat()
+        history = [
+            {"timestamp": old, "project": "old"},
+            {"timestamp": recent, "project": "new"},
+        ]
+        pruned = _prune_old_entries(history)
+        assert len(pruned) == 1
+        assert pruned[0]["project"] == "new"
+
+
+class TestRecordMissionCost:
+    def test_records_top_level(self, claude_json, instance):
+        record_mission_cost(claude_json, instance, "koan", "fix tests")
+        history = _load_history(instance)
+        assert len(history) == 1
+        entry = history[0]
+        assert entry["project"] == "koan"
+        assert entry["mission"] == "fix tests"
+        assert entry["input_tokens"] == 1500
+        assert entry["output_tokens"] == 500
+        assert entry["total_tokens"] == 2000
+        assert "timestamp" in entry
+
+    def test_records_nested(self, claude_json_nested, instance):
+        record_mission_cost(claude_json_nested, instance, "webapp")
+        history = _load_history(instance)
+        assert len(history) == 1
+        assert history[0]["total_tokens"] == 4000
+        assert history[0]["mission"] == "(autonomous)"
+
+    def test_no_tokens_no_record(self, claude_json_no_tokens, instance):
+        record_mission_cost(claude_json_no_tokens, instance, "koan", "test")
+        assert _load_history(instance) == []
+
+    def test_invalid_json_no_record(self, claude_json_invalid, instance):
+        record_mission_cost(claude_json_invalid, instance, "koan", "test")
+        assert _load_history(instance) == []
+
+    def test_multiple_records_accumulate(self, claude_json, instance):
+        record_mission_cost(claude_json, instance, "koan", "mission 1")
+        record_mission_cost(claude_json, instance, "koan", "mission 2")
+        history = _load_history(instance)
+        assert len(history) == 2
+
+    def test_prunes_old_on_record(self, claude_json, instance):
+        old = (datetime.now() - timedelta(days=MAX_HISTORY_DAYS + 1)).isoformat()
+        _save_history(instance, [
+            {"timestamp": old, "project": "old", "mission": "old", "input_tokens": 0,
+             "output_tokens": 0, "total_tokens": 0},
+        ])
+        record_mission_cost(claude_json, instance, "koan", "new")
+        history = _load_history(instance)
+        assert len(history) == 1
+        assert history[0]["mission"] == "new"
+
+
+class TestGetCostSummary:
+    def _make_entry(self, project="koan", mission="test mission", total=2000,
+                    inp=1500, out=500, days_ago=0):
+        ts = (datetime.now() - timedelta(days=days_ago)).isoformat()
+        return {
+            "timestamp": ts,
+            "project": project,
+            "mission": mission,
+            "input_tokens": inp,
+            "output_tokens": out,
+            "total_tokens": total,
+        }
+
+    def test_empty_history(self, instance):
+        result = get_cost_summary(instance)
+        assert "No cost data yet" in result
+
+    def test_no_recent_data(self, instance):
+        _save_history(instance, [self._make_entry(days_ago=10)])
+        result = get_cost_summary(instance, days=3)
+        assert "No cost data" in result
+        assert "last 3 days" in result
+
+    def test_today_breakdown(self, instance):
+        _save_history(instance, [
+            self._make_entry(mission="fix auth bug", total=3000, inp=2000, out=1000),
+            self._make_entry(mission="add tests", total=1500, inp=1000, out=500),
+        ])
+        result = get_cost_summary(instance)
+        assert "fix auth bug" in result
+        assert "add tests" in result
+        assert "3.0k total" in result
+        assert "1.5k total" in result
+        assert "2 runs" in result
+
+    def test_project_filter(self, instance):
+        _save_history(instance, [
+            self._make_entry(project="koan", mission="koan task"),
+            self._make_entry(project="webapp", mission="webapp task"),
+        ])
+        result = get_cost_summary(instance, project="koan")
+        assert "koan task" in result
+        assert "webapp task" not in result
+        assert "(koan)" in result
+
+    def test_multi_project_summary(self, instance):
+        _save_history(instance, [
+            self._make_entry(project="koan", total=2000),
+            self._make_entry(project="webapp", total=3000),
+        ])
+        result = get_cost_summary(instance)
+        assert "By project:" in result
+        assert "koan:" in result
+        assert "webapp:" in result
+
+    def test_long_mission_truncated(self, instance):
+        long_name = "x" * 60
+        _save_history(instance, [self._make_entry(mission=long_name)])
+        result = get_cost_summary(instance)
+        assert "..." in result
+        assert long_name not in result
+
+    def test_days_parameter(self, instance):
+        _save_history(instance, [
+            self._make_entry(days_ago=0, mission="today"),
+            self._make_entry(days_ago=5, mission="5 days ago"),
+            self._make_entry(days_ago=20, mission="20 days ago"),
+        ])
+        result = get_cost_summary(instance, days=7)
+        assert "today" in result
+        assert "5 days ago" in result
+        assert "20 days ago" not in result
+        assert "2 runs" in result
+
+    def test_total_tokens(self, instance):
+        _save_history(instance, [
+            self._make_entry(total=2000),
+            self._make_entry(total=3000),
+        ])
+        result = get_cost_summary(instance)
+        assert "5.0k tokens" in result
+
+
+class TestCLI:
+    def test_record_command(self, claude_json, instance, monkeypatch):
+        import app.cost_tracker as mod
+        monkeypatch.setattr("sys.argv", [
+            "cost_tracker.py", "record",
+            str(claude_json), str(instance), "koan", "test mission",
+        ])
+        mod.main()
+        history = _load_history(instance)
+        assert len(history) == 1
+        assert history[0]["mission"] == "test mission"
+
+    def test_record_no_mission(self, claude_json, instance, monkeypatch):
+        import app.cost_tracker as mod
+        monkeypatch.setattr("sys.argv", [
+            "cost_tracker.py", "record",
+            str(claude_json), str(instance), "koan",
+        ])
+        mod.main()
+        history = _load_history(instance)
+        assert len(history) == 1
+        assert history[0]["mission"] == "(autonomous)"
+
+    def test_unknown_command(self, monkeypatch):
+        import app.cost_tracker as mod
+        monkeypatch.setattr("sys.argv", ["cost_tracker.py", "unknown"])
+        with pytest.raises(SystemExit):
+            mod.main()
+
+    def test_missing_args(self, monkeypatch):
+        import app.cost_tracker as mod
+        monkeypatch.setattr("sys.argv", ["cost_tracker.py", "record"])
+        with pytest.raises(SystemExit):
+            mod.main()


### PR DESCRIPTION
## Summary
- New `cost_tracker.py` module records per-mission token usage (input/output) from Claude JSON output
- `/cost [project] [days]` shows per-mission breakdown (today + previous days), per-project totals, grand total
- `/budget` is an alias for `/cost`
- `run.sh` calls `cost_tracker.py record` after each mission run
- Data stored in `instance/cost_history.json` with 30-day auto-pruning

## Test plan
- [x] 33 new tests for cost_tracker.py (extraction, recording, summary, CLI, edge cases)
- [x] 7 new tests for awake.py (handler logic + command routing for /cost and /budget)
- [x] Full suite: 1032 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)