### PR TITLE
refactor: DRY improvements across v0.60 changes

### DIFF
--- a/koan/app/banners/__init__.py
+++ b/koan/app/banners/__init__.py
@@ -48,28 +48,28 @@ def _apply_replacements(line: str, replacements: dict, base_color: str) -> str:
     return f"{base_color}{line}{RESET}"
 
 
+def _colorize_art(art: str, replacements: dict, base_color: str) -> str:
+    """Apply ANSI colors to ASCII art with given replacements and base color."""
+    lines = art.split("\n")
+    return "\n".join(_apply_replacements(line, replacements, base_color) for line in lines)
+
+
 def colorize_agent(art: str) -> str:
     """Apply ANSI colors to the agent (run loop) banner."""
-    replacements = {
-        "◉": CYAN,  # Eyes glow cyan
-        "☢": YELLOW,  # Radioactive symbol in yellow
-    }
-    lines = art.split("\n")
-    colored = [_apply_replacements(line, replacements, f"{DIM}{BLUE}") for line in lines]
-    return "\n".join(colored)
+    return _colorize_art(art, {
+        "◉": CYAN,
+        "☢": YELLOW,
+    }, f"{DIM}{BLUE}")
 
 
 def colorize_bridge(art: str) -> str:
     """Apply ANSI colors to the bridge (awake) banner."""
-    replacements = {
-        "◇": CYAN,  # Signal waves in cyan
+    return _colorize_art(art, {
+        "◇": CYAN,
         "◆": CYAN,
-        "→": GREEN,  # Arrows in green
+        "→": GREEN,
         "←": GREEN,
-    }
-    lines = art.split("\n")
-    colored = [_apply_replacements(line, replacements, f"{DIM}{MAGENTA}") for line in lines]
-    return "\n".join(colored)
+    }, f"{DIM}{MAGENTA}")
 
 
 def _print_banner(art_file: str, colorizer: callable, version_info: str = "") -> None:
@@ -109,16 +109,13 @@ def _visible_len(s: str) -> int:
 
 def colorize_startup(art: str) -> str:
     """Apply ANSI colors to the unified startup banner."""
-    replacements = {
-        "K Ō A N": f"{BOLD}{CYAN}",  # Title text in bold cyan
-        "cognitive sparring partner": f"{DIM}{WHITE}",  # Tagline in dim white
-        "─────────────────────": f"{DIM}{CYAN}",  # Separator line
-        "◉": CYAN,  # Eyes glow cyan
-        "☢": YELLOW,  # Radioactive symbol in yellow
-    }
-    lines = art.split("\n")
-    colored = [_apply_replacements(line, replacements, f"{DIM}{BLUE}") for line in lines]
-    return "\n".join(colored)
+    return _colorize_art(art, {
+        "K Ō A N": f"{BOLD}{CYAN}",
+        "cognitive sparring partner": f"{DIM}{WHITE}",
+        "─────────────────────": f"{DIM}{CYAN}",
+        "◉": CYAN,
+        "☢": YELLOW,
+    }, f"{DIM}{BLUE}")
 
 
 def _format_info_lines(system_info: dict) -> list:

