### PR TITLE
Pass CLI prompts via temp file stdin

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -306,6 +306,8 @@ def handle_chat(text: str):
     Uses restricted tools (Read/Glob/Grep by default) to prevent prompt
     injection attacks via Telegram messages. No Bash, Edit, or Write access.
     """
+    from app.cli_exec import run_cli
+
     # Save user message to history
     save_conversation_message(CONVERSATION_HISTORY_FILE, "user", text)
 
@@ -322,9 +324,8 @@ def handle_chat(text: str):
     )
 
     try:
-        result = subprocess.run(
+        result = run_cli(
             cmd,
-            stdin=subprocess.DEVNULL,
             capture_output=True, text=True, timeout=CHAT_TIMEOUT,
             cwd=PROJECT_PATH or str(KOAN_ROOT),
         )
@@ -353,9 +354,8 @@ def handle_chat(text: str):
             max_turns=1,
         )
         try:
-            result = subprocess.run(
+            result = run_cli(
                 lite_cmd,
-                stdin=subprocess.DEVNULL,
                 capture_output=True, text=True, timeout=CHAT_TIMEOUT,
                 cwd=PROJECT_PATH or str(KOAN_ROOT),
             )

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -79,10 +79,11 @@ def run_claude(cmd: list, cwd: str, timeout: int = 600) -> dict:
     Returns:
         Dict with keys: success (bool), output (str), error (str).
     """
+    from app.cli_exec import run_cli
+
     try:
-        result = subprocess.run(
+        result = run_cli(
             cmd,
-            stdin=subprocess.DEVNULL,
             capture_output=True, text=True,
             timeout=timeout, cwd=cwd,
         )

--- a/koan/app/cli_exec.py
+++ b/koan/app/cli_exec.py
@@ -1,0 +1,103 @@
+"""CLI execution helpers — secure prompt passing via temp files.
+
+Prevents prompts from leaking into ``ps`` process listings by writing
+them to a temporary file (``0o600``) and redirecting that file as the
+subprocess stdin.  The ``-p`` argument visible in ``ps`` becomes the
+short placeholder ``@stdin`` instead of the full prompt text.
+"""
+
+import os
+import subprocess
+import tempfile
+from typing import Callable, List, Optional, Tuple
+
+STDIN_PLACEHOLDER = "@stdin"
+
+
+def prepare_prompt_file(cmd: List[str]) -> Tuple[List[str], Optional[str]]:
+    """Extract the ``-p`` prompt from *cmd* and write it to a secure temp file.
+
+    Returns ``(modified_cmd, temp_file_path)``.  If no ``-p`` argument is
+    found or it already equals :data:`STDIN_PLACEHOLDER`, returns
+    ``(cmd, None)`` unchanged.
+    """
+    try:
+        idx = cmd.index("-p")
+    except ValueError:
+        return cmd, None
+
+    if idx + 1 >= len(cmd):
+        return cmd, None
+
+    prompt = cmd[idx + 1]
+    if prompt == STDIN_PLACEHOLDER:
+        return cmd, None
+
+    fd, path = tempfile.mkstemp(suffix=".md", prefix="koan-prompt-")
+    try:
+        os.write(fd, prompt.encode("utf-8"))
+    finally:
+        os.close(fd)
+    os.chmod(path, 0o600)
+
+    new_cmd = cmd.copy()
+    new_cmd[idx + 1] = STDIN_PLACEHOLDER
+    return new_cmd, path
+
+
+def _cleanup_prompt_file(path: Optional[str]) -> None:
+    """Silently remove a temp prompt file if it exists."""
+    if path:
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+
+
+def run_cli(cmd, **kwargs) -> subprocess.CompletedProcess:
+    """Run a CLI command with the prompt passed via temp-file stdin.
+
+    Drop-in replacement for ``subprocess.run(cmd, stdin=DEVNULL, ...)``.
+    """
+    cmd, prompt_path = prepare_prompt_file(cmd)
+    if prompt_path:
+        try:
+            with open(prompt_path) as f:
+                kwargs.pop("stdin", None)
+                kwargs["stdin"] = f
+                return subprocess.run(cmd, **kwargs)
+        finally:
+            _cleanup_prompt_file(prompt_path)
+    else:
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+        return subprocess.run(cmd, **kwargs)
+
+
+def popen_cli(
+    cmd, **kwargs
+) -> Tuple[subprocess.Popen, Callable[[], None]]:
+    """Start a :class:`~subprocess.Popen` process with the prompt via temp-file stdin.
+
+    Returns ``(proc, cleanup)`` where *cleanup()* **must** be called after
+    the process exits to close the file handle and delete the temp file.
+    """
+    cmd, prompt_path = prepare_prompt_file(cmd)
+    if prompt_path:
+        stdin_file = open(prompt_path)  # noqa: SIM115
+        kwargs.pop("stdin", None)
+        kwargs["stdin"] = stdin_file
+        try:
+            proc = subprocess.Popen(cmd, **kwargs)
+        except Exception:
+            stdin_file.close()
+            _cleanup_prompt_file(prompt_path)
+            raise
+
+        def cleanup():
+            stdin_file.close()
+            _cleanup_prompt_file(prompt_path)
+
+        return proc, cleanup
+    else:
+        kwargs.setdefault("stdin", subprocess.DEVNULL)
+        return subprocess.Popen(cmd, **kwargs), lambda: None

--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -266,6 +266,8 @@ def chat_page():
 @app.route("/chat/send", methods=["POST"])
 def chat_send():
     """Send a message — either as mission or direct outbox message."""
+    from app.cli_exec import run_cli
+
     text = request.form.get("message", "").strip()
     mode = request.form.get("mode", "chat")  # chat or mission
 
@@ -302,7 +304,7 @@ def chat_send():
         )
 
         try:
