### PR TITLE
fix: add missing stderr logging for subprocess errors

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -370,7 +370,9 @@ def _handle_usage():
             response = re.sub(r'^#{1,6}\s+', '', response, flags=re.MULTILINE)
             send_telegram(response)
         else:
-            # Fallback: send raw data
+            # Log error, then fallback to raw data
+            if result.returncode != 0:
+                print(f"[awake] /usage Claude error: {result.stderr[:200]}")
             fallback = f"Quota: {usage_text[:200]}\n\nMissions: {missions_text[:300]}"
             send_telegram(fallback)
     except subprocess.TimeoutExpired:
@@ -509,6 +511,8 @@ def _handle_sparring():
             send_telegram(response)
             save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", response)
         else:
+            if result.returncode != 0:
+                print(f"[awake] /sparring Claude error: {result.stderr[:200]}")
             send_telegram("Nothing compelling to say right now. Come back later.")
     except subprocess.TimeoutExpired:
         send_telegram("Timeout — my brain needs more time. Try again.")

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -62,7 +62,7 @@ def call_claude(prompt: str) -> str:
         timeout=60,
     )
     if result.returncode != 0:
-        print(f"[pick_mission] Claude returned exit code {result.returncode}", file=sys.stderr)
+        print(f"[pick_mission] Claude error (code {result.returncode}): {result.stderr[:200]}", file=sys.stderr)
         return ""
 
     # Parse JSON output

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -118,6 +118,8 @@ def run_reflection(instance_dir: Path) -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
+        elif result.returncode != 0:
+            print(f"[self_reflection] Claude error: {result.stderr[:200]}", file=sys.stderr)
     except subprocess.TimeoutExpired:
         print("[self_reflection] Claude timeout", file=sys.stderr)
     except Exception as e:

--- a/koan/tests/test_self_reflection.py
+++ b/koan/tests/test_self_reflection.py
@@ -162,6 +162,16 @@ class TestRunReflection:
         assert result == ""
 
     @patch("app.self_reflection.subprocess.run")
+    def test_claude_failure_logs_stderr(self, mock_run, instance_dir, capsys):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="API rate limit exceeded"
+        )
+        run_reflection(instance_dir)
+        captured = capsys.readouterr()
+        assert "[self_reflection] Claude error:" in captured.err
+        assert "API rate limit" in captured.err
+
+    @patch("app.self_reflection.subprocess.run")
     def test_claude_empty_output(self, mock_run, instance_dir):
         mock_run.return_value = MagicMock(returncode=0, stdout="   ")
         result = run_reflection(instance_dir)


### PR DESCRIPTION
## Summary

- Adds stderr logging when Claude subprocess calls fail (non-zero exit code)
- Fixes 4 locations: `self_reflection.py`, `pick_mission.py`, `awake.py` (2 handlers)
- Completes issue #61 M4 finding (missing stderr logging)

## Changes

| File | Change |
|------|--------|
| `self_reflection.py` | Log stderr when `returncode != 0` |
| `pick_mission.py` | Include stderr in error message |
| `awake.py` | `/usage` and `/sparring` handlers log stderr before fallback |
| `test_self_reflection.py` | New test verifying stderr is logged |

## Test plan

- [x] 854 tests pass
- [x] New test `test_claude_failure_logs_stderr` verifies behavior

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)