### PR TITLE
Move cached_count_open_prs from iteration_manager to github.py

### DIFF
--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -26,10 +26,9 @@ import json
 import random
 import re
 import sys
-import time
 from collections import namedtuple
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 from app.loop_manager import resolve_focus_area
 
@@ -271,28 +270,6 @@ def _check_focus(koan_root: str):
         return None
 
 
-# TTL cache for count_open_prs results (avoids repeated gh CLI calls per iteration)
-_pr_count_cache: Dict[str, tuple] = {}  # key -> (count, timestamp)
-_PR_COUNT_TTL = 300  # 5 minutes
-
-
-def _cached_count_open_prs(github_url: str, author: str) -> int:
-    """count_open_prs with a 5-minute TTL cache."""
-    from app.github import count_open_prs
-
-    key = f"{github_url}:{author}"
-    now = time.monotonic()
-    cached = _pr_count_cache.get(key)
-    if cached and (now - cached[1]) < _PR_COUNT_TTL:
-        return cached[0]
-
-    result = count_open_prs(github_url, author)
-    # Cache errors (-1) too — avoids hammering gh on repeated failures.
-    # Fail-open: -1 means project stays included until cache expires.
-    _pr_count_cache[key] = (result, now)
-    return result
-
-
 def _select_random_exploration_project(
     projects: List[Tuple[str, str]],
     last_project: str = "",
@@ -386,7 +363,7 @@ def _filter_exploration_projects(
     ]
 
     # Gate 2: max_open_prs limit
-    from app.github import get_gh_username
+    from app.github import get_gh_username, cached_count_open_prs
     author = get_gh_username()
 
     filtered = []
@@ -412,7 +389,7 @@ def _filter_exploration_projects(
             filtered.append((name, path))
             continue
 
-        open_count = _cached_count_open_prs(github_url, author)
+        open_count = cached_count_open_prs(github_url, author)
         if open_count < 0:
             # Error — fail-open, include project
             filtered.append((name, path))

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -1119,7 +1119,7 @@ class TestFilterExplorationProjectsPrLimit:
 
     def setup_method(self):
         """Clear the PR count cache between tests."""
-        from app.iteration_manager import _pr_count_cache
+        from app.github import _pr_count_cache
         _pr_count_cache.clear()
 
     @patch("app.github.get_gh_username", return_value="koan-bot")

--- a/koan/tests/test_silent_exceptions.py
+++ b/koan/tests/test_silent_exceptions.py
@@ -55,8 +55,8 @@ ALLOWLIST: Set[Tuple[str, int]] = {
     ("prompt_builder.py", 55),       # shared-journal.md loading
     ("awake.py", 173),               # pending.md read for chat context
     # --- GitHub API best-effort (None/empty is safe) ---
-    ("github.py", 182),              # gh username cache miss
-    ("github.py", 215),              # parent repo detection
+    ("github.py", 183),              # gh username cache miss
+    ("github.py", 216),              # parent repo detection
     ("github_auth.py", 56),          # token validation
     # --- Git operations (abort after failed rebase) ---
     ("claude_step.py", 52),          # rebase --abort after failed rebase


### PR DESCRIPTION
The TTL-cached PR count function is shared infrastructure (used by
iteration_manager's project filtering). Moving it to github.py
alongside count_open_prs keeps the caching close to the API wrapper
and removes time/Dict imports from iteration_manager.

Co-Authored-By: Claude <noreply@anthropic.com>
