### PR TITLE
Stream CLI output to journal in real-time

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -25,6 +25,12 @@ fast_reply: false
 # Use `tail -f .koan-debug.log` to watch dispatch decisions, commands, and errors
 # debug: false
 
+# CLI output journal — stream CLI output to the daily journal file in real-time
+# When enabled, mission and contemplative CLI output is appended to the project's
+# journal file as it runs. Use `tail -f instance/journal/YYYY-MM-DD/project.md`
+# to watch the agent work. Set to false to disable.
+# cli_output_journal: true
+
 # Branch prefix — used for all agent-created branches
 # Default is "koan" which creates branches like "koan/fix-something"
 # Change this for multi-bot setups to avoid branch name collisions

--- a/koan/app/cli_journal_streamer.py
+++ b/koan/app/cli_journal_streamer.py
@@ -1,0 +1,258 @@
+"""CLI output journal streamer — tail thread for real-time visibility.
+
+Provides a lightweight tail thread that polls a subprocess stdout temp file
+and appends new content to the project's daily journal file. This gives
+users real-time visibility via ``tail -f`` on the journal without changing
+the subprocess I/O path at all.
+
+Usage::
+
+    stream = start_journal_stream(stdout_file, instance_dir, project_name, run_num)
+    # ... run subprocess ...
+    stop_journal_stream(stream, exit_code, stderr_file)
+"""
+
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Optional, Tuple
+
+
+_POLL_INTERVAL = 1.0  # seconds between tail polls
+_CHUNK_SIZE = 8192    # bytes per read
+
+
+def _decode_safe(data: bytes) -> tuple:
+    """Decode bytes to str, preserving incomplete trailing UTF-8 sequences.
+
+    Returns ``(decoded_text, leftover_bytes)`` where *leftover_bytes* are
+    0–3 trailing bytes that form an incomplete multi-byte character.
+    """
+    # Try full decode first (fast path — no split)
+    try:
+        return data.decode("utf-8"), b""
+    except UnicodeDecodeError:
+        pass
+    # Walk back up to 3 bytes to find the split point
+    for i in range(1, min(4, len(data)) + 1):
+        try:
+            return data[:-i].decode("utf-8"), data[-i:]
+        except UnicodeDecodeError:
+            continue
+    # Fallback: replace all invalid bytes
+    return data.decode("utf-8", errors="replace"), b""
+
+
+def _get_append_fn():
+    """Lazy import of append_to_journal to avoid circular imports."""
+    from app.journal import append_to_journal
+    return append_to_journal
+
+
+def _journal_write(instance_dir: Path, project_name: str, content: str) -> None:
+    """Append content to journal, logging errors to stderr."""
+    try:
+        _get_append_fn()(instance_dir, project_name, content)
+    except Exception as e:
+        print(f"[cli-journal] write error: {e}", file=sys.stderr)
+
+
+def _tail_loop(
+    stdout_file: str,
+    instance_dir: Path,
+    project_name: str,
+    stop_event: threading.Event,
+) -> None:
+    """Poll *stdout_file* for new bytes and append them to the journal."""
+    append = _get_append_fn()
+    pos = 0
+    leftover = b""  # incomplete UTF-8 trailing bytes from previous read
+
+    while not stop_event.is_set():
+        try:
+            size = os.path.getsize(stdout_file)
+        except OSError:
+            stop_event.wait(_POLL_INTERVAL)
+            continue
+
+        if size <= pos:
+            stop_event.wait(_POLL_INTERVAL)
+            continue
+
+        try:
+            with open(stdout_file, "rb") as f:
+                f.seek(pos)
+                raw = f.read(_CHUNK_SIZE)
+                if raw:
+                    pos += len(raw)
+                    chunk = leftover + raw
+                    text, leftover = _decode_safe(chunk)
+                    if text:
+                        try:
+                            append(instance_dir, project_name, text)
+                        except Exception:
+                            pass  # non-critical; avoid log spam in tight loop
+        except OSError:
+            pass  # file may not exist yet
+
+        stop_event.wait(_POLL_INTERVAL)
+
+    # Final flush: pick up anything written since last poll
+    try:
+        size = os.path.getsize(stdout_file)
+        if size > pos:
+            with open(stdout_file, "rb") as f:
+                f.seek(pos)
+                raw = f.read()
+                if raw:
+                    chunk = leftover + raw
+                    leftover = b""
+                    append(instance_dir, project_name, chunk.decode("utf-8", errors="replace"))
+        elif leftover:
+            append(instance_dir, project_name, leftover.decode("utf-8", errors="replace"))
+    except Exception as e:
+        print(f"[cli-journal] final flush error: {e}", file=sys.stderr)
+
+
+def start_tail_thread(
+    stdout_file: str,
+    instance_dir: str,
+    project_name: str,
+    run_num: int,
+) -> Tuple[threading.Thread, threading.Event]:
+    """Start a background thread that tails *stdout_file* into the journal.
+
+    Writes a header line to the journal immediately, then polls for new
+    content every ~1 s and appends it.
+
+    Args:
+        stdout_file: Path to the subprocess stdout temp file.
+        instance_dir: Path to the instance directory.
+        project_name: Current project name.
+        run_num: Current run number (for the header).
+
+    Returns:
+        ``(thread, stop_event)`` — call :func:`stop_tail_thread` when done.
+    """
+    inst = Path(instance_dir)
+
+    header = (
+        f"\n---\n### 🖥️ CLI Output — Run {run_num} "
+        f"({time.strftime('%H:%M')})\n\n"
+    )
+    _journal_write(inst, project_name, header)
+
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=_tail_loop,
+        args=(stdout_file, inst, project_name, stop_event),
+        name="cli-journal-tail",
+        daemon=True,
+    )
+    thread.start()
+    return thread, stop_event
+
+
+def stop_tail_thread(
+    thread: threading.Thread,
+    stop_event: threading.Event,
+    timeout: float = 5.0,
+) -> None:
+    """Signal the tail thread to stop and wait for it to finish.
+
+    Args:
+        thread: The tail thread returned by :func:`start_tail_thread`.
+        stop_event: The stop event returned by :func:`start_tail_thread`.
+        timeout: Max seconds to wait for thread join.
+    """
+    stop_event.set()
+    thread.join(timeout=timeout)
+
+
+def append_stderr_to_journal(
+    stderr_file: str,
+    instance_dir: str,
+    project_name: str,
+    run_num: int,
+) -> None:
+    """Append stderr content to the journal on error.
+
+    Only call this when the subprocess exited with a non-zero code.
+
+    Args:
+        stderr_file: Path to the subprocess stderr temp file.
+        instance_dir: Path to the instance directory.
+        project_name: Current project name.
+        run_num: Current run number.
+    """
+    try:
+        content = Path(stderr_file).read_text(encoding="utf-8", errors="replace").strip()
+    except OSError:
+        return
+    if not content:
+        return
+
+    entry = (
+        f"\n---\n### ⚠️ CLI Errors — Run {run_num}\n\n"
+        f"```\n{content}\n```\n"
+    )
+    _journal_write(Path(instance_dir), project_name, entry)
+
+
+# ---------------------------------------------------------------------------
+# High-level lifecycle helpers (used by run.py)
+# ---------------------------------------------------------------------------
+
+# Opaque handle returned by start_journal_stream
+_StreamHandle = Optional[Tuple[threading.Thread, threading.Event]]
+
+
+def start_journal_stream(
+    stdout_file: str,
+    instance_dir: str,
+    project_name: str,
+    run_num: int,
+) -> _StreamHandle:
+    """Start journal streaming if ``cli_output_journal`` is enabled.
+
+    Returns an opaque handle to pass to :func:`stop_journal_stream`,
+    or ``None`` if streaming is disabled or setup fails.
+    """
+    try:
+        from app.config import get_cli_output_journal
+        if not get_cli_output_journal():
+            return None
+        thread, stop_event = start_tail_thread(
+            stdout_file, instance_dir, project_name, run_num,
+        )
+        return (thread, stop_event)
+    except Exception as e:
+        print(f"[cli-journal] start error: {e}", file=sys.stderr)
+        return None
+
+
+def stop_journal_stream(
+    handle: _StreamHandle,
+    exit_code: int,
+    stderr_file: str,
+    instance_dir: str,
+    project_name: str,
+    run_num: int,
+) -> None:
+    """Stop journal streaming and append stderr on error.
+
+    Safe to call with ``handle=None`` (no-op).
+    """
+    if handle is None:
+        return
+    thread, stop_event = handle
+    try:
+        stop_tail_thread(thread, stop_event)
+        if exit_code != 0:
+            append_stderr_to_journal(
+                stderr_file, instance_dir, project_name, run_num,
+            )
+    except Exception as e:
+        print(f"[cli-journal] stop error: {e}", file=sys.stderr)

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -186,6 +186,21 @@ def get_debug_enabled() -> bool:
     return bool(config.get("debug", False))
 
 
