### PR TITLE
feat: extract loop management utilities from run.sh into Python

### DIFF
--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -1,0 +1,355 @@
+"""
+Koan -- Loop management utilities for run.sh.
+
+Extracts data-processing and decision-making logic from the main loop
+into testable Python functions. Follows the pattern set by mission_runner.py
+and contemplative_runner.py.
+
+Extracted blocks:
+1. Project config validation and lookup (bash array parsing -> Python)
+2. Autonomous mode focus area resolution
+3. Pending.md file creation
+4. Interruptible sleep logic with wake-on-mission
+
+CLI interface for run.sh:
+    python -m app.loop_manager resolve-focus --mode <mode>
+    python -m app.loop_manager create-pending --instance ... --project-name ...
+    python -m app.loop_manager validate-projects
+    python -m app.loop_manager lookup-project --name <name>
+    python -m app.loop_manager interruptible-sleep --interval <seconds> --koan-root ...
+"""
+
+import os
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+# --- Focus area resolution ---
+
+# Maps autonomous mode to human-readable focus area description.
+_FOCUS_AREAS = {
+    "review": "Low-cost review: audit code, find issues, suggest improvements (READ-ONLY)",
+    "implement": "Medium-cost implementation: prototype fixes, small improvements",
+    "deep": "High-cost deep work: refactoring, architectural changes",
+}
+
+
+def resolve_focus_area(autonomous_mode: str, has_mission: bool = False) -> str:
+    """Resolve the focus area description for a given autonomous mode.
+
+    Args:
+        autonomous_mode: Current mode (review/implement/deep/wait).
+        has_mission: Whether a specific mission was assigned.
+
+    Returns:
+        Human-readable focus area string.
+    """
+    if has_mission:
+        return "Execute assigned mission"
+    return _FOCUS_AREAS.get(autonomous_mode, "General autonomous work")
+
+
+# --- Project config validation and lookup ---
+
+
+def validate_projects(
+    project_names: list, project_paths: list, max_projects: int = 5
+) -> Optional[str]:
+    """Validate project configuration.
+
+    Args:
+        project_names: List of project names.
+        project_paths: Corresponding list of project paths.
+        max_projects: Maximum allowed projects.
+
+    Returns:
+        Error message string if validation fails, None if valid.
+    """
+    if not project_names:
+        return "No projects configured. Set KOAN_PROJECT_PATH or KOAN_PROJECTS env var."
+
+    if len(project_names) > max_projects:
+        return f"Max {max_projects} projects allowed. You have {len(project_names)}."
+
+    for name, path in zip(project_names, project_paths):
+        if not os.path.isdir(path):
+            return f"Project '{name}' path does not exist: {path}"
+
+    return None
+
+
+def lookup_project(project_name: str, project_names: list, project_paths: list) -> Optional[str]:
+    """Find project path by name.
+
+    Args:
+        project_name: Name to look up.
+        project_names: List of known project names.
+        project_paths: Corresponding list of project paths.
+
+    Returns:
+        Project path if found, None otherwise.
+    """
+    for name, path in zip(project_names, project_paths):
+        if name == project_name:
+            return path
+    return None
+
+
+def format_project_list(project_names: list) -> str:
+    """Format project names as a sorted bullet list.
+
+    Args:
+        project_names: List of project names.
+
+    Returns:
+        Formatted string with bullet points, one per line.
+    """
+    return "\n".join(f"  \u2022 {name}" for name in sorted(project_names))
+
+
+# --- Pending.md creation ---
+
+
+def create_pending_file(
+    instance_dir: str,
+    project_name: str,
+    run_num: int,
+    max_runs: int,
+    autonomous_mode: str,
+    mission_title: str = "",
+) -> str:
+    """Create the pending.md progress journal file for a run.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project_name: Current project name.
+        run_num: Current run number.
+        max_runs: Maximum runs per session.
+        autonomous_mode: Current autonomous mode.
+        mission_title: Mission title (empty for autonomous runs).
+
+    Returns:
+        Path to the created pending.md file.
+    """
+    pending_path = Path(instance_dir) / "journal" / "pending.md"
+    journal_dir = Path(instance_dir) / "journal" / datetime.now().strftime("%Y-%m-%d")
+    journal_dir.mkdir(parents=True, exist_ok=True)
+
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    if mission_title:
+        header = f"# Mission: {mission_title}"
+        mode = autonomous_mode if autonomous_mode else "mission"
+    else:
+        header = "# Autonomous run"
+        mode = autonomous_mode
+
+    content = f"""{header}
+Project: {project_name}
+Started: {now}
+Run: {run_num}/{max_runs}
+Mode: {mode}
+
+---
+"""
+    pending_path.write_text(content)
+    return str(pending_path)
+
+
+# --- Interruptible sleep ---
+
+
+def _check_signal_file(koan_root: str, filename: str) -> bool:
+    """Check if a signal file (.koan-stop, .koan-pause, etc.) exists."""
+    return os.path.isfile(os.path.join(koan_root, filename))
+
+
+def _check_pending_missions(instance_dir: str) -> bool:
+    """Check if there are pending missions in missions.md."""
+    try:
+        from app.missions import count_pending
+
+        missions_path = Path(instance_dir) / "missions.md"
+        if not missions_path.exists():
+            return False
+        return count_pending(missions_path.read_text()) > 0
+    except Exception:
+        return False
+
+
+def interruptible_sleep(
+    interval: int,
+    koan_root: str,
+    instance_dir: str,
+    check_interval: int = 10,
+) -> str:
+    """Sleep for a given interval, waking early on events.
+
+    Checks for stop, pause, restart, shutdown files and pending missions
+    every check_interval seconds.
+
+    Args:
+        interval: Total sleep duration in seconds.
+        koan_root: Path to koan root directory.
+        instance_dir: Path to instance directory.
+        check_interval: How often to check for wake events (seconds).
+
+    Returns:
+        Reason for waking: "timeout", "mission", "stop", "pause", "restart", "shutdown".
+    """
+    elapsed = 0
+    while elapsed < interval:
+        time.sleep(check_interval)
+        elapsed += check_interval
+
+        if _check_pending_missions(instance_dir):
+            return "mission"
+        if _check_signal_file(koan_root, ".koan-stop"):
+            return "stop"
+        if _check_signal_file(koan_root, ".koan-pause"):
+            return "pause"
+        if _check_signal_file(koan_root, ".koan-restart"):
+            return "restart"
+        if _check_signal_file(koan_root, ".koan-shutdown"):
+            return "shutdown"
+
+    return "timeout"
+
+
+# --- CLI interface for run.sh ---
+
+
+def _cli_resolve_focus(args: list) -> None:
+    """CLI: python -m app.loop_manager resolve-focus --mode <mode> [--has-mission]"""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", required=True)
+    parser.add_argument("--has-mission", action="store_true")
+    parsed = parser.parse_args(args)
+
+    print(resolve_focus_area(parsed.mode, parsed.has_mission))
+
+
+def _cli_create_pending(args: list) -> None:
+    """CLI: python -m app.loop_manager create-pending ..."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--instance", required=True)
+    parser.add_argument("--project-name", required=True)
+    parser.add_argument("--run-num", type=int, required=True)
+    parser.add_argument("--max-runs", type=int, required=True)
+    parser.add_argument("--autonomous-mode", default="implement")
+    parser.add_argument("--mission-title", default="")
+    parsed = parser.parse_args(args)
+
+    path = create_pending_file(
+        instance_dir=parsed.instance,
+        project_name=parsed.project_name,
+        run_num=parsed.run_num,
+        max_runs=parsed.max_runs,
+        autonomous_mode=parsed.autonomous_mode,
+        mission_title=parsed.mission_title,
+    )
+    print(path)
+
+
+def _cli_validate_projects(args: list) -> None:
+    """CLI: python -m app.loop_manager validate-projects"""
+    from app.utils import get_known_projects
+
+    projects = get_known_projects()
+    if not projects:
+        print("No projects configured.", file=sys.stderr)
+        sys.exit(1)
+
+    names = [p[0] for p in projects]
+    paths = [p[1] for p in projects]
+    error = validate_projects(names, paths)
+    if error:
+        print(error, file=sys.stderr)
+        sys.exit(1)
+
+    # Output project count and names for bash
+    for name, path in projects:
+        print(f"{name}:{path}")
+
+
+def _cli_lookup_project(args: list) -> None:
+    """CLI: python -m app.loop_manager lookup-project --name <name>"""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--name", required=True)
+    parsed = parser.parse_args(args)
+
+    from app.utils import get_known_projects
+
+    projects = get_known_projects()
+    names = [p[0] for p in projects]
+    paths = [p[1] for p in projects]
+
+    path = lookup_project(parsed.name, names, paths)
+    if path is None:
+        print(f"Unknown project: {parsed.name}", file=sys.stderr)
+        print(format_project_list(names), file=sys.stderr)
+        sys.exit(1)
+
+    print(path)
+
+
+def _cli_interruptible_sleep(args: list) -> None:
+    """CLI: python -m app.loop_manager interruptible-sleep ..."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--interval", type=int, required=True)
+    parser.add_argument("--koan-root", required=True)
+    parser.add_argument("--instance", required=True)
+    parser.add_argument("--check-interval", type=int, default=10)
+    parsed = parser.parse_args(args)
+
+    reason = interruptible_sleep(
+        interval=parsed.interval,
+        koan_root=parsed.koan_root,
+        instance_dir=parsed.instance,
+        check_interval=parsed.check_interval,
+    )
+    print(reason)
+
+
+def main() -> None:
+    """CLI entry point."""
+    if len(sys.argv) < 2:
+        print(
+            "Usage: loop_manager.py <resolve-focus|create-pending|validate-projects|"
+            "lookup-project|interruptible-sleep> [args]",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    subcommand = sys.argv[1]
+    remaining = sys.argv[2:]
+
+    commands = {
+        "resolve-focus": _cli_resolve_focus,
+        "create-pending": _cli_create_pending,
+        "validate-projects": _cli_validate_projects,
+        "lookup-project": _cli_lookup_project,
+        "interruptible-sleep": _cli_interruptible_sleep,
+    }
+
+    handler = commands.get(subcommand)
+    if handler is None:
+        print(f"Unknown subcommand: {subcommand}", file=sys.stderr)
+        sys.exit(1)
+
+    handler(remaining)
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -1,0 +1,629 @@
+"""Tests for loop_manager.py — loop management utilities for run.sh."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# --- Test resolve_focus_area ---
+
+
+class TestResolveFocusArea:
+    """Test focus area resolution from autonomous mode."""
+
+    def test_review_mode(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("review")
+        assert "READ-ONLY" in result
+        assert "review" in result.lower()
+
+    def test_implement_mode(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("implement")
+        assert "implementation" in result.lower()
+
+    def test_deep_mode(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("deep")
+        assert "deep work" in result.lower()
+
+    def test_unknown_mode_fallback(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("unknown")
+        assert result == "General autonomous work"
+
+    def test_has_mission_overrides_mode(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("deep", has_mission=True)
+        assert result == "Execute assigned mission"
+
+    def test_has_mission_with_review(self):
+        from app.loop_manager import resolve_focus_area
+
+        result = resolve_focus_area("review", has_mission=True)
+        assert result == "Execute assigned mission"
+
+    def test_wait_mode_no_special_handling(self):
+        from app.loop_manager import resolve_focus_area
+
+        # wait mode is handled separately in run.sh before resolve_focus_area
+        result = resolve_focus_area("wait")
+        assert result == "General autonomous work"
+
+
+# --- Test validate_projects ---
+
+
+class TestValidateProjects:
+    """Test project configuration validation."""
+
+    def test_valid_projects(self, tmp_path):
+        from app.loop_manager import validate_projects
+
+        p1 = tmp_path / "proj1"
+        p2 = tmp_path / "proj2"
+        p1.mkdir()
+        p2.mkdir()
+
+        result = validate_projects(["proj1", "proj2"], [str(p1), str(p2)])
+        assert result is None
+
+    def test_empty_projects(self):
+        from app.loop_manager import validate_projects
+
+        result = validate_projects([], [])
+        assert result is not None
+        assert "No projects" in result
+
+    def test_too_many_projects(self, tmp_path):
+        from app.loop_manager import validate_projects
+
+        names = [f"p{i}" for i in range(6)]
+        paths = [str(tmp_path)] * 6
+
+        result = validate_projects(names, paths)
+        assert result is not None
+        assert "Max 5" in result
+
+    def test_custom_max_projects(self, tmp_path):
+        from app.loop_manager import validate_projects
+
+        names = ["p1", "p2", "p3"]
+        paths = [str(tmp_path)] * 3
+
+        # With max_projects=2, 3 projects should fail
+        result = validate_projects(names, paths, max_projects=2)
+        assert result is not None
+        assert "Max 2" in result
+
+    def test_missing_path(self, tmp_path):
+        from app.loop_manager import validate_projects
+
+        result = validate_projects(["proj1"], ["/nonexistent/path/xyz"])
+        assert result is not None
+        assert "does not exist" in result
+        assert "proj1" in result
+
+    def test_single_valid_project(self, tmp_path):
+        from app.loop_manager import validate_projects
+
+        result = validate_projects(["koan"], [str(tmp_path)])
+        assert result is None
+
+
+# --- Test lookup_project ---
+
+
+class TestLookupProject:
+    """Test project name to path lookup."""
+
+    def test_found(self):
+        from app.loop_manager import lookup_project
+
+        result = lookup_project("web-app", ["koan", "web-app"], ["/a", "/b"])
+        assert result == "/b"
+
+    def test_not_found(self):
+        from app.loop_manager import lookup_project
+
+        result = lookup_project("unknown", ["koan", "web-app"], ["/a", "/b"])
+        assert result is None
+
+    def test_first_match(self):
+        from app.loop_manager import lookup_project
+
+        result = lookup_project("koan", ["koan", "koan"], ["/first", "/second"])
+        assert result == "/first"
+
+    def test_empty_lists(self):
+        from app.loop_manager import lookup_project
+
+        result = lookup_project("anything", [], [])
+        assert result is None
+
+
+# --- Test format_project_list ---
+
+
+class TestFormatProjectList:
+    """Test project list formatting."""
+
+    def test_sorted_output(self):
+        from app.loop_manager import format_project_list
+
+        result = format_project_list(["web-app", "backend", "koan"])
+        lines = result.strip().split("\n")
+        assert len(lines) == 3
+        assert "backend" in lines[0]
+        assert "koan" in lines[1]
+        assert "web-app" in lines[2]
+
+    def test_bullet_points(self):
+        from app.loop_manager import format_project_list
+
+        result = format_project_list(["proj"])
+        assert "\u2022" in result  # bullet character
+
+    def test_empty_list(self):
+        from app.loop_manager import format_project_list
+
+        result = format_project_list([])
+        assert result == ""
+
+
+# --- Test create_pending_file ---
+
+
+class TestCreatePendingFile:
+    """Test pending.md file creation."""
+
+    def test_mission_pending(self, tmp_path):
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="koan",
+            run_num=3,
+            max_runs=20,
+            autonomous_mode="implement",
+            mission_title="Fix the bug",
+        )
+
+        content = Path(path).read_text()
+        assert "# Mission: Fix the bug" in content
+        assert "Project: koan" in content
+        assert "Run: 3/20" in content
+        assert "Mode: implement" in content
+        assert "---" in content
+
+    def test_autonomous_pending(self, tmp_path):
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="web-app",
+            run_num=1,
+            max_runs=25,
+            autonomous_mode="deep",
+        )
+
+        content = Path(path).read_text()
+        assert "# Autonomous run" in content
+        assert "Project: web-app" in content
+        assert "Run: 1/25" in content
+        assert "Mode: deep" in content
+
+    def test_creates_journal_directory(self, tmp_path):
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        create_pending_file(
+            instance_dir=instance,
+            project_name="koan",
+            run_num=1,
+            max_runs=20,
+            autonomous_mode="implement",
+        )
+
+        # Should have created today's journal directory
+        from datetime import datetime
+        today = datetime.now().strftime("%Y-%m-%d")
+        assert os.path.isdir(os.path.join(instance, "journal", today))
+
+    def test_returns_path(self, tmp_path):
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="koan",
+            run_num=1,
+            max_runs=20,
+            autonomous_mode="implement",
+        )
+
+        assert path.endswith("pending.md")
+        assert os.path.isfile(path)
+
+    def test_mission_mode_fallback(self, tmp_path):
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        # Empty autonomous mode with mission title should show "mission"
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="koan",
+            run_num=1,
+            max_runs=20,
+            autonomous_mode="",
+            mission_title="Do stuff",
+        )
+
+        content = Path(path).read_text()
+        assert "Mode: mission" in content
+
+
+# --- Test interruptible_sleep ---
+
+
+class TestInterruptibleSleep:
+    """Test interruptible sleep with wake-on-event."""
+
+    def test_timeout(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Very short interval + check interval — should timeout immediately
+        result = interruptible_sleep(
+            interval=1,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "timeout"
+
+    def test_stop_file_wakes(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Pre-create stop file
+        Path(os.path.join(koan_root, ".koan-stop")).touch()
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "stop"
+
+    def test_pause_file_wakes(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Pre-create pause file
+        Path(os.path.join(koan_root, ".koan-pause")).touch()
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "pause"
+
+    def test_restart_file_wakes(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Pre-create restart file
+        Path(os.path.join(koan_root, ".koan-restart")).touch()
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "restart"
+
+    def test_shutdown_file_wakes(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Pre-create shutdown file
+        Path(os.path.join(koan_root, ".koan-shutdown")).touch()
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "shutdown"
+
+    def test_mission_wakes(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Create a missions.md with a pending mission
+        missions_md = Path(instance) / "missions.md"
+        missions_md.write_text("## En attente\n\n- Fix the bug\n\n## Terminées\n")
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "mission"
+
+    def test_priority_stop_over_pause(self, tmp_path):
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        # Both stop and pause — stop is checked first (after mission)
+        Path(os.path.join(koan_root, ".koan-stop")).touch()
+        Path(os.path.join(koan_root, ".koan-pause")).touch()
+
+        result = interruptible_sleep(
+            interval=60,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+        )
+        assert result == "stop"
+
+
+# --- Test internal helpers ---
+
+
+class TestCheckHelpers:
+    """Test file-checking helper functions."""
+
+    def test_check_signal_file_stop_exists(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        Path(tmp_path / ".koan-stop").touch()
+        assert _check_signal_file(str(tmp_path), ".koan-stop") is True
+
+    def test_check_signal_file_stop_missing(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        assert _check_signal_file(str(tmp_path), ".koan-stop") is False
+
+    def test_check_signal_file_pause_exists(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        Path(tmp_path / ".koan-pause").touch()
+        assert _check_signal_file(str(tmp_path), ".koan-pause") is True
+
+    def test_check_signal_file_pause_missing(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        assert _check_signal_file(str(tmp_path), ".koan-pause") is False
+
+    def test_check_signal_file_shutdown_exists(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        Path(tmp_path / ".koan-shutdown").touch()
+        assert _check_signal_file(str(tmp_path), ".koan-shutdown") is True
+
+    def test_check_signal_file_shutdown_missing(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        assert _check_signal_file(str(tmp_path), ".koan-shutdown") is False
+
+    def test_check_signal_file_restart_exists(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        Path(tmp_path / ".koan-restart").touch()
+        assert _check_signal_file(str(tmp_path), ".koan-restart") is True
+
+    def test_check_signal_file_restart_missing(self, tmp_path):
+        from app.loop_manager import _check_signal_file
+
+        assert _check_signal_file(str(tmp_path), ".koan-restart") is False
+
+    def test_check_pending_missions_with_missions(self, tmp_path):
+        from app.loop_manager import _check_pending_missions
+
+        missions = tmp_path / "missions.md"
+        missions.write_text("## En attente\n\n- Do something\n\n## Terminées\n")
+
+        assert _check_pending_missions(str(tmp_path)) is True
+
+    def test_check_pending_missions_empty(self, tmp_path):
+        from app.loop_manager import _check_pending_missions
+
+        missions = tmp_path / "missions.md"
+        missions.write_text("## En attente\n\n## Terminées\n")
+
+        assert _check_pending_missions(str(tmp_path)) is False
+
+    def test_check_pending_missions_no_file(self, tmp_path):
+        from app.loop_manager import _check_pending_missions
+
+        assert _check_pending_missions(str(tmp_path)) is False
+
+
+# --- Test CLI interface ---
+
+
+class TestCLI:
+    """Test CLI interface for run.sh integration."""
+
+    def test_resolve_focus_cli(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "resolve-focus",
+             "--mode", "deep"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 0
+        assert "deep work" in result.stdout.lower()
+
+    def test_resolve_focus_with_mission(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "resolve-focus",
+             "--mode", "review", "--has-mission"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 0
+        assert "Execute assigned mission" in result.stdout
+
+    def test_create_pending_cli(self, tmp_path):
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "journal").mkdir()
+
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "create-pending",
+             "--instance", str(instance),
+             "--project-name", "koan",
+             "--run-num", "5",
+             "--max-runs", "20",
+             "--autonomous-mode", "deep",
+             "--mission-title", "Test mission"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode == 0
+        assert "pending.md" in result.stdout
+
+        # Verify the file was created
+        pending = instance / "journal" / "pending.md"
+        assert pending.exists()
+        content = pending.read_text()
+        assert "# Mission: Test mission" in content
+
+    def test_unknown_subcommand(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "unknown-cmd"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode != 0
+
+    def test_no_subcommand(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+        )
+        assert result.returncode != 0
+
+    def test_interruptible_sleep_cli(self, tmp_path):
+        """Test CLI with very short interval — should timeout quickly."""
+        koan_root = tmp_path / "root"
+        instance = tmp_path / "instance"
+        koan_root.mkdir()
+        instance.mkdir()
+
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "interruptible-sleep",
+             "--interval", "1",
+             "--koan-root", str(koan_root),
+             "--instance", str(instance),
+             "--check-interval", "1"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            timeout=10,
+        )
+        assert result.returncode == 0
+        assert "timeout" in result.stdout.strip()
+
+    def test_validate_projects_cli(self, tmp_path, monkeypatch):
+        """Test validate-projects CLI."""
+        proj = tmp_path / "myproj"
+        proj.mkdir()
+        monkeypatch.setenv("KOAN_PROJECTS", f"myproj:{proj}")
+
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "validate-projects"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            env={**os.environ, "KOAN_PROJECTS": f"myproj:{proj}"},
+        )
+        assert result.returncode == 0
+        assert "myproj" in result.stdout
+
+    def test_lookup_project_cli(self, tmp_path):
+        """Test lookup-project CLI."""
+        proj = tmp_path / "koan"
+        proj.mkdir()
+
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "lookup-project",
+             "--name", "koan"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            env={**os.environ, "KOAN_PROJECTS": f"koan:{proj}"},
+        )
+        assert result.returncode == 0
+        assert str(proj) in result.stdout
+
+    def test_lookup_project_not_found(self, tmp_path):
+        """Test lookup-project CLI with unknown project."""
+        proj = tmp_path / "koan"
+        proj.mkdir()
+
+        result = subprocess.run(
+            [sys.executable, "-m", "app.loop_manager", "lookup-project",
+             "--name", "unknown"],
+            capture_output=True, text=True,
+            cwd=str(Path(__file__).parent.parent),
+            env={**os.environ, "KOAN_PROJECTS": f"koan:{proj}"},
+        )
+        assert result.returncode != 0
+        assert "Unknown project" in result.stderr


### PR DESCRIPTION
New loop_manager.py module handles:
- Focus area resolution (case statement -> dict lookup)
- Pending.md file creation (heredoc -> Python templating)
- Interruptible sleep with wake-on-event (3 duplicate loops -> 1 function) Now also checks .koan-restart signal (adapted to upstream)
- Project config validation and lookup

run.sh shrinks from 801 to 746 lines (-55). Logic moves to 353 lines of testable Python with CLI interface following mission_runner.py pattern.

52 new tests, 2572 total.