### PR TITLE
feat: session outcome tracker for smarter autonomous decisions

### DIFF
--- a/koan/app/session_tracker.py
+++ b/koan/app/session_tracker.py
@@ -1,0 +1,332 @@
+"""Kōan — Session outcome tracking for smarter autonomous decisions.
+
+Records what each session accomplished and detects "stale" projects
+where consecutive sessions produce no actionable work. This breaks the
+pattern of 17 consecutive verification sessions by giving the agent
+(and the iteration planner) concrete feedback on recent productivity.
+
+Data is stored in instance/session_outcomes.json (append-only, capped).
+
+Integration points:
+- Write: mission_runner.run_post_mission() records after each session
+- Read: deep_research.py injects staleness warnings into agent prompt
+- Read: iteration_manager.py weights project selection by freshness
+"""
+
+import json
+import re
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+# Maximum entries to keep in session_outcomes.json (rolling window)
+MAX_OUTCOMES = 200
+
+# Keywords that signal an empty/non-productive session
+_EMPTY_KEYWORDS = [
+    "verification session",
+    "no code",
+    "no new code",
+    "waiting state",
+    "legitimate waiting state",
+    "blocked on merge",
+    "housekeeping only",
+    "no actionable work",
+    "same state",
+    "same pattern",
+    "no code changes",
+    "nothing actionable",
+    "merge queue",
+    "all work blocked",
+    "pas de code",
+    "identical session",
+    "no changes needed",
+]
+
+# Keywords that signal a productive session
+_PRODUCTIVE_KEYWORDS = [
+    "branch pushed",
+    "branch `koan/",
+    "pr #",
+    "pr created",
+    "tests pass",
+    "implemented",
+    "fixed",
+    "added",
+    "created",
+    "refactored",
+    "cleaned",
+    "migrated",
+    "wrote",
+    "built",
+]
+
+
+def classify_session(journal_content: str) -> str:
+    """Classify a session as productive, empty, or blocked.
+
+    Uses keyword matching on the journal/pending content to determine
+    whether the session produced actionable output.
+
+    Args:
+        journal_content: The session's journal entry or pending.md content.
+
+    Returns:
+        "productive", "empty", or "blocked"
+    """
+    if not journal_content:
+        return "empty"
+
+    lower = journal_content.lower()
+
+    # Check for empty/blocked signals first (more specific)
+    empty_score = sum(1 for kw in _EMPTY_KEYWORDS if kw in lower)
+    productive_score = sum(1 for kw in _PRODUCTIVE_KEYWORDS if kw in lower)
+
+    # Strong empty signals override productive keywords
+    if empty_score >= 3:
+        return "empty"
+
+    # Check for blocked-on-merges pattern specifically
+    if "blocked on merge" in lower or "merge queue" in lower:
+        if productive_score < 2:
+            return "blocked"
+
+    # Productive wins if it has clear signals
+    if productive_score >= 2:
+        return "productive"
+
+    # Weak signals — use ratio
+    if empty_score > productive_score:
+        return "empty"
+
+    # Default: benefit of the doubt
+    return "productive"
+
+
+def _extract_summary(journal_content: str, max_chars: int = 120) -> str:
+    """Extract a brief summary from journal content.
+
+    Looks for the first substantive line (not a header, not empty).
+    """
+    if not journal_content:
+        return ""
+
+    for line in journal_content.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or line.startswith("---"):
+            continue
+        if line.startswith("Project:") or line.startswith("Started:"):
+            continue
+        if line.startswith("Run:") or line.startswith("Mode:"):
+            continue
+        # Found a content line
+        if len(line) > max_chars:
+            return line[:max_chars] + "..."
+        return line
+
+    return ""
+
+
+def record_outcome(
+    instance_dir: str,
+    project: str,
+    mode: str,
+    duration_minutes: int,
+    journal_content: str,
+) -> dict:
+    """Record a session outcome to session_outcomes.json.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project: Project name.
+        mode: Autonomous mode (review/implement/deep).
+        duration_minutes: Session duration in minutes.
+        journal_content: The session's journal/pending content for classification.
+
+    Returns:
+        The recorded outcome dict.
+    """
+    outcome_type = classify_session(journal_content)
+    summary = _extract_summary(journal_content)
+
+    entry = {
+        "timestamp": datetime.now().isoformat(timespec="seconds"),
+        "project": project,
+        "mode": mode,
+        "duration_minutes": duration_minutes,
+        "outcome": outcome_type,
+        "summary": summary,
+    }
+
+    outcomes_path = Path(instance_dir) / "session_outcomes.json"
+
+    # Load existing outcomes
+    outcomes = _load_outcomes(outcomes_path)
+
+    # Append and cap
+    outcomes.append(entry)
+    if len(outcomes) > MAX_OUTCOMES:
+        outcomes = outcomes[-MAX_OUTCOMES:]
+
+    # Write atomically
+    try:
+        from app.utils import atomic_write
+        atomic_write(outcomes_path, json.dumps(outcomes, indent=2))
+    except Exception as e:
+        print(f"[session_tracker] Failed to write outcomes: {e}", file=sys.stderr)
+
+    return entry
+
+
+def _load_outcomes(outcomes_path: Path) -> list:
+    """Load outcomes from JSON file. Returns empty list on error."""
+    if not outcomes_path.exists():
+        return []
+    try:
+        return json.loads(outcomes_path.read_text())
+    except (json.JSONDecodeError, OSError) as e:
+        print(f"[session_tracker] Failed to read outcomes: {e}", file=sys.stderr)
+        return []
+
+
+def get_recent_outcomes(
+    instance_dir: str,
+    project: str,
+    limit: int = 10,
+) -> List[dict]:
+    """Get the last N outcomes for a project.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project: Project name to filter by.
+        limit: Maximum number of outcomes to return.
+
+    Returns:
+        List of outcome dicts, most recent last.
+    """
+    outcomes_path = Path(instance_dir) / "session_outcomes.json"
+    all_outcomes = _load_outcomes(outcomes_path)
+
+    project_outcomes = [o for o in all_outcomes if o.get("project") == project]
+    return project_outcomes[-limit:]
+
+
+def get_staleness_score(instance_dir: str, project: str) -> int:
+    """Count consecutive empty/blocked sessions for a project.
+
+    Counts backwards from the most recent session. Stops at the first
+    productive session.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project: Project name.
+
+    Returns:
+        Number of consecutive non-productive sessions. 0 = fresh.
+    """
+    recent = get_recent_outcomes(instance_dir, project, limit=20)
+    if not recent:
+        return 0
+
+    count = 0
+    for outcome in reversed(recent):
+        if outcome.get("outcome") == "productive":
+            break
+        count += 1
+
+    return count
+
+
+def get_staleness_warning(instance_dir: str, project: str) -> str:
+    """Generate a human-readable staleness warning if appropriate.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project: Project name.
+
+    Returns:
+        Warning string, or empty string if project is fresh.
+    """
+    score = get_staleness_score(instance_dir, project)
+    if score < 3:
+        return ""
+
+    recent = get_recent_outcomes(instance_dir, project, limit=score + 1)
+    empty_summaries = [
+        o.get("summary", "")
+        for o in recent[-score:]
+        if o.get("outcome") != "productive"
+    ]
+
+    # Build contextual warning
+    if score >= 5:
+        intensity = "CRITICAL"
+        advice = (
+            "This project has had {score} consecutive non-productive sessions. "
+            "STOP doing verification/housekeeping. Either:\n"
+            "  1. Find genuinely NEW work (a bug, a missing feature, an architectural issue)\n"
+            "  2. Skip this project entirely and work on something else\n"
+            "  3. Write a strategic proposal or analysis that adds real value"
+        )
+    elif score >= 3:
+        intensity = "WARNING"
+        advice = (
+            "Last {score} sessions found nothing actionable. "
+            "Avoid repeating the same checks. Look for genuinely new work, "
+            "or consider that this project may not need attention right now."
+        )
+    else:
+        return ""
+
+    lines = [
+        f"### {intensity}: Project Staleness Detected",
+        "",
+        advice.format(score=score),
+        "",
+    ]
+
+    if empty_summaries:
+        lines.append("Recent non-productive sessions:")
+        for s in empty_summaries[-3:]:  # Show last 3
+            if s:
+                lines.append(f"  - {s[:100]}")
+        lines.append("")
+
+    return "\n".join(lines)
+
+
+def get_project_freshness(
+    instance_dir: str,
+    projects: List[Tuple[str, str]],
+) -> Dict[str, int]:
+    """Get freshness scores for all projects (for weighted selection).
+
+    Returns a dict mapping project name to a weight (higher = fresher).
+    Fresh projects get weight 10, stale projects get progressively less.
+    Projects with staleness >= 5 get weight 1 (minimal chance).
+
+    Args:
+        instance_dir: Path to instance directory.
+        projects: List of (name, path) tuples.
+
+    Returns:
+        Dict mapping project name to weight (1-10).
+    """
+    weights = {}
+    for name, _ in projects:
+        score = get_staleness_score(instance_dir, name)
+        if score == 0:
+            weights[name] = 10
+        elif score == 1:
+            weights[name] = 8
+        elif score == 2:
+            weights[name] = 6
+        elif score <= 4:
+            weights[name] = 3
+        else:
+            weights[name] = 1  # Heavily deprioritized
+
+    return weights

