### PR TITLE
Improve test isolation across test suite

### DIFF
--- a/koan/tests/test_git_auto_merge.py
+++ b/koan/tests/test_git_auto_merge.py
@@ -81,7 +81,8 @@ class TestGetAutoMergeConfig:
         assert result["strategy"] == "merge"  # Overridden via projects.yaml
         assert result["enabled"] is True  # Inherited from defaults
 
-    def test_missing_config_section(self):
+    @patch("app.projects_config.load_projects_config", return_value=None)
+    def test_missing_config_section(self, mock_projects):
         """When git_auto_merge section missing, return safe defaults."""
         config = {}
         result = get_auto_merge_config(config, "koan")
@@ -343,7 +344,8 @@ class TestGetAuthorEnv:
 # --- Integration Tests ---
 
 class TestIntegration:
-    def test_full_config_resolution_global_only(self):
+    @patch("app.projects_config.load_projects_config", return_value=None)
+    def test_full_config_resolution_global_only(self, mock_projects):
         """Test full config resolution uses global config.yaml settings."""
         config = {
             "git_auto_merge": {

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -548,8 +548,9 @@ class TestPlanIteration:
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
     @patch("random.randint", return_value=99)  # No contemplation
-    def test_autonomous_mode(self, mock_rand, mock_focus, mock_refresh, mock_pick,
+    def test_autonomous_mode(self, mock_rand, mock_schedule, mock_focus, mock_refresh, mock_pick,
                              instance_dir, koan_root, usage_state):
         usage_md = instance_dir / "usage.md"
         usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
@@ -572,8 +573,9 @@ class TestPlanIteration:
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
     @patch("random.randint", return_value=3)  # Contemplation triggers (< 10%)
-    def test_contemplative_mode(self, mock_rand, mock_focus, mock_refresh, mock_pick,
+    def test_contemplative_mode(self, mock_rand, mock_schedule, mock_focus, mock_refresh, mock_pick,
                                 instance_dir, koan_root, usage_state):
         usage_md = instance_dir / "usage.md"
         usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
@@ -1419,9 +1421,10 @@ projects:
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._filter_exploration_projects")
     @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
     @patch("random.randint", return_value=3)  # Would trigger contemplation
     def test_contemplation_uses_filtered_project(
-        self, mock_rand, mock_focus, mock_filter, mock_refresh, mock_pick,
+        self, mock_rand, mock_schedule, mock_focus, mock_filter, mock_refresh, mock_pick,
         instance_dir, koan_root, usage_state,
     ):
         """Contemplative sessions use exploration-filtered project list."""

--- a/koan/tests/test_messaging_integration.py
+++ b/koan/tests/test_messaging_integration.py
@@ -350,12 +350,13 @@ class TestProviderLifecycle:
         
         if provider == "telegram":
             from app.messaging.telegram import TelegramProvider
-            provider_instance = TelegramProvider()
+            with patch("app.utils.load_dotenv"):
+                provider_instance = TelegramProvider()
+                assert provider_instance.configure() is False
         else:
             from app.messaging.slack import SlackProvider
             provider_instance = SlackProvider()
-        
-        assert provider_instance.configure() is False
+            assert provider_instance.configure() is False
 
     def test_telegram_configure_succeeds_with_env(self, monkeypatch):
         set_provider_env_vars(monkeypatch, "telegram")

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -44,7 +44,8 @@ class TestBuildMissionCommand:
         from app.mission_runner import build_mission_command
 
         cmd = build_mission_command(prompt="test", extra_flags="")
-        assert "--model" not in cmd
+        base = build_mission_command(prompt="test")
+        assert len(cmd) == len(base)
 
     @patch("app.cli_provider.get_provider_name", return_value="claude")
     def test_whitespace_extra_flags_ignored(self, mock_provider):
@@ -269,7 +270,8 @@ class TestCheckAutoMerge:
 
     @patch("app.git_auto_merge.auto_merge_branch")
     @patch("app.git_sync.run_git", return_value="koan/my-feature")
-    def test_checks_koan_branch(self, mock_git, mock_merge, tmp_path):
+    @patch("app.config.get_branch_prefix", return_value="koan/")
+    def test_checks_koan_branch(self, mock_prefix, mock_git, mock_merge, tmp_path):
         from app.mission_runner import check_auto_merge
 
         result = check_auto_merge(str(tmp_path), "project", str(tmp_path))

--- a/koan/tests/test_telegram_provider.py
+++ b/koan/tests/test_telegram_provider.py
@@ -28,13 +28,15 @@ class TestConfigure:
         assert p._chat_id == "123"
         assert "tok" in p._api_base
 
-    def test_missing_token(self, monkeypatch):
+    @patch("app.utils.load_dotenv")
+    def test_missing_token(self, mock_dotenv, monkeypatch):
         monkeypatch.delenv("KOAN_TELEGRAM_TOKEN", raising=False)
         monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "123")
         p = TelegramProvider()
         assert p.configure() is False
 
-    def test_missing_chat_id(self, monkeypatch):
+    @patch("app.utils.load_dotenv")
+    def test_missing_chat_id(self, mock_dotenv, monkeypatch):
         monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "tok")
         monkeypatch.delenv("KOAN_TELEGRAM_CHAT_ID", raising=False)
         p = TelegramProvider()

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -650,7 +650,9 @@ class TestGetStartOnPause:
 class TestGetKnownProjects:
     """Tests for get_known_projects() — returns List[Tuple[str, str]]."""
 
-    def test_parses_koan_projects_env(self, monkeypatch):
+    def test_parses_koan_projects_env(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.setenv("KOAN_PROJECTS", "koan:/home/koan;web:/home/web")
         from app.utils import get_known_projects
         result = get_known_projects()
@@ -658,33 +660,43 @@ class TestGetKnownProjects:
         assert result[0] == ("koan", "/home/koan")
         assert result[1] == ("web", "/home/web")
 
-    def test_sorted_alphabetically(self, monkeypatch):
+    def test_sorted_alphabetically(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.setenv("KOAN_PROJECTS", "zebra:/z;alpha:/a")
         from app.utils import get_known_projects
         result = get_known_projects()
         assert result[0][0] == "alpha"
         assert result[1][0] == "zebra"
 
-    def test_project_path_no_longer_supported(self, monkeypatch):
+    def test_project_path_no_longer_supported(self, tmp_path, monkeypatch):
         """KOAN_PROJECT_PATH is no longer a fallback for get_known_projects()."""
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.delenv("KOAN_PROJECTS", raising=False)
         monkeypatch.setenv("KOAN_PROJECT_PATH", "/single/path")
         from app.utils import get_known_projects
         assert get_known_projects() == []
 
-    def test_empty_when_no_config(self, monkeypatch):
+    def test_empty_when_no_config(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.delenv("KOAN_PROJECTS", raising=False)
         from app.utils import get_known_projects
         assert get_known_projects() == []
 
-    def test_handles_whitespace(self, monkeypatch):
+    def test_handles_whitespace(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.setenv("KOAN_PROJECTS", " koan : /home/koan ; web : /home/web ")
         from app.utils import get_known_projects
         result = get_known_projects()
         assert len(result) == 2
         assert result[0] == ("koan", "/home/koan")
 
-    def test_skips_malformed_entries(self, monkeypatch):
+    def test_skips_malformed_entries(self, tmp_path, monkeypatch):
+        from app import utils
+        monkeypatch.setattr(utils, "KOAN_ROOT", tmp_path)
         monkeypatch.setenv("KOAN_PROJECTS", "koan:/home/koan;badentry;web:/home/web")
         from app.utils import get_known_projects
         result = get_known_projects()


### PR DESCRIPTION
Mock external dependencies that were leaking state from the real environment into tests:

- Patch load_projects_config in git_auto_merge tests that don't need real project config, preventing projects.yaml from polluting results.
- Add _check_schedule mock to iteration_manager tests that already mock _check_focus, matching the current iteration pipeline signature.
- Patch load_dotenv in Telegram provider tests so .env files cannot override monkeypatch.delenv calls for missing-credential scenarios.
- Mock get_branch_prefix in mission_runner auto-merge test to avoid dependency on real instance config.
- Set KOAN_ROOT to tmp_path in TestGetKnownProjects so get_known_projects() reads from an empty directory instead of the real projects.yaml.
- Move provider-specific assertion inside its branch in messaging integration lifecycle test.