+def get_cli_output_journal() -> bool:
+    """Check if CLI output journal streaming is enabled.
+
+    When True, mission and contemplative CLI output is streamed to the
+    project's daily journal file in real-time for ``tail -f`` visibility.
+
+    Config key: cli_output_journal (default: True — opt-out to disable).
+    """
+    config = _load_config()
+    value = config.get("cli_output_journal")
+    if value is None:
+        return True
+    return bool(value)
+
+
 def get_max_runs() -> int:
     """Get maximum runs per day from config.yaml.
 

--- a/koan/tests/test_cli_journal_streamer.py
+++ b/koan/tests/test_cli_journal_streamer.py
@@ -1,0 +1,207 @@
+"""Tests for cli_journal_streamer — tail thread, stderr append, lifecycle."""
+
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def tmp_env(tmp_path):
+    """Set up a temp instance directory with journal structure."""
+    instance_dir = tmp_path / "instance"
+    instance_dir.mkdir()
+    (instance_dir / "journal").mkdir()
+    return {
+        "instance_dir": str(instance_dir),
+        "project_name": "test-project",
+    }
+
+
+@pytest.fixture
+def stdout_file(tmp_path):
+    """Create a temp file for simulated subprocess stdout."""
+    path = tmp_path / "stdout.txt"
+    path.write_text("")
+    return str(path)
+
+
+@pytest.fixture
+def stderr_file(tmp_path):
+    """Create a temp file for simulated subprocess stderr."""
+    path = tmp_path / "stderr.txt"
+    path.write_text("")
+    return str(path)
+
+
+def _journal_content(tmp_env):
+    """Read today's journal file if it exists, else return empty string."""
+    from datetime import datetime
+    today = datetime.now().strftime("%Y-%m-%d")
+    path = Path(tmp_env["instance_dir"]) / "journal" / today / "test-project.md"
+    return path.read_text() if path.exists() else ""
+
+
+class TestStartTailThread:
+    """Test start_tail_thread / stop_tail_thread lifecycle."""
+
+    def test_streams_new_content_to_journal(self, tmp_env, stdout_file):
+        from app.cli_journal_streamer import start_tail_thread, stop_tail_thread
+
+        thread, stop_event = start_tail_thread(
+            stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+        )
+        assert thread.is_alive()
+
+        with open(stdout_file, "a") as f:
+            f.write("line one\n")
+            f.flush()
+
+        time.sleep(2.0)
+        stop_tail_thread(thread, stop_event)
+        assert not thread.is_alive()
+
+        content = _journal_content(tmp_env)
+        assert "CLI Output" in content
+        assert "line one" in content
+
+    def test_writes_header_immediately(self, tmp_env, stdout_file):
+        from app.cli_journal_streamer import start_tail_thread, stop_tail_thread
+
+        thread, stop_event = start_tail_thread(
+            stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=3,
+        )
+
+        time.sleep(0.5)
+        content = _journal_content(tmp_env)
+        assert "Run 3" in content
+        assert "🖥️" in content
+
+        stop_tail_thread(thread, stop_event)
+
+    def test_final_flush_on_stop(self, tmp_env, stdout_file):
+        from app.cli_journal_streamer import start_tail_thread, stop_tail_thread
+
+        thread, stop_event = start_tail_thread(
+            stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+        )
+
+        with open(stdout_file, "a") as f:
+            f.write("final line\n")
+            f.flush()
+
+        stop_tail_thread(thread, stop_event)
+        assert "final line" in _journal_content(tmp_env)
+
+    def test_handles_missing_stdout_file(self, tmp_env, tmp_path):
+        from app.cli_journal_streamer import start_tail_thread, stop_tail_thread
+
+        nonexistent = str(tmp_path / "does-not-exist.txt")
+        thread, stop_event = start_tail_thread(
+            nonexistent, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+        )
+        time.sleep(1.5)
+        stop_tail_thread(thread, stop_event)
+        assert not thread.is_alive()
+
+
+class TestAppendStderrToJournal:
+    """Test append_stderr_to_journal."""
+
+    def test_appends_stderr_on_error(self, tmp_env, stderr_file):
+        from app.cli_journal_streamer import append_stderr_to_journal
+
+        Path(stderr_file).write_text("Error: something went wrong\n")
+        append_stderr_to_journal(
+            stderr_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=2,
+        )
+
+        content = _journal_content(tmp_env)
+        assert "CLI Errors" in content
+        assert "Run 2" in content
+        assert "something went wrong" in content
+
+    def test_skips_empty_stderr(self, tmp_env, stderr_file):
+        from app.cli_journal_streamer import append_stderr_to_journal
+
+        Path(stderr_file).write_text("")
+        append_stderr_to_journal(
+            stderr_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+        )
+        assert _journal_content(tmp_env) == ""
+
+    def test_skips_missing_stderr_file(self, tmp_env, tmp_path):
+        from app.cli_journal_streamer import append_stderr_to_journal
+
+        nonexistent = str(tmp_path / "no-such-file.txt")
+        append_stderr_to_journal(
+            nonexistent, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+        )
+
+
+class TestJournalStreamLifecycle:
+    """Test start_journal_stream / stop_journal_stream high-level helpers."""
+
+    def test_start_returns_handle_when_enabled(self, tmp_env, stdout_file):
+        from app.cli_journal_streamer import start_journal_stream, stop_journal_stream
+
+        with patch("app.config._load_config", return_value={"cli_output_journal": True}):
+            handle = start_journal_stream(
+                stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+            )
+        assert handle is not None
+
+        stop_journal_stream(handle, 0, stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], 1)
+        assert "CLI Output" in _journal_content(tmp_env)
+
+    def test_start_returns_none_when_disabled(self, tmp_env, stdout_file):
+        from app.cli_journal_streamer import start_journal_stream
+
+        with patch("app.config._load_config", return_value={"cli_output_journal": False}):
+            handle = start_journal_stream(
+                stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=1,
+            )
+        assert handle is None
+
+    def test_stop_is_noop_with_none_handle(self, tmp_env, stderr_file):
+        from app.cli_journal_streamer import stop_journal_stream
+
+        # Should not raise
+        stop_journal_stream(None, 1, stderr_file, tmp_env["instance_dir"], tmp_env["project_name"], 1)
+
+    def test_stop_appends_stderr_on_nonzero_exit(self, tmp_env, stdout_file, stderr_file):
+        from app.cli_journal_streamer import start_journal_stream, stop_journal_stream
+
+        Path(stderr_file).write_text("fatal error\n")
+
+        with patch("app.config._load_config", return_value={"cli_output_journal": True}):
+            handle = start_journal_stream(
+                stdout_file, tmp_env["instance_dir"], tmp_env["project_name"], run_num=5,
+            )
+
+        stop_journal_stream(handle, 1, stderr_file, tmp_env["instance_dir"], tmp_env["project_name"], 5)
+
+        content = _journal_content(tmp_env)
+        assert "CLI Errors" in content
+        assert "fatal error" in content
+
+
+class TestConfigOption:
+    """Test get_cli_output_journal config function."""
+
+    def test_default_is_true(self):
+        from app.config import get_cli_output_journal
+        with patch("app.config._load_config", return_value={}):
+            assert get_cli_output_journal() is True
+
+    def test_explicit_true(self):
+        from app.config import get_cli_output_journal
+        with patch("app.config._load_config", return_value={"cli_output_journal": True}):
+            assert get_cli_output_journal() is True
+
+    def test_explicit_false(self):
+        from app.config import get_cli_output_journal
+        with patch("app.config._load_config", return_value={"cli_output_journal": False}):
+            assert get_cli_output_journal() is False

