### PR TITLE
fix(tests): isolate CLI_PROVIDER env vars in conftest

### DIFF
--- a/koan/tests/conftest.py
+++ b/koan/tests/conftest.py
@@ -12,6 +12,9 @@ def isolate_env(monkeypatch):
     monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "fake-token")
     monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "123456")
     monkeypatch.delenv("KOAN_PROJECTS", raising=False)
+    # Prevent host CLI provider env vars from leaking into tests
+    monkeypatch.delenv("CLI_PROVIDER", raising=False)
+    monkeypatch.delenv("KOAN_CLI_PROVIDER", raising=False)
 
 
 @pytest.fixture

--- a/koan/tests/test_setup_wizard.py
+++ b/koan/tests/test_setup_wizard.py
@@ -295,6 +295,7 @@ class TestProjectValidation:
         assert data["is_git_repo"] is True
 
 
+    @pytest.mark.skipif(os.getuid() == 0, reason="root ignores file permissions")
     def test_validate_non_writable_path(self, wizard_app):
         """Non-writable directory should fail validation."""
         client, root = wizard_app


### PR DESCRIPTION
## Problem

When the host environment has `CLI_PROVIDER=copilot` or `KOAN_CLI_PROVIDER=copilot` set, 19 tests fail because they expect `claude` as the default provider.

## Fix

- **conftest.py**: Added `CLI_PROVIDER` and `KOAN_CLI_PROVIDER` to the autouse `isolate_env` fixture
- **test_setup_wizard.py**: Skip chmod test when running as root

## Result

3913 passed, 1 skipped, 0 failures (was: 20 failures)

---
🤖 Kōan autonomous session