### PR TITLE
chore: code quality cleanup and test coverage

### DIFF
--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -19,7 +19,6 @@ import json
 import os
 import re
 import subprocess
-import sys
 import time
 from datetime import date, datetime
 from pathlib import Path

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -8,6 +8,7 @@ instead of reimplementing section detection and parsing.
 """
 
 import re
+from collections import defaultdict
 from typing import Dict, List, Optional, Tuple
 
 
@@ -195,7 +196,6 @@ def group_by_project(content: str) -> Dict[str, Dict[str, List[str]]]:
 
     Returns {project: {"pending": [...], "in_progress": [...]}}.
     """
-    from collections import defaultdict
     result = defaultdict(lambda: {"pending": [], "in_progress": []})
 
     sections = parse_sections(content)

--- a/koan/app/setup_wizard.py
+++ b/koan/app/setup_wizard.py
@@ -17,7 +17,6 @@ import os
 import re
 import shutil
 import subprocess
-import sys
 import webbrowser
 from pathlib import Path
 from typing import Optional

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -623,3 +623,73 @@ class TestGetKnownProjects:
         from app.utils import get_known_projects
         monkeypatch.setenv("KOAN_PROJECTS", "koan:/k;;:/empty;webapp:/w")
         assert get_known_projects() == ["koan", "webapp"]
+
+
+class TestGetFastReplyModel:
+    def test_returns_lightweight_model_when_enabled(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("fast_reply: true\nmodels:\n  lightweight: haiku\n")
+        from app.utils import get_fast_reply_model
+        assert get_fast_reply_model() == "haiku"
+
+    def test_returns_empty_when_disabled(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("fast_reply: false\n")
+        from app.utils import get_fast_reply_model
+        assert get_fast_reply_model() == ""
+
+    def test_returns_empty_when_missing(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("other_setting: value\n")
+        from app.utils import get_fast_reply_model
+        assert get_fast_reply_model() == ""
+
+    def test_returns_empty_when_no_config(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        from app.utils import get_fast_reply_model
+        assert get_fast_reply_model() == ""
+
+
+class TestGetContemplativeChance:
+    def test_returns_config_value(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("contemplative_chance: 25\n")
+        from app.utils import get_contemplative_chance
+        assert get_contemplative_chance() == 25
+
+    def test_returns_default_when_missing(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("other_setting: value\n")
+        from app.utils import get_contemplative_chance
+        assert get_contemplative_chance() == 10
+
+    def test_returns_default_when_no_config(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        from app.utils import get_contemplative_chance
+        assert get_contemplative_chance() == 10
+
+    def test_zero_disables_contemplative_mode(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
+        config_dir = tmp_path / "instance"
+        config_dir.mkdir()
+        (config_dir / "config.yaml").write_text("contemplative_chance: 0\n")
+        from app.utils import get_contemplative_chance
+        assert get_contemplative_chance() == 0


### PR DESCRIPTION
- Remove unused `sys` import from dashboard.py and setup_wizard.py
- Move `defaultdict` import to module level in missions.py for consistency
- Add 8 tests for get_fast_reply_model() and get_contemplative_chance()

861 tests pass.