### PR TITLE
fix: centralized prompt path helper + error specificity

### DIFF
--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -21,10 +21,11 @@ import sys
 from pathlib import Path
 
 from app.cli_provider import build_full_command
+from app.prompts import get_prompt_path
 from app.utils import get_model_config
 
 
-PROMPT_TEMPLATE_PATH = Path(__file__).parent.parent / "system-prompts" / "pick-mission.md"
+PROMPT_TEMPLATE_PATH = get_prompt_path("pick-mission")
 
 
 def build_prompt(

--- a/koan/app/post_mission_reflection.py
+++ b/koan/app/post_mission_reflection.py
@@ -14,6 +14,7 @@ from datetime import datetime
 from pathlib import Path
 
 from app.cli_provider import build_full_command
+from app.prompts import get_prompt_path
 from app.utils import atomic_write
 
 
@@ -61,8 +62,7 @@ def _get_prompt_template() -> str:
     Returns:
         Prompt template string
     """
-    prompt_file = Path(__file__).parent.parent / "system-prompts" / "post-mission-reflection.md"
-    return prompt_file.read_text()
+    return get_prompt_path("post-mission-reflection").read_text()
 
 
 def build_reflection_prompt(instance_dir: Path, mission_text: str) -> str:

--- a/koan/app/prompts.py
+++ b/koan/app/prompts.py
@@ -8,6 +8,18 @@ from pathlib import Path
 PROMPT_DIR = Path(__file__).parent.parent / "system-prompts"
 
 
+def get_prompt_path(name: str) -> Path:
+    """Return the full path to a system prompt file.
+
+    Args:
+        name: Prompt file name without .md extension (e.g. "chat", "pick-mission")
+
+    Returns:
+        Path to the prompt file (e.g. koan/system-prompts/chat.md)
+    """
+    return PROMPT_DIR / f"{name}.md"
+
+
 def _substitute(template: str, kwargs: dict) -> str:
     """Replace {KEY} placeholders in a template string."""
     for key, value in kwargs.items():

--- a/koan/app/reset_parser.py
+++ b/koan/app/reset_parser.py
@@ -56,7 +56,7 @@ def parse_reset_time(text: str, now: Optional[datetime] = None) -> Tuple[Optiona
 
     try:
         tz = ZoneInfo(tz_name)
-    except Exception:
+    except (KeyError, ValueError):
         tz = ZoneInfo("Europe/Paris")
 
     # Parse the time component

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from app.prompts import PROMPT_DIR, _substitute, load_prompt, load_skill_prompt
+from app.prompts import PROMPT_DIR, _substitute, get_prompt_path, load_prompt, load_skill_prompt
 
 
 # ---------- _substitute ----------
@@ -85,6 +85,35 @@ class TestLoadPrompt:
             name = md_file.stem
             result = load_prompt(name)
             assert len(result) > 0, f"Prompt {name} is empty"
+
+
+# ---------- get_prompt_path ----------
+
+
+class TestGetPromptPath:
+    """Tests for the prompt path helper."""
+
+    def test_returns_path_object(self):
+        result = get_prompt_path("chat")
+        assert isinstance(result, Path)
+
+    def test_path_includes_md_extension(self):
+        result = get_prompt_path("format-telegram")
+        assert result.name == "format-telegram.md"
+
+    def test_path_is_in_prompt_dir(self):
+        result = get_prompt_path("agent")
+        assert result.parent == PROMPT_DIR
+
+    def test_path_for_existing_prompt(self):
+        result = get_prompt_path("chat")
+        assert result.exists()
+
+    def test_path_for_nonexistent_prompt(self):
+        """Path is returned even if file doesn't exist (caller handles that)."""
+        result = get_prompt_path("does-not-exist")
+        assert isinstance(result, Path)
+        assert not result.exists()
 
 
 # ---------- load_skill_prompt ----------


### PR DESCRIPTION
## Summary
- Adds `get_prompt_path()` helper in `prompts.py` — centralizes the common pattern of building system-prompt file paths
- Refactors `pick_mission.py` and `post_mission_reflection.py` to use the new helper (eliminates duplicated `Path(__file__).parent.parent / "system-prompts"` pattern)
- Fixes broad exception catch in `reset_parser.py:59` — now catches specific `KeyError, ValueError` instead of generic `Exception`

## Test plan
- [x] 5 new tests for `get_prompt_path()` added
- [x] Full test suite passes (2062 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)