### PR TITLE
fix: add stdin=DEVNULL to all subprocess calls to prevent bad FD in d…

### DIFF
--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -45,6 +45,7 @@ def _rebase_onto_target(base: str, project_path: str) -> Optional[str]:
         except Exception:
             subprocess.run(
                 ["git", "rebase", "--abort"],
+                stdin=subprocess.DEVNULL,
                 capture_output=True, cwd=project_path,
             )
     return None

--- a/koan/app/git_utils.py
+++ b/koan/app/git_utils.py
@@ -36,6 +36,7 @@ def run_git(
             run_env = {**os.environ, **env}
         result = subprocess.run(
             ["git"] + list(args),
+            stdin=subprocess.DEVNULL,
             cwd=cwd,
             capture_output=True,
             text=True,
@@ -69,6 +70,7 @@ def run_git_strict(
     """
     result = subprocess.run(
         ["git"] + list(args),
+        stdin=subprocess.DEVNULL,
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -25,8 +25,9 @@ def run_gh(*args, cwd=None, timeout=30, stdin_data=None):
         RuntimeError: If the ``gh`` command exits with a non-zero code.
     """
     cmd = ["gh", *args]
+    stdin_kwarg = {"input": stdin_data} if stdin_data is not None else {"stdin": subprocess.DEVNULL}
     result = subprocess.run(
-        cmd, input=stdin_data,
+        cmd, **stdin_kwarg,
         capture_output=True, text=True, timeout=timeout, cwd=cwd,
     )
     if result.returncode != 0:

--- a/koan/app/github_auth.py
+++ b/koan/app/github_auth.py
@@ -45,6 +45,7 @@ def get_gh_token(username: str) -> Optional[str]:
     try:
         result = subprocess.run(
             ["gh", "auth", "token", "--user", username],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=10,

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -257,6 +257,7 @@ def _launch_python_process(
             [python, script_name],
             cwd=str(koan_dir),
             env=env,
+            stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,
@@ -312,6 +313,7 @@ def start_ollama(koan_root: Path, verify_timeout: float = OLLAMA_VERIFY_TIMEOUT)
     try:
         proc = subprocess.Popen(
             [ollama_bin, "serve"],
+            stdin=subprocess.DEVNULL,
             stdout=log_fh,
             stderr=subprocess.STDOUT,
             start_new_session=True,

--- a/koan/app/prompts.py
+++ b/koan/app/prompts.py
@@ -36,6 +36,7 @@ def _read_prompt_with_git_fallback(path: Path) -> str:
     try:
         result = subprocess.run(
             ["git", "rev-parse", "--show-toplevel"],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=5,
@@ -51,6 +52,7 @@ def _read_prompt_with_git_fallback(path: Path) -> str:
         try:
             result = subprocess.run(
                 ["git", "show", f"{remote}:{rel_path}"],
+                stdin=subprocess.DEVNULL,
                 capture_output=True,
                 text=True,
                 timeout=5,

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -156,6 +156,7 @@ def get_github_remote(project_path: str) -> Optional[str]:
         try:
             result = subprocess.run(
                 ["git", "remote", "get-url", remote],
+                stdin=subprocess.DEVNULL,
                 capture_output=True, text=True, timeout=5,
                 cwd=project_path,
             )

--- a/koan/tests/test_claude_step.py
+++ b/koan/tests/test_claude_step.py
@@ -46,6 +46,7 @@ class TestRunGit:
         _run_git(["git", "status"], cwd="/tmp/test", timeout=30)
         mock_run.assert_called_once_with(
             ["git", "status"],
+            stdin=subprocess.DEVNULL,
             capture_output=True,
             text=True,
             timeout=30,

--- a/koan/tests/test_github_auth.py
+++ b/koan/tests/test_github_auth.py
@@ -48,6 +48,7 @@ class TestGetGhToken:
         assert get_gh_token("my-bot") == "ghp_abc123token"
         mock_run.assert_called_once_with(
             ["gh", "auth", "token", "--user", "my-bot"],
+            stdin=subprocess.DEVNULL,
             capture_output=True, text=True, timeout=10,
         )
 


### PR DESCRIPTION
…aemon mode

When run.py is launched as a daemon via pid_manager, stdin was inherited from the caller. If the terminal closes, FD 0 becomes invalid, causing child Python processes to crash with 'Fatal Python error: init_sys_streams: can't initialize sys standard streams - OSError: [Errno 9] Bad file descriptor'.

Primary fix: pid_manager.py now redirects stdin to /dev/null for all daemon processes (run, awake, ollama).

Defensive hardening: added stdin=subprocess.DEVNULL to all subprocess calls that don't need stdin input (github.py, prompts.py, git_utils.py, claude_step.py, utils.py, github_auth.py).