### PR TITLE
feat(logs): redirect process output to log files, add make logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ projects.yaml
 # wp-copilot-skills: Ignore symlinked agents (pointing to shared installation)
 .github/agents/wp.*
 .github/prompts/wp.*
+
+# Process log files
+logs/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ make setup          # Create venv, install dependencies
 make start          # Start full stack (auto-detects provider: awake+run or ollama+awake+run)
 make stop           # Stop all running processes (run + awake + ollama)
 make status         # Show running process status
+make logs           # Watch live output from all processes
 make run            # Start main agent loop (foreground)
 make awake          # Start Telegram bridge (foreground)
 make ollama         # Start full Ollama stack (ollama serve + awake + run)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ export
 .PHONY: install setup start stop status
 .PHONY: clean say migrate test sync-instance
 .PHONY: awake run errand-run errand-awake dashboard
-.PHONY: ollama
+.PHONY: ollama logs
 
 PYTHON_BIN ?= python3
 
@@ -57,6 +57,15 @@ errand-awake: setup
 ollama: setup
 	@echo "→ Starting Kōan with Ollama stack..."
 	@cd koan && KOAN_ROOT=$(PWD) PYTHONPATH=. ../$(PYTHON) -m app.pid_manager start-stack $(PWD)
+
+logs:
+	@mkdir -p logs
+	@if [ ! -f logs/run.log ] && [ ! -f logs/awake.log ] && [ ! -f logs/ollama.log ]; then \
+		echo "No log files found. Start Kōan first with 'make start'."; \
+		exit 1; \
+	fi
+	@echo "→ Watching Kōan logs (Ctrl-C to stop watching — Kōan keeps running)"
+	@tail -F logs/run.log logs/awake.log logs/ollama.log 2>/dev/null
 
 install:
 	@echo "→ Starting Kōan Setup Wizard..."

--- a/README.md
+++ b/README.md
@@ -140,8 +140,12 @@ See [INSTALL.md](INSTALL.md) for detailed setup instructions.
 | Target | Description |
 |--------|-------------|
 | `make setup` | Create venv and install dependencies |
-| `make awake` | Start Telegram bridge |
-| `make run` | Start agent loop |
+| `make start` | Start full stack as background processes |
+| `make stop` | Stop all running processes |
+| `make status` | Show running process status |
+| `make logs` | Watch live output from all processes |
+| `make awake` | Start Telegram bridge (foreground) |
+| `make run` | Start agent loop (foreground) |
 | `make dashboard` | Start local web dashboard (port 5001) |
 | `make test` | Run test suite |
 | `make say m="..."` | Send a message as if from Telegram |

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -63,7 +63,7 @@ _COLORS = {}
 def _init_colors():
     """Initialize ANSI color codes based on TTY detection."""
     global _COLORS
-    if sys.stdout.isatty():
+    if os.environ.get("KOAN_FORCE_COLOR", "") or sys.stdout.isatty():
         _COLORS = {
             "reset": "\033[0m",
             "bold": "\033[1m",

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -66,6 +66,18 @@ class TestLog:
         out = capsys.readouterr().out
         assert "[custom]" in out
 
+    def test_force_color_env_enables_colors(self, capsys, monkeypatch):
+        """KOAN_FORCE_COLOR=1 enables ANSI colors even without TTY."""
+        monkeypatch.setenv("KOAN_FORCE_COLOR", "1")
+        from app.run import _init_colors, _COLORS
+        # Force re-init
+        import app.run as run_mod
+        run_mod._COLORS = {}
+        _init_colors()
+        colors = run_mod._COLORS
+        assert colors.get("reset") == "\033[0m"
+        assert colors.get("red") == "\033[31m"
+
 
 # ---------------------------------------------------------------------------
 # Test: parse_projects


### PR DESCRIPTION
## Summary

Implements the UX improvements from #240 — process output now goes to log files instead of `/dev/null`, with a new `make logs` command for live monitoring.

### Changes

**pid_manager.py:**
- `start_runner()`, `start_awake()`, `start_ollama()` redirect stdout+stderr to `logs/{run,awake,ollama}.log`
- New `_log_dir()` / `_open_log_file()` helpers create and manage the logs directory
- `KOAN_FORCE_COLOR=1` set in subprocess env so ANSI colors are preserved in log files
- `_print_stack_results()` shows `make logs` / `make status` / `make stop` hints after successful startup

**run.py:**
- `_init_colors()` now checks `KOAN_FORCE_COLOR` env var (aligns with `bridge_log.py` behavior)

**Makefile:**
- New `make logs` target: `tail -F` on all log files with a helpful Ctrl-C message

**Other:**
- `.gitignore`: added `logs/` directory
- `CLAUDE.md`, `README.md`: documented new commands

### Tests

15 new tests:
- `TestLogDir` (2): directory creation
- `TestOpenLogFile` (3): file creation, truncation, writability
- `TestStarterLogFiles` (6): log file + KOAN_FORCE_COLOR for all 3 starters
- `TestPrintStackResults` (3): UX hints display logic
- `TestLog::test_force_color_env_enables_colors` (1): run.py color env

Closes #240

---
🤖 Kōan autonomous session