### PR TITLE
test: add coverage for restart_manager and recurring_scheduler

### DIFF
--- a/koan/tests/test_recurring_scheduler.py
+++ b/koan/tests/test_recurring_scheduler.py
@@ -1,0 +1,123 @@
+"""Tests for recurring_scheduler.py — CLI entry point for recurring missions."""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+import pytest
+
+from app.recurring_scheduler import main
+
+
+# ---------------------------------------------------------------------------
+# CLI argument handling
+# ---------------------------------------------------------------------------
+
+
+class TestCLIArgs:
+    def test_missing_arg_exits_1(self):
+        """Missing instance_dir argument should exit with code 1."""
+        with patch("sys.argv", ["recurring_scheduler.py"]), \
+             patch("sys.stderr", new_callable=StringIO) as mock_stderr, \
+             pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 1
+        assert "Usage:" in mock_stderr.getvalue()
+
+    def test_missing_recurring_json_exits_0(self, tmp_path):
+        """If recurring.json doesn't exist, exit silently with code 0."""
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             pytest.raises(SystemExit) as exc_info:
+            main()
+        assert exc_info.value.code == 0
+
+
+# ---------------------------------------------------------------------------
+# Successful injection
+# ---------------------------------------------------------------------------
+
+
+class TestSuccessfulInjection:
+    def test_prints_injected_missions(self, tmp_path):
+        """Injected missions should be printed with [recurring] prefix."""
+        recurring_file = tmp_path / "recurring.json"
+        recurring_file.write_text("[]")  # Empty but valid JSON
+
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             patch("app.recurring.check_and_inject", return_value=["Mission 1", "Mission 2"]) as mock_inject, \
+             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+
+        output = mock_stdout.getvalue()
+        assert "[recurring] Injected: Mission 1" in output
+        assert "[recurring] Injected: Mission 2" in output
+        mock_inject.assert_called_once()
+
+    def test_no_output_when_nothing_injected(self, tmp_path):
+        """No output when check_and_inject returns empty list."""
+        recurring_file = tmp_path / "recurring.json"
+        recurring_file.write_text("[]")
+
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             patch("app.recurring.check_and_inject", return_value=[]), \
+             patch("sys.stdout", new_callable=StringIO) as mock_stdout:
+            main()
+
+        assert mock_stdout.getvalue() == ""
+
+
+# ---------------------------------------------------------------------------
+# Error handling
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    def test_exception_logged_to_stderr(self, tmp_path):
+        """Exceptions should be logged to stderr, not crash."""
+        recurring_file = tmp_path / "recurring.json"
+        recurring_file.write_text("[]")
+
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             patch("app.recurring.check_and_inject", side_effect=ValueError("parse error")), \
+             patch("sys.stderr", new_callable=StringIO) as mock_stderr:
+            # Should not raise
+            main()
+
+        output = mock_stderr.getvalue()
+        assert "[recurring] Error:" in output
+        assert "parse error" in output
+
+    def test_does_not_exit_on_error(self, tmp_path):
+        """Errors are non-fatal — function should return, not exit."""
+        recurring_file = tmp_path / "recurring.json"
+        recurring_file.write_text("[]")
+
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             patch("app.recurring.check_and_inject", side_effect=Exception("boom")), \
+             patch("sys.stderr", new_callable=StringIO):
+            # Should complete without raising or exiting
+            main()
+
+
+# ---------------------------------------------------------------------------
+# Path resolution
+# ---------------------------------------------------------------------------
+
+
+class TestPathResolution:
+    def test_recurring_json_path(self, tmp_path):
+        """Should look for recurring.json in instance_dir."""
+        recurring_file = tmp_path / "recurring.json"
+        recurring_file.write_text("[]")
+
+        with patch("sys.argv", ["recurring_scheduler.py", str(tmp_path)]), \
+             patch("app.recurring.check_and_inject") as mock_inject:
+            mock_inject.return_value = []
+            main()
+
+        # Check that check_and_inject was called with correct paths
+        args = mock_inject.call_args[0]
+        assert args[0] == recurring_file
+        assert args[1] == tmp_path / "missions.md"

