### PR TITLE
refactor: extract duplicated markdown stripping into shared text_util…

### DIFF
--- a/koan/app/ai_runner.py
+++ b/koan/app/ai_runner.py
@@ -149,22 +149,9 @@ def _get_missions_context(instance_dir: Path) -> str:
 
 def _clean_response(text: str) -> str:
     """Clean Claude CLI output for Telegram delivery."""
-    import re
+    from app.text_utils import clean_cli_response
 
-    lines = text.splitlines()
-    lines = [
-        line for line in lines
-        if not re.match(r'^Error:.*max turns', line, re.IGNORECASE)
-    ]
-    cleaned = "\n".join(lines).strip()
-    cleaned = cleaned.replace("```", "")
-    cleaned = cleaned.replace("**", "")
-    cleaned = cleaned.replace("__", "")
-    cleaned = cleaned.replace("~~", "")
-    cleaned = re.sub(r'^#{1,6}\s+', '', cleaned, flags=re.MULTILINE)
-    if len(cleaned) > 2000:
-        cleaned = cleaned[:1997] + "..."
-    return cleaned.strip()
+    return clean_cli_response(text)
 
 
 # ---------------------------------------------------------------------------

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -281,24 +281,9 @@ def _clean_chat_response(text: str) -> str:
 
     Strips error artifacts, markdown, and truncates for smartphone reading.
     """
-    # Remove Claude CLI error lines
-    lines = text.splitlines()
-    lines = [l for l in lines if not re.match(r'^Error:.*max turns', l, re.IGNORECASE)]
-    cleaned = "\n".join(lines).strip()
+    from app.text_utils import clean_cli_response
 
-    # Strip markdown artifacts
-    cleaned = cleaned.replace("```", "")
-    cleaned = cleaned.replace("**", "")
-    cleaned = cleaned.replace("__", "")
-    cleaned = cleaned.replace("~~", "")
-    # Strip heading markers
-    cleaned = re.sub(r'^#{1,6}\s+', '', cleaned, flags=re.MULTILINE)
-
-    # Truncate for smartphone (Telegram limit is 4096, keep 2000 for readability)
-    if len(cleaned) > 2000:
-        cleaned = cleaned[:1997] + "..."
-
-    return cleaned.strip()
+    return clean_cli_response(text)
 
 
 def handle_chat(text: str):

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -175,13 +175,12 @@ def format_message(raw_content: str, soul: str, prefs: str,
         )
 
         if result.returncode == 0 and result.stdout.strip():
+            from app.text_utils import strip_markdown
+
             formatted = result.stdout.strip()
 
             # Safety check: remove any remaining markdown artifacts
-            formatted = formatted.replace("```", "")
-            formatted = formatted.replace("**", "")
-            formatted = formatted.replace("__", "")
-            formatted = formatted.replace("~~", "")
+            formatted = strip_markdown(formatted)
 
             return formatted
         else:
@@ -206,15 +205,14 @@ def fallback_format(raw_content: str) -> str:
     Returns:
         Minimally cleaned message
     """
-    # Remove markdown artifacts
-    cleaned = raw_content
-    for symbol in ["```", "**", "__", "~~", "##", "#"]:
-        cleaned = cleaned.replace(symbol, "")
+    from app.text_utils import strip_markdown, DEFAULT_MAX_LENGTH
+
+    cleaned = strip_markdown(raw_content)
     # Strip list markers at line start
     cleaned = re.sub(r'^[\-\*>]\s+', '', cleaned, flags=re.MULTILINE)
-    # Truncate for smartphone (Telegram limit is 4096, keep 2000 for readability)
-    if len(cleaned) > 2000:
-        cleaned = cleaned[:1997] + "..."
+    # Truncate for smartphone readability
+    if len(cleaned) > DEFAULT_MAX_LENGTH:
+        cleaned = cleaned[:DEFAULT_MAX_LENGTH - 3] + "..."
     return cleaned.strip()
 
 