-            result = subprocess.run(
+            result = run_cli(
                 cmd,
                 capture_output=True, text=True, timeout=CHAT_TIMEOUT,
                 cwd=project_path,
@@ -329,7 +331,7 @@ def chat_send():
                 max_turns=1,
             )
             try:
-                result = subprocess.run(
+                result = run_cli(
                     lite_cmd,
                     capture_output=True, text=True, timeout=CHAT_TIMEOUT,
                     cwd=project_path,

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -161,12 +161,12 @@ def format_message(raw_content: str, soul: str, prefs: str,
         print("[format_outbox] KOAN_ROOT not set, using current directory", file=sys.stderr)
 
     try:
-        # Call CLI to format the message (lightweight model)
+        from app.cli_exec import run_cli
+
         models = get_model_config()
         cmd = build_full_command(prompt=prompt, model=models["lightweight"])
-        result = subprocess.run(
+        result = run_cli(
             cmd,
-            stdin=subprocess.DEVNULL,
             cwd=koan_root,
             capture_output=True,
             text=True,

--- a/koan/app/local_llm_runner.py
+++ b/koan/app/local_llm_runner.py
@@ -484,6 +484,10 @@ def main():
 
     args = parser.parse_args()
 
+    # Support stdin-based prompt passing (security: avoids ps leaking)
+    if args.prompt == "@stdin":
+        args.prompt = sys.stdin.read()
+
     # Resolve config from env vars if not provided via args
     base_url = args.base_url or os.environ.get("KOAN_LOCAL_LLM_BASE_URL", "http://localhost:11434/v1")
     model = args.model or os.environ.get("KOAN_LOCAL_LLM_MODEL", "")

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -62,9 +62,10 @@ def call_claude(prompt: str) -> str:
         max_turns=1,
         output_format="json",
     )
-    result = subprocess.run(
+    from app.cli_exec import run_cli
+
+    result = run_cli(
         cmd,
-        stdin=subprocess.DEVNULL,
         cwd=koan_root if koan_root else None,
         capture_output=True,
         text=True,

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -204,9 +204,10 @@ def run_command(
         max_turns=max_turns,
     )
 
-    result = subprocess.run(
+    from app.cli_exec import run_cli
+
+    result = run_cli(
         cmd,
-        stdin=subprocess.DEVNULL,
         capture_output=True, text=True, timeout=timeout,
         cwd=project_path,
     )

--- a/koan/app/rituals.py
+++ b/koan/app/rituals.py
@@ -63,14 +63,15 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         return False
 
     try:
+        from app.cli_exec import run_cli
+
         cmd = build_full_command(
             prompt=prompt,
             allowed_tools=["Read", "Write", "Glob"],
             max_turns=7,
         )
-        result = subprocess.run(
+        result = run_cli(
             cmd,
-            stdin=subprocess.DEVNULL,
             cwd=koan_root,
             capture_output=True, text=True, timeout=90,
             check=False

--- a/koan/app/self_reflection.py
+++ b/koan/app/self_reflection.py
@@ -117,11 +117,11 @@ def run_reflection(instance_dir: Path) -> str:
 
     try:
         from app.claude_step import strip_cli_noise
+        from app.cli_exec import run_cli
 
         cmd = build_full_command(prompt=prompt, max_turns=1)
-        result = subprocess.run(
+        result = run_cli(
             cmd,
-            stdin=subprocess.DEVNULL,
             cwd=koan_root if koan_root else None,
             capture_output=True, text=True, timeout=60,
             check=False

--- a/koan/skills/core/magic/handler.py
+++ b/koan/skills/core/magic/handler.py
@@ -60,7 +60,8 @@ def handle(ctx):
             max_turns=1,
             model=fast_model or "",
         )
-        result = subprocess.run(
+        from app.cli_exec import run_cli
+        result = run_cli(
             cmd,
             capture_output=True, text=True, timeout=90,
             cwd=path,

--- a/koan/skills/core/sparring/handler.py
+++ b/koan/skills/core/sparring/handler.py
@@ -79,7 +79,8 @@ def handle(ctx):
             max_turns=1,
             model=fast_model or "",
         )
-        result = subprocess.run(
+        from app.cli_exec import run_cli
+        result = run_cli(
             cmd, capture_output=True, text=True, timeout=60,
         )
         if result.returncode == 0 and result.stdout.strip():

--- a/koan/tests/test_cli_exec.py
+++ b/koan/tests/test_cli_exec.py
@@ -1,0 +1,228 @@
+"""Tests for app.cli_exec — secure prompt passing via temp files."""
+
+import os
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.cli_exec import (
+    STDIN_PLACEHOLDER,
+    prepare_prompt_file,
+    run_cli,
+    popen_cli,
+    _cleanup_prompt_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# prepare_prompt_file
+# ---------------------------------------------------------------------------
+
+class TestPreparePromptFile:
+    """Tests for prepare_prompt_file()."""
+
+    def test_extracts_prompt_and_writes_temp_file(self):
+        cmd = ["claude", "-p", "my secret prompt", "--model", "opus"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        try:
+            assert path is not None
+            assert os.path.isfile(path)
+            assert new_cmd == ["claude", "-p", STDIN_PLACEHOLDER, "--model", "opus"]
+            with open(path) as f:
+                assert f.read() == "my secret prompt"
+            # Check permissions are restrictive
+            mode = os.stat(path).st_mode & 0o777
+            assert mode == 0o600
+        finally:
+            _cleanup_prompt_file(path)
+
+    def test_no_p_flag_returns_unchanged(self):
+        cmd = ["claude", "--model", "opus"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        assert new_cmd is cmd
+        assert path is None
+
+    def test_p_at_end_with_no_value_returns_unchanged(self):
+        cmd = ["claude", "-p"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        assert new_cmd is cmd
+        assert path is None
+
+    def test_already_placeholder_returns_none(self):
+        cmd = ["claude", "-p", STDIN_PLACEHOLDER, "--model", "opus"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        assert new_cmd is cmd
+        assert path is None
+
+    def test_preserves_original_cmd(self):
+        cmd = ["claude", "-p", "secret"]
+        original = cmd.copy()
+        new_cmd, path = prepare_prompt_file(cmd)
+        try:
+            assert cmd == original  # original not mutated
+            assert new_cmd is not cmd
+        finally:
+            _cleanup_prompt_file(path)
+
+    def test_handles_unicode_prompt(self):
+        cmd = ["claude", "-p", "日本語のプロンプト 🎯"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        try:
+            with open(path, encoding="utf-8") as f:
+                assert f.read() == "日本語のプロンプト 🎯"
+        finally:
+            _cleanup_prompt_file(path)
+
+    def test_handles_empty_prompt(self):
+        cmd = ["claude", "-p", ""]
+        new_cmd, path = prepare_prompt_file(cmd)
+        try:
+            assert path is not None
+            with open(path) as f:
+                assert f.read() == ""
+            assert new_cmd[2] == STDIN_PLACEHOLDER
+        finally:
+            _cleanup_prompt_file(path)
+
+    def test_copilot_gh_mode(self):
+        cmd = ["gh", "copilot", "-p", "my prompt", "--model", "opus"]
+        new_cmd, path = prepare_prompt_file(cmd)
+        try:
+            assert new_cmd == ["gh", "copilot", "-p", STDIN_PLACEHOLDER, "--model", "opus"]
+            with open(path) as f:
+                assert f.read() == "my prompt"
+        finally:
+            _cleanup_prompt_file(path)
+
+
+# ---------------------------------------------------------------------------
+# _cleanup_prompt_file
+# ---------------------------------------------------------------------------
+
+class TestCleanupPromptFile:
+
+    def test_removes_existing_file(self, tmp_path):
+        f = tmp_path / "test.md"
+        f.write_text("data")
+        _cleanup_prompt_file(str(f))
+        assert not f.exists()
+
+    def test_ignores_none(self):
+        _cleanup_prompt_file(None)  # should not raise
+
+    def test_ignores_missing_file(self):
+        _cleanup_prompt_file("/nonexistent/path/file.md")  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# run_cli
+# ---------------------------------------------------------------------------
+
+class TestRunCli:
+
+    @patch("app.cli_exec.subprocess.run")
+    def test_passes_prompt_via_stdin_fd(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "ok", "")
+        cmd = ["claude", "-p", "secret prompt", "--model", "opus"]
+
+        result = run_cli(cmd, capture_output=True, text=True, timeout=60)
+
+        call_args = mock_run.call_args
+        actual_cmd = call_args[0][0]
+        assert actual_cmd[2] == STDIN_PLACEHOLDER
+        assert "secret prompt" not in actual_cmd
+        # stdin should be a file object, not DEVNULL
+        assert call_args[1]["stdin"] != subprocess.DEVNULL
+
+    @patch("app.cli_exec.subprocess.run")
+    def test_falls_back_to_devnull_without_p(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "ok", "")
+        cmd = ["git", "status"]
+
+        run_cli(cmd, capture_output=True, text=True)
+
+        call_args = mock_run.call_args
+        assert call_args[1]["stdin"] == subprocess.DEVNULL
+
+    @patch("app.cli_exec.subprocess.run")
+    def test_cleans_up_temp_file_on_success(self, mock_run):
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "ok", "")
+        cmd = ["claude", "-p", "test prompt"]
+
+        import glob
+        before = set(glob.glob("/tmp/koan-prompt-*"))
+        run_cli(cmd, capture_output=True, text=True)
+        after = set(glob.glob("/tmp/koan-prompt-*"))
+        assert after - before == set()
+
+    @patch("app.cli_exec.subprocess.run", side_effect=Exception("boom"))
+    def test_cleans_up_temp_file_on_exception(self, mock_run):
+        cmd = ["claude", "-p", "test prompt"]
+
+        import glob
+        before = set(glob.glob("/tmp/koan-prompt-*"))
+        with pytest.raises(Exception, match="boom"):
+            run_cli(cmd, capture_output=True, text=True)
+        after = set(glob.glob("/tmp/koan-prompt-*"))
+        assert after - before == set()
+
+    @patch("app.cli_exec.subprocess.run")
+    def test_removes_existing_stdin_kwarg(self, mock_run):
+        """If caller passes stdin=DEVNULL, it gets replaced with the file."""
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "ok", "")
+        cmd = ["claude", "-p", "prompt"]
+
+        run_cli(cmd, stdin=subprocess.DEVNULL, capture_output=True, text=True)
+
+        call_args = mock_run.call_args
+        assert call_args[1]["stdin"] != subprocess.DEVNULL
+
+
+# ---------------------------------------------------------------------------
+# popen_cli
+# ---------------------------------------------------------------------------
+
+class TestPopenCli:
+
+    @patch("app.cli_exec.subprocess.Popen")
+    def test_returns_proc_and_cleanup(self, mock_popen):
+        mock_proc = MagicMock()
+        mock_popen.return_value = mock_proc
+        cmd = ["claude", "-p", "secret", "--model", "opus"]
+
+        proc, cleanup = popen_cli(cmd, stdout=subprocess.PIPE)
+
+        assert proc is mock_proc
+        actual_cmd = mock_popen.call_args[0][0]
+        assert actual_cmd[2] == STDIN_PLACEHOLDER
+
+        # Cleanup should remove the temp file
+        import glob
+        before = set(glob.glob("/tmp/koan-prompt-*"))
+        cleanup()
+        after = set(glob.glob("/tmp/koan-prompt-*"))
+        assert len(after) <= len(before)
+
+    @patch("app.cli_exec.subprocess.Popen")
+    def test_no_p_flag_returns_noop_cleanup(self, mock_popen):
+        mock_popen.return_value = MagicMock()
+        cmd = ["git", "status"]
+
+        proc, cleanup = popen_cli(cmd)
+
+        call_args = mock_popen.call_args
+        assert call_args[1].get("stdin", subprocess.DEVNULL) == subprocess.DEVNULL
+        cleanup()  # should not raise
+
+    @patch("app.cli_exec.subprocess.Popen")
+    def test_stdin_is_file_object(self, mock_popen):
+        mock_popen.return_value = MagicMock()
+        cmd = ["claude", "-p", "prompt"]
+
+        proc, cleanup = popen_cli(cmd)
+
+        call_args = mock_popen.call_args
+        stdin_arg = call_args[1]["stdin"]
+        assert hasattr(stdin_arg, "read")  # it's a file object
+        cleanup()

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -71,7 +71,7 @@ class TestFallbackFormat:
 
 
 class TestFormatForTelegram:
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_returns_claude_output_on_success(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="Voici le résumé formaté.\n", stderr=""
@@ -80,7 +80,7 @@ class TestFormatForTelegram:
         assert result == "Voici le résumé formaté."
         mock_run.assert_called_once()
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_strips_markdown_from_claude_output(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="**bold** and ```code``` and __under__ and ~~strike~~", stderr=""
@@ -91,7 +91,7 @@ class TestFormatForTelegram:
         assert "__" not in result
         assert "~~" not in result
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_fallback_on_nonzero_returncode(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=1, stdout="", stderr="error"
@@ -101,7 +101,7 @@ class TestFormatForTelegram:
         assert "#" not in result
         assert "Raw content" in result
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_fallback_on_empty_stdout(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="  \n  ", stderr=""
@@ -109,19 +109,19 @@ class TestFormatForTelegram:
         result = format_message("Some raw content", "soul", "")
         assert "Some raw content" in result
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_fallback_on_timeout(self, mock_run):
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="claude", timeout=30)
         result = format_message("Raw", "soul", "")
         assert result == "Raw"
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_fallback_on_exception(self, mock_run):
         mock_run.side_effect = FileNotFoundError("claude not found")
         result = format_message("Raw", "soul", "")
         assert result == "Raw"
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_prompt_includes_soul_and_prefs(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "my-soul", "my-prefs")
@@ -130,7 +130,7 @@ class TestFormatForTelegram:
         assert "my-soul" in prompt
         assert "my-prefs" in prompt
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_prompt_omits_prefs_when_empty(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "")
@@ -138,7 +138,7 @@ class TestFormatForTelegram:
         prompt = call_args[2]
         assert "Human preferences:" not in prompt
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_prompt_includes_memory_context(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "prefs", memory_context="Session 61: tests")
@@ -147,7 +147,7 @@ class TestFormatForTelegram:
         assert "Session 61: tests" in prompt
         assert "Recent memory context" in prompt
 
-    @patch("app.format_outbox.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_prompt_omits_memory_when_empty(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "prefs", memory_context="")

--- a/koan/tests/test_plan_runner.py
+++ b/koan/tests/test_plan_runner.py
@@ -331,7 +331,7 @@ class TestRunIssuePlan:
 # ---------------------------------------------------------------------------
 
 class TestGeneratePlan:
-    @patch("app.claude_step.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_returns_claude_output(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="## Plan\n\nStep 1", stderr=""
@@ -345,7 +345,7 @@ class TestGeneratePlan:
             result = _generate_plan("/project", "Add feature", skill_dir=skill_dir)
             assert "Step 1" in result
 
-    @patch("app.claude_step.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_includes_context(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="plan", stderr="")
         with patch("app.prompts.load_skill_prompt") as mock_load, \
@@ -358,7 +358,7 @@ class TestGeneratePlan:
             _, kwargs = mock_load.call_args
             assert kwargs["CONTEXT"] == "prev"
 
-    @patch("app.claude_step.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_raises_on_failure(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="rate limited")
         with patch("app.prompts.load_skill_prompt", return_value="prompt"), \
@@ -369,7 +369,7 @@ class TestGeneratePlan:
             with pytest.raises(RuntimeError, match="invocation failed"):
                 _generate_plan("/project", "idea", skill_dir=Path("/fake"))
 
-    @patch("app.claude_step.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_uses_read_only_tools(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="plan", stderr="")
         with patch("app.prompts.load_skill_prompt", return_value="prompt"), \
@@ -379,7 +379,7 @@ class TestGeneratePlan:
             call_kwargs = mock_run.call_args[1]
             assert call_kwargs.get("cwd") == "/project"
 
-    @patch("app.claude_step.subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_no_skill_dir_uses_load_prompt(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="plan", stderr="")
         with patch("app.prompts.load_prompt", return_value="prompt") as mock_load, \
@@ -396,7 +396,7 @@ class TestGeneratePlan:
 # ---------------------------------------------------------------------------
 
 class TestGenerateIterationPlan:
-    @patch("subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_uses_plan_iterate_prompt(self, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0, stdout="## Updated Plan", stderr=""
@@ -416,7 +416,7 @@ class TestGenerateIterationPlan:
                 skill_dir, "plan-iterate", ISSUE_CONTEXT="issue context here"
             )
 
-    @patch("subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_no_skill_dir_uses_load_prompt(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="plan", stderr="")
         with patch("app.prompts.load_prompt") as mock_load, \
@@ -429,7 +429,7 @@ class TestGenerateIterationPlan:
                 "plan-iterate", ISSUE_CONTEXT="context"
             )
 
-    @patch("subprocess.run")
+    @patch("app.cli_exec.run_cli")
     def test_raises_on_failure(self, mock_run):
         mock_run.return_value = MagicMock(returncode=1, stderr="error")
         with patch("app.prompts.load_skill_prompt", return_value="prompt"), \

--- a/koan/tests/test_sparring_skill.py
+++ b/koan/tests/test_sparring_skill.py
@@ -22,7 +22,7 @@ def _make_ctx(instance_dir, send_message=None):
     return ctx
 
 
-_P_SUB = "skills.core.sparring.handler.subprocess"
+_P_SUB = "app.cli_exec.run_cli"
 _P_PROMPT = "app.prompts.load_skill_prompt"
 _P_MODEL = "app.config.get_fast_reply_model"
 _P_SAVE = "app.conversation_history.save_conversation_message"
@@ -43,7 +43,7 @@ class TestSparringContextLoading:
         instance = tmp_path / "instance"
         instance.mkdir()
         (instance / "soul.md").write_text("I am Kōan.")
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response text")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response text")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -58,7 +58,7 @@ class TestSparringContextLoading:
         """Missing soul.md = empty string, no crash."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -76,7 +76,7 @@ class TestSparringContextLoading:
         global_dir = instance / "memory" / "global"
         global_dir.mkdir(parents=True)
         (global_dir / "strategy.md").write_text("Focus on koan first.")
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -94,7 +94,7 @@ class TestSparringContextLoading:
         global_dir = instance / "memory" / "global"
         global_dir.mkdir(parents=True)
         (global_dir / "emotional-memory.md").write_text("x" * 2000)
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -112,7 +112,7 @@ class TestSparringContextLoading:
         global_dir = instance / "memory" / "global"
         global_dir.mkdir(parents=True)
         (global_dir / "human-preferences.md").write_text("Prefers French.")
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -131,7 +131,7 @@ class TestSparringContextLoading:
             "# Missions\n\n## Pending\n\n- task A\n- task B\n\n"
             "## In Progress\n\n- active task\n\n## Done\n"
         )
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -147,7 +147,7 @@ class TestSparringContextLoading:
         """Missing missions.md = empty RECENT_MISSIONS."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -165,7 +165,7 @@ class TestSparringContextLoading:
         (instance / "missions.md").write_text(
             "# Missions\n\n## Pending\n\n## In Progress\n\n## Done\n\n- old\n"
         )
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -189,7 +189,7 @@ class TestSparringTimeHint:
         instance = tmp_path / "instance"
         instance.mkdir()
         mock_dt.now.return_value.hour = 9
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -205,7 +205,7 @@ class TestSparringTimeHint:
         instance = tmp_path / "instance"
         instance.mkdir()
         mock_dt.now.return_value.hour = 23
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -221,7 +221,7 @@ class TestSparringTimeHint:
         instance = tmp_path / "instance"
         instance.mkdir()
         mock_dt.now.return_value.hour = 14
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -237,7 +237,7 @@ class TestSparringTimeHint:
         instance = tmp_path / "instance"
         instance.mkdir()
         mock_dt.now.return_value.hour = 19
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -260,12 +260,12 @@ class TestSparringClaudeCall:
         """Claude is called with -p and --max-turns 1."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
 
-        cmd = mock_sub.run.call_args[0][0]
+        cmd = mock_sub.call_args[0][0]
         assert cmd[0] == "claude"
         assert "-p" in cmd
         assert "--max-turns" in cmd
@@ -278,12 +278,12 @@ class TestSparringClaudeCall:
         """When fast_reply_model is set, --model flag is added."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
 
-        cmd = mock_sub.run.call_args[0][0]
+        cmd = mock_sub.call_args[0][0]
         assert "--model" in cmd
         model_idx = cmd.index("--model")
         assert cmd[model_idx + 1] == "haiku"
@@ -295,12 +295,12 @@ class TestSparringClaudeCall:
         """When no fast_reply_model, no --model flag."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
 
-        cmd = mock_sub.run.call_args[0][0]
+        cmd = mock_sub.call_args[0][0]
         assert "--model" not in cmd
 
     @patch(_P_SUB)
@@ -310,12 +310,12 @@ class TestSparringClaudeCall:
         """Subprocess is called with timeout=60."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
 
-        kwargs = mock_sub.run.call_args[1]
+        kwargs = mock_sub.call_args[1]
         assert kwargs["timeout"] == 60
 
 
@@ -334,7 +334,7 @@ class TestSparringResponse:
         """Successful Claude output is returned."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Deep thought here")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Deep thought here")
 
         from skills.core.sparring.handler import handle
         result = handle(_make_ctx(instance))
@@ -348,7 +348,7 @@ class TestSparringResponse:
         """Bold and code block markers are removed from response."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(
+        mock_sub.return_value = MagicMock(
             returncode=0, stdout="**Bold** and ```code```"
         )
 
@@ -366,7 +366,7 @@ class TestSparringResponse:
         """Response is saved to telegram history."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Deep thought")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Deep thought")
 
         from skills.core.sparring.handler import handle
         handle(_make_ctx(instance))
@@ -383,7 +383,7 @@ class TestSparringResponse:
         """Non-zero exit code returns a fallback message."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(
+        mock_sub.return_value = MagicMock(
             returncode=1, stdout="", stderr="error"
         )
 
@@ -398,7 +398,7 @@ class TestSparringResponse:
         """Empty stdout returns fallback even with exit 0."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="  ")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="  ")
 
         from skills.core.sparring.handler import handle
         result = handle(_make_ctx(instance))
@@ -410,7 +410,7 @@ class TestSparringResponse:
         """Subprocess timeout returns a timeout message."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        with patch(_P_SUB + ".run", side_effect=subprocess.TimeoutExpired("claude", 60)):
+        with patch(_P_SUB, side_effect=subprocess.TimeoutExpired("claude", 60)):
             from skills.core.sparring.handler import handle
             result = handle(_make_ctx(instance))
         assert "Timeout" in result
@@ -421,7 +421,7 @@ class TestSparringResponse:
         """Generic exception returns error message."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        with patch(_P_SUB + ".run", side_effect=RuntimeError("something broke")):
+        with patch(_P_SUB, side_effect=RuntimeError("something broke")):
             from skills.core.sparring.handler import handle
             result = handle(_make_ctx(instance))
         assert "Error" in result
@@ -441,7 +441,7 @@ class TestSparringNotification:
         """Sends a thinking notification when send_message is available."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
         send = MagicMock()
 
         from skills.core.sparring.handler import handle
@@ -457,7 +457,7 @@ class TestSparringNotification:
         """No send_message function = no notification, no crash."""
         instance = tmp_path / "instance"
         instance.mkdir()
-        mock_sub.run.return_value = MagicMock(returncode=0, stdout="Response")
+        mock_sub.return_value = MagicMock(returncode=0, stdout="Response")
 
         from skills.core.sparring.handler import handle
         ctx = _make_ctx(instance, send_message=None)


### PR DESCRIPTION
Add koan/app/cli_exec.py module that writes LLM prompts to secure temporary files (0o600 permissions) and redirects them as subprocess stdin instead of passing them as command-line arguments. This prevents the full prompt text from being visible to all system users via `ps aux`.

All 11 CLI execution points now use run_cli() or popen_cli() from the new module. The `-p` argument value is replaced with the short placeholder `@stdin`, so process listings show only `claude -p @stdin --model ...` instead of the entire prompt.

Key changes:
- New cli_exec.py with prepare_prompt_file(), run_cli(), popen_cli()
- run.py::run_claude_task() uses popen_cli() with cleanup callback
- claude_step.py, provider/__init__.py, awake.py, dashboard.py, self_reflection.py, format_outbox.py, pick_mission.py, rituals.py, magic/handler.py, sparring/handler.py all use run_cli()
- local_llm_runner.py detects @stdin and reads prompt from sys.stdin
- 19 new tests in test_cli_exec.py; existing test mocks updated to target cli_exec module