--- a/koan/tests/test_restart_manager.py
+++ b/koan/tests/test_restart_manager.py
@@ -1,0 +1,210 @@
+"""Tests for restart_manager.py — file-based restart signaling."""
+
+import os
+import sys
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.restart_manager import (
+    RESTART_FILE,
+    RESTART_EXIT_CODE,
+    request_restart,
+    check_restart,
+    clear_restart,
+    reexec_bridge,
+)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_restart_file_name(self):
+        assert RESTART_FILE == ".koan-restart"
+
+    def test_restart_exit_code(self):
+        assert RESTART_EXIT_CODE == 42
+
+
+# ---------------------------------------------------------------------------
+# request_restart
+# ---------------------------------------------------------------------------
+
+
+class TestRequestRestart:
+    def test_creates_file(self, tmp_path):
+        request_restart(tmp_path)
+        restart_file = tmp_path / RESTART_FILE
+        assert restart_file.exists()
+
+    def test_file_contains_timestamp(self, tmp_path):
+        request_restart(tmp_path)
+        content = (tmp_path / RESTART_FILE).read_text()
+        assert "restart requested at" in content
+        assert ":" in content  # Time format HH:MM:SS
+
+    def test_overwrites_existing_file(self, tmp_path):
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("old content")
+        request_restart(tmp_path)
+        content = restart_file.read_text()
+        assert "old content" not in content
+        assert "restart requested at" in content
+
+
+# ---------------------------------------------------------------------------
+# check_restart
+# ---------------------------------------------------------------------------
+
+
+class TestCheckRestart:
+    def test_returns_false_when_no_file(self, tmp_path):
+        assert check_restart(tmp_path) is False
+
+    def test_returns_true_when_file_exists(self, tmp_path):
+        (tmp_path / RESTART_FILE).write_text("restart")
+        assert check_restart(tmp_path) is True
+
+    def test_respects_since_parameter_newer(self, tmp_path):
+        """File modified after 'since' should return True."""
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        # File was just created, so mtime is recent
+        old_time = time.time() - 60  # 1 minute ago
+        assert check_restart(tmp_path, since=old_time) is True
+
+    def test_respects_since_parameter_older(self, tmp_path):
+        """File modified before 'since' should return False (stale signal)."""
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        # Set file mtime to 5 seconds ago
+        old_mtime = time.time() - 5
+        os.utime(restart_file, (old_mtime, old_mtime))
+        # Check with 'since' = 2 seconds ago (more recent than file)
+        since_time = time.time() - 2
+        assert check_restart(tmp_path, since=since_time) is False
+
+    def test_since_zero_ignores_mtime(self, tmp_path):
+        """When since=0, mtime is not checked."""
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        # Even with old mtime, since=0 should return True
+        old_mtime = time.time() - 3600  # 1 hour ago
+        os.utime(restart_file, (old_mtime, old_mtime))
+        assert check_restart(tmp_path, since=0) is True
+
+    def test_since_exact_boundary(self, tmp_path):
+        """File with mtime == since should return False (not strictly after)."""
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        mtime = restart_file.stat().st_mtime
+        # since == mtime means file was NOT modified AFTER since
+        assert check_restart(tmp_path, since=mtime) is False
+
+
+# ---------------------------------------------------------------------------
+# clear_restart
+# ---------------------------------------------------------------------------
+
+
+class TestClearRestart:
+    def test_removes_existing_file(self, tmp_path):
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        clear_restart(tmp_path)
+        assert not restart_file.exists()
+
+    def test_no_error_when_file_missing(self, tmp_path):
+        # Should not raise even if file doesn't exist
+        clear_restart(tmp_path)
+        assert not (tmp_path / RESTART_FILE).exists()
+
+    def test_idempotent(self, tmp_path):
+        """Multiple clears should be safe."""
+        restart_file = tmp_path / RESTART_FILE
+        restart_file.write_text("restart")
+        clear_restart(tmp_path)
+        clear_restart(tmp_path)
+        clear_restart(tmp_path)
+        assert not restart_file.exists()
+
+
+# ---------------------------------------------------------------------------
+# reexec_bridge
+# ---------------------------------------------------------------------------
+
+
+class TestReexecBridge:
+    def test_calls_execv_with_correct_args(self):
+        """reexec_bridge should call os.execv with sys.executable and sys.argv."""
+        mock_execv = MagicMock()
+        mock_argv = ["bridge.py", "--some-arg"]
+        mock_executable = "/usr/bin/python3"
+
+        with patch("app.restart_manager.os.execv", mock_execv), \
+             patch("app.restart_manager.sys.argv", mock_argv), \
+             patch("app.restart_manager.sys.executable", mock_executable):
+            reexec_bridge()
+
+        mock_execv.assert_called_once_with(
+            "/usr/bin/python3",
+            ["/usr/bin/python3", "bridge.py", "--some-arg"]
+        )
+
+    def test_preserves_all_argv(self):
+        """All command line arguments should be passed to the new process."""
+        mock_execv = MagicMock()
+        mock_argv = ["script.py", "-v", "--config", "/path/to/config.yaml", "extra"]
+
+        with patch("app.restart_manager.os.execv", mock_execv), \
+             patch("app.restart_manager.sys.argv", mock_argv), \
+             patch("app.restart_manager.sys.executable", "/python"):
+            reexec_bridge()
+
+        args = mock_execv.call_args[0][1]
+        assert args == ["/python", "script.py", "-v", "--config", "/path/to/config.yaml", "extra"]
+
+
+# ---------------------------------------------------------------------------
+# Integration scenarios
+# ---------------------------------------------------------------------------
+
+
+class TestRestartWorkflow:
+    def test_full_restart_cycle(self, tmp_path):
+        """Test the complete request → check → clear cycle."""
+        # Initially no restart pending
+        assert check_restart(tmp_path) is False
+
+        # Request restart
+        request_restart(tmp_path)
+        assert check_restart(tmp_path) is True
+
+        # Clear it
+        clear_restart(tmp_path)
+        assert check_restart(tmp_path) is False
+
+    def test_stale_signal_ignored(self, tmp_path):
+        """Stale restart signals from previous incarnation should be ignored."""
+        # Create a restart signal
+        request_restart(tmp_path)
+        restart_file = tmp_path / RESTART_FILE
+
+        # Backdate the file to simulate stale signal
+        old_mtime = time.time() - 300  # 5 minutes ago
+        os.utime(restart_file, (old_mtime, old_mtime))
+
+        # Process startup time is "now"
+        startup_time = time.time()
+
+        # Stale signal should be ignored
+        assert check_restart(tmp_path, since=startup_time) is False
+
+        # But a fresh request should work
+        request_restart(tmp_path)
+        assert check_restart(tmp_path, since=startup_time) is True


### PR DESCRIPTION
## Summary

- **restart_manager.py**: 18 tests covering file-based restart signaling (request, check, clear, reexec), timestamp validation, and stale signal detection
- **recurring_scheduler.py**: 7 tests covering CLI args, path resolution, output formatting, and error handling

Previously these 2 modules had zero test coverage.

## Test count

- Before: 2873 tests
- After: 2898 tests (+25)

---

🤖 Generated with [Claude Code](https://claude.ai/code)