### PR TITLE
chore: remove unused imports from awake.py and skill_manager.py

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -43,18 +43,11 @@ from app.bridge_state import (
     TELEGRAM_HISTORY_FILE,
     TOPICS_FILE,
     _get_registry,
-    _reset_registry,
 )
 from app.cli_provider import build_full_command
 from app.command_handlers import (
-    CORE_COMMANDS,
-    _dispatch_skill,
-    _handle_help,
-    _handle_help_command,
-    _handle_skill_command,
     handle_command,
     handle_mission,
-    handle_resume,
     set_callbacks,
 )
 from app.format_outbox import format_for_telegram, load_soul, load_human_prefs, load_memory_context

--- a/koan/app/skill_manager.py
+++ b/koan/app/skill_manager.py
@@ -22,7 +22,7 @@ import subprocess
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Dict, Optional, Tuple
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Removed 8 unused imports from awake.py (bridge_state and command_handlers)
- Removed unused `List` type import from skill_manager.py

Detected via static analysis after the recent refactoring (utils.py split).

## Test plan
- [x] All affected module tests pass (234 tests)
- [x] Full test suite passes (2873 tests, 2 failures in daily_report tests are fixed in PR #168)

🤖 Generated with [Claude Code](https://claude.com/claude-code)