### PR TITLE
fix: eliminate RuntimeWarning in test_github_auth.py

### DIFF
--- a/koan/tests/test_github_auth.py
+++ b/koan/tests/test_github_auth.py
@@ -13,6 +13,7 @@ from app.github_auth import (
     get_gh_env,
     setup_github_auth,
 )
+from tests._helpers import run_module
 
 
 # ── get_github_user ──────────────────────────────────────────────
@@ -140,8 +141,7 @@ class TestCLIEntryPoint:
         mock_run = MagicMock(return_value=MagicMock(returncode=0, stdout="ghp_token123\n"))
         monkeypatch.setattr(subprocess, "run", mock_run)
         with pytest.raises(SystemExit) as exc_info:
-            import runpy
-            runpy.run_module("app.github_auth", run_name="__main__")
+            run_module("app.github_auth", run_name="__main__")
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
         assert "GH_TOKEN=ghp_token123" in captured.out
@@ -149,8 +149,7 @@ class TestCLIEntryPoint:
     def test_exits_0_when_no_user(self, monkeypatch):
         monkeypatch.delenv("GITHUB_USER", raising=False)
         with pytest.raises(SystemExit) as exc_info:
-            import runpy
-            runpy.run_module("app.github_auth", run_name="__main__")
+            run_module("app.github_auth", run_name="__main__")
         assert exc_info.value.code == 0
 
     def test_exits_1_on_failure(self, monkeypatch):
@@ -160,6 +159,5 @@ class TestCLIEntryPoint:
         monkeypatch.setattr(subprocess, "run", mock_run)
         with patch("app.notify.send_telegram"):
             with pytest.raises(SystemExit) as exc_info:
-                import runpy
-                runpy.run_module("app.github_auth", run_name="__main__")
+                run_module("app.github_auth", run_name="__main__")
             assert exc_info.value.code == 1


### PR DESCRIPTION
## Summary
- Use the `run_module` helper from `tests/_helpers.py` instead of raw `runpy.run_module()`
- This clears `sys.modules` before execution to avoid the "found in sys.modules after import" warning
- Reduces test warnings from 3 to 0

## Test plan
- [x] All 21 tests in test_github_auth.py pass
- [x] Full test suite passes (2134 tests)
- [x] No RuntimeWarnings when running with `-W error::RuntimeWarning`

🤖 Generated with [Claude Code](https://claude.com/claude-code)