### PR TITLE
test: add coverage for reflect, verbose, and language skills

### DIFF
--- a/koan/tests/test_language_skill.py
+++ b/koan/tests/test_language_skill.py
@@ -1,0 +1,122 @@
+"""Tests for the /language skill handler."""
+
+from unittest.mock import MagicMock, patch
+
+from app.skills import SkillContext
+
+
+def _make_ctx(args=""):
+    """Create a minimal SkillContext for testing."""
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = "language"
+    ctx.args = args
+    return ctx
+
+
+class TestLanguageNoArgs:
+    """Tests for /language with no arguments."""
+
+    def test_no_args_shows_usage(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.get_language", return_value=None):
+            ctx = _make_ctx("")
+            result = handle(ctx)
+
+        assert "Usage:" in result
+        assert "/language" in result
+
+    def test_no_args_shows_current_language(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.get_language", return_value="french"):
+            ctx = _make_ctx("")
+            result = handle(ctx)
+
+        assert "french" in result.lower()
+        assert "Current" in result or "current" in result.lower()
+
+    def test_no_args_when_no_override_set(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.get_language", return_value=None):
+            ctx = _make_ctx("")
+            result = handle(ctx)
+
+        assert "No" in result or "no" in result
+        assert "input" in result.lower() or "language" in result.lower()
+
+
+class TestLanguageSet:
+    """Tests for /language <lang>."""
+
+    def test_set_french(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.set_language") as mock_set:
+            ctx = _make_ctx("french")
+            result = handle(ctx)
+
+        mock_set.assert_called_once_with("french")
+        assert "french" in result.lower()
+
+    def test_set_english(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.set_language") as mock_set:
+            ctx = _make_ctx("English")
+            result = handle(ctx)
+
+        mock_set.assert_called_once_with("English")
+        assert "english" in result.lower()
+
+    def test_set_with_whitespace(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.set_language") as mock_set:
+            ctx = _make_ctx("  spanish  ")
+            result = handle(ctx)
+
+        mock_set.assert_called_once_with("spanish")
+
+    def test_response_confirms_language(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.set_language"):
+            ctx = _make_ctx("german")
+            result = handle(ctx)
+
+        assert "german" in result.lower()
+        assert "🌐" in result
+
+
+class TestLanguageReset:
+    """Tests for /language reset."""
+
+    def test_reset_calls_reset_language(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.reset_language") as mock_reset:
+            ctx = _make_ctx("reset")
+            result = handle(ctx)
+
+        mock_reset.assert_called_once()
+
+    def test_reset_case_insensitive(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.reset_language") as mock_reset:
+            ctx = _make_ctx("RESET")
+            result = handle(ctx)
+
+        mock_reset.assert_called_once()
+
+    def test_reset_response_confirms(self):
+        from skills.core.language.handler import handle
+
+        with patch("app.language_preference.reset_language"):
+            ctx = _make_ctx("reset")
+            result = handle(ctx)
+
+        assert "reset" in result.lower() or "input" in result.lower()
+        assert "🌐" in result

--- a/koan/tests/test_reflect_skill.py
+++ b/koan/tests/test_reflect_skill.py
@@ -1,0 +1,90 @@
+"""Tests for the /reflect skill handler."""
+
+from unittest.mock import MagicMock
+
+from app.skills import SkillContext
+
+
+def _make_ctx(instance_dir, args=""):
+    """Create a minimal SkillContext for testing."""
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = "reflect"
+    ctx.instance_dir = instance_dir
+    ctx.args = args
+    return ctx
+
+
+class TestReflectSkill:
+    """Tests for /reflect command."""
+
+    def test_no_args_returns_usage(self, tmp_path):
+        from skills.core.reflect.handler import handle
+
+        ctx = _make_ctx(tmp_path, args="")
+        result = handle(ctx)
+        assert "Usage:" in result
+        assert "/reflect" in result
+
+    def test_empty_whitespace_returns_usage(self, tmp_path):
+        from skills.core.reflect.handler import handle
+
+        ctx = _make_ctx(tmp_path, args="   ")
+        result = handle(ctx)
+        assert "Usage:" in result
+
+    def test_writes_to_shared_journal(self, tmp_path):
+        from skills.core.reflect.handler import handle
+
+        ctx = _make_ctx(tmp_path, args="This is my deep thought")
+        result = handle(ctx)
+
+        assert "Noted" in result
+        assert "journal" in result.lower()
+
+        shared_journal = tmp_path / "shared-journal.md"
+        assert shared_journal.exists()
+        content = shared_journal.read_text()
+        assert "Human" in content
+        assert "This is my deep thought" in content
+
+    def test_appends_multiple_entries(self, tmp_path):
+        from skills.core.reflect.handler import handle
+
+        # First entry
+        ctx1 = _make_ctx(tmp_path, args="First thought")
+        handle(ctx1)
+
+        # Second entry
+        ctx2 = _make_ctx(tmp_path, args="Second thought")
+        handle(ctx2)
+
+        shared_journal = tmp_path / "shared-journal.md"
+        content = shared_journal.read_text()
+        assert "First thought" in content
+        assert "Second thought" in content
+        # Should have two Human sections
+        assert content.count("## Human") == 2
+
+    def test_creates_parent_directory(self, tmp_path):
+        from skills.core.reflect.handler import handle
+
+        nested = tmp_path / "sub" / "instance"
+        ctx = _make_ctx(nested, args="Thought in nested dir")
+        result = handle(ctx)
+
+        assert "Noted" in result
+        shared_journal = nested / "shared-journal.md"
+        assert shared_journal.exists()
+
+    def test_entry_includes_timestamp(self, tmp_path):
+        from skills.core.reflect.handler import handle
+        from datetime import datetime
+
+        ctx = _make_ctx(tmp_path, args="Timestamped thought")
+        handle(ctx)
+
+        shared_journal = tmp_path / "shared-journal.md"
+        content = shared_journal.read_text()
+        # Check for date format like "2026-02-07"
+        today = datetime.now().strftime("%Y-%m-%d")
+        assert today in content

--- a/koan/tests/test_verbose_skill.py
+++ b/koan/tests/test_verbose_skill.py
@@ -1,0 +1,118 @@
+"""Tests for the /verbose and /silent skill handlers."""
+
+from unittest.mock import MagicMock
+
+from app.skills import SkillContext
+
+
+def _make_ctx(command_name, koan_root):
+    """Create a minimal SkillContext for testing."""
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = command_name
+    ctx.koan_root = koan_root
+    ctx.args = ""
+    return ctx
+
+
+class TestVerboseCommand:
+    """Tests for /verbose command."""
+
+    def test_verbose_creates_marker_file(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        ctx = _make_ctx("verbose", tmp_path)
+        result = handle(ctx)
+
+        assert "ON" in result or "🔔" in result
+        marker = tmp_path / ".koan-verbose"
+        assert marker.exists()
+
+    def test_verbose_overwrites_existing(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        marker = tmp_path / ".koan-verbose"
+        marker.write_text("OLD_CONTENT")
+
+        ctx = _make_ctx("verbose", tmp_path)
+        result = handle(ctx)
+
+        assert "ON" in result
+        assert marker.read_text() == "VERBOSE"
+
+    def test_verbose_response_mentions_updates(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        ctx = _make_ctx("verbose", tmp_path)
+        result = handle(ctx)
+
+        assert "progress" in result.lower() or "update" in result.lower()
+
+
+class TestSilentCommand:
+    """Tests for /silent command."""
+
+    def test_silent_removes_marker(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        marker = tmp_path / ".koan-verbose"
+        marker.write_text("VERBOSE")
+
+        ctx = _make_ctx("silent", tmp_path)
+        result = handle(ctx)
+
+        assert "OFF" in result or "🔕" in result
+        assert not marker.exists()
+
+    def test_silent_when_already_silent(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        # No marker file exists
+        ctx = _make_ctx("silent", tmp_path)
+        result = handle(ctx)
+
+        assert "Already" in result or "silent" in result.lower()
+
+    def test_silent_response_mentions_conclusion(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        marker = tmp_path / ".koan-verbose"
+        marker.write_text("VERBOSE")
+
+        ctx = _make_ctx("silent", tmp_path)
+        result = handle(ctx)
+
+        assert "silent" in result.lower() or "conclusion" in result.lower()
+
+
+class TestVerboseSilentToggle:
+    """Test toggling between verbose and silent modes."""
+
+    def test_toggle_verbose_then_silent(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        marker = tmp_path / ".koan-verbose"
+
+        # Enable verbose
+        ctx_verbose = _make_ctx("verbose", tmp_path)
+        handle(ctx_verbose)
+        assert marker.exists()
+
+        # Disable with silent
+        ctx_silent = _make_ctx("silent", tmp_path)
+        handle(ctx_silent)
+        assert not marker.exists()
+
+    def test_toggle_silent_then_verbose(self, tmp_path):
+        from skills.core.verbose.handler import handle
+
+        marker = tmp_path / ".koan-verbose"
+
+        # Ensure silent (no file)
+        ctx_silent = _make_ctx("silent", tmp_path)
+        handle(ctx_silent)
+        assert not marker.exists()
+
+        # Enable verbose
+        ctx_verbose = _make_ctx("verbose", tmp_path)
+        handle(ctx_verbose)
+        assert marker.exists()


### PR DESCRIPTION
## Summary
- Adds 24 new tests for 3 skill handlers that had no dedicated test files
- `/reflect` skill: journal writing, timestamps, directory creation, multiple entries
- `/verbose` and `/silent` skills: marker file toggle behavior
- `/language` skill: set, reset, and status display

## Test coverage
- 2081 tests total (+24)
- Skills now at 17/20 covered (up from 14/20)

## Test plan
- [x] All new tests pass
- [x] Full test suite passes (2081 tests, 54s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)