### PR TITLE
fix(github): replace set.clear() with FIFO eviction in dedup sets

### DIFF
--- a/koan/app/bounded_set.py
+++ b/koan/app/bounded_set.py
@@ -1,0 +1,52 @@
+"""Bounded set with FIFO eviction.
+
+A set-like container with a maximum size. When the set is full,
+the oldest entries are evicted first (FIFO order).
+
+Used for in-memory deduplication (e.g. processed comment IDs,
+error reply keys) where unbounded growth would leak memory and
+clearing all entries at once would lose dedup state.
+"""
+
+
+class BoundedSet:
+    """Set with a maximum size and FIFO eviction.
+
+    Backed by a dict (Python 3.7+ preserves insertion order)
+    for O(1) membership test and FIFO eviction of oldest entries.
+
+    Args:
+        maxlen: Maximum number of entries. When full, adding a new
+            entry evicts the oldest one.
+    """
+
+    __slots__ = ("_data", "_maxlen")
+
+    def __init__(self, maxlen: int = 10000):
+        if maxlen < 1:
+            raise ValueError(f"maxlen must be >= 1, got {maxlen}")
+        self._data: dict = {}
+        self._maxlen = maxlen
+
+    def add(self, item) -> None:
+        """Add an item. Evicts the oldest entry if at capacity."""
+        if item in self._data:
+            return
+        if len(self._data) >= self._maxlen:
+            # Evict oldest (first key in insertion order)
+            oldest = next(iter(self._data))
+            del self._data[oldest]
+        self._data[item] = None
+
+    def __contains__(self, item) -> bool:
+        return item in self._data
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+    def clear(self) -> None:
+        """Remove all entries."""
+        self._data.clear()
+
+    def __repr__(self) -> str:
+        return f"BoundedSet(maxlen={self._maxlen}, size={len(self._data)})"

--- a/koan/app/github_notifications.py
+++ b/koan/app/github_notifications.py
@@ -17,14 +17,15 @@ import time
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
+from app.bounded_set import BoundedSet
 from app.github import api, run_gh
 
 log = logging.getLogger(__name__)
 
 # In-memory set of processed comment IDs (resets on restart).
-# Bounded: evict all entries when limit is reached.
+# Bounded: FIFO eviction when limit is reached (oldest entries removed first).
 _MAX_PROCESSED_COMMENTS = 10000
-_processed_comments: Set[str] = set()
+_processed_comments: BoundedSet = BoundedSet(maxlen=_MAX_PROCESSED_COMMENTS)
 
 # Regex for extracting @mention commands, skipping code blocks
 _CODE_BLOCK_RE = re.compile(r'```.*?```|`[^`]+`', re.DOTALL)
@@ -202,8 +203,6 @@ def check_already_processed(comment_id: str, bot_username: str,
             for reaction in reactions:
                 if (reaction.get("user", {}).get("login") == bot_username
                         and reaction.get("content") == "+1"):
-                    if len(_processed_comments) >= _MAX_PROCESSED_COMMENTS:
-                        _processed_comments.clear()
                     _processed_comments.add(comment_id)
                     return True
     except (RuntimeError, json.JSONDecodeError):
@@ -230,8 +229,6 @@ def add_reaction(owner: str, repo: str, comment_id: str, emoji: str = "+1") -> b
             method="POST",
             extra_args=["-f", f"content={emoji}"],
         )
-        if len(_processed_comments) >= _MAX_PROCESSED_COMMENTS:
-            _processed_comments.clear()
         _processed_comments.add(comment_id)
         return True
     except RuntimeError:

--- a/koan/tests/test_bounded_set.py
+++ b/koan/tests/test_bounded_set.py
@@ -1,0 +1,115 @@
+"""Tests for BoundedSet — FIFO eviction set."""
+
+from app.bounded_set import BoundedSet
+import pytest
+
+
+class TestBoundedSetBasic:
+    """Basic set operations."""
+
+    def test_add_and_contains(self):
+        s = BoundedSet(maxlen=10)
+        s.add("a")
+        assert "a" in s
+        assert "b" not in s
+
+    def test_len(self):
+        s = BoundedSet(maxlen=10)
+        assert len(s) == 0
+        s.add("a")
+        s.add("b")
+        assert len(s) == 2
+
+    def test_duplicate_add_is_noop(self):
+        s = BoundedSet(maxlen=10)
+        s.add("a")
+        s.add("a")
+        assert len(s) == 1
+
+    def test_clear(self):
+        s = BoundedSet(maxlen=10)
+        s.add("a")
+        s.add("b")
+        s.clear()
+        assert len(s) == 0
+        assert "a" not in s
+
+    def test_repr(self):
+        s = BoundedSet(maxlen=5)
+        s.add("x")
+        assert "maxlen=5" in repr(s)
+        assert "size=1" in repr(s)
+
+    def test_invalid_maxlen_raises(self):
+        with pytest.raises(ValueError):
+            BoundedSet(maxlen=0)
+        with pytest.raises(ValueError):
+            BoundedSet(maxlen=-1)
+
+
+class TestBoundedSetEviction:
+    """FIFO eviction behavior."""
+
+    def test_evicts_oldest_when_full(self):
+        s = BoundedSet(maxlen=3)
+        s.add("a")
+        s.add("b")
+        s.add("c")
+        assert len(s) == 3
+
+        # Adding a 4th should evict "a" (oldest)
+        s.add("d")
+        assert len(s) == 3
+        assert "a" not in s
+        assert "b" in s
+        assert "c" in s
+        assert "d" in s
+
+    def test_evicts_in_fifo_order(self):
+        s = BoundedSet(maxlen=2)
+        s.add("first")
+        s.add("second")
+
+        s.add("third")  # evicts "first"
+        assert "first" not in s
+        assert "second" in s
+        assert "third" in s
+
+        s.add("fourth")  # evicts "second"
+        assert "second" not in s
+        assert "third" in s
+        assert "fourth" in s
+
+    def test_maxlen_one(self):
+        s = BoundedSet(maxlen=1)
+        s.add("a")
+        assert "a" in s
+        s.add("b")
+        assert "a" not in s
+        assert "b" in s
+        assert len(s) == 1
+
+    def test_duplicate_does_not_trigger_eviction(self):
+        s = BoundedSet(maxlen=3)
+        s.add("a")
+        s.add("b")
+        s.add("c")
+        # Re-adding existing item should not evict anything
+        s.add("b")
+        assert len(s) == 3
+        assert "a" in s
+        assert "b" in s
+        assert "c" in s
+
+    def test_large_set_eviction(self):
+        """Verify eviction works over many insertions."""
+        s = BoundedSet(maxlen=100)
+        for i in range(500):
+            s.add(f"item-{i}")
+
+        assert len(s) == 100
+        # Only the last 100 should remain
+        for i in range(400):
+            assert f"item-{i}" not in s
+        for i in range(400, 500):
+            assert f"item-{i}" in s


### PR DESCRIPTION
Both _error_replies (github_command_handler) and _processed_comments (github_notifications) used set.clear() when reaching capacity, dropping ALL dedup state at once. This created a window where previously-seen errors could be re-posted and previously-processed comments could be re-processed.

Replace bare sets with BoundedSet — a dict-backed set that evicts the oldest entry on insertion when full (FIFO order). This preserves recent dedup state while bounding memory usage.

Changelog: Fix duplicate GitHub error replies and comment re-processing when in-memory dedup sets reach capacity.