### PR TITLE
fix(awake): handle CTRL-C gracefully without traceback

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -876,20 +876,24 @@ def main():
     print(f"[awake] Polling every {POLL_INTERVAL}s (chat mode: fast reply)")
     offset = None
 
-    while True:
-        updates = get_updates(offset)
-        for update in updates:
-            offset = update["update_id"] + 1
-            msg = update.get("message", {})
-            text = msg.get("text", "")
-            chat_id = str(msg.get("chat", {}).get("id", ""))
-            if chat_id == CHAT_ID and text:
-                print(f"[awake] Received: {text[:60]}")
-                handle_message(text)
+    try:
+        while True:
+            updates = get_updates(offset)
+            for update in updates:
+                offset = update["update_id"] + 1
+                msg = update.get("message", {})
+                text = msg.get("text", "")
+                chat_id = str(msg.get("chat", {}).get("id", ""))
+                if chat_id == CHAT_ID and text:
+                    print(f"[awake] Received: {text[:60]}")
+                    handle_message(text)
 
-        flush_outbox()
-        write_heartbeat(str(KOAN_ROOT))
-        time.sleep(POLL_INTERVAL)
+            flush_outbox()
+            write_heartbeat(str(KOAN_ROOT))
+            time.sleep(POLL_INTERVAL)
+    except KeyboardInterrupt:
+        print("\n[awake] Shutting down.")
+        sys.exit(0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Wrap the `main()` polling loop with `try/except KeyboardInterrupt` so CTRL-C prints `[awake] Shutting down.` and exits cleanly instead of dumping a 30-line Python backtrace through requests/urllib3/ssl
- Worker threads are already daemonic — no cleanup needed

## Test plan
- [x] 2 new tests: `test_main_ctrl_c_exits_gracefully` and `test_main_ctrl_c_during_sleep_exits_gracefully`
- [x] Full suite: 802 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)