--- a/koan/app/projects_merged.py
+++ b/koan/app/projects_merged.py
@@ -47,7 +47,6 @@ def refresh_projects(koan_root: str) -> List[Tuple[str, str]]:
     Call at startup and when /projects command is invoked.
     Returns the merged project list.
     """
-    from app.projects_config import load_projects_config, get_projects_from_config
     from app.workspace_discovery import discover_workspace_projects
 
     warnings = []

--- a/koan/app/skill_dispatch.py
+++ b/koan/app/skill_dispatch.py
@@ -189,20 +189,22 @@ def build_skill_command(
     python = os.path.join(koan_root, ".venv", "bin", "python3")
     base_cmd = [python, "-m", runner_module]
 
-    if command == "plan":
-        return _build_plan_cmd(base_cmd, args, project_path)
-    elif command == "implement":
-        return _build_implement_cmd(base_cmd, args, project_path)
-    elif command in ("rebase", "recreate"):
-        return _build_pr_url_cmd(base_cmd, args, project_path)
-    elif command == "ai":
-        return _build_ai_cmd(base_cmd, project_name, project_path, instance_dir)
-    elif command == "check":
-        return _build_check_cmd(base_cmd, args, instance_dir, koan_root)
-    elif command in ("claudemd", "claude", "claude.md", "claude_md"):
-        return _build_claudemd_cmd(base_cmd, project_name, project_path)
+    # Dispatch to command-specific builder
+    _COMMAND_BUILDERS = {
+        "plan": lambda: _build_plan_cmd(base_cmd, args, project_path),
+        "implement": lambda: _build_implement_cmd(base_cmd, args, project_path),
+        "rebase": lambda: _build_pr_url_cmd(base_cmd, args, project_path),
+        "recreate": lambda: _build_pr_url_cmd(base_cmd, args, project_path),
+        "ai": lambda: _build_ai_cmd(base_cmd, project_name, project_path, instance_dir),
+        "check": lambda: _build_check_cmd(base_cmd, args, instance_dir, koan_root),
+        "claudemd": lambda: _build_claudemd_cmd(base_cmd, project_name, project_path),
+        "claude": lambda: _build_claudemd_cmd(base_cmd, project_name, project_path),
+        "claude.md": lambda: _build_claudemd_cmd(base_cmd, project_name, project_path),
+        "claude_md": lambda: _build_claudemd_cmd(base_cmd, project_name, project_path),
+    }
 
-    return None
+    builder = _COMMAND_BUILDERS.get(command)
+    return builder() if builder else None
 
 
 def _extract_issue_url_and_context(args: str) -> Optional[Tuple[str, str]]:

--- a/koan/app/startup_info.py
+++ b/koan/app/startup_info.py
@@ -56,9 +56,11 @@ def gather_startup_info(koan_root: Path) -> dict:
 
 def _get_provider(koan_root: Path) -> str:
     """Detect the CLI provider from env or config."""
-    provider = os.environ.get("KOAN_CLI_PROVIDER", "").strip()
-    if not provider:
-        provider = os.environ.get("CLI_PROVIDER", "").strip()
+    try:
+        from app.utils import get_cli_provider_env
+        provider = get_cli_provider_env()
+    except Exception:
+        provider = ""
     if not provider:
         provider = _get_config_value("cli_provider", "claude")
     return provider

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -174,15 +174,15 @@ def _build_prompt(
             PLAN=plan,
             CONTEXT=context,
         )
-    else:
-        from app.prompts import load_prompt
-        return load_prompt(
-            "implement",
-            ISSUE_URL=issue_url,
-            ISSUE_TITLE=issue_title,
-            PLAN=plan,
-            CONTEXT=context,
-        )
+
+    from app.prompts import load_prompt
+    return load_prompt(
+        "implement",
+        ISSUE_URL=issue_url,
+        ISSUE_TITLE=issue_title,
+        PLAN=plan,
+        CONTEXT=context,
+    )
 
 
 def _execute_implementation(

--- a/koan/skills/core/status/handler.py
+++ b/koan/skills/core/status/handler.py
@@ -1,7 +1,5 @@
 """Kōan status skill — consolidates /status, /ping, /usage."""
 
-import re
-
 # Telegram lines wrap around 40-45 chars on mobile; 60 is a good balance
 # between readability and information density.
 _MAX_MISSION_DISPLAY_LEN = 60
@@ -37,6 +35,7 @@ def handle(ctx):
 def _handle_status(ctx) -> str:
     """Build status message grouped by project."""
     from app.missions import group_by_project
+    from app.utils import parse_project
 
     koan_root = ctx.koan_root
     instance_dir = ctx.instance_dir
@@ -103,12 +102,12 @@ def _handle_status(ctx) -> str:
                     if in_progress:
                         parts.append(f"  In progress: {len(in_progress)}")
                         for m in in_progress[:2]:
-                            display = re.sub(r'\[projec?t:[a-zA-Z0-9_-]+\]\s*', '', m)
+                            _, display = parse_project(m)
                             parts.append(f"    {_truncate(display)}")
                     if pending:
                         parts.append(f"  Pending: {len(pending)}")
                         for m in pending[:3]:
-                            display = re.sub(r'\[projec?t:[a-zA-Z0-9_-]+\]\s*', '', m)
+                            _, display = parse_project(m)
                             parts.append(f"    {_truncate(display)}")
 
     return "\n".join(parts)


### PR DESCRIPTION
## Summary

Clean up code introduced since `v0.60` tag across 6 files, reducing duplication and improving consistency.

## Changes

| File | What | Why |
|------|------|-----|
| `banners/__init__.py` | Extract `_colorize_art()` helper | Eliminates identical split/join/apply pattern repeated in 3 colorize functions |
| `projects_merged.py` | Remove dead import in `refresh_projects()` | Import was duplicated — already present in `_load_yaml_projects()` |
| `startup_info.py` | Reuse `get_cli_provider_env()` from utils | Was reimplementing the same KOAN_CLI_PROVIDER/CLI_PROVIDER env resolution |
| `skill_dispatch.py` | Replace if/elif chain with dispatch dict | Cleaner extensibility, less repetition for claudemd variants |
| `status/handler.py` | Use `parse_project()` from utils | Replaces inline `re.sub()` duplicating `_PROJECT_TAG_STRIP_RE` |
| `implement_runner.py` | Early return in `_build_prompt()` | Removes unnecessary else block |

## Testing

All **4395 tests pass**, 0 regressions. Review via wp-review skill: quality 9/10, security 10/10.

No behavior changes — pure refactoring.