--- a/koan/app/text_utils.py
+++ b/koan/app/text_utils.py
@@ -1,0 +1,64 @@
+"""Kōan — Text utilities for messaging delivery.
+
+Shared helpers for cleaning CLI output and stripping markdown formatting
+before sending to messaging providers (Telegram, Slack, etc.).
+
+These functions ensure consistent text processing across all message paths:
+- Chat responses (awake.py)
+- Outbox formatting (format_outbox.py)
+- AI runner responses (ai_runner.py)
+"""
+
+import re
+
+# Markdown symbols to strip (order matters: longer patterns first)
+_MARKDOWN_SYMBOLS = ("```", "**", "__", "~~")
+
+# CLI error patterns to filter from responses
+_CLI_ERROR_RE = re.compile(r'^Error:.*max turns', re.IGNORECASE)
+
+# Heading markers: # through ######
+_HEADING_RE = re.compile(r'^#{1,6}\s+', re.MULTILINE)
+
+# Default max message length for smartphone readability
+DEFAULT_MAX_LENGTH = 2000
+
+
+def strip_markdown(text: str) -> str:
+    """Strip markdown formatting artifacts from text.
+
+    Removes code fences, bold, underline, strikethrough, and heading markers.
+    Designed for plain-text messaging (Telegram, Slack).
+
+    Args:
+        text: Raw text potentially containing markdown.
+
+    Returns:
+        Text with markdown artifacts removed.
+    """
+    for symbol in _MARKDOWN_SYMBOLS:
+        text = text.replace(symbol, "")
+    text = _HEADING_RE.sub("", text)
+    return text
+
+
+def clean_cli_response(text: str, max_length: int = DEFAULT_MAX_LENGTH) -> str:
+    """Clean Claude CLI output for messaging delivery.
+
+    Strips CLI error artifacts, markdown formatting, and truncates for
+    smartphone reading. Used by chat responses and AI runner output.
+
+    Args:
+        text: Raw CLI stdout text.
+        max_length: Maximum character length (default 2000).
+
+    Returns:
+        Cleaned, truncated plain text.
+    """
+    lines = text.splitlines()
+    lines = [line for line in lines if not _CLI_ERROR_RE.match(line)]
+    cleaned = "\n".join(lines).strip()
+    cleaned = strip_markdown(cleaned)
+    if len(cleaned) > max_length:
+        cleaned = cleaned[:max_length - 3] + "..."
+    return cleaned.strip()

