### PR TITLE
fix: prevent missions from staying in Pending after completion

### DIFF
--- a/koan/app/mission_history.py
+++ b/koan/app/mission_history.py
@@ -8,7 +8,7 @@ import json
 import time
 from pathlib import Path
 
-from app.utils import atomic_write
+from app.utils import _PROJECT_TAG_STRIP_RE, atomic_write
 
 
 _HISTORY_FILE = "mission_history.json"
@@ -20,9 +20,15 @@ def _history_path(instance_dir: str) -> Path:
 
 
 def _normalize_key(mission_text: str) -> str:
-    """Normalize mission text to a stable key for matching."""
+    """Normalize mission text to a stable key for matching.
+
+    Strips leading ``- ``, ``[project:X]`` / ``[projet:X]`` tags, and
+    whitespace so the same mission recorded with or without a project tag
+    shares one dedup counter.
+    """
     line = mission_text.strip().split("\n")[0]
     line = line.lstrip("- ").strip()
+    line = _PROJECT_TAG_STRIP_RE.sub("", line).strip()
     return line
 
 


### PR DESCRIPTION
Three bugs caused completed missions to remain in Pending, leading to infinite re-execution:

1. _move_pending_to_section() used index-based removal that mismatched when ### sub-headers existed. Replaced with text-based scanning via new _remove_pending_by_text() helper.

2. Quota exhaustion path skipped _finalize_mission(). Moved mission completion before the post-mission pipeline so it always runs.

3. _normalize_key() didn't strip [project:X] tags, causing the same mission with/without tags to get separate dedup counters.

Also added diagnostic logging when mission removal is a no-op.