--- a/koan/tests/test_session_tracker.py
+++ b/koan/tests/test_session_tracker.py
@@ -1,0 +1,409 @@
+"""Tests for session_tracker.py — session outcome tracking and staleness detection."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.session_tracker import (
+    classify_session,
+    record_outcome,
+    get_recent_outcomes,
+    get_staleness_score,
+    get_staleness_warning,
+    get_project_freshness,
+    _extract_summary,
+    _load_outcomes,
+    MAX_OUTCOMES,
+)
+
+
+@pytest.fixture
+def tracker_env(tmp_path):
+    """Create a minimal environment for session tracker testing."""
+    instance = tmp_path / "instance"
+    instance.mkdir()
+    return str(instance)
+
+
+# --- classify_session ---
+
+class TestClassifySession:
+    """Tests for session classification logic."""
+
+    def test_empty_content(self):
+        assert classify_session("") == "empty"
+
+    def test_productive_with_branch(self):
+        content = "Branch `koan/fix-auth` pushed. Tests pass. PR #42 created."
+        assert classify_session(content) == "productive"
+
+    def test_productive_with_implementation(self):
+        content = "Implemented new feature. Added 15 tests. Branch pushed."
+        assert classify_session(content) == "productive"
+
+    def test_empty_verification_session(self):
+        content = (
+            "Verification session — 28 koan/* branches pending merge, "
+            "codebase healthy. No code changes. Legitimate waiting state. "
+            "All work blocked on merge reviews."
+        )
+        assert classify_session(content) == "empty"
+
+    def test_empty_housekeeping(self):
+        content = (
+            "Housekeeping only. No actionable work found. "
+            "Same state as previous sessions. Waiting state."
+        )
+        assert classify_session(content) == "empty"
+
+    def test_blocked_on_merges(self):
+        content = (
+            "All 5 branches verified. Blocked on merge reviews. "
+            "No new issues found."
+        )
+        assert classify_session(content) == "blocked"
+
+    def test_productive_with_fixes(self):
+        content = "Fixed 4 failing SEO tests. Cleaned up imports. Branch pushed."
+        assert classify_session(content) == "productive"
+
+    def test_productive_refactoring(self):
+        content = "Refactored PII encryption. Migrated datetime.utcnow(). Tests pass."
+        assert classify_session(content) == "productive"
+
+    def test_french_no_code(self):
+        content = "Pas de code — mission analytique. Issue #105 created."
+        assert classify_session(content) == "productive"  # issue created = productive
+
+    def test_strong_empty_overrides_weak_productive(self):
+        """Many empty signals should override a few productive ones."""
+        content = (
+            "Verification session. No code changes. "
+            "Same state as sessions 20-36. Legitimate waiting state. "
+            "Merge queue is only bottleneck. Created a comment."
+        )
+        assert classify_session(content) == "empty"
+
+    def test_merge_queue_without_productive(self):
+        content = "Merge queue is the bottleneck. All branches verified clean."
+        assert classify_session(content) == "blocked"
+
+    def test_default_productive(self):
+        """Ambiguous content defaults to productive."""
+        content = "Explored the codebase. Read several files."
+        assert classify_session(content) == "productive"
+
+    def test_identical_session_keyword(self):
+        content = "Identical session to previous. No code."
+        assert classify_session(content) == "empty"
+
+
+# --- _extract_summary ---
+
+class TestExtractSummary:
+
+    def test_empty_content(self):
+        assert _extract_summary("") == ""
+
+    def test_skips_headers_and_metadata(self):
+        content = """# Autonomous run
+Project: koan
+Started: 2026-02-21 11:13:50
+Run: 3/3
+Mode: deep
+
+---
+11:13 — Reading context files
+"""
+        assert _extract_summary(content) == "11:13 — Reading context files"
+
+    def test_truncates_long_lines(self):
+        content = "A" * 200
+        result = _extract_summary(content)
+        assert len(result) <= 123  # 120 + "..."
+        assert result.endswith("...")
+
+
+# --- record_outcome ---
+
+def _mock_atomic_write(path, content):
+    """Test-safe atomic_write that just writes directly."""
+    Path(path).write_text(content)
+
+
+class TestRecordOutcome:
+
+    def test_records_productive(self, tracker_env, monkeypatch):
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        entry = record_outcome(
+            tracker_env, "koan", "deep", 15,
+            "Implemented session tracker. Branch pushed. Tests pass.",
+        )
+        assert entry["outcome"] == "productive"
+        assert entry["project"] == "koan"
+        assert entry["mode"] == "deep"
+        assert entry["duration_minutes"] == 15
+
+        # Verify file was written
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        data = json.loads(outcomes_path.read_text())
+        assert len(data) == 1
+        assert data[0]["outcome"] == "productive"
+
+    def test_records_empty(self, tracker_env, monkeypatch):
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        entry = record_outcome(
+            tracker_env, "backend", "review", 5,
+            "Verification session. No code. Waiting state.",
+        )
+        assert entry["outcome"] == "empty"
+
+    def test_appends_to_existing(self, tracker_env, monkeypatch):
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"timestamp": "2026-02-20T10:00:00", "project": "koan",
+             "mode": "deep", "duration_minutes": 10,
+             "outcome": "productive", "summary": "old session"}
+        ]))
+
+        record_outcome(
+            tracker_env, "koan", "implement", 8,
+            "Added tests. Branch pushed.",
+        )
+
+        data = json.loads(outcomes_path.read_text())
+        assert len(data) == 2
+
+    def test_caps_at_max(self, tracker_env, monkeypatch):
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        # Pre-fill with MAX_OUTCOMES entries
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        existing = [
+            {"timestamp": f"2026-02-{i:02d}T10:00:00", "project": "koan",
+             "mode": "deep", "duration_minutes": 5,
+             "outcome": "productive", "summary": f"session {i}"}
+            for i in range(MAX_OUTCOMES)
+        ]
+        outcomes_path.write_text(json.dumps(existing))
+
+        record_outcome(tracker_env, "koan", "deep", 5, "new session. branch pushed.")
+
+        data = json.loads(outcomes_path.read_text())
+        assert len(data) == MAX_OUTCOMES
+        # The oldest entry should have been dropped
+        assert data[-1]["summary"] == "new session. branch pushed."
+
+    def test_handles_corrupt_file(self, tracker_env, monkeypatch):
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text("not json")
+
+        entry = record_outcome(
+            tracker_env, "koan", "deep", 5,
+            "Fixed bug. Branch pushed.",
+        )
+        assert entry["outcome"] == "productive"
+
+        # Should have overwritten with valid data
+        data = json.loads(outcomes_path.read_text())
+        assert len(data) == 1
+
+
+# --- get_recent_outcomes ---
+
+class TestGetRecentOutcomes:
+
+    def test_no_file(self, tracker_env):
+        result = get_recent_outcomes(tracker_env, "koan")
+        assert result == []
+
+    def test_filters_by_project(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": "a"},
+            {"project": "backend", "outcome": "empty", "summary": "b"},
+            {"project": "koan", "outcome": "empty", "summary": "c"},
+        ]))
+
+        result = get_recent_outcomes(tracker_env, "koan")
+        assert len(result) == 2
+        assert result[0]["summary"] == "a"
+        assert result[1]["summary"] == "c"
+
+    def test_respects_limit(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": str(i)}
+            for i in range(20)
+        ]))
+
+        result = get_recent_outcomes(tracker_env, "koan", limit=5)
+        assert len(result) == 5
+        # Should be the last 5
+        assert result[0]["summary"] == "15"
+
+
+# --- get_staleness_score ---
+
+class TestGetStalenessScore:
+
+    def test_no_data(self, tracker_env):
+        assert get_staleness_score(tracker_env, "koan") == 0
+
+    def test_all_productive(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": str(i)}
+            for i in range(5)
+        ]))
+        assert get_staleness_score(tracker_env, "koan") == 0
+
+    def test_consecutive_empty(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": "good"},
+            {"project": "koan", "outcome": "empty", "summary": "bad1"},
+            {"project": "koan", "outcome": "empty", "summary": "bad2"},
+            {"project": "koan", "outcome": "blocked", "summary": "bad3"},
+        ]))
+        assert get_staleness_score(tracker_env, "koan") == 3
+
+    def test_mixed_with_productive_break(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": "old empty"},
+            {"project": "koan", "outcome": "productive", "summary": "break"},
+            {"project": "koan", "outcome": "empty", "summary": "new empty"},
+        ]))
+        # Only 1 consecutive empty (after the productive break)
+        assert get_staleness_score(tracker_env, "koan") == 1
+
+    def test_different_project_not_counted(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": "good"},
+            {"project": "backend", "outcome": "empty", "summary": "not koan"},
+            {"project": "koan", "outcome": "empty", "summary": "bad"},
+        ]))
+        assert get_staleness_score(tracker_env, "koan") == 1
+
+
+# --- get_staleness_warning ---
+
+class TestGetStalenessWarning:
+
+    def test_no_warning_for_fresh(self, tracker_env):
+        assert get_staleness_warning(tracker_env, "koan") == ""
+
+    def test_no_warning_under_threshold(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": "e1"},
+            {"project": "koan", "outcome": "empty", "summary": "e2"},
+        ]))
+        assert get_staleness_warning(tracker_env, "koan") == ""
+
+    def test_warning_at_3(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": "e1"},
+            {"project": "koan", "outcome": "empty", "summary": "e2"},
+            {"project": "koan", "outcome": "empty", "summary": "e3"},
+        ]))
+        warning = get_staleness_warning(tracker_env, "koan")
+        assert "WARNING" in warning
+        assert "3 sessions" in warning
+
+    def test_critical_at_5(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": f"e{i}"}
+            for i in range(6)
+        ]))
+        warning = get_staleness_warning(tracker_env, "koan")
+        assert "CRITICAL" in warning
+        assert "STOP" in warning
+
+    def test_warning_includes_summaries(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": "verification again"},
+            {"project": "koan", "outcome": "empty", "summary": "still waiting"},
+            {"project": "koan", "outcome": "empty", "summary": "same state"},
+        ]))
+        warning = get_staleness_warning(tracker_env, "koan")
+        assert "verification again" in warning or "still waiting" in warning
+
+
+# --- get_project_freshness ---
+
+class TestGetProjectFreshness:
+
+    def test_all_fresh(self, tracker_env):
+        """Projects with no history get max weight."""
+        projects = [("koan", "/p/koan"), ("backend", "/p/backend")]
+        weights = get_project_freshness(tracker_env, projects)
+        assert weights["koan"] == 10
+        assert weights["backend"] == 10
+
+    def test_stale_project_lower_weight(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "productive", "summary": "good"},
+            {"project": "backend", "outcome": "empty", "summary": "e1"},
+            {"project": "backend", "outcome": "empty", "summary": "e2"},
+            {"project": "backend", "outcome": "empty", "summary": "e3"},
+            {"project": "backend", "outcome": "empty", "summary": "e4"},
+            {"project": "backend", "outcome": "empty", "summary": "e5"},
+        ]))
+        projects = [("koan", "/p/koan"), ("backend", "/p/backend")]
+        weights = get_project_freshness(tracker_env, projects)
+        assert weights["koan"] == 10
+        assert weights["backend"] == 1  # Very stale
+
+    def test_medium_staleness(self, tracker_env):
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "koan", "outcome": "empty", "summary": "e1"},
+            {"project": "koan", "outcome": "empty", "summary": "e2"},
+        ]))
+        projects = [("koan", "/p/koan")]
+        weights = get_project_freshness(tracker_env, projects)
+        assert weights["koan"] == 6  # staleness 2 → weight 6
+
+
+# --- Integration with deep_research ---
+
+class TestDeepResearchStaleness:
+
+    def test_staleness_warning_in_format(self, tmp_path):
+        """DeepResearch.format_for_agent() includes staleness warning."""
+        instance = tmp_path / "instance"
+        project_path = tmp_path / "project"
+        (instance / "memory" / "projects" / "testproj").mkdir(parents=True)
+        (instance / "journal").mkdir(parents=True)
+        project_path.mkdir()
+
+        # Create stale outcomes
+        outcomes_path = instance / "session_outcomes.json"
+        outcomes_path.write_text(json.dumps([
+            {"project": "testproj", "outcome": "empty", "summary": f"e{i}"}
+            for i in range(5)
+        ]))
+
+        from app.deep_research import DeepResearch
+        research = DeepResearch(instance, "testproj", project_path)
+
+        with pytest.MonkeyPatch.context() as m:
+            m.setattr(research, "get_open_issues", lambda limit=10: [])
+            output = research.format_for_agent()
+
+        assert "CRITICAL" in output
+        assert "STOP" in output


### PR DESCRIPTION
## Summary
- New `session_tracker.py` module that records session outcomes (productive/empty/blocked) and detects project staleness
- Prevents the "17 consecutive verification sessions" anti-pattern by giving the agent concrete feedback on recent productivity
- Three integration points: outcome recording (mission_runner), staleness warnings in agent prompt (deep_research), weighted project selection (iteration_manager)

## How it works
1. **After each session**: `mission_runner.run_post_mission()` reads pending.md content and classifies the session using keyword matching (empty signals: "verification session", "no code", "waiting state" vs productive signals: "branch pushed", "PR #", "implemented")
2. **Before autonomous sessions**: `deep_research.format_for_agent()` checks staleness score and injects WARNING (3+ empty) or CRITICAL (5+ empty) into the agent prompt
3. **Project selection**: `iteration_manager._select_random_exploration_project()` uses freshness weights — stale projects get deprioritized (weight 1 vs 10 for fresh)

## Test plan
- [x] 38 new tests covering classify, record, staleness, freshness, deep_research integration
- [x] Full test suite passes (6017 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)