### PR TITLE
fix: normalize missions.md to collapse excessive blank lines

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -107,7 +107,7 @@ def insert_mission(content: str, entry: str) -> str:
     else:
         content += f"\n## Pending\n\n{entry}\n"
 
-    return content
+    return normalize_content(content)
 
 
 def count_pending(content: str) -> int:
@@ -207,6 +207,32 @@ def group_by_project(content: str) -> Dict[str, Dict[str, List[str]]]:
         result[project]["in_progress"].append(item)
 
     return dict(result)
+
+
+def normalize_content(content: str) -> str:
+    """Normalize missions.md content by collapsing excessive blank lines.
+
+    Rules:
+    - Max 1 blank line between any two non-blank lines
+    - No trailing blank lines at end of file (just a final newline)
+    - Preserves all non-blank content exactly as-is
+    """
+    lines = content.splitlines()
+    result = []
+    prev_blank = False
+
+    for line in lines:
+        is_blank = line.strip() == ""
+        if is_blank and prev_blank:
+            continue  # skip consecutive blank lines
+        result.append(line)
+        prev_blank = is_blank
+
+    # Strip trailing blank lines, ensure single final newline
+    while result and result[-1].strip() == "":
+        result.pop()
+
+    return "\n".join(result) + "\n" if result else ""
 
 
 def find_section_boundaries(lines: List[str]) -> Dict[str, Tuple[int, int]]:

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -148,7 +148,8 @@ def recover_missions(instance_dir: str) -> int:
                 new_lines.append("")
 
     from app.utils import atomic_write
-    atomic_write(missions_path, "\n".join(new_lines) + "\n")
+    from app.missions import normalize_content
+    atomic_write(missions_path, normalize_content("\n".join(new_lines) + "\n"))
     return len(recovered)
 
 

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -382,6 +382,9 @@ def insert_pending_mission(missions_path: Path, entry: str):
             else:
                 content += f"\n## Pending\n\n{entry}\n"
 
+            from app.missions import normalize_content
+            content = normalize_content(content)
+
             f.seek(0)
             f.truncate()
             f.write(content)


### PR DESCRIPTION
## Summary

- Added `normalize_content()` in `missions.py` — collapses consecutive blank lines to max 1, strips trailing blanks
- Integrated into all write paths: `insert_mission()`, `insert_pending_mission()`, `recover.py`
- 11 new tests covering edge cases (empty input, 40+ blank lines, indentation preservation, insert normalization)
- 810 tests pass

## Problem

`missions.md` accumulates blank lines over time (40+ in my instance) as the Claude agent moves missions between sections, leaving empty lines behind. The `insert_mission()` function skips existing newlines then adds `\n{entry}\n`, but nothing cleans up the gaps left by removed entries.

## Test plan

- [x] `test_collapses_consecutive_blank_lines` — verifies no triple newlines remain
- [x] `test_many_blank_lines_in_pending` — real-world 40-line gap scenario
- [x] `test_preserves_single_blank_lines` — doesn't over-normalize
- [x] `test_insert_mission_returns_normalized` — integration test
- [x] Full suite: 810 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)