--- a/koan/tests/test_text_utils.py
+++ b/koan/tests/test_text_utils.py
@@ -1,0 +1,168 @@
+"""Tests for text_utils — shared text processing for messaging delivery."""
+
+import pytest
+from app.text_utils import strip_markdown, clean_cli_response, DEFAULT_MAX_LENGTH
+
+
+class TestStripMarkdown:
+    """Tests for strip_markdown()."""
+
+    def test_plain_text_unchanged(self):
+        assert strip_markdown("Hello world") == "Hello world"
+
+    def test_empty_string(self):
+        assert strip_markdown("") == ""
+
+    def test_strips_bold(self):
+        assert strip_markdown("This is **bold** text") == "This is bold text"
+
+    def test_strips_underline(self):
+        assert strip_markdown("This is __underlined__") == "This is underlined"
+
+    def test_strips_strikethrough(self):
+        assert strip_markdown("This is ~~deleted~~") == "This is deleted"
+
+    def test_strips_code_fences(self):
+        text = "```python\nprint('hello')\n```"
+        assert strip_markdown(text) == "python\nprint('hello')\n"
+
+    def test_strips_inline_code_fence(self):
+        assert strip_markdown("Use ```code``` here") == "Use code here"
+
+    def test_strips_heading_h1(self):
+        assert strip_markdown("# Title") == "Title"
+
+    def test_strips_heading_h2(self):
+        assert strip_markdown("## Section") == "Section"
+
+    def test_strips_heading_h3(self):
+        assert strip_markdown("### Subsection") == "Subsection"
+
+    def test_strips_heading_h6(self):
+        assert strip_markdown("###### Deep heading") == "Deep heading"
+
+    def test_hash_without_space_preserved(self):
+        """A # without trailing space is NOT a heading."""
+        assert strip_markdown("#hashtag") == "#hashtag"
+
+    def test_multiline_headings(self):
+        text = "# Title\n\n## Section\n\nSome text\n\n### Sub"
+        expected = "Title\n\nSection\n\nSome text\n\nSub"
+        assert strip_markdown(text) == expected
+
+    def test_combined_formatting(self):
+        text = "## **Bold heading**\n\nSome ~~deleted~~ and __underlined__ text"
+        expected = "Bold heading\n\nSome deleted and underlined text"
+        assert strip_markdown(text) == expected
+
+    def test_nested_bold_in_code_fence(self):
+        text = "```\n**not bold inside fence**\n```"
+        result = strip_markdown(text)
+        assert "**" not in result
+        assert "```" not in result
+        assert "not bold inside fence" in result
+
+    def test_whitespace_only(self):
+        assert strip_markdown("   \n  \n  ") == "   \n  \n  "
+
+    def test_no_heading_mid_line(self):
+        """Heading markers only stripped at line start."""
+        assert strip_markdown("This is not ## a heading") == "This is not ## a heading"
+
+    def test_multiple_bold_pairs(self):
+        text = "**first** and **second** bold"
+        assert strip_markdown(text) == "first and second bold"
+
+
+class TestCleanCliResponse:
+    """Tests for clean_cli_response()."""
+
+    def test_plain_response(self):
+        assert clean_cli_response("Hello world") == "Hello world"
+
+    def test_empty_response(self):
+        assert clean_cli_response("") == ""
+
+    def test_strips_max_turns_error(self):
+        text = "Error: max turns reached\nActual response"
+        assert clean_cli_response(text) == "Actual response"
+
+    def test_strips_max_turns_case_insensitive(self):
+        text = "error: MAX TURNS reached in conversation\nOK"
+        assert clean_cli_response(text) == "OK"
+
+    def test_strips_markdown(self):
+        text = "## Title\n\n**Bold** and ```code```"
+        result = clean_cli_response(text)
+        assert "##" not in result
+        assert "**" not in result
+        assert "```" not in result
+        assert "Title" in result
+        assert "Bold" in result
+
+    def test_truncates_at_default_limit(self):
+        text = "x" * 3000
+        result = clean_cli_response(text)
+        assert len(result) == DEFAULT_MAX_LENGTH
+        assert result.endswith("...")
+
+    def test_truncates_at_custom_limit(self):
+        text = "x" * 500
+        result = clean_cli_response(text, max_length=100)
+        assert len(result) == 100
+        assert result.endswith("...")
+
+    def test_no_truncation_within_limit(self):
+        text = "Short message"
+        result = clean_cli_response(text)
+        assert result == "Short message"
+
+    def test_exact_limit_no_truncation(self):
+        text = "x" * DEFAULT_MAX_LENGTH
+        result = clean_cli_response(text)
+        assert result == text
+        assert not result.endswith("...")
+
+    def test_strips_surrounding_whitespace(self):
+        text = "  \n  Hello  \n  "
+        assert clean_cli_response(text) == "Hello"
+
+    def test_preserves_non_error_lines(self):
+        text = "Line 1\nError: something else\nLine 3"
+        result = clean_cli_response(text)
+        assert "Line 1" in result
+        assert "Error: something else" in result
+        assert "Line 3" in result
+
+    def test_only_strips_max_turns_errors(self):
+        text = "Error: max turns limit\nError: network timeout\nDone"
+        result = clean_cli_response(text)
+        assert "max turns" not in result
+        assert "Error: network timeout" in result
+        assert "Done" in result
+
+    def test_full_pipeline(self):
+        """Tests the complete cleaning pipeline: error strip + markdown strip + truncate."""
+        text = (
+            "Error: max turns reached\n"
+            "## Report\n"
+            "\n"
+            "**Found** 3 issues:\n"
+            "- ~~old~~ new approach\n"
+            "- __underline__ check\n"
+        )
+        result = clean_cli_response(text)
+        assert "max turns" not in result
+        assert "**" not in result
+        assert "~~" not in result
+        assert "__" not in result
+        assert "Found 3 issues:" in result
+        assert "Report" in result
+
+    def test_multiple_error_lines(self):
+        text = "Error: max turns 1\nError: max turns 2\nActual content"
+        assert clean_cli_response(text) == "Actual content"
+
+    def test_error_line_only(self):
+        text = "Error: max turns reached"
+        assert clean_cli_response(text) == ""


### PR DESCRIPTION
…s module

DRY refactoring of markdown-stripping logic duplicated across 3 modules:
- awake.py (_clean_chat_response)
- ai_runner.py (_clean_response)
- format_outbox.py (format_message + fallback_format)

New koan/app/text_utils.py provides:
- strip_markdown(): removes code fences, bold, italic, strikethrough, heading markers
- clean_cli_response(): strips CLI error prefixes + markdown + truncates to max_length
- DEFAULT_MAX_LENGTH constant (2000) replaces magic number in 3 locations

Net reduction: ~45 lines of duplicated code replaced by delegating calls. All 5071 tests pass (33 new tests for text_utils).