### PR TITLE
fix(security): implement audit findings from GitHub #61

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -370,6 +370,8 @@ def _handle_usage():
             response = re.sub(r'^#{1,6}\s+', '', response, flags=re.MULTILINE)
             send_telegram(response)
         else:
+            if result.stderr:
+                print(f"[awake] /usage Claude stderr: {result.stderr[:500]}")
             # Fallback: send raw data
             fallback = f"Quota: {usage_text[:200]}\n\nMissions: {missions_text[:300]}"
             send_telegram(fallback)
@@ -509,6 +511,8 @@ def _handle_sparring():
             send_telegram(response)
             save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", response)
         else:
+            if result.stderr:
+                print(f"[awake] /sparring Claude stderr: {result.stderr[:500]}")
             send_telegram("Nothing compelling to say right now. Come back later.")
     except subprocess.TimeoutExpired:
         send_telegram("Timeout — my brain needs more time. Try again.")
@@ -773,6 +777,8 @@ def handle_chat(text: str):
                 save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", response)
                 print(f"[awake] Chat reply (lite retry): {response[:80]}...")
             else:
+                if result.stderr:
+                    print(f"[awake] Lite retry stderr: {result.stderr[:500]}")
                 timeout_msg = f"Timeout after {CHAT_TIMEOUT}s — try a shorter question, or send 'mission: ...' for complex tasks."
                 send_telegram(timeout_msg)
                 save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", timeout_msg)

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -63,6 +63,8 @@ def call_claude(prompt: str) -> str:
     )
     if result.returncode != 0:
         print(f"[pick_mission] Claude returned exit code {result.returncode}", file=sys.stderr)
+        if result.stderr:
+            print(f"[pick_mission] stderr: {result.stderr[:500]}", file=sys.stderr)
         return ""
 
     # Parse JSON output

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -118,6 +118,8 @@ def run_reflection(instance_dir: Path) -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
+        if result.stderr:
+            print(f"[self_reflection] Claude stderr: {result.stderr[:500]}", file=sys.stderr)
     except subprocess.TimeoutExpired:
         print("[self_reflection] Claude timeout", file=sys.stderr)
     except Exception as e:

--- a/koan/app/setup_wizard.py
+++ b/koan/app/setup_wizard.py
@@ -326,6 +326,10 @@ def validate_project():
     if not project_path.is_dir():
         return jsonify({"valid": False, "error": "Path is not a directory"})
 
+    # Check writability
+    if not os.access(project_path, os.W_OK):
+        return jsonify({"valid": False, "error": "Path is not writable"})
+
     # Check for CLAUDE.md (optional but nice to have)
     has_claude_md = (project_path / "CLAUDE.md").exists()
 

--- a/koan/tests/test_setup_wizard.py
+++ b/koan/tests/test_setup_wizard.py
@@ -295,6 +295,27 @@ class TestProjectValidation:
         assert data["is_git_repo"] is True
 
 
+    def test_validate_non_writable_path(self, wizard_app):
+        """Non-writable directory should fail validation."""
+        client, root = wizard_app
+
+        project_dir = root / "readonly-project"
+        project_dir.mkdir()
+        project_dir.chmod(0o444)
+
+        try:
+            response = client.post(
+                "/step/projects/validate",
+                json={"path": str(project_dir)},
+                content_type="application/json"
+            )
+            data = json.loads(response.data)
+            assert data["valid"] is False
+            assert "not writable" in data["error"].lower()
+        finally:
+            project_dir.chmod(0o755)
+
+
 class TestProjectSave:
     """Tests for saving project configuration."""
 


### PR DESCRIPTION
- M1: Disable Flask debug mode by default in dashboard.py (opt-in via --debug flag)
- M3: Print warning to stderr when dashboard binds to non-localhost address
- M4: Add stderr logging for subprocess calls in awake.py, dashboard.py, pick_mission.py, and self_reflection.py (5 call sites)
- L3: Validate path writability in setup_wizard project validation

Closes #61