### PR TITLE
koan.atoomic/fix three silent bugs

### DIFF
--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -494,6 +494,10 @@ def process_single_notification(
     import os
 
     koan_root = os.environ.get("KOAN_ROOT", "")
+    if not koan_root:
+        log.error("GitHub: KOAN_ROOT not set — cannot insert mission")
+        mark_notification_read(str(notification.get("id", "")))
+        return False, "KOAN_ROOT not configured"
     missions_path = Path(koan_root) / "instance" / "missions.md"
     try:
         insert_pending_mission(missions_path, mission_entry)

--- a/koan/app/rituals.py
+++ b/koan/app/rituals.py
@@ -8,10 +8,12 @@ messages that make Kōan feel like a collaborator, not just a tool.
 Usage: python -m app.rituals <morning|evening> <instance_dir>
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
+from app.cli_exec import run_cli
 from app.cli_provider import build_full_command
 from app.claude_step import strip_cli_noise
 from app.prompts import get_prompt_path
@@ -55,16 +57,12 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         print(f"[rituals] {e}", file=sys.stderr)
         return False
 
-    # Get KOAN_ROOT for proper working directory
-    import os
     koan_root = os.environ.get("KOAN_ROOT", "")
     if not koan_root:
         print("[rituals] KOAN_ROOT not set", file=sys.stderr)
         return False
 
     try:
-        from app.cli_exec import run_cli
-
         cmd = build_full_command(
             prompt=prompt,
             allowed_tools=["Read", "Write", "Glob"],

--- a/koan/app/session_tracker.py
+++ b/koan/app/session_tracker.py
@@ -204,7 +204,8 @@ def _load_outcomes(outcomes_path: Path) -> list:
         data = json.loads(outcomes_path.read_text())
         if not isinstance(data, list):
             print(
-                f"[session_tracker] Unexpected JSON type: {type(data).__name__}",
+                f"[session_tracker] Unexpected JSON type {type(data).__name__}, "
+                "expected list — resetting",
                 file=sys.stderr,
             )
             return []

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -560,6 +560,71 @@ class TestProcessSingleNotification:
         assert "read-only" in error
         mock_read.assert_called_with("12345")
 
+    @patch("app.github_command_handler.mark_notification_read")
+    @patch("app.github_command_handler.add_reaction", return_value=True)
+    @patch("app.github_command_handler.check_user_permission", return_value=True)
+    @patch("app.github_command_handler.check_already_processed", return_value=False)
+    @patch("app.github_command_handler.is_self_mention", return_value=False)
+    @patch("app.github_command_handler.is_notification_stale", return_value=False)
+    @patch("app.github_command_handler.get_comment_from_notification")
+    @patch("app.github_command_handler.resolve_project_from_notification")
+    @patch("app.utils.insert_pending_mission")
+    def test_empty_koan_root_rejects_mission(
+        self, mock_insert, mock_resolve, mock_get_comment,
+        mock_stale, mock_self, mock_processed, mock_perm,
+        mock_react, mock_read, registry, sample_notification,
+    ):
+        """Empty KOAN_ROOT should fail early, not write to relative path."""
+        mock_resolve.return_value = ("koan", "sukria", "koan")
+        mock_get_comment.return_value = {
+            "id": 99999,
+            "body": "@testbot rebase",
+            "user": {"login": "alice"},
+        }
+        config = {"github": {"nickname": "testbot", "authorized_users": ["*"]}}
+
+        with patch.dict("os.environ", {"KOAN_ROOT": ""}):
+            success, error = process_single_notification(
+                sample_notification, registry, config, None, "testbot",
+            )
+
+        assert success is False
+        assert "KOAN_ROOT" in error
+        mock_insert.assert_not_called()
+        mock_read.assert_called_with("12345")
+
+    @patch("app.github_command_handler.mark_notification_read")
+    @patch("app.github_command_handler.add_reaction", return_value=True)
+    @patch("app.github_command_handler.check_user_permission", return_value=True)
+    @patch("app.github_command_handler.check_already_processed", return_value=False)
+    @patch("app.github_command_handler.is_self_mention", return_value=False)
+    @patch("app.github_command_handler.is_notification_stale", return_value=False)
+    @patch("app.github_command_handler.get_comment_from_notification")
+    @patch("app.github_command_handler.resolve_project_from_notification")
+    @patch("app.utils.insert_pending_mission")
+    def test_missing_koan_root_rejects_mission(
+        self, mock_insert, mock_resolve, mock_get_comment,
+        mock_stale, mock_self, mock_processed, mock_perm,
+        mock_react, mock_read, registry, sample_notification, monkeypatch,
+    ):
+        """Unset KOAN_ROOT should fail early, not write to relative path."""
+        mock_resolve.return_value = ("koan", "sukria", "koan")
+        mock_get_comment.return_value = {
+            "id": 99999,
+            "body": "@testbot rebase",
+            "user": {"login": "alice"},
+        }
+        config = {"github": {"nickname": "testbot", "authorized_users": ["*"]}}
+
+        monkeypatch.delenv("KOAN_ROOT", raising=False)
+        success, error = process_single_notification(
+            sample_notification, registry, config, None, "testbot",
+        )
+
+        assert success is False
+        assert "KOAN_ROOT" in error
+        mock_insert.assert_not_called()
+
 
 class TestTryReply:
     """Tests for the _try_reply helper that generates AI replies."""

--- a/koan/tests/test_session_tracker.py
+++ b/koan/tests/test_session_tracker.py
@@ -383,6 +383,55 @@ class TestGetProjectFreshness:
         assert weights["koan"] == 6  # staleness 2 → weight 6
 
 
+# --- _load_outcomes type validation ---
+
+class TestLoadOutcomesTypeValidation:
+
+    def test_dict_json_returns_empty_list(self, tracker_env):
+        """A corrupted file containing a JSON object should not crash callers."""
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text("{}")
+        result = get_recent_outcomes(tracker_env, "koan")
+        assert result == []
+
+    def test_string_json_returns_empty_list(self, tracker_env):
+        """A JSON string should not be iterated as a list."""
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text('"hello"')
+        result = get_recent_outcomes(tracker_env, "koan")
+        assert result == []
+
+    def test_int_json_returns_empty_list(self, tracker_env):
+        """A JSON number should not crash the system."""
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text("42")
+        result = get_recent_outcomes(tracker_env, "koan")
+        assert result == []
+
+    def test_record_outcome_with_corrupt_dict_file(self, tracker_env, monkeypatch):
+        """record_outcome should overwrite corrupt data and succeed."""
+        monkeypatch.setattr("app.utils.atomic_write", _mock_atomic_write)
+
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text('{"not": "a list"}')
+
+        entry = record_outcome(
+            tracker_env, "koan", "implement", 5,
+            "Fixed bug. Branch pushed.",
+        )
+        assert entry["outcome"] == "productive"
+
+        data = json.loads(outcomes_path.read_text())
+        assert isinstance(data, list)
+        assert len(data) == 1
+
+    def test_staleness_with_dict_file(self, tracker_env):
+        """get_staleness_score should not crash on corrupted JSON object."""
+        outcomes_path = Path(tracker_env) / "session_outcomes.json"
+        outcomes_path.write_text('{"corrupt": true}')
+        assert get_staleness_score(tracker_env, "koan") == 0
+
+
 # --- Integration with deep_research ---
 
 class TestDeepResearchStaleness:

--- a/koan/tests/test_silent_exceptions.py
+++ b/koan/tests/test_silent_exceptions.py
@@ -33,7 +33,9 @@ APP_DIR = Path(__file__).parent.parent / "app"
 # When adding: include a short justification comment.
 ALLOWLIST: Set[Tuple[str, int]] = {
     # --- Shutdown / terminal cleanup (terminal may be gone) ---
-    ("run.py", 78),                  # ANSI reset on shutdown
+    ("run.py", 79),                  # ANSI reset on shutdown
+    ("run.py", 1658),                # _get_koan_branch: git rev-parse fallback
+    ("run.py", 1834),                # _cleanup_temp_files: unlink best-effort
     # --- Best-effort display / info gathering ---
     ("ai_runner.py", 127),           # dir listing for prompt context
     ("startup_info.py", 25),         # config value fallback


### PR DESCRIPTION
- **fix: replace --author flag with GIT_AUTHOR env vars in auto-merge**
- **feat: add /projects command and get_known_projects() utility**
- **feat: detect fork remotes and create PR upstream instead of auto-merging**
- **feat: add /ping command to check if run loop is alive**
- **feat: add recurring missions with /daily /hourly /weekly commands**
- **feat: add /queue command — full numbered mission queue**
- **feat: add /mcp command and MCP server integration for personal assistant capabilities**
- **feat: add /priority command to reorder mission queue from Telegram**
- **feat: add /progress page with live SSE stream of pending.md**
- **feat: add /log and /journal command to read journal entries from Telegram**
- **feat: add /pr command for pull request review and update workflow**
- **feat: translate /help command output to English**
- **feat: add README.md and avatar.png to instance.example**
- **feat: increase max_runs default from 10 to 25**
- **feat: smarter mission classification with /chat escape hatch**
- **feat: add copilot as alternative CLI provider**
- **feat: abstract messaging layer to support Slack alongside Telegram**
- **feat: simplify instance.example template to English**
- **feat: add ASCII art banners for agent loop and bridge startup**
- **fix: validate JSON types and guard missing KOAN_ROOT**
