### PR TITLE
Add systemd service support for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,8 @@ instance/                 # Your private data (gitignored)
 | `make dashboard` | Web UI (port 5001) |
 | `make test` | Run test suite |
 | `make say m="..."` | Send a test message |
+| `make install-systemctl-service` | Install systemd service (Linux only) |
+| `make uninstall-systemctl-service` | Remove systemd service |
 | `make clean` | Remove virtualenv |
 
 ## Philosophy

--- a/koan/systemd/install-service.sh
+++ b/koan/systemd/install-service.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Install Kōan systemd services.
+# Usage: ./install-service.sh <koan_root> <python_path>
+set -euo pipefail
+
+KOAN_ROOT="${1:?Usage: $0 <koan_root> <python_path>}"
+PYTHON="${2:?Usage: $0 <koan_root> <python_path>}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Validations ---
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Error: systemd services are only supported on Linux." >&2
+    exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "Error: systemctl not found. systemd is required." >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: must be run as root (use sudo)." >&2
+    exit 1
+fi
+
+# Resolve to absolute paths
+KOAN_ROOT="$(cd "$KOAN_ROOT" && pwd)"
+PYTHON="$(cd "$(dirname "$PYTHON")" && pwd)/$(basename "$PYTHON")"
+
+if [ ! -f "$KOAN_ROOT/koan/app/run.py" ]; then
+    echo "Error: $KOAN_ROOT does not look like a Kōan installation." >&2
+    exit 1
+fi
+
+if [ ! -x "$PYTHON" ]; then
+    echo "Error: Python binary not found or not executable: $PYTHON" >&2
+    exit 1
+fi
+
+# --- Generate service files ---
+
+mkdir -p "$KOAN_ROOT/logs"
+
+for template in "$SCRIPT_DIR"/koan*.service.template; do
+    service_name="$(basename "$template" .template)"
+    echo "→ Generating $service_name"
+    sed \
+        -e "s|__KOAN_ROOT__|${KOAN_ROOT}|g" \
+        -e "s|__PYTHON__|${PYTHON}|g" \
+        "$template" > "/etc/systemd/system/$service_name"
+done
+
+# --- Enable and reload ---
+
+echo "→ Reloading systemd daemon"
+systemctl daemon-reload
+
+echo "→ Enabling koan-awake.service"
+systemctl enable koan-awake.service
+
+echo "→ Enabling koan.service"
+systemctl enable koan.service
+
+echo "✓ Kōan systemd services installed and enabled."
+echo "  Use 'make start' to start, or: systemctl start koan"

--- a/koan/systemd/koan-awake.service.template
+++ b/koan/systemd/koan-awake.service.template
@@ -1,0 +1,18 @@
+[Unit]
+Description=Kōan Communication Bridge
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=__KOAN_ROOT__/koan
+EnvironmentFile=__KOAN_ROOT__/.env
+Environment=KOAN_ROOT=__KOAN_ROOT__
+Environment=PYTHONPATH=__KOAN_ROOT__/koan
+ExecStart=__PYTHON__ app/awake.py
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:__KOAN_ROOT__/logs/awake.log
+StandardError=append:__KOAN_ROOT__/logs/awake.log
+
+[Install]
+WantedBy=multi-user.target

--- a/koan/systemd/koan.service.template
+++ b/koan/systemd/koan.service.template
@@ -1,0 +1,19 @@
+[Unit]
+Description=Kōan Agent Loop
+After=network.target koan-awake.service
+BindsTo=koan-awake.service
+
+[Service]
+Type=simple
+WorkingDirectory=__KOAN_ROOT__/koan
+EnvironmentFile=__KOAN_ROOT__/.env
+Environment=KOAN_ROOT=__KOAN_ROOT__
+Environment=PYTHONPATH=__KOAN_ROOT__/koan
+ExecStart=__PYTHON__ app/run.py
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:__KOAN_ROOT__/logs/run.log
+StandardError=append:__KOAN_ROOT__/logs/run.log
+
+[Install]
+WantedBy=multi-user.target

--- a/koan/systemd/uninstall-service.sh
+++ b/koan/systemd/uninstall-service.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Uninstall Kōan systemd services.
+# Usage: ./uninstall-service.sh
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Error: systemd services are only supported on Linux." >&2
+    exit 1
+fi
+
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "Error: systemctl not found." >&2
+    exit 1
+fi
+
+if [ "$(id -u)" -ne 0 ]; then
+    echo "Error: must be run as root (use sudo)." >&2
+    exit 1
+fi
+
+SERVICES="koan.service koan-awake.service"
+
+for svc in $SERVICES; do
+    if [ -f "/etc/systemd/system/$svc" ]; then
+        echo "→ Stopping $svc"
+        systemctl stop "$svc" 2>/dev/null || true
+        echo "→ Disabling $svc"
+        systemctl disable "$svc" 2>/dev/null || true
+        echo "→ Removing $svc"
+        rm -f "/etc/systemd/system/$svc"
+    else
+        echo "  $svc not installed, skipping"
+    fi
+done
+
+echo "→ Reloading systemd daemon"
+systemctl daemon-reload
+
+echo "✓ Kōan systemd services removed."


### PR DESCRIPTION
Add native systemd integration so Kōan can run as a managed system
service on Linux. Two unit files are created: koan.service (agent
loop) and koan-awake.service (messaging bridge), linked via BindsTo
so stopping one stops both.

The Makefile auto-detects Linux + systemd at parse time and delegates
make start/stop/status to systemctl when available. On first start,
the service is auto-installed (one-time sudo prompt). macOS and
non-systemd Linux are unaffected — they continue using the existing
Python PID manager.

Services use Type=simple with Restart=on-failure (RestartSec=10).
Logs go to both the systemd journal and the logs/ directory via
StandardOutput=append, preserving compatibility with make logs.

New targets: make install-systemctl-service (explicit install) and
make uninstall-systemctl-service (stop + disable + remove + reload).
