### PR TITLE
feat(startup): advertise status with pause reason and /resume hint

### DIFF
--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -181,6 +181,53 @@ class TestSetStatus:
 
 
 # ---------------------------------------------------------------------------
+# Test: _build_startup_status
+# ---------------------------------------------------------------------------
+
+class TestBuildStartupStatus:
+    def test_active_when_not_paused(self, tmp_path):
+        from app.run import _build_startup_status
+        result = _build_startup_status(str(tmp_path))
+        assert "Active" in result
+        assert "ready to work" in result
+        assert "/resume" not in result
+
+    def test_paused_with_quota_reason_and_display(self, tmp_path):
+        from app.run import _build_startup_status
+        (tmp_path / ".koan-pause").touch()
+        (tmp_path / ".koan-pause-reason").write_text("quota\n1739300000\nresets 10am (Europe/Paris)\n")
+        result = _build_startup_status(str(tmp_path))
+        assert "Paused" in result
+        assert "quota" in result
+        assert "resets 10am (Europe/Paris)" in result
+        assert "/resume" in result
+
+    def test_paused_with_max_runs_no_display(self, tmp_path):
+        from app.run import _build_startup_status
+        (tmp_path / ".koan-pause").touch()
+        (tmp_path / ".koan-pause-reason").write_text("max_runs\n1739300000\n\n")
+        result = _build_startup_status(str(tmp_path))
+        assert "Paused" in result
+        assert "max_runs" in result
+        assert "/resume" in result
+
+    def test_paused_with_no_reason_file(self, tmp_path):
+        from app.run import _build_startup_status
+        (tmp_path / ".koan-pause").touch()
+        result = _build_startup_status(str(tmp_path))
+        assert "Paused" in result
+        assert "/resume" in result
+
+    def test_paused_with_empty_reason_file(self, tmp_path):
+        from app.run import _build_startup_status
+        (tmp_path / ".koan-pause").touch()
+        (tmp_path / ".koan-pause-reason").write_text("")
+        result = _build_startup_status(str(tmp_path))
+        assert "Paused" in result
+        assert "/resume" in result
+
+
+# ---------------------------------------------------------------------------
 # Test: SignalState
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Improves the startup notification to always show a clear status line:
- `✅ Active — ready to work` when running normally
- `⏸️ Paused (reason) — details. Use /resume to unpause.` when paused

## Why

Previously, a brief ' Currently PAUSED.' was appended with no context about why the agent is paused or how to resume. Users starting in pause mode had no indication that `/resume` exists.

## Changes

- Added `_build_startup_status()` helper in `run.py` that reads pause state from `pause_manager` and builds a descriptive status line
- Startup notification now includes a dedicated `Status:` line
- `.koan-status` file reflects the actual state instead of generic 'Starting up'
- 5 new tests covering active, quota pause, max_runs pause, and edge cases

---
🤖 Created by Kōan