### PR TITLE
fix: add missing stderr logging for Claude subprocess errors (issue #61 M4)

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -438,6 +438,8 @@ def _handle_usage():
             if result.stderr:
                 print(f"[awake] /usage Claude stderr: {result.stderr[:500]}")
             # Fallback: send raw data
+            if result.returncode != 0:
+                print(f"[awake] /usage Claude error (exit {result.returncode}): {result.stderr[:200]}")
             fallback = f"Quota: {usage_text[:200]}\n\nMissions: {missions_text[:300]}"
             send_telegram(fallback)
     except subprocess.TimeoutExpired:
@@ -576,7 +578,9 @@ def _handle_sparring():
             send_telegram(response)
             save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", response)
         else:
-            if result.stderr:
+            if result.returncode != 0:
+                print(f"[awake] /sparring Claude error (exit {result.returncode}): {result.stderr[:200]}")
+            elif result.stderr:
                 print(f"[awake] /sparring Claude stderr: {result.stderr[:500]}")
             send_telegram("Nothing compelling to say right now. Come back later.")
     except subprocess.TimeoutExpired:

--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -298,6 +298,8 @@ def chat_send():
                 cwd=project_path,
             )
             response = result.stdout.strip()
+            if result.returncode != 0:
+                print(f"[dashboard] Claude error (exit {result.returncode}): {result.stderr[:200]}", file=sys.stderr)
             if not response:
                 if result.stderr:
                     print(f"[dashboard] Claude stderr: {result.stderr[:500]}")
@@ -318,6 +320,8 @@ def chat_send():
                 if result.stderr:
                     print(f"[dashboard] Lite retry stderr: {result.stderr[:500]}")
                 response = result.stdout.strip()
+                if result.returncode != 0:
+                    print(f"[dashboard] Claude error on retry (exit {result.returncode}): {result.stderr[:200]}", file=sys.stderr)
                 if response:
                     save_telegram_message(TELEGRAM_HISTORY_FILE, "assistant", response)
                     return jsonify({"ok": True, "type": "chat", "response": response})

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -62,9 +62,7 @@ def call_claude(prompt: str) -> str:
         timeout=60,
     )
     if result.returncode != 0:
-        print(f"[pick_mission] Claude returned exit code {result.returncode}", file=sys.stderr)
-        if result.stderr:
-            print(f"[pick_mission] stderr: {result.stderr[:500]}", file=sys.stderr)
+        print(f"[pick_mission] Claude error (exit {result.returncode}): {result.stderr[:200]}", file=sys.stderr)
         return ""
 
     # Parse JSON output

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -118,8 +118,8 @@ def run_reflection(instance_dir: Path) -> str:
         )
         if result.returncode == 0 and result.stdout.strip():
             return result.stdout.strip()
-        if result.stderr:
-            print(f"[self_reflection] Claude stderr: {result.stderr[:500]}", file=sys.stderr)
+        else:
+            print(f"[self_reflection] Claude error (exit {result.returncode}): {result.stderr[:200]}", file=sys.stderr)
     except subprocess.TimeoutExpired:
         print("[self_reflection] Claude timeout", file=sys.stderr)
     except Exception as e:

--- a/koan/tests/test_pick_mission.py
+++ b/koan/tests/test_pick_mission.py
@@ -224,6 +224,17 @@ class TestCallClaude:
     @patch("app.pick_mission.get_model_config", return_value={"lightweight": "haiku"})
     @patch("app.pick_mission.build_claude_flags", return_value=[])
     @patch("app.pick_mission.subprocess.run")
+    def test_nonzero_exit_code_logs_stderr(self, mock_run, mock_flags, mock_models, capsys):
+        """Verify that Claude errors are logged to stderr (M4 security finding)."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="Rate limit exceeded")
+        call_claude("test prompt")
+        captured = capsys.readouterr()
+        assert "[pick_mission] Claude error" in captured.err
+        assert "Rate limit exceeded" in captured.err
+
+    @patch("app.pick_mission.get_model_config", return_value={"lightweight": "haiku"})
+    @patch("app.pick_mission.build_claude_flags", return_value=[])
+    @patch("app.pick_mission.subprocess.run")
     def test_json_with_content_field(self, mock_run, mock_flags, mock_models):
         mock_run.return_value = MagicMock(
             returncode=0,

--- a/koan/tests/test_self_reflection.py
+++ b/koan/tests/test_self_reflection.py
@@ -162,6 +162,15 @@ class TestRunReflection:
         assert result == ""
 
     @patch("app.self_reflection.subprocess.run")
+    def test_claude_failure_logs_stderr(self, mock_run, instance_dir, capsys):
+        """Verify that Claude errors are logged to stderr (M4 security finding)."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="", stderr="API key invalid")
+        run_reflection(instance_dir)
+        captured = capsys.readouterr()
+        assert "[self_reflection] Claude error" in captured.err
+        assert "API key invalid" in captured.err
+
+    @patch("app.self_reflection.subprocess.run")
     def test_claude_empty_output(self, mock_run, instance_dir):
         mock_run.return_value = MagicMock(returncode=0, stdout="   ")
         result = run_reflection(instance_dir)


### PR DESCRIPTION
## Summary
- Added stderr logging to 4 modules when Claude CLI returns non-zero exit code
- Addresses security finding M4 from issue #61 (subprocess stderr not always checked)
- 2 new tests verify the logging behavior

## Changes
- `self_reflection.py`: log stderr on error exit
- `pick_mission.py`: include stderr in existing error message  
- `dashboard.py`: log stderr on both initial call and retry
- `awake.py`: log stderr for `/usage` and `/sparring` handlers

## Test plan
- [x] 855 tests pass (+2 new)
- [x] Verified affected modules compile

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)