### PR TITLE
Fix /recreate on merged and closed PRs

### DIFF
--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -522,6 +522,17 @@ def main(argv=None):
     )
 
     if not success and _is_conflict_failure(summary):
+        # Check PR state before falling back — recreate only works on open PRs
+        try:
+            ctx = fetch_pr_context(owner, repo, pr_number)
+            pr_state = ctx.get("state", "").upper()
+        except Exception:
+            pr_state = ""
+
+        if pr_state in ("MERGED", "CLOSED"):
+            print(f"{summary}\nCannot fall back to /recreate: PR #{pr_number} is {pr_state.lower()}.")
+            return 1
+
         print(f"{summary}\nFalling back to /recreate...")
         from app.recreate_pr import run_recreate
 


### PR DESCRIPTION
Add PR state guard to run_recreate() that rejects MERGED and CLOSED PRs early with a clear error message instead of running the full recreation pipeline and returning a generic "no changes" error.

The /recreate skill is designed for open PRs whose branch has diverged too far for a clean rebase. When invoked on a merged PR, the fresh branch from upstream already contains the PR's changes, so Claude correctly finds nothing to implement — but the error gave no indication of why.

Also fix silent failure swallowing in the recreation pipeline:
- _reimpl_feature() now returns run_claude_step()'s bool result
- The "no changes" error message includes full actions_log context so Claude CLI failures are visible to the user
- The rebase→recreate fallback path in rebase_pr.py also checks PR state before cascading into /recreate