### PR TITLE
refactor(git): consolidate 5 run_git() implementations into git_utils.py

### DIFF
--- a/koan/app/git_sync.py
+++ b/koan/app/git_sync.py
@@ -14,11 +14,12 @@ Usage:
     python3 git_sync.py <instance_dir> <project_name> <project_path>
 """
 
-import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
 from typing import List
+
+from app.git_utils import run_git as _run_git_core
 
 
 # ---------------------------------------------------------------------------
@@ -26,16 +27,13 @@ from typing import List
 # ---------------------------------------------------------------------------
 
 def run_git(cwd: str, *args: str) -> str:
-    """Run a git command and return stdout, or empty string on failure."""
-    try:
-        result = subprocess.run(
-            ["git"] + list(args),
-            capture_output=True, text=True, timeout=10,
-            cwd=cwd,
-        )
-        return result.stdout.strip()
-    except (subprocess.TimeoutExpired, FileNotFoundError):
-        return ""
+    """Run a git command and return stdout, or empty string on failure.
+
+    Thin wrapper around git_utils.run_git() preserving the original
+    string-return interface for backward compatibility.
+    """
+    rc, stdout, _ = _run_git_core(*args, cwd=cwd, timeout=10)
+    return stdout if rc == 0 else ""
 
 
 def _get_prefix() -> str:

--- a/koan/app/git_utils.py
+++ b/koan/app/git_utils.py
@@ -1,0 +1,80 @@
+"""
+Kōan -- Shared git command helpers.
+
+Centralizes subprocess-based git invocation used across the codebase.
+Replaces 5 separate run_git() implementations with two unified functions:
+
+- run_git(): Returns (returncode, stdout, stderr) tuple. Never raises.
+- run_git_strict(): Returns stdout string. Raises RuntimeError on failure.
+"""
+
+import os
+import subprocess
+from typing import Dict, Optional, Tuple
+
+
+def run_git(
+    *args: str,
+    cwd: str = None,
+    timeout: int = 30,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[int, str, str]:
+    """Run a git command and return (returncode, stdout, stderr).
+
+    Args:
+        *args: Git subcommand and arguments (e.g. "status", "--porcelain").
+        cwd: Working directory for the git command.
+        timeout: Command timeout in seconds (default: 30).
+        env: Optional extra environment variables, merged on top of os.environ.
+
+    Returns:
+        (returncode, stdout, stderr) tuple. Never raises on git failures.
+    """
+    try:
+        run_env = None
+        if env:
+            run_env = {**os.environ, **env}
+        result = subprocess.run(
+            ["git"] + list(args),
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=run_env,
+        )
+        return result.returncode, result.stdout.strip(), result.stderr.strip()
+    except subprocess.TimeoutExpired:
+        return 1, "", "Git command timed out"
+    except Exception as e:
+        return 1, "", str(e)
+
+
+def run_git_strict(
+    *args: str,
+    cwd: str = None,
+    timeout: int = 60,
+) -> str:
+    """Run a git command, raise RuntimeError on failure.
+
+    Args:
+        *args: Git subcommand and arguments (e.g. "fetch", "origin", "main").
+        cwd: Working directory for the git command.
+        timeout: Command timeout in seconds (default: 60).
+
+    Returns:
+        Stripped stdout on success.
+
+    Raises:
+        RuntimeError: If git exits with non-zero status.
+    """
+    result = subprocess.run(
+        ["git"] + list(args),
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        cwd=cwd,
+    )
+    if result.returncode != 0:
+        cmd_str = " ".join(["git"] + list(args))
+        raise RuntimeError(f"git failed: {cmd_str} — {result.stderr[:200]}")
+    return result.stdout.strip()

--- a/koan/tests/test_git_sync.py
+++ b/koan/tests/test_git_sync.py
@@ -31,7 +31,7 @@ class TestRunGit:
 
     def test_returns_empty_on_timeout(self):
         """run_git returns empty on timeout."""
-        with patch("app.git_sync.subprocess.run", side_effect=subprocess.TimeoutExpired("git", 10)):
+        with patch("app.git_sync._run_git_core", return_value=(1, "", "Git command timed out")):
             assert run_git("/tmp", "status") == ""
 
 

--- a/koan/tests/test_git_utils.py
+++ b/koan/tests/test_git_utils.py
@@ -1,0 +1,157 @@
+"""Tests for git_utils.py — centralized git command helpers."""
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.git_utils import run_git, run_git_strict
+
+
+class TestRunGit:
+    """Tests for run_git() — tuple-returning variant."""
+
+    @patch("app.git_utils.subprocess.run")
+    def test_returns_tuple(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="  output  \n", stderr="  warn  \n"
+        )
+        rc, out, err = run_git("status")
+        assert rc == 0
+        assert out == "output"
+        assert err == "warn"
+
+    @patch("app.git_utils.subprocess.run")
+    def test_prepends_git(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("log", "--oneline", "-5")
+        args = mock_run.call_args[0][0]
+        assert args == ["git", "log", "--oneline", "-5"]
+
+    @patch("app.git_utils.subprocess.run")
+    def test_passes_cwd(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("status", cwd="/some/path")
+        assert mock_run.call_args[1]["cwd"] == "/some/path"
+
+    @patch("app.git_utils.subprocess.run")
+    def test_default_timeout_30(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("status")
+        assert mock_run.call_args[1]["timeout"] == 30
+
+    @patch("app.git_utils.subprocess.run")
+    def test_custom_timeout(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("clone", "url", timeout=120)
+        assert mock_run.call_args[1]["timeout"] == 120
+
+    @patch("app.git_utils.subprocess.run")
+    def test_env_merged(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("push", env={"GH_TOKEN": "tok123"})
+        env = mock_run.call_args[1]["env"]
+        assert env["GH_TOKEN"] == "tok123"
+        # Original env vars should also be present
+        assert "PATH" in env
+
+    @patch("app.git_utils.subprocess.run")
+    def test_no_env_passes_none(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git("status")
+        assert mock_run.call_args[1]["env"] is None
+
+    @patch("app.git_utils.subprocess.run")
+    def test_nonzero_exit(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=128, stdout="", stderr="fatal: not a repo"
+        )
+        rc, out, err = run_git("status")
+        assert rc == 128
+        assert "not a repo" in err
+
+    @patch("app.git_utils.subprocess.run")
+    def test_timeout_returns_error_tuple(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=30)
+        rc, out, err = run_git("fetch")
+        assert rc == 1
+        assert out == ""
+        assert "timed out" in err.lower()
+
+    @patch("app.git_utils.subprocess.run")
+    def test_file_not_found_returns_error_tuple(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("git not found")
+        rc, out, err = run_git("status")
+        assert rc == 1
+        assert out == ""
+        assert err != ""
+
+
+class TestRunGitStrict:
+    """Tests for run_git_strict() — raises on failure."""
+
+    @patch("app.git_utils.subprocess.run")
+    def test_returns_stdout_on_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="  abc123  \n", stderr=""
+        )
+        result = run_git_strict("rev-parse", "HEAD")
+        assert result == "abc123"
+
+    @patch("app.git_utils.subprocess.run")
+    def test_prepends_git(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git_strict("fetch", "origin")
+        args = mock_run.call_args[0][0]
+        assert args == ["git", "fetch", "origin"]
+
+    @patch("app.git_utils.subprocess.run")
+    def test_raises_on_failure(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="fatal: bad ref"
+        )
+        with pytest.raises(RuntimeError, match="git failed"):
+            run_git_strict("checkout", "nonexistent")
+
+    @patch("app.git_utils.subprocess.run")
+    def test_error_includes_command(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=128, stdout="", stderr="fatal error"
+        )
+        with pytest.raises(RuntimeError, match="git checkout bad-branch"):
+            run_git_strict("checkout", "bad-branch")
+
+    @patch("app.git_utils.subprocess.run")
+    def test_default_timeout_60(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git_strict("status")
+        assert mock_run.call_args[1]["timeout"] == 60
+
+    @patch("app.git_utils.subprocess.run")
+    def test_custom_timeout(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git_strict("clone", "url", timeout=120)
+        assert mock_run.call_args[1]["timeout"] == 120
+
+    @patch("app.git_utils.subprocess.run")
+    def test_passes_cwd(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        run_git_strict("status", cwd="/repo")
+        assert mock_run.call_args[1]["cwd"] == "/repo"
+
+    @patch("app.git_utils.subprocess.run")
+    def test_timeout_raises(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="git", timeout=60)
+        with pytest.raises(subprocess.TimeoutExpired):
+            run_git_strict("fetch")
+
+    @patch("app.git_utils.subprocess.run")
+    def test_error_truncates_stderr(self, mock_run):
+        long_err = "x" * 500
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr=long_err
+        )
+        with pytest.raises(RuntimeError) as exc_info:
+            run_git_strict("push")
+        # Error message should truncate stderr to 200 chars
+        assert len(str(exc_info.value)) < 300


### PR DESCRIPTION
## Summary

Consolidates **5 separate `run_git()` / `_run_git()` implementations** scattered across the codebase into a single `git_utils.py` module with two unified functions:

- **`run_git()`**: Returns `(returncode, stdout, stderr)` tuple. Never raises. Default timeout: 30s.
- **`run_git_strict()`**: Returns stdout string. Raises `RuntimeError` on failure. Default timeout: 60s.

### Migrated modules

| Module | Old signature | New approach |
|--------|--------------|-------------|
| `git_sync.py` | `run_git(cwd, *args) → str` | Thin wrapper: `rc == 0 ? stdout : ""` |
| `git_auto_merge.py` | `run_git(cwd, *args, env=) → (int, str, str)` | Thin wrapper preserving `(cwd, *args)` interface |
| `claude_step.py` | `_run_git(cmd_with_git, cwd=, timeout=) → str` | Wrapper strips leading `"git"` from cmd, delegates to `run_git_strict()` |
| `skill_manager.py` | `_run_git(*args, cwd=, timeout=) → (int, str, str)` | Direct import as `_run_git` |
| `update_manager.py` | `_run_git(args, cwd) → CompletedProcess` | Returns `_GitResult` with `.returncode`/`.stdout`/`.stderr` |

### Backward compatibility

All existing callers and external import paths (`from app.git_sync import run_git`, etc.) continue to work unchanged — each module retains a thin wrapper preserving its original interface.

### Tests

- 19 new tests in `test_git_utils.py`
- Updated `test_git_auto_merge.py`, `test_git_sync.py`, `test_update_manager.py` to mock at the correct level
- **3855 tests pass, 0 regressions** (20 pre-existing failures unchanged)

Addresses Phase 1 of #206.

---
🤖 Autonomous session by Kōan