### PR TITLE
feat: smarter mission classification with /chat escape hatch

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -110,8 +110,8 @@ def is_mission(text: str) -> bool:
     # Explicit prefix always wins
     if text.lower().startswith("mission:") or text.lower().startswith("mission :"):
         return True
-    # Long messages (>200 chars) with imperative verbs are likely missions
-    if len(text) > 200 and MISSION_RE.search(text):
+    # Long messages (>200 chars) that start with imperative verbs are likely missions
+    if len(text) > 200 and MISSION_RE.match(text):
         return True
     # Short imperative sentences
     if MISSION_RE.match(text):
@@ -135,6 +135,15 @@ def parse_project(text: str) -> Tuple[Optional[str], str]:
 def handle_command(text: str):
     """Handle /commands locally — no Claude needed."""
     cmd = text.strip().lower()
+
+    # /chat forces chat mode — bypass mission classification
+    if cmd.startswith("/chat"):
+        chat_text = text[5:].strip()
+        if not chat_text:
+            send_telegram("Usage: /chat <message>\nForces chat mode for messages that look like missions.")
+            return
+        _run_in_worker(handle_chat, chat_text)
+        return
 
     if cmd == "/stop":
         (KOAN_ROOT / ".koan-stop").write_text("STOP")
@@ -290,6 +299,7 @@ def _handle_help():
         "/silent — mute updates (default mode)\n"
         "\n"
         "INTERACTION\n"
+        "/chat <msg> — force chat mode (bypass mission detection)\n"
         "/sparring — start a strategic sparring session\n"
         "/reflect <text> — note a reflection in the shared journal\n"
         "/help — this help\n"
@@ -302,6 +312,8 @@ def _handle_help():
         "\n"
         "To target a project:\n"
         "  [project:myproject] fix the login bug\n"
+        "\n"
+        "To force chat: /chat <message> (useful when your message looks like a mission)\n"
         "\n"
         "Any other message = free conversation."
     )

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -77,6 +77,70 @@ class TestIsMission:
     def test_empty_string(self):
         assert is_mission("") is False
 
+    def test_long_message_with_verb_only_at_start(self):
+        """Long messages should only match verbs at the start, not mid-text."""
+        # Verb at start — IS a mission
+        long_mission = "implement " + "x " * 150
+        assert is_mission(long_mission) is True
+        # Verb buried mid-text — NOT a mission
+        long_chat = "I was thinking about how we should " + "x " * 100 + " and then implement something"
+        assert is_mission(long_chat) is False
+
+    def test_conversational_with_action_verb(self):
+        """Short messages starting with action verbs but clearly conversational."""
+        # These are correctly classified as missions by the current heuristic.
+        # Users should use /chat to override when needed.
+        assert is_mission("add me to the list") is True  # starts with "add"
+        assert is_mission("run me through the pipeline") is True  # starts with "run"
+
+    def test_long_conversational_not_mission(self):
+        """Long conversational messages without leading verbs are not missions."""
+        long_chat = "Hey, I wanted to discuss something with you. " + "blah " * 60
+        assert is_mission(long_chat) is False
+
+
+# ---------------------------------------------------------------------------
+# /chat command (force chat mode)
+# ---------------------------------------------------------------------------
+
+class TestHandleChatCommand:
+    """Test /chat prefix to force chat mode."""
+
+    @patch("app.awake._run_in_worker")
+    def test_chat_command_routes_to_chat(self, mock_worker):
+        """'/chat fix the bug' should route to chat, not mission."""
+        handle_command("/chat fix the bug")
+        mock_worker.assert_called_once_with(handle_chat, "fix the bug")
+
+    @patch("app.awake._run_in_worker")
+    def test_chat_command_strips_prefix(self, mock_worker):
+        """/chat should strip the prefix and pass the rest as chat text."""
+        handle_command("/chat implement dark mode for the dashboard")
+        mock_worker.assert_called_once_with(
+            handle_chat, "implement dark mode for the dashboard"
+        )
+
+    @patch("app.awake.send_telegram")
+    def test_chat_command_empty_shows_usage(self, mock_send):
+        """/chat with no text should show usage help."""
+        handle_command("/chat")
+        msg = mock_send.call_args[0][0]
+        assert "Usage" in msg
+        assert "/chat" in msg
+
+    @patch("app.awake.send_telegram")
+    def test_chat_command_whitespace_only_shows_usage(self, mock_send):
+        """/chat followed by only whitespace shows usage."""
+        handle_command("/chat   ")
+        msg = mock_send.call_args[0][0]
+        assert "Usage" in msg
+
+    @patch("app.awake._run_in_worker")
+    def test_chat_via_handle_message(self, mock_worker):
+        """/chat goes through handle_message -> handle_command -> chat."""
+        handle_message("/chat add me to the list of testers")
+        mock_worker.assert_called_once_with(handle_chat, "add me to the list of testers")
+
 
 # ---------------------------------------------------------------------------
 # is_command
@@ -959,6 +1023,12 @@ class TestHandleHelp:
         _handle_help()
         msg = mock_send.call_args[0][0]
         assert "mission" in msg.lower()
+
+    @patch("app.awake.send_telegram")
+    def test_help_mentions_chat_command(self, mock_send):
+        _handle_help()
+        msg = mock_send.call_args[0][0]
+        assert "/chat" in msg
 
     @patch("app.awake._handle_help")
     def test_handle_command_routes_help(self, mock_help):


### PR DESCRIPTION
## Summary

- Add `/chat` command to force chat mode for messages that look like missions (e.g. `/chat add me to the testers list` won't be queued as a mission)
- Fix `is_mission()` long message heuristic: change `MISSION_RE.search()` to `.match()` so only messages *starting* with action verbs are classified as missions
- Document `/chat` in `/help` output
- 8 new tests (5 /chat command, 3 is_mission edge cases)

## Context

Clean rebase of the work from commit 55de159 (originally merged to local main as `koan/smarter-mission-classification`) onto `upstream/main`.

## Test plan

- [x] All 809 tests pass on the branch
- [x] `/chat` command routes to chat handler, bypasses mission detection
- [x] `is_mission()` no longer false-positives on long conversational messages with mid-text verbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)