### PR TITLE
fix: daily_report CLI tests use correct KOAN_ROOT

### DIFF
--- a/koan/tests/test_daily_report.py
+++ b/koan/tests/test_daily_report.py
@@ -282,30 +282,28 @@ class TestSendDailyReport:
 # ---------------------------------------------------------------------------
 
 class TestDailyReportCLI:
-    def test_cli_morning_flag(self, tmp_path):
-        missions_file = tmp_path / "missions.md"
+    def test_cli_morning_flag(self, tmp_path, monkeypatch):
+        # Set KOAN_ROOT to tmp_path so runpy.run_module uses correct paths
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        # Create instance dir for INSTANCE_DIR resolution
+        (tmp_path / "instance").mkdir()
+        missions_file = tmp_path / "instance" / "missions.md"
         missions_file.write_text("# Missions\n\n## En attente\n\n## En cours\n\n## Terminées\n\n")
-        marker = tmp_path / ".marker"
         with patch("sys.argv", ["daily_report.py", "--morning"]), \
              patch("app.notify.format_and_send", return_value=True), \
-             patch("app.daily_report.format_and_send", return_value=True), \
-             patch("app.daily_report.MISSIONS_FILE", missions_file), \
-             patch("app.daily_report.INSTANCE_DIR", tmp_path), \
-             patch("app.daily_report.REPORT_MARKER", marker), \
              pytest.raises(SystemExit) as exc_info:
             run_module("app.daily_report", run_name="__main__")
         assert exc_info.value.code == 0
 
-    def test_cli_evening_flag(self, tmp_path):
-        missions_file = tmp_path / "missions.md"
+    def test_cli_evening_flag(self, tmp_path, monkeypatch):
+        # Set KOAN_ROOT to tmp_path so runpy.run_module uses correct paths
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        # Create instance dir for INSTANCE_DIR resolution
+        (tmp_path / "instance").mkdir()
+        missions_file = tmp_path / "instance" / "missions.md"
         missions_file.write_text("# Missions\n\n## En attente\n\n## En cours\n\n## Terminées\n\n")
-        marker = tmp_path / ".marker"
         with patch("sys.argv", ["daily_report.py", "--evening"]), \
              patch("app.notify.format_and_send", return_value=True), \
-             patch("app.daily_report.format_and_send", return_value=True), \
-             patch("app.daily_report.MISSIONS_FILE", missions_file), \
-             patch("app.daily_report.INSTANCE_DIR", tmp_path), \
-             patch("app.daily_report.REPORT_MARKER", marker), \
              pytest.raises(SystemExit) as exc_info:
             run_module("app.daily_report", run_name="__main__")
         assert exc_info.value.code == 0


### PR DESCRIPTION
## Summary

Fix 2 failing tests in `test_daily_report.py::TestDailyReportCLI`:
- `test_cli_morning_flag`
- `test_cli_evening_flag`

## Root cause

When `runpy.run_module()` runs, it re-evaluates the module from scratch. The module reads `KOAN_ROOT` from the environment and creates module-level constants like `REPORT_MARKER = KOAN_ROOT / ".koan-daily-report"`.

The tests were patching `app.daily_report.REPORT_MARKER` but this doesn't affect the newly created globals when `runpy` re-runs the module.

## Fix

Use `monkeypatch.setenv("KOAN_ROOT", str(tmp_path))` before calling `run_module`, so the module initializes with the correct paths. Also create the expected `instance/` directory structure.

## Test plan

- [x] All 24 tests in test_daily_report.py pass
- [x] Full suite: 2751 passed (previously 2 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)