--- a/koan/tests/test_silent_exceptions.py
+++ b/koan/tests/test_silent_exceptions.py
@@ -34,8 +34,8 @@ APP_DIR = Path(__file__).parent.parent / "app"
 ALLOWLIST: Set[Tuple[str, int]] = {
     # --- Shutdown / terminal cleanup (terminal may be gone) ---
     ("run.py", 79),                  # ANSI reset on shutdown
-    ("run.py", 1679),                # _get_koan_branch: git rev-parse fallback
-    ("run.py", 1855),                # _cleanup_temp_files: unlink best-effort
+    ("run.py", 1718),                # _get_koan_branch: git rev-parse fallback
+    ("run.py", 1894),                # _cleanup_temp_files: unlink best-effort
     # --- Best-effort display / info gathering ---
     ("ai_runner.py", 127),           # dir listing for prompt context
     ("startup_info.py", 25),         # config value fallback
@@ -61,6 +61,7 @@ ALLOWLIST: Set[Tuple[str, int]] = {
     # --- Git operations (abort after failed rebase) ---
     ("claude_step.py", 52),          # rebase --abort after failed rebase
     # --- Non-critical subsystem fallbacks ---
+    ("cli_journal_streamer.py", 95), # journal append in tail-thread tight loop
     ("iteration_manager.py", 318),   # recurring mission injection
     ("schedule_manager.py", 186),    # schedule check
     ("usage_tracker.py", 282),       # budget file read


### PR DESCRIPTION
Add a lightweight tail thread that polls the subprocess stdout temp file every ~1s and appends new content to the project's daily journal file. This gives users real-time visibility into what the CLI (Claude/Copilot) is doing via `tail -f` on the journal, without changing the subprocess I/O path at all.

The feature is enabled by default and can be disabled via `cli_output_journal: false` in config.yaml. It covers mission execution and contemplative sessions. Stderr is appended to the journal only on non-zero exit.

New module: cli_journal_streamer.py with start_tail_thread(), stop_tail_thread(), and append_stderr_to_journal() functions. Contemplative sessions now use temp files instead of /dev/null so their output can also be streamed.