### PR TITLE
cleanup: remove dead code, extract functions, add prompts tests

### DIFF
--- a/koan/app/git_sync.py
+++ b/koan/app/git_sync.py
@@ -14,12 +14,11 @@ Usage:
     python3 git_sync.py <instance_dir> <project_name> <project_path>
 """
 
-import fcntl
 import subprocess
 import sys
-from datetime import date, datetime
+from datetime import datetime
 from pathlib import Path
-from typing import List, Tuple
+from typing import List
 
 
 # ---------------------------------------------------------------------------

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -9,6 +9,7 @@ with genuine observations.
 Usage: python -m app.self_reflection <instance_dir> [--force]
 """
 
+import re
 import subprocess
 import sys
 from datetime import datetime
@@ -33,7 +34,6 @@ def should_reflect(instance_dir: Path, interval: int = 10) -> bool:
 
     content = summary_file.read_text()
     # Count session lines (format: "Session N (project: X) : ...")
-    import re
     sessions = re.findall(r"Session (\d+)", content)
     if not sessions:
         return False

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -1,0 +1,52 @@
+"""Tests for prompts.py — system prompt template loader."""
+
+import pytest
+from pathlib import Path
+
+from app.prompts import load_prompt, PROMPT_DIR
+
+
+class TestLoadPrompt:
+    """Tests for load_prompt()."""
+
+    def test_load_existing_prompt(self):
+        """Should load a known prompt template."""
+        result = load_prompt("chat", SOUL="test soul", TOOLS_DESC="", PREFS="",
+                             SUMMARY="", JOURNAL="", MISSIONS="")
+        assert "test soul" in result
+        assert "{SOUL}" not in result
+
+    def test_placeholder_substitution(self):
+        """Should replace all provided placeholders."""
+        result = load_prompt("chat", SOUL="SOUL_VAL", TOOLS_DESC="TOOLS_VAL",
+                             PREFS="PREFS_VAL", SUMMARY="SUM_VAL",
+                             JOURNAL="JOURNAL_VAL", MISSIONS="MISS_VAL")
+        assert "SOUL_VAL" in result
+        assert "TOOLS_VAL" in result
+        assert "PREFS_VAL" in result
+        assert "{SOUL}" not in result
+        assert "{TOOLS_DESC}" not in result
+
+    def test_missing_prompt_raises(self):
+        """Should raise FileNotFoundError for nonexistent prompt."""
+        with pytest.raises(FileNotFoundError):
+            load_prompt("nonexistent-prompt-xyz")
+
+    def test_no_kwargs_leaves_placeholders(self):
+        """Without kwargs, placeholders remain in the template."""
+        result = load_prompt("chat")
+        assert "{SOUL}" in result
+
+    def test_prompt_dir_exists(self):
+        """PROMPT_DIR should point to the system-prompts directory."""
+        assert PROMPT_DIR.exists()
+        assert PROMPT_DIR.is_dir()
+        assert (PROMPT_DIR / "chat.md").exists()
+
+    def test_all_known_prompts_loadable(self):
+        """All .md files in system-prompts/ should be loadable."""
+        for md_file in PROMPT_DIR.glob("*.md"):
+            name = md_file.stem
+            result = load_prompt(name)
+            assert isinstance(result, str)
+            assert len(result) > 0


### PR DESCRIPTION
## Summary

Nightshift easy wins — code cleanup, DRY, and test coverage.

- **Remove unused imports** in `git_sync.py` (`fcntl`, `date`, `Tuple` — never referenced)
- **Fix import order** in `self_reflection.py` (move `import re` from function body to top-level)
- **Remove stale 5-project limit** in `run.sh` (contradicts `projects.yaml` migration from session 56 which explicitly removed the limit)
- **Remove dead `MISSION_SUMMARY` variable** in `run.sh` (assigned but never used — the comment at line 628 explains it was intentionally deprecated)
- **Extract `run_contemplative_session()`** — eliminates duplicated contemplative prompt+flags+exec code (was copy-pasted in pause mode and autonomous mode)
- **Extract `commit_instance()`** — DRYs the instance git add+commit+push pattern (was duplicated for quota exhaustion and regular post-run commits)
- **Add `test_prompts.py`** — 6 tests covering `prompts.py`, the only module without a test file

## Test plan

- [x] All 806 tests pass (6 new)
- [x] `bash -n run.sh` validates syntax
- [ ] CI green on 3.12/3.13/3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)