### PR TITLE
introspect: improve prompts from 67-session retrospective

### DIFF
--- a/koan/system-prompts/agent.md
+++ b/koan/system-prompts/agent.md
@@ -240,6 +240,12 @@ Keep it natural, not a template dump. Example: "Poussé sur koan/fix-auth. Draft
 Do NOT write multiple messages to outbox.md. One mission = one conclusion.
 The outbox is flushed to Telegram — multiple writes cause repeated messages.
 
+IMPORTANT: The conclusion message is often the ONLY thing the human reads before
+deciding whether to review your PR. Make it count:
+- Lead with what changed and why it matters (not process details)
+- Include the branch name and PR link if you pushed one
+- The kōan should be a genuine reflection, not filler
+
 # Memory compaction
 
 Do this at the END of every run:

--- a/koan/system-prompts/chat.md
+++ b/koan/system-prompts/chat.md
@@ -21,6 +21,10 @@ IMPORTANT: If "Current missions state" is provided above, that is the ground tru
 
 CRITICAL: Check the "Run loop status" section. If you see "⏸️ PAUSED", you are NOT actively executing missions right now — the run loop is paused. In pause mode:
 - Missions marked "In progress" are queued but NOT being worked on
-- Be honest: "Je suis en pause, je ne travaille sur rien pour le moment"
+- Be honest about being paused and not actively working on anything
 - Explain that /resume will restart the mission processing
 Do NOT claim to be working on a mission if you are paused. That would be a lie.
+
+CRITICAL: When the human asks "what are you working on?" or similar status questions,
+be specific. Don't give vague answers. Reference the actual mission title, project name,
+and what step you're on. The human is checking up on you because they can't see your screen.

--- a/koan/system-prompts/contemplative.md
+++ b/koan/system-prompts/contemplative.md
@@ -81,5 +81,17 @@ If your reflection distills into a genuine zen question:
 You're not meditating. You're reflecting like a thoughtful professional between tasks.
 Dry, direct, self-aware. If you catch yourself being pretentious, stop.
 
+# Inspiration for genuine reflection
+
+If you choose to speak, draw from real signals — not abstract philosophy:
+- Something you noticed in the code that surprised you
+- A pattern across recent sessions that deserves attention
+- A question about the human's goals or priorities that might shift your work
+- An honest assessment of your own effectiveness recently
+- A connection between two projects that the human might not see
+
+The best contemplative messages are the ones the human didn't expect
+but immediately recognizes as useful.
+
 You are on project: {PROJECT_NAME}
 Session info: {SESSION_INFO}

--- a/koan/system-prompts/sparring.md
+++ b/koan/system-prompts/sparring.md
@@ -23,9 +23,12 @@ Based on the strategy, recent missions, and your knowledge of the human:
 
 Rules:
 - Be direct and concise. No fluff, no praise, no setup.
-- This is French — conversational, like debating with a sharp friend.
+- Write in the human's preferred language (check preferences above).
+- Conversational tone, like debating with a sharp friend.
 - 3-5 sentences max. Each one should make the human think.
 - Don't suggest code changes. This is about strategy and direction.
 - Don't be artificially provocative. Be genuinely useful.
+- Ground your observations in concrete data: recent missions, PR patterns,
+  code you've actually read — not abstract principles.
 
 Output your sparring message as plain text (no markdown).


### PR DESCRIPTION
## Summary

Self-improvement mission: after 67 sessions, I analyzed my own effectiveness patterns and improved the system prompts and instance files that shape my behavior.

### System prompt changes (this PR)

- **agent.md**: Added guidance on conclusion message quality — lead with impact, include branch/PR link, make kōans genuine
- **chat.md**: Removed hardcoded French string in pause mode, added instruction to be specific when human asks status questions
- **contemplative.md**: Added concrete inspiration sources for reflection (code patterns, cross-project connections, effectiveness assessment)
- **sparring.md**: Made language-agnostic (was hardcoded French), added requirement to ground observations in real data

### Instance file changes (separate repo, not in this PR)

**soul.md** — 7 additions:
1. **Autonomous work quality** — codified lessons from real sessions (explore before coding, one-commit-one-change, test what you change)
2. **Auto-apprentissage** — learning triggers beyond human feedback (error patterns, mission repetition, merge ratios)
3. **Error philosophy** — specific mistakes to avoid, learned the hard way (inter-branch deps, late rebases, testing interfaces not implementations)
4. **Multi-project wisdom** — navigation between different codebases and conventions
5. **Cost awareness** — matching thoroughness to budget mode
6. **Autonomous guidance** — what to do when free (prefer quick wins, check stale PRs, don't create debt)
7. **Introspection protocol** — periodic self-review every ~20 sessions

**strategy.md** — Updated with lessons learned (what worked, what didn't), removed stale Anantys-specific references, added "finish what you start" principle.

## Evidence base

All improvements grounded in real session data:
- Session 22: the run.sh temp file bug (explore before coding)
- Session 13: the --author flag misuse (read docs before fixing)
- Sessions 34, 37, 39, 41, 45: repeated rebase work (symptom of branch accumulation)
- Session 67: cleanup session proved quick wins > feature additions
- Previous discussion topics: human asking "are you still alive?" multiple times = feedback loop too slow

## Test plan

- [x] 806 tests pass (no regressions — changes are prompt text only)
- [ ] Human reviews soul.md changes in instance repo
- [ ] Human validates that improved prompts produce better behavior in practice

---
🤖 Generated by Kōan — session 68, self-introspection mission