### PR TITLE
fix(systemd): add Requires=koan-awake.service for start pull-in

### DIFF
--- a/koan/systemd/koan.service.template
+++ b/koan/systemd/koan.service.template
@@ -1,6 +1,7 @@
 [Unit]
 Description=Kōan Agent Loop
 After=network.target koan-awake.service
+Requires=koan-awake.service
 BindsTo=koan-awake.service
 
 [Service]


### PR DESCRIPTION
koan.service had BindsTo=koan-awake.service (lifecycle coupling for stop) but no Requires= or Wants= directive. This meant 'systemctl start koan' would NOT automatically start koan-awake — the bridge had to be started separately or rely on boot-time ordering.

Add Requires=koan-awake.service so 'systemctl start koan' pulls in the bridge automatically, matching the Makefile's single-command 'make start' expectation.

Also add 18 tests:
- TestUsesStdinPassing: 5 tests for _uses_stdin_passing() provider detection (claude, copilot, local, import error, runtime error)
- TestRunCli/TestPopenCli: 2 end-to-end Copilot provider tests verifying prompt stays in -p args with stdin=DEVNULL
- TestMain: 4 tests for systemd_service.py CLI entrypoint (wrong argc, template rendering, SUDO_USER home filtering)
- TestServiceTemplateContent: 7 tests validating actual .template files have correct systemd directives (Requires, BindsTo, PartOf, After, EnvironmentFile, Restart, placeholders)