### PR TITLE
Fix Copilot CLI permission denied errors

### DIFF
--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -154,12 +154,20 @@ def format_for_telegram(raw_content: str, soul: str, prefs: str,
     if lang_instruction:
         prompt += f"\n\n{lang_instruction}"
 
+    # Get KOAN_ROOT for proper working directory
+    import os
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if not koan_root:
+        print("[format_outbox] KOAN_ROOT not set, using current directory", file=sys.stderr)
+        koan_root = None
+
     try:
         # Call CLI to format the message (lightweight model)
         models = get_model_config()
         cmd = build_full_command(prompt=prompt, model=models["lightweight"])
         result = subprocess.run(
             cmd,
+            cwd=koan_root,
             input=None,  # Prompt is self-contained
             capture_output=True,
             text=True,

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -51,6 +51,10 @@ def build_prompt(
 
 def call_claude(prompt: str) -> str:
     """Call Claude CLI with the picker prompt. Returns raw text output."""
+    # Get KOAN_ROOT for proper working directory
+    import os
+    koan_root = os.environ.get("KOAN_ROOT", "")
+
     models = get_model_config()
     cmd = build_full_command(
         prompt=prompt,
@@ -60,6 +64,7 @@ def call_claude(prompt: str) -> str:
     )
     result = subprocess.run(
         cmd,
+        cwd=koan_root if koan_root else None,
         capture_output=True,
         text=True,
         timeout=60,

--- a/koan/app/rituals.py
+++ b/koan/app/rituals.py
@@ -55,6 +55,13 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         print(f"[rituals] {e}", file=sys.stderr)
         return False
 
+    # Get KOAN_ROOT for proper working directory
+    import os
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if not koan_root:
+        print("[rituals] KOAN_ROOT not set", file=sys.stderr)
+        return False
+
     try:
         cmd = build_full_command(
             prompt=prompt,
@@ -63,6 +70,7 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         )
         result = subprocess.run(
             cmd,
+            cwd=koan_root,
             capture_output=True, text=True, timeout=90,
             check=False
         )

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -522,7 +522,7 @@ def handle_pause(
                 cmd=cmd,
                 stdout_file=os.devnull,
                 stderr_file=os.devnull,
-                cwd=instance,
+                cwd=koan_root,
             )
             log("pause", "Contemplative session ended.")
         except KeyboardInterrupt:
@@ -681,7 +681,7 @@ def main_loop():
                         project_name=project_name,
                         session_info=f"Run {run_num}/{max_runs} on {project_name}. Mode: {plan['autonomous_mode']}.",
                     )
-                    run_claude_task(cmd, os.devnull, os.devnull, cwd=instance)
+                    run_claude_task(cmd, os.devnull, os.devnull, cwd=koan_root)
                 except KeyboardInterrupt:
                     raise
                 except Exception as e:

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -111,12 +111,17 @@ def run_reflection(instance_dir: Path) -> str:
     """
     prompt = build_reflection_prompt(instance_dir)
 
+    # Get KOAN_ROOT for proper working directory
+    import os
+    koan_root = os.environ.get("KOAN_ROOT", "")
+
     try:
         from app.claude_step import strip_cli_noise
 
         cmd = build_full_command(prompt=prompt, max_turns=1)
         result = subprocess.run(
             cmd,
+            cwd=koan_root if koan_root else None,
             capture_output=True, text=True, timeout=60,
             check=False
         )


### PR DESCRIPTION
Fix "Permission denied" errors when Copilot CLI attempts to access files in parent directories. The issue was caused by subprocess working directory mismatch when running Python code via the Makefile.

The Makefile executes `cd koan` before running Python, causing all subprocess.run() calls to inherit CWD=/root/workspace/koan/koan instead of the trusted project root /root/workspace/koan. This caused Copilot CLI to deny access to instance/ files (soul.md, preferences.md, etc.) because they appeared to be outside the trusted directory hierarchy.

The fix adds `cwd=koan_root` parameter to all subprocess.run() calls that invoke the CLI provider, ensuring the working directory is always set to the project root where Copilot has appropriate permissions. Also changes two contemplative session calls in run.py from `cwd=instance` to `cwd=koan_root` for consistency.

Files modified:
- koan/app/rituals.py: Add cwd=koan_root to CLI subprocess call
- koan/app/run.py: Change contemplative sessions to use koan_root
- koan/app/format_outbox.py: Add cwd=koan_root to format CLI call
- koan/app/pick_mission.py: Add cwd=koan_root to picker CLI call
- koan/app/self_reflection.py: Add cwd=koan_root to reflection CLI call