### PR TITLE
feat(browser): Playwright MCP browser access for agent missions

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -78,6 +78,15 @@ usage:
   session_token_limit: 500000   # Tokens per 5h session window
   weekly_token_limit: 5000000   # Tokens per 7-day window
 
+# Browser access (Playwright MCP)
+# Enables Claude to interact with web browsers for E2E testing,
+# documentation fetching, and web automation.
+# Requires Node.js/npx installed on the system.
+browser:
+  enabled: false                  # Global on/off switch
+  headless: true                  # Run browser in headless mode (no visible window)
+  allowed_domains: []             # Planned (not yet enforced). Example: ["localhost", "docs.python.org"]
+
 # Per-project overrides
 # Override git_auto_merge settings for specific projects
 # Example: if you have a project named "myapp" configured via KOAN_PROJECTS

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -186,6 +186,10 @@ def handle_command(text: str):
         _handle_ping()
         return
 
+    if cmd == "/browser":
+        _handle_browser()
+        return
+
     if cmd == "/help":
         _handle_help()
         return
@@ -272,6 +276,12 @@ def _handle_ping():
         send_telegram("❌ Run loop is not running.\n\nTo restart:\n  make run &")
 
 
+def _handle_browser():
+    """Show browser access status."""
+    from app.browser_access import format_browser_status
+    send_telegram(format_browser_status())
+
+
 def _handle_help():
     """Send the list of available commands."""
     help_text = (
@@ -286,6 +296,7 @@ def _handle_help():
         "/status — quick status (missions, pause, loop)\n"
         "/usage — detailed status (quota, progress)\n"
         "/ping — check if run loop is alive (✅/❌)\n"
+        "/browser — browser access status\n"
         "/verbose — receive every progress update\n"
         "/silent — mute updates (default mode)\n"
         "\n"

--- a/koan/app/browser_access.py
+++ b/koan/app/browser_access.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Kōan — Browser Access via Playwright MCP
+
+Manages the Playwright MCP server configuration for Claude CLI,
+enabling browser-based E2E testing, documentation fetching, and
+web automation within agent missions.
+
+Uses the @playwright/mcp npm package via Claude's --mcp-config flag.
+
+Config (instance/config.yaml):
+    browser:
+      enabled: false
+      headless: true
+      allowed_domains: []    # empty = all domains allowed
+
+CLI entry point (for run.sh):
+    python3 -m app.browser_access flags    → print --mcp-config flags
+    python3 -m app.browser_access status   → print browser status
+"""
+
+import json
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from typing import List, Optional
+
+# Lazy import to avoid circular dependency at module level
+_config_cache = None
+
+
+def _load_config() -> dict:
+    """Load config.yaml lazily, with caching."""
+    global _config_cache
+    if _config_cache is not None:
+        return _config_cache
+    from app.utils import load_config
+    _config_cache = load_config()
+    return _config_cache
+
+
+def _reset_config_cache():
+    """Reset config cache (for testing)."""
+    global _config_cache
+    _config_cache = None
+
+
+def get_browser_config() -> dict:
+    """Get browser configuration from config.yaml.
+
+    Returns dict with keys: enabled, headless, allowed_domains.
+    """
+    config = _load_config()
+    browser = config.get("browser", {})
+    return {
+        "enabled": bool(browser.get("enabled", False)),
+        "headless": bool(browser.get("headless", True)),
+        "allowed_domains": list(browser.get("allowed_domains", [])),
+    }
+
+
+def is_browser_enabled() -> bool:
+    """Check if browser access is enabled in config."""
+    return get_browser_config()["enabled"]
+
+
+def is_npx_available() -> bool:
+    """Check if npx is available on the system."""
+    return shutil.which("npx") is not None
+
+
+def get_mcp_config_path() -> Path:
+    """Get path to the generated MCP config JSON file."""
+    koan_root = Path(os.environ.get("KOAN_ROOT", "."))
+    return koan_root / "instance" / ".mcp-playwright.json"
+
+
+def build_mcp_config(headless: bool = True) -> dict:
+    """Build the MCP server configuration dict for Playwright.
+
+    This generates a Claude CLI-compatible MCP config that launches
+    the Playwright MCP server via npx.
+
+    Args:
+        headless: Run browser in headless mode (default True).
+
+    Returns:
+        Dict suitable for writing to a JSON config file.
+    """
+    args = ["npx", "-y", "@playwright/mcp@latest"]
+    if headless:
+        args.append("--headless")
+
+    return {
+        "mcpServers": {
+            "playwright": {
+                "command": args[0],
+                "args": args[1:],
+            }
+        }
+    }
+
+
+def write_mcp_config() -> Optional[Path]:
+    """Write the Playwright MCP config file if browser is enabled.
+
+    Creates/updates instance/.mcp-playwright.json with the current
+    browser configuration.
+
+    Returns:
+        Path to the config file if written, None if browser is disabled.
+    """
+    browser_config = get_browser_config()
+    if not browser_config["enabled"]:
+        return None
+
+    config = build_mcp_config(headless=browser_config["headless"])
+    config_path = get_mcp_config_path()
+
+    # Atomic write
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(
+        dir=str(config_path.parent), prefix=".mcp-", suffix=".json"
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(config, f, indent=2)
+        os.replace(tmp, str(config_path))
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+    return config_path
+
+
+def get_browser_mcp_flags() -> List[str]:
+    """Get CLI flags to enable Playwright MCP for Claude invocations.
+
+    Writes the MCP config file if needed and returns the flags to
+    append to a Claude CLI command.
+
+    Returns:
+        List of CLI flags (e.g., ["--mcp-config", "/path/to/.mcp-playwright.json"])
+        or empty list if browser is disabled.
+    """
+    if not is_browser_enabled():
+        return []
+
+    config_path = write_mcp_config()
+    return ["--mcp-config", str(config_path)]
+
+
+def get_browser_status() -> dict:
+    """Get comprehensive browser access status.
+
+    Returns:
+        Dict with keys: enabled, headless, npx_available, config_file_exists,
+        allowed_domains.
+    """
+    browser_config = get_browser_config()
+    config_path = get_mcp_config_path()
+
+    return {
+        "enabled": browser_config["enabled"],
+        "headless": browser_config["headless"],
+        "npx_available": is_npx_available(),
+        "config_file_exists": config_path.exists(),
+        "allowed_domains": browser_config["allowed_domains"],
+    }
+
+
+def format_browser_status() -> str:
+    """Format browser status for human-readable display (Telegram).
+
+    Returns:
+        Multi-line status string.
+    """
+    status = get_browser_status()
+
+    if not status["enabled"]:
+        return (
+            "Browser access: DISABLED\n"
+            "Enable in config.yaml:\n"
+            "  browser:\n"
+            "    enabled: true"
+        )
+
+    lines = []
+    lines.append("Browser access: ENABLED")
+    lines.append(f"  Mode: {'headless' if status['headless'] else 'visible'}")
+
+    if status["npx_available"]:
+        lines.append("  npx: available")
+    else:
+        lines.append("  npx: NOT FOUND (install Node.js)")
+
+    if status["allowed_domains"]:
+        lines.append(f"  Domains: {', '.join(status['allowed_domains'])}")
+    else:
+        lines.append("  Domains: all (no restrictions)")
+
+    if status["config_file_exists"]:
+        lines.append("  MCP config: written")
+    else:
+        lines.append("  MCP config: not yet generated")
+
+    return "\n".join(lines)
+
+
+def get_browser_flags_for_shell() -> str:
+    """Get browser MCP flags as a shell-safe string.
+
+    Designed to be called from run.sh:
+        BROWSER_FLAGS=$("$PYTHON" -c "from app.browser_access import get_browser_flags_for_shell; print(get_browser_flags_for_shell())")
+
+    Returns:
+        Space-separated CLI flags string (may be empty).
+    """
+    flags = get_browser_mcp_flags()
+    return " ".join(flags)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (for run.sh integration)
+# ---------------------------------------------------------------------------
+
+def main():
+    """CLI entry point for browser access module.
+
+    Usage:
+        python3 -m app.browser_access flags    → print MCP flags for Claude CLI
+        python3 -m app.browser_access status   → print browser status
+    """
+    if len(sys.argv) < 2:
+        print("Usage: python3 -m app.browser_access [flags|status]", file=sys.stderr)
+        sys.exit(1)
+
+    command = sys.argv[1]
+
+    if command == "flags":
+        print(get_browser_flags_for_shell())
+    elif command == "status":
+        print(format_browser_status())
+    else:
+        print(f"Unknown command: {command}", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/tests/test_browser_access.py
+++ b/koan/tests/test_browser_access.py
@@ -1,0 +1,411 @@
+"""Tests for browser_access.py — Playwright MCP integration."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.browser_access import (
+    get_browser_config,
+    is_browser_enabled,
+    is_npx_available,
+    build_mcp_config,
+    write_mcp_config,
+    get_browser_mcp_flags,
+    get_browser_status,
+    format_browser_status,
+    get_browser_flags_for_shell,
+    get_mcp_config_path,
+    _reset_config_cache,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    """Reset config cache between tests."""
+    _reset_config_cache()
+    yield
+    _reset_config_cache()
+
+
+@pytest.fixture
+def browser_instance(tmp_path, monkeypatch):
+    """Set up a temporary KOAN_ROOT with instance dir."""
+    monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+    inst = tmp_path / "instance"
+    inst.mkdir()
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Config reading
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrowserConfig:
+    """Test config.yaml browser section parsing."""
+
+    def test_defaults_when_no_config(self, browser_instance):
+        """Browser disabled by default with headless=True."""
+        with patch("app.browser_access._load_config", return_value={}):
+            config = get_browser_config()
+        assert config["enabled"] is False
+        assert config["headless"] is True
+        assert config["allowed_domains"] == []
+
+    def test_enabled_browser(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            config = get_browser_config()
+        assert config["enabled"] is True
+        assert config["headless"] is True
+
+    def test_visible_mode(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True, "headless": False}
+        }):
+            config = get_browser_config()
+        assert config["headless"] is False
+
+    def test_allowed_domains(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {
+                "enabled": True,
+                "allowed_domains": ["localhost", "docs.python.org"],
+            }
+        }):
+            config = get_browser_config()
+        assert config["allowed_domains"] == ["localhost", "docs.python.org"]
+
+    def test_partial_config(self, browser_instance):
+        """Missing keys use defaults."""
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            config = get_browser_config()
+        assert config["headless"] is True
+        assert config["allowed_domains"] == []
+
+
+class TestIsBrowserEnabled:
+    def test_disabled_by_default(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            assert is_browser_enabled() is False
+
+    def test_enabled(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            assert is_browser_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# MCP config generation
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMcpConfig:
+    """Test MCP config dict generation."""
+
+    def test_headless_config(self):
+        config = build_mcp_config(headless=True)
+        assert "mcpServers" in config
+        assert "playwright" in config["mcpServers"]
+        server = config["mcpServers"]["playwright"]
+        assert server["command"] == "npx"
+        assert "-y" in server["args"]
+        assert "@playwright/mcp@latest" in server["args"]
+        assert "--headless" in server["args"]
+
+    def test_visible_config(self):
+        config = build_mcp_config(headless=False)
+        server = config["mcpServers"]["playwright"]
+        assert "--headless" not in server["args"]
+
+    def test_config_is_valid_json(self):
+        """Config can be serialized to JSON."""
+        config = build_mcp_config()
+        json_str = json.dumps(config)
+        parsed = json.loads(json_str)
+        assert parsed == config
+
+
+class TestWriteMcpConfig:
+    """Test MCP config file writing."""
+
+    def test_writes_config_file(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True, "headless": True}
+        }):
+            path = write_mcp_config()
+        assert path is not None
+        assert path.exists()
+        content = json.loads(path.read_text())
+        assert "mcpServers" in content
+        assert "playwright" in content["mcpServers"]
+
+    def test_returns_none_when_disabled(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            assert write_mcp_config() is None
+
+    def test_config_file_location(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            path = write_mcp_config()
+        expected = browser_instance / "instance" / ".mcp-playwright.json"
+        assert path == expected
+
+    def test_overwrites_existing_config(self, browser_instance):
+        config_path = browser_instance / "instance" / ".mcp-playwright.json"
+        config_path.write_text('{"old": true}')
+
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            write_mcp_config()
+
+        content = json.loads(config_path.read_text())
+        assert "old" not in content
+        assert "mcpServers" in content
+
+
+# ---------------------------------------------------------------------------
+# CLI flag generation
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrowserMcpFlags:
+    """Test CLI flag generation for Claude invocations."""
+
+    def test_returns_flags_when_enabled(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            flags = get_browser_mcp_flags()
+        assert len(flags) == 2
+        assert flags[0] == "--mcp-config"
+        assert ".mcp-playwright.json" in flags[1]
+
+    def test_returns_empty_when_disabled(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            flags = get_browser_mcp_flags()
+        assert flags == []
+
+    def test_creates_config_file(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            flags = get_browser_mcp_flags()
+        config_path = Path(flags[1])
+        assert config_path.exists()
+
+
+class TestGetBrowserFlagsForShell:
+    """Test shell-safe flag string generation."""
+
+    def test_returns_space_separated_flags(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            result = get_browser_flags_for_shell()
+        assert "--mcp-config" in result
+        assert ".mcp-playwright.json" in result
+
+    def test_returns_empty_string_when_disabled(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            result = get_browser_flags_for_shell()
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# Status reporting
+# ---------------------------------------------------------------------------
+
+
+class TestGetBrowserStatus:
+    """Test status dict generation."""
+
+    def test_disabled_status(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            status = get_browser_status()
+        assert status["enabled"] is False
+        assert status["headless"] is True
+        assert status["config_file_exists"] is False
+
+    def test_enabled_status(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            # Write config to make config_file_exists true
+            write_mcp_config()
+            status = get_browser_status()
+        assert status["enabled"] is True
+        assert status["config_file_exists"] is True
+
+    def test_npx_check(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            with patch("shutil.which", return_value="/usr/bin/npx"):
+                status = get_browser_status()
+            assert status["npx_available"] is True
+
+            with patch("shutil.which", return_value=None):
+                _reset_config_cache()
+                status = get_browser_status()
+            assert status["npx_available"] is False
+
+
+class TestFormatBrowserStatus:
+    """Test human-readable status formatting."""
+
+    def test_disabled_message(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={}):
+            output = format_browser_status()
+        assert "DISABLED" in output
+        assert "config.yaml" in output
+
+    def test_enabled_message(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            with patch("shutil.which", return_value="/usr/bin/npx"):
+                output = format_browser_status()
+        assert "ENABLED" in output
+        assert "headless" in output
+        assert "npx: available" in output
+
+    def test_npx_missing_warning(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            with patch("shutil.which", return_value=None):
+                output = format_browser_status()
+        assert "NOT FOUND" in output
+
+    def test_domain_restrictions_shown(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {
+                "enabled": True,
+                "allowed_domains": ["localhost", "example.com"],
+            }
+        }):
+            with patch("shutil.which", return_value="/usr/bin/npx"):
+                output = format_browser_status()
+        assert "localhost" in output
+        assert "example.com" in output
+
+    def test_no_domain_restrictions(self, browser_instance):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            with patch("shutil.which", return_value="/usr/bin/npx"):
+                output = format_browser_status()
+        assert "all (no restrictions)" in output
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+class TestCLIEntryPoint:
+    """Test python3 -m app.browser_access."""
+
+    # cwd must be the koan/ dir (where app/ lives) for module resolution
+    _koan_dir = str(Path(__file__).parent.parent)
+
+    def test_flags_command(self, browser_instance):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-m", "app.browser_access", "flags"],
+            capture_output=True, text=True, timeout=10,
+            cwd=self._koan_dir,
+            env={**os.environ, "KOAN_ROOT": str(browser_instance)},
+        )
+        # Disabled by default, so empty output
+        assert result.returncode == 0
+        assert result.stdout.strip() == ""
+
+    def test_status_command(self, browser_instance):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-m", "app.browser_access", "status"],
+            capture_output=True, text=True, timeout=10,
+            cwd=self._koan_dir,
+            env={**os.environ, "KOAN_ROOT": str(browser_instance)},
+        )
+        assert result.returncode == 0
+        assert "DISABLED" in result.stdout
+
+    def test_unknown_command(self, browser_instance):
+        import subprocess
+        result = subprocess.run(
+            [sys.executable, "-m", "app.browser_access", "foobar"],
+            capture_output=True, text=True, timeout=10,
+            cwd=self._koan_dir,
+            env={**os.environ, "KOAN_ROOT": str(browser_instance)},
+        )
+        assert result.returncode != 0
+
+
+# ---------------------------------------------------------------------------
+# Awake.py integration
+# ---------------------------------------------------------------------------
+
+
+class TestAwakeBrowserCommand:
+    """Test /browser command in awake.py."""
+
+    @patch("app.awake.send_telegram")
+    def test_browser_command_disabled(self, mock_send):
+        with patch("app.browser_access._load_config", return_value={}):
+            from app.awake import handle_command
+            handle_command("/browser")
+        mock_send.assert_called_once()
+        assert "DISABLED" in mock_send.call_args[0][0]
+
+    @patch("app.awake.send_telegram")
+    def test_browser_command_enabled(self, mock_send):
+        with patch("app.browser_access._load_config", return_value={
+            "browser": {"enabled": True}
+        }):
+            with patch("shutil.which", return_value="/usr/bin/npx"):
+                from app.awake import handle_command
+                handle_command("/browser")
+        mock_send.assert_called_once()
+        assert "ENABLED" in mock_send.call_args[0][0]
+
+    @patch("app.awake.send_telegram")
+    def test_help_includes_browser(self, mock_send):
+        from app.awake import handle_command
+        handle_command("/help")
+        mock_send.assert_called_once()
+        assert "/browser" in mock_send.call_args[0][0]
+
+
+# ---------------------------------------------------------------------------
+# run.sh integration
+# ---------------------------------------------------------------------------
+
+
+class TestRunShIntegration:
+    """Test that run.sh correctly references browser_access."""
+
+    def test_run_sh_has_browser_flags(self):
+        """run.sh should call get_browser_flags_for_shell."""
+        run_sh = Path(__file__).parent.parent / "run.sh"
+        content = run_sh.read_text()
+        assert "browser_access" in content
+        assert "BROWSER_FLAGS" in content
+        assert "get_browser_flags_for_shell" in content
+
+    def test_run_sh_injects_browser_context(self):
+        """run.sh should inject browser capability text into prompt."""
+        run_sh = Path(__file__).parent.parent / "run.sh"
+        content = run_sh.read_text()
+        assert "Browser Access" in content
+        assert "Playwright MCP" in content


### PR DESCRIPTION
## Summary

- New `browser_access.py` module manages Playwright MCP server configuration for Claude CLI
- Generates `instance/.mcp-playwright.json` and injects `--mcp-config` flags into mission invocations
- `/browser` Telegram command shows status (enabled/disabled, npx availability, config state)
- Config via `browser:` section in `config.yaml` (disabled by default, opt-in)
- 35 new tests, 888 total pass

## Implementation Details

**Phase 1 of GitHub #64** — enables Claude to use browser tools during missions for E2E testing, documentation fetching, and web automation.

### Config
\`\`\`yaml
browser:
  enabled: false        # Global kill switch
  headless: true         # No visible browser window
  allowed_domains: []    # Planned, not yet enforced
\`\`\`

### Integration Points
- \`run.sh\`: \`BROWSER_FLAGS\` variable + prompt context injection when enabled
- \`awake.py\`: \`/browser\` command + updated \`/help\`
- \`instance.example/config.yaml\`: template with browser section

### What's NOT included (Phase 2+)
- Domain allowlist enforcement
- Chrome native (\`--chrome\` flag) support
- Browser session recording/screenshots storage
- Per-project browser config overrides

## Test plan
- [x] 35 unit tests covering config, MCP generation, flags, status, CLI entry point
- [x] Integration tests for \`/browser\` command in awake.py
- [x] run.sh structure tests verifying flag injection
- [x] Full suite: 888 pass
- [x] atoomic.refactor applied (removed unused imports)
- [x] atoomic.review: 8/10 quality, 9/10 security

🤖 Generated with [Claude Code](https://claude.com/claude-code)