### PR TITLE
test: add tests for focus and magic skills

### DIFF
--- a/koan/tests/test_focus_skill.py
+++ b/koan/tests/test_focus_skill.py
@@ -1,0 +1,140 @@
+"""Tests for the /focus and /unfocus skill handlers."""
+
+import json
+from unittest.mock import MagicMock
+
+from app.skills import SkillContext
+
+
+def _make_ctx(command_name, koan_root, args=""):
+    """Create a minimal SkillContext for testing."""
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = command_name
+    ctx.koan_root = koan_root
+    ctx.args = args
+    return ctx
+
+
+class TestFocusCommand:
+    """Tests for /focus command."""
+
+    def test_focus_creates_marker_file(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path)
+        result = handle(ctx)
+
+        assert "ON" in result or "🎯" in result
+        marker = tmp_path / ".koan-focus"
+        assert marker.exists()
+
+    def test_focus_default_duration(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path)
+        result = handle(ctx)
+
+        # Default is 5h
+        assert "5h" in result or "5 h" in result
+        marker = tmp_path / ".koan-focus"
+        assert marker.exists()
+
+    def test_focus_custom_duration(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path, args="3h")
+        result = handle(ctx)
+
+        assert "3h" in result or "3 h" in result
+        marker = tmp_path / ".koan-focus"
+        assert marker.exists()
+
+    def test_focus_duration_with_minutes(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path, args="2h30m")
+        result = handle(ctx)
+
+        assert "ON" in result
+        marker = tmp_path / ".koan-focus"
+        assert marker.exists()
+
+    def test_focus_invalid_duration(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path, args="invalid")
+        result = handle(ctx)
+
+        assert "Invalid" in result or "❌" in result
+        marker = tmp_path / ".koan-focus"
+        assert not marker.exists()
+
+    def test_focus_response_mentions_missions_only(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        ctx = _make_ctx("focus", tmp_path)
+        result = handle(ctx)
+
+        assert "mission" in result.lower()
+
+
+class TestUnfocusCommand:
+    """Tests for /unfocus command."""
+
+    def test_unfocus_removes_marker(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        # First create focus state
+        marker = tmp_path / ".koan-focus"
+        marker.write_text(json.dumps({"end_time": 9999999999}))
+
+        ctx = _make_ctx("unfocus", tmp_path)
+        result = handle(ctx)
+
+        assert "OFF" in result or "🎯" in result
+        assert not marker.exists()
+
+    def test_unfocus_when_not_focused(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        # No marker file exists
+        ctx = _make_ctx("unfocus", tmp_path)
+        result = handle(ctx)
+
+        assert "Not" in result or "not" in result
+
+
+class TestFocusUnfocusToggle:
+    """Test toggling between focus and unfocus modes."""
+
+    def test_toggle_focus_then_unfocus(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        marker = tmp_path / ".koan-focus"
+
+        # Enable focus
+        ctx_focus = _make_ctx("focus", tmp_path)
+        handle(ctx_focus)
+        assert marker.exists()
+
+        # Disable with unfocus
+        ctx_unfocus = _make_ctx("unfocus", tmp_path)
+        handle(ctx_unfocus)
+        assert not marker.exists()
+
+    def test_focus_overwrites_existing(self, tmp_path):
+        from skills.core.focus.handler import handle
+
+        marker = tmp_path / ".koan-focus"
+
+        # Enable focus with 2h
+        ctx1 = _make_ctx("focus", tmp_path, args="2h")
+        handle(ctx1)
+        assert marker.exists()
+
+        # Enable again with 4h - should overwrite
+        ctx2 = _make_ctx("focus", tmp_path, args="4h")
+        result = handle(ctx2)
+
+        assert marker.exists()
+        assert "4h" in result or "4 h" in result

--- a/koan/tests/test_magic_skill.py
+++ b/koan/tests/test_magic_skill.py
@@ -1,0 +1,312 @@
+"""Tests for the /magic skill handler — creative project exploration."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.skills import SkillContext
+
+
+def _make_ctx(koan_root, instance_dir, send_message=None):
+    """Create a minimal SkillContext for testing."""
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = "magic"
+    ctx.koan_root = koan_root
+    ctx.instance_dir = instance_dir
+    ctx.args = ""
+    ctx.send_message = send_message
+    return ctx
+
+
+class TestGetProjects:
+    """Tests for _get_projects helper."""
+
+    def test_returns_empty_when_no_projects(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import _get_projects
+
+        monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+        monkeypatch.delenv("KOAN_PROJECT_PATH", raising=False)
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+        with patch("app.utils.get_known_projects", return_value=[]):
+            result = _get_projects(ctx)
+
+        assert result == []
+
+    def test_returns_projects_from_get_known_projects(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import _get_projects
+
+        # Create a real directory to pass the is_dir check
+        project_path = tmp_path / "myproject"
+        project_path.mkdir()
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+        with patch(
+            "app.utils.get_known_projects",
+            return_value=[("myproject", str(project_path))],
+        ):
+            result = _get_projects(ctx)
+
+        assert len(result) == 1
+        assert result[0][0] == "myproject"
+
+    def test_filters_out_nonexistent_directories(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import _get_projects
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+        with patch(
+            "app.utils.get_known_projects",
+            return_value=[("fake", "/nonexistent/path")],
+        ):
+            result = _get_projects(ctx)
+
+        assert result == []
+
+    def test_fallback_to_koan_project_path(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import _get_projects
+
+        project_path = tmp_path / "fallback"
+        project_path.mkdir()
+
+        monkeypatch.setenv("KOAN_PROJECT_PATH", str(project_path))
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+        with patch(
+            "app.utils.get_known_projects",
+            side_effect=Exception("Failed"),
+        ):
+            result = _get_projects(ctx)
+
+        assert len(result) == 1
+        assert result[0][0] == "fallback"
+
+
+class TestGetMissionsContext:
+    """Tests for _get_missions_context helper."""
+
+    def test_returns_default_when_no_file(self, tmp_path):
+        from skills.core.magic.handler import _get_missions_context
+
+        result = _get_missions_context(tmp_path)
+        assert "No active missions" in result
+
+    def test_returns_pending_missions(self, tmp_path):
+        from skills.core.magic.handler import _get_missions_context
+
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            """# Missions
+
+## Pending
+
+- Task 1
+- Task 2
+
+## In Progress
+
+## Done
+"""
+        )
+
+        result = _get_missions_context(tmp_path)
+        assert "Pending" in result
+        assert "Task 1" in result
+
+    def test_returns_in_progress_missions(self, tmp_path):
+        from skills.core.magic.handler import _get_missions_context
+
+        missions_file = tmp_path / "missions.md"
+        missions_file.write_text(
+            """# Missions
+
+## Pending
+
+## In Progress
+
+- Working on feature
+
+## Done
+"""
+        )
+
+        result = _get_missions_context(tmp_path)
+        assert "In progress" in result
+        assert "Working on feature" in result
+
+
+class TestGatherGitActivity:
+    """Tests for _gather_git_activity helper."""
+
+    def test_returns_message_for_non_git_directory(self, tmp_path):
+        from skills.core.magic.handler import _gather_git_activity
+
+        result = _gather_git_activity(str(tmp_path))
+        # Either returns empty or an error message
+        assert isinstance(result, str)
+
+    def test_handles_timeout_gracefully(self, tmp_path):
+        from skills.core.magic.handler import _gather_git_activity
+
+        with patch(
+            "skills.core.magic.handler.subprocess.run",
+            side_effect=TimeoutError("Timed out"),
+        ):
+            result = _gather_git_activity(str(tmp_path))
+
+        # Should not raise, returns a string
+        assert isinstance(result, str)
+
+
+class TestGatherProjectStructure:
+    """Tests for _gather_project_structure helper."""
+
+    def test_returns_directories_and_files(self, tmp_path):
+        from skills.core.magic.handler import _gather_project_structure
+
+        # Create some structure
+        (tmp_path / "src").mkdir()
+        (tmp_path / "tests").mkdir()
+        (tmp_path / "README.md").touch()
+        (tmp_path / "setup.py").touch()
+        (tmp_path / ".hidden").touch()  # Should be excluded
+
+        result = _gather_project_structure(str(tmp_path))
+
+        assert "src/" in result
+        assert "tests/" in result
+        assert "README.md" in result
+        assert "setup.py" in result
+        assert ".hidden" not in result
+
+    def test_handles_empty_directory(self, tmp_path):
+        from skills.core.magic.handler import _gather_project_structure
+
+        result = _gather_project_structure(str(tmp_path))
+        # Empty but valid
+        assert isinstance(result, str)
+
+
+class TestCleanResponse:
+    """Tests for _clean_response helper."""
+
+    def test_removes_markdown_formatting(self):
+        from skills.core.magic.handler import _clean_response
+
+        text = "# Header\n**bold** and `code`"
+        result = _clean_response(text)
+
+        assert "**" not in result
+        assert result.startswith("Header") or "Header" in result
+
+    def test_removes_code_blocks(self):
+        from skills.core.magic.handler import _clean_response
+
+        text = "```python\nprint('hello')\n```"
+        result = _clean_response(text)
+
+        assert "```" not in result
+        assert "print('hello')" in result
+
+    def test_truncates_long_responses(self):
+        from skills.core.magic.handler import _clean_response
+
+        text = "x" * 3000
+        result = _clean_response(text)
+
+        assert len(result) <= 2000
+        assert result.endswith("...")
+
+    def test_removes_max_turns_error(self):
+        from skills.core.magic.handler import _clean_response
+
+        text = "Error: max turns reached\nActual content here"
+        result = _clean_response(text)
+
+        assert "max turns" not in result
+        assert "Actual content here" in result
+
+
+class TestHandle:
+    """Tests for the main handle function."""
+
+    def test_returns_message_when_no_projects(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import handle
+
+        monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+        monkeypatch.delenv("KOAN_PROJECT_PATH", raising=False)
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+        with patch("app.utils.get_known_projects", return_value=[]):
+            result = handle(ctx)
+
+        assert "No projects" in result
+
+    def test_sends_exploring_message(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import handle
+        import subprocess as sp
+
+        project_path = tmp_path / "testproj"
+        project_path.mkdir()
+        (tmp_path / "soul.md").write_text("Test soul")
+
+        send_fn = MagicMock()
+        ctx = _make_ctx(tmp_path, tmp_path, send_message=send_fn)
+
+        with patch(
+            "app.utils.get_known_projects",
+            return_value=[("testproj", str(project_path))],
+        ):
+            with patch.object(sp, "run") as mock_run:
+                mock_run.return_value = MagicMock(
+                    returncode=0, stdout="Great idea!", stderr=""
+                )
+                handle(ctx)
+
+        send_fn.assert_called_once()
+        assert "testproj" in send_fn.call_args[0][0]
+
+    def test_handles_claude_timeout(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import handle
+        import subprocess as sp
+
+        project_path = tmp_path / "testproj"
+        project_path.mkdir()
+        (tmp_path / "soul.md").write_text("Test soul")
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+
+        with patch(
+            "app.utils.get_known_projects",
+            return_value=[("testproj", str(project_path))],
+        ):
+            with patch.object(
+                sp, "run",
+                side_effect=sp.TimeoutExpired(cmd="claude", timeout=90),
+            ):
+                result = handle(ctx)
+
+        assert "Timeout" in result or "Try again" in result
+
+    def test_handles_claude_error(self, tmp_path, monkeypatch):
+        from skills.core.magic.handler import handle
+        import subprocess as sp
+
+        project_path = tmp_path / "testproj"
+        project_path.mkdir()
+        (tmp_path / "soul.md").write_text("Test soul")
+
+        ctx = _make_ctx(tmp_path, tmp_path)
+
+        with patch(
+            "app.utils.get_known_projects",
+            return_value=[("testproj", str(project_path))],
+        ):
+            with patch.object(
+                sp, "run",
+                side_effect=Exception("Something went wrong"),
+            ):
+                result = handle(ctx)
+
+        assert "Error" in result or "Try again" in result


### PR DESCRIPTION
## Summary

Add 29 new tests for the two remaining skill handlers without dedicated test files:
- `test_focus_skill.py` (10 tests): /focus and /unfocus command handlers
- `test_magic_skill.py` (19 tests): /magic creative project exploration

## Details

**Focus skill tests** (10):
- Focus creates marker file with correct duration
- Custom duration parsing (e.g., "3h", "2h30m")
- Invalid duration handling
- Unfocus removes marker
- Toggle behavior

**Magic skill tests** (19):
- `_get_projects()` helper: project discovery, filtering, fallback
- `_get_missions_context()`: parsing pending/in-progress missions
- `_gather_git_activity()`: git log handling, timeout resilience
- `_gather_project_structure()`: directory listing, hidden file filtering
- `_clean_response()`: markdown cleanup, truncation
- `handle()`: no projects case, exploring message, timeout/error handling

## Test plan

- [x] All 29 new tests pass
- [x] Full suite: 2780 tests (2778 pass, 2 pre-existing failures in test_daily_report.py)
- [x] All 27 core skills now have dedicated test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)