### PR TITLE
refactor: extract run_log.py and startup_manager.py from run.py

### DIFF
--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -33,6 +33,17 @@ from app.iteration_manager import plan_iteration
 from app.loop_manager import check_pending_missions, interruptible_sleep
 from app.pid_manager import acquire_pidfile, release_pidfile
 from app.restart_manager import check_restart, clear_restart, RESTART_EXIT_CODE
+from app.run_log import (  # noqa: F401 — re-exported for backward compat
+    _ANSI_RESET,
+    _CATEGORY_COLORS,
+    _COLORS,
+    _init_colors,
+    _reset_terminal,
+    _styled,
+    bold_cyan,
+    bold_green,
+    log,
+)
 from app.shutdown_manager import is_shutdown_requested, clear_shutdown
 from app.utils import atomic_write
 
@@ -54,94 +65,6 @@ MAX_BACKOFF_ITERATION = 300
 
 # Notification throttling: notify on first error, then every N errors.
 ERROR_NOTIFICATION_INTERVAL = 5
-
-
-# ---------------------------------------------------------------------------
-# Colored logging
-# ---------------------------------------------------------------------------
-
-_COLORS = {}
-
-# Standalone ANSI reset (no dependency on _COLORS initialization)
-_ANSI_RESET = "\033[0m"
-
-
-def _reset_terminal():
-    """Write an ANSI reset to stdout and flush, restoring default attributes.
-
-    Called on exit paths to ensure the terminal is not left with active
-    ANSI attributes (DIM, BOLD, color, etc.) after Kōan shuts down.
-    """
-    try:
-        sys.stdout.write(_ANSI_RESET)
-        sys.stdout.flush()
-    except OSError:
-        pass  # Terminal may be gone during shutdown
-
-
-def _init_colors():
-    """Initialize ANSI color codes based on TTY detection."""
-    global _COLORS
-    if os.environ.get("KOAN_FORCE_COLOR", "") or sys.stdout.isatty():
-        _COLORS = {
-            "reset": "\033[0m",
-            "bold": "\033[1m",
-            "dim": "\033[2m",
-            "red": "\033[31m",
-            "green": "\033[32m",
-            "yellow": "\033[33m",
-            "blue": "\033[34m",
-            "magenta": "\033[35m",
-            "cyan": "\033[36m",
-            "white": "\033[37m",
-        }
-    else:
-        _COLORS = {k: "" for k in [
-            "reset", "bold", "dim", "red", "green", "yellow",
-            "blue", "magenta", "cyan", "white",
-        ]}
-
-
-_CATEGORY_COLORS = {
-    "koan": "cyan",
-    "error": "bold+red",
-    "init": "blue",
-    "health": "yellow",
-    "git": "magenta",
-    "github": "bold+magenta",
-    "mission": "green",
-    "quota": "bold+yellow",
-    "pause": "dim+blue",
-    "warning": "yellow",
-    "warn": "yellow",
-}
-
-
-def log(category: str, message: str):
-    """Print a colored log message."""
-    if not _COLORS:
-        _init_colors()
-    color_spec = _CATEGORY_COLORS.get(category, "white")
-    parts = color_spec.split("+")
-    prefix = "".join(_COLORS.get(p, "") for p in parts)
-    reset = _COLORS.get("reset", "")
-    print(f"{prefix}[{category}]{reset} {message}", flush=True)
-
-
-def _styled(text: str, *styles: str) -> str:
-    """Apply ANSI styles to text. E.g. _styled("hi", "bold", "cyan")."""
-    if not _COLORS:
-        _init_colors()
-    prefix = "".join(_COLORS.get(s, "") for s in styles)
-    return f"{prefix}{text}{_COLORS.get('reset', '')}"
-
-
-def bold_cyan(text: str) -> str:
-    return _styled(text, "bold", "cyan")
-
-
-def bold_green(text: str) -> str:
-    return _styled(text, "bold", "green")
 
 
 # ---------------------------------------------------------------------------
@@ -421,210 +344,17 @@ def parse_projects() -> list:
 
 
 # ---------------------------------------------------------------------------
-# Startup sequence
+# Startup sequence (delegated to startup_manager.py)
 # ---------------------------------------------------------------------------
 
 def run_startup(koan_root: str, instance: str, projects: list):
-    """Run all startup tasks (crash recovery, health, sync, etc.)."""
-    from app.banners import print_agent_banner
-    from app.github_auth import setup_github_auth
-    from app.git_sync import GitSync
-    from app.health_check import check_and_alert
-    from app.recover import recover_missions
-    from app.utils import (
-        get_branch_prefix,
-        get_cli_binary_for_shell,
-        get_interval_seconds,
-        get_max_runs,
-        get_start_on_pause,
-    )
+    """Run all startup tasks (crash recovery, health, sync, etc.).
 
-    # Load config
-    max_runs = get_max_runs()
-    interval = get_interval_seconds()
-    branch_prefix = get_branch_prefix()
-    cli_provider = get_cli_binary_for_shell()
-
-    # Print banner
-    try:
-        print_agent_banner(f"agent loop — {cli_provider}")
-    except Exception as e:
-        log("error", f"Banner display failed: {e}")
-
-    with protected_phase("Startup checks"):
-        # Crash recovery
-        log("health", "Checking for interrupted missions...")
-        try:
-            recover_missions(instance)
-        except Exception as e:
-            log("error", f"Crash recovery failed: {e}")
-
-        # Auto-migrate env vars to projects.yaml (one-shot, idempotent)
-        try:
-            from app.projects_migration import run_migration
-            migration_msgs = run_migration(koan_root)
-            for msg in migration_msgs:
-                log("init", f"[migration] {msg}")
-        except Exception as e:
-            log("error", f"Projects migration failed: {e}")
-
-        # Auto-populate github_url in projects.yaml from git remotes
-        try:
-            from app.projects_config import ensure_github_urls
-            gh_msgs = ensure_github_urls(koan_root)
-            for msg in gh_msgs:
-                log("init", f"[github-urls] {msg}")
-        except Exception as e:
-            log("error", f"GitHub URL population failed: {e}")
-
-        # Initialize workspace + yaml merged project registry
-        try:
-            from app.projects_merged import (
-                refresh_projects, 
-                get_warnings, 
-                populate_workspace_github_urls,
-                get_yaml_project_names
-            )
-            
-            projects = refresh_projects(koan_root)
-            
-            # Count workspace projects (not in projects.yaml)
-            yaml_project_names = get_yaml_project_names(koan_root)
-            ws_count = sum(1 for name, _ in projects if name not in yaml_project_names)
-            if ws_count:
-                log("init", f"[workspace] Discovered {ws_count} project(s) from workspace/")
-            
-            # Populate github_url cache for workspace projects
-            gh_count = populate_workspace_github_urls(koan_root)
-            if gh_count:
-                log("init", f"[workspace] Cached {gh_count} github_url(s) from git remotes")
-            
-            # Log any warnings from merge
-            for warning in get_warnings():
-                log("warn", f"[workspace] {warning}")
-        except Exception as e:
-            log("error", f"Workspace discovery failed: {e}")
-
-        # Sanity checks (all modules in koan/sanity/, alphabetical order)
-        log("health", "Running sanity checks...")
-        try:
-            from sanity import run_all
-            for name, modified, changes in run_all(instance):
-                if modified:
-                    for change in changes:
-                        log("health", f"  [{name}] {change}")
-        except Exception as e:
-            log("error", f"Sanity checks failed: {e}")
-
-        # Memory cleanup
-        log("health", "Running memory cleanup...")
-        try:
-            from app.memory_manager import run_cleanup
-            run_cleanup(instance)
-        except Exception as e:
-            log("error", f"Memory cleanup failed: {e}")
-
-        # Mission history cleanup
-        try:
-            from app.mission_history import cleanup_old_entries
-            cleanup_old_entries(instance)
-        except Exception as e:
-            log("error", f"Mission history cleanup failed: {e}")
-
-        # Health check
-        log("health", "Checking Telegram bridge health...")
-        try:
-            check_and_alert(koan_root, max_age=120)
-        except Exception as e:
-            log("error", f"Health check failed: {e}")
-
-    with protected_phase("Self-reflection check"):
-        log("health", "Checking self-reflection trigger...")
-        try:
-            from app.self_reflection import (
-                should_reflect, run_reflection, save_reflection, notify_outbox,
-            )
-            inst_path = Path(instance)
-            if should_reflect(inst_path):
-                observations = run_reflection(inst_path)
-                if observations:
-                    save_reflection(inst_path, observations)
-                    notify_outbox(inst_path, observations)
-        except Exception as e:
-            log("error", f"Self-reflection check failed: {e}")
-
-    # Start on pause
-    if get_start_on_pause():
-        # Remove stale system-generated reason files (quota, max_runs) to
-        # prevent auto-resume from a previous session.  Preserve manual
-        # pauses — user explicitly requested them via /pause.
-        koan_root_path = Path(koan_root)
-        reason_file = koan_root_path / ".koan-pause-reason"
-        if reason_file.exists():
-            try:
-                first_line = reason_file.read_text().strip().splitlines()[0]
-            except (OSError, IndexError):
-                first_line = ""
-            if first_line != "manual":
-                reason_file.unlink(missing_ok=True)
-        if not (koan_root_path / ".koan-pause").exists():
-            log("pause", "start_on_pause=true in config. Entering pause mode.")
-            (koan_root_path / ".koan-pause").touch()
-
-    # Git identity
-    koan_email = os.environ.get("KOAN_EMAIL", "")
-    if koan_email:
-        os.environ["GIT_AUTHOR_NAME"] = "Kōan"
-        os.environ["GIT_AUTHOR_EMAIL"] = koan_email
-        os.environ["GIT_COMMITTER_NAME"] = "Kōan"
-        os.environ["GIT_COMMITTER_EMAIL"] = koan_email
-
-    # GitHub auth
-    if os.environ.get("GITHUB_USER"):
-        success = setup_github_auth()
-        if success:
-            log("init", f"GitHub CLI authenticated as {os.environ['GITHUB_USER']}")
-        else:
-            log("init", f"Warning: GitHub auth failed for {os.environ['GITHUB_USER']}")
-
-    # Startup notification
-    log("init", f"Starting. Max runs: {max_runs}, interval: {interval}s")
-
-    project_list = "\n".join(f"  • {n}" for n, _ in sorted(projects))
-    status_line = _build_startup_status(koan_root)
-    set_status(koan_root, status_line)
-    _notify(instance, (
-        f"Kōan starting — {max_runs} max runs, {interval}s interval.\n"
-        f"Projects:\n{project_list}\n"
-        f"Current: {projects[0][0]}.\n"
-        f"Status: {status_line}"
-    ))
-
-    with protected_phase("Git sync"):
-        log("git", "Running git sync...")
-        for name, path in projects:
-            try:
-                gs = GitSync(instance, name, path)
-                gs.sync_and_report()
-            except Exception as e:
-                log("error", f"Git sync failed for {name}: {e}")
-
-    # Daily report
-    try:
-        from app.daily_report import send_daily_report
-        send_daily_report()
-    except Exception as e:
-        log("error", f"Daily report failed: {e}")
-
-    with protected_phase("Morning ritual"):
-        log("init", "Running morning ritual...")
-        try:
-            from app.rituals import run_ritual
-            run_ritual("morning", Path(instance))
-        except Exception as e:
-            log("error", f"Morning ritual failed: {e}")
-
-    return max_runs, interval, branch_prefix
+    Delegates to app.startup_manager which decomposes the startup
+    into independently testable steps.
+    """
+    from app.startup_manager import run_startup as _run_startup
+    return _run_startup(koan_root, instance, projects)
 
 
 # ---------------------------------------------------------------------------

--- a/koan/app/run_log.py
+++ b/koan/app/run_log.py
@@ -1,0 +1,122 @@
+"""Colored logging for the Koan agent loop.
+
+Provides ANSI-colored log output with category-based color coding,
+styled text helpers, and terminal reset for clean shutdown.
+
+Categories:
+  koan     (cyan)           — general agent messages
+  error    (bold+red)       — errors
+  init     (blue)           — startup messages
+  health   (yellow)         — health checks, sanity
+  git      (magenta)        — git operations
+  github   (bold+magenta)   — GitHub operations
+  mission  (green)          — mission lifecycle
+  quota    (bold+yellow)    — quota/usage
+  pause    (dim+blue)       — pause state
+  warning  (yellow)         — warnings
+  warn     (yellow)         — warnings (alias)
+
+Usage:
+    from app.run_log import log, bold_cyan
+    log("init", "Starting up...")
+    print(bold_cyan("=== Run 1/5 ==="))
+"""
+
+import os
+import sys
+
+
+# ---------------------------------------------------------------------------
+# Color state
+# ---------------------------------------------------------------------------
+
+_COLORS = {}
+
+# Standalone ANSI reset (no dependency on _COLORS initialization)
+_ANSI_RESET = "\033[0m"
+
+
+def _reset_terminal():
+    """Write an ANSI reset to stdout and flush, restoring default attributes.
+
+    Called on exit paths to ensure the terminal is not left with active
+    ANSI attributes (DIM, BOLD, color, etc.) after Koan shuts down.
+    """
+    try:
+        sys.stdout.write(_ANSI_RESET)
+        sys.stdout.flush()
+    except OSError:
+        pass  # Terminal may be gone during shutdown
+
+
+def _init_colors():
+    """Initialize ANSI color codes based on TTY detection."""
+    global _COLORS
+    if os.environ.get("KOAN_FORCE_COLOR", "") or sys.stdout.isatty():
+        _COLORS = {
+            "reset": "\033[0m",
+            "bold": "\033[1m",
+            "dim": "\033[2m",
+            "red": "\033[31m",
+            "green": "\033[32m",
+            "yellow": "\033[33m",
+            "blue": "\033[34m",
+            "magenta": "\033[35m",
+            "cyan": "\033[36m",
+            "white": "\033[37m",
+        }
+    else:
+        _COLORS = {k: "" for k in [
+            "reset", "bold", "dim", "red", "green", "yellow",
+            "blue", "magenta", "cyan", "white",
+        ]}
+
+
+# ---------------------------------------------------------------------------
+# Category → color mapping
+# ---------------------------------------------------------------------------
+
+_CATEGORY_COLORS = {
+    "koan": "cyan",
+    "error": "bold+red",
+    "init": "blue",
+    "health": "yellow",
+    "git": "magenta",
+    "github": "bold+magenta",
+    "mission": "green",
+    "quota": "bold+yellow",
+    "pause": "dim+blue",
+    "warning": "yellow",
+    "warn": "yellow",
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def log(category: str, message: str):
+    """Print a colored log message."""
+    if not _COLORS:
+        _init_colors()
+    color_spec = _CATEGORY_COLORS.get(category, "white")
+    parts = color_spec.split("+")
+    prefix = "".join(_COLORS.get(p, "") for p in parts)
+    reset = _COLORS.get("reset", "")
+    print(f"{prefix}[{category}]{reset} {message}", flush=True)
+
+
+def _styled(text: str, *styles: str) -> str:
+    """Apply ANSI styles to text. E.g. _styled("hi", "bold", "cyan")."""
+    if not _COLORS:
+        _init_colors()
+    prefix = "".join(_COLORS.get(s, "") for s in styles)
+    return f"{prefix}{text}{_COLORS.get('reset', '')}"
+
+
+def bold_cyan(text: str) -> str:
+    return _styled(text, "bold", "cyan")
+
+
+def bold_green(text: str) -> str:
+    return _styled(text, "bold", "green")

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -1,0 +1,288 @@
+"""Startup orchestration for the Koan agent loop.
+
+Decomposes the startup sequence into independently testable steps.
+Each step is wrapped in try/except to prevent one failure from
+blocking the entire startup.
+
+Called from run.py's main_loop() during process initialization.
+"""
+
+import os
+from pathlib import Path
+
+from app.run_log import log
+
+
+# ---------------------------------------------------------------------------
+# Individual startup steps
+# ---------------------------------------------------------------------------
+
+def recover_crashed_missions(instance: str):
+    """Check for and recover missions left in-progress by a crash."""
+    log("health", "Checking for interrupted missions...")
+    from app.recover import recover_missions
+    recover_missions(instance)
+
+
+def run_migrations(koan_root: str):
+    """Auto-migrate env vars to projects.yaml (one-shot, idempotent)."""
+    from app.projects_migration import run_migration
+    migration_msgs = run_migration(koan_root)
+    for msg in migration_msgs:
+        log("init", f"[migration] {msg}")
+
+
+def populate_github_urls(koan_root: str):
+    """Auto-populate github_url in projects.yaml from git remotes."""
+    from app.projects_config import ensure_github_urls
+    gh_msgs = ensure_github_urls(koan_root)
+    for msg in gh_msgs:
+        log("init", f"[github-urls] {msg}")
+
+
+def discover_workspace(koan_root: str, projects: list) -> list:
+    """Initialize workspace + yaml merged project registry.
+
+    Returns the refreshed project list.
+    """
+    from app.projects_merged import (
+        refresh_projects,
+        get_warnings,
+        populate_workspace_github_urls,
+        get_yaml_project_names,
+    )
+
+    projects = refresh_projects(koan_root)
+
+    # Count workspace projects (not in projects.yaml)
+    yaml_project_names = get_yaml_project_names(koan_root)
+    ws_count = sum(1 for name, _ in projects if name not in yaml_project_names)
+    if ws_count:
+        log("init", f"[workspace] Discovered {ws_count} project(s) from workspace/")
+
+    # Populate github_url cache for workspace projects
+    gh_count = populate_workspace_github_urls(koan_root)
+    if gh_count:
+        log("init", f"[workspace] Cached {gh_count} github_url(s) from git remotes")
+
+    # Log any warnings from merge
+    for warning in get_warnings():
+        log("warn", f"[workspace] {warning}")
+
+    return projects
+
+
+def run_sanity_checks(instance: str):
+    """Run all sanity checks from koan/sanity/."""
+    log("health", "Running sanity checks...")
+    from sanity import run_all
+    for name, modified, changes in run_all(instance):
+        if modified:
+            for change in changes:
+                log("health", f"  [{name}] {change}")
+
+
+def cleanup_memory(instance: str):
+    """Run memory compaction and cleanup."""
+    log("health", "Running memory cleanup...")
+    from app.memory_manager import run_cleanup
+    run_cleanup(instance)
+
+
+def cleanup_mission_history(instance: str):
+    """Prune old entries from mission history."""
+    from app.mission_history import cleanup_old_entries
+    cleanup_old_entries(instance)
+
+
+def check_health(koan_root: str, max_age: int = 120):
+    """Check Telegram bridge health (heartbeat age)."""
+    log("health", "Checking Telegram bridge health...")
+    from app.health_check import check_and_alert
+    check_and_alert(koan_root, max_age=max_age)
+
+
+def check_self_reflection(instance: str):
+    """Trigger periodic self-reflection if due."""
+    log("health", "Checking self-reflection trigger...")
+    from app.self_reflection import (
+        should_reflect, run_reflection, save_reflection, notify_outbox,
+    )
+    inst_path = Path(instance)
+    if should_reflect(inst_path):
+        observations = run_reflection(inst_path)
+        if observations:
+            save_reflection(inst_path, observations)
+            notify_outbox(inst_path, observations)
+
+
+def handle_start_on_pause(koan_root: str):
+    """Enter pause mode on startup if configured.
+
+    Removes stale system-generated reason files (quota, max_runs)
+    to prevent auto-resume from a previous session. Preserves
+    manual pauses (user explicitly requested via /pause).
+    """
+    from app.utils import get_start_on_pause
+
+    if not get_start_on_pause():
+        return
+
+    koan_root_path = Path(koan_root)
+    reason_file = koan_root_path / ".koan-pause-reason"
+    if reason_file.exists():
+        try:
+            first_line = reason_file.read_text().strip().splitlines()[0]
+        except (OSError, IndexError):
+            first_line = ""
+        if first_line != "manual":
+            reason_file.unlink(missing_ok=True)
+    if not (koan_root_path / ".koan-pause").exists():
+        log("pause", "start_on_pause=true in config. Entering pause mode.")
+        (koan_root_path / ".koan-pause").touch()
+
+
+def setup_git_identity():
+    """Set git author/committer from KOAN_EMAIL env var."""
+    koan_email = os.environ.get("KOAN_EMAIL", "")
+    if koan_email:
+        os.environ["GIT_AUTHOR_NAME"] = "Kōan"
+        os.environ["GIT_AUTHOR_EMAIL"] = koan_email
+        os.environ["GIT_COMMITTER_NAME"] = "Kōan"
+        os.environ["GIT_COMMITTER_EMAIL"] = koan_email
+
+
+def setup_github_auth():
+    """Authenticate GitHub CLI if GITHUB_USER is set."""
+    if not os.environ.get("GITHUB_USER"):
+        return
+    from app.github_auth import setup_github_auth as _setup_auth
+    success = _setup_auth()
+    if success:
+        log("init", f"GitHub CLI authenticated as {os.environ['GITHUB_USER']}")
+    else:
+        log("init", f"Warning: GitHub auth failed for {os.environ['GITHUB_USER']}")
+
+
+def run_git_sync(instance: str, projects: list):
+    """Sync all project branches with their remotes."""
+    log("git", "Running git sync...")
+    from app.git_sync import GitSync
+    for name, path in projects:
+        try:
+            gs = GitSync(instance, name, path)
+            gs.sync_and_report()
+        except Exception as e:
+            log("error", f"Git sync failed for {name}: {e}")
+
+
+def run_daily_report():
+    """Send daily report if due."""
+    from app.daily_report import send_daily_report
+    send_daily_report()
+
+
+def run_morning_ritual(instance: str):
+    """Execute the morning ritual."""
+    log("init", "Running morning ritual...")
+    from app.rituals import run_ritual
+    run_ritual("morning", Path(instance))
+
+
+# ---------------------------------------------------------------------------
+# Safe step runner
+# ---------------------------------------------------------------------------
+
+def _safe_run(step_name: str, fn, *args, **kwargs):
+    """Run a startup step, catching and logging any exception."""
+    try:
+        return fn(*args, **kwargs)
+    except Exception as e:
+        log("error", f"{step_name} failed: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Main orchestrator
+# ---------------------------------------------------------------------------
+
+def run_startup(koan_root: str, instance: str, projects: list):
+    """Run all startup tasks (crash recovery, health, sync, etc.).
+
+    Returns (max_runs, interval, branch_prefix) configuration tuple.
+    """
+    from app.banners import print_agent_banner
+    from app.utils import (
+        get_branch_prefix,
+        get_cli_binary_for_shell,
+        get_interval_seconds,
+        get_max_runs,
+    )
+
+    # Load config
+    max_runs = get_max_runs()
+    interval = get_interval_seconds()
+    branch_prefix = get_branch_prefix()
+    cli_provider = get_cli_binary_for_shell()
+
+    # Print banner
+    try:
+        print_agent_banner(f"agent loop — {cli_provider}")
+    except Exception as e:
+        log("error", f"Banner display failed: {e}")
+
+    # --- Protected startup checks ---
+    # Import protected_phase lazily to avoid circular import
+    # (run.py imports startup_manager, signal handling lives in run.py)
+    from app.run import protected_phase
+
+    with protected_phase("Startup checks"):
+        _safe_run("Crash recovery", recover_crashed_missions, instance)
+        _safe_run("Projects migration", run_migrations, koan_root)
+        _safe_run("GitHub URL population", populate_github_urls, koan_root)
+
+        result = _safe_run("Workspace discovery", discover_workspace, koan_root, projects)
+        if result is not None:
+            projects = result
+
+        _safe_run("Sanity checks", run_sanity_checks, instance)
+        _safe_run("Memory cleanup", cleanup_memory, instance)
+        _safe_run("Mission history cleanup", cleanup_mission_history, instance)
+        _safe_run("Health check", check_health, koan_root)
+
+    with protected_phase("Self-reflection check"):
+        _safe_run("Self-reflection check", check_self_reflection, instance)
+
+    # Start on pause
+    handle_start_on_pause(koan_root)
+
+    # Git identity and GitHub auth
+    setup_git_identity()
+    setup_github_auth()
+
+    # Startup notification
+    log("init", f"Starting. Max runs: {max_runs}, interval: {interval}s")
+
+    # Import status/notify helpers lazily from run
+    from app.run import set_status, _build_startup_status, _notify
+
+    project_list = "\n".join(f"  • {n}" for n, _ in sorted(projects))
+    status_line = _build_startup_status(koan_root)
+    set_status(koan_root, status_line)
+    _notify(instance, (
+        f"Kōan starting — {max_runs} max runs, {interval}s interval.\n"
+        f"Projects:\n{project_list}\n"
+        f"Current: {projects[0][0]}.\n"
+        f"Status: {status_line}"
+    ))
+
+    with protected_phase("Git sync"):
+        run_git_sync(instance, projects)
+
+    # Daily report
+    _safe_run("Daily report", run_daily_report)
+
+    with protected_phase("Morning ritual"):
+        _safe_run("Morning ritual", run_morning_ritual, instance)
+
+    return max_runs, interval, branch_prefix

--- a/koan/tests/test_github_url_resolution.py
+++ b/koan/tests/test_github_url_resolution.py
@@ -859,11 +859,12 @@ class TestStartupEnsureGithubUrls:
     """Tests that run_startup calls ensure_github_urls."""
 
     def test_ensure_called_in_startup(self):
-        """Verify the ensure_github_urls call exists in run_startup source."""
+        """Verify the ensure_github_urls call exists in startup source."""
         import inspect
-        from app import run
+        from app import startup_manager
 
-        source = inspect.getsource(run.run_startup)
+        # run_startup delegates to startup_manager — check canonical source
+        source = inspect.getsource(startup_manager.populate_github_urls)
         assert "ensure_github_urls" in source
         assert "github-urls" in source
 

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -77,12 +77,12 @@ class TestLog:
     def test_force_color_env_enables_colors(self, capsys, monkeypatch):
         """KOAN_FORCE_COLOR=1 enables ANSI colors even without TTY."""
         monkeypatch.setenv("KOAN_FORCE_COLOR", "1")
-        from app.run import _init_colors, _COLORS
-        # Force re-init
-        import app.run as run_mod
-        run_mod._COLORS = {}
+        from app.run_log import _init_colors, _COLORS
+        # Force re-init — target canonical module (run_log owns _COLORS)
+        import app.run_log as log_mod
+        log_mod._COLORS = {}
         _init_colors()
-        colors = run_mod._COLORS
+        colors = log_mod._COLORS
         assert colors.get("reset") == "\033[0m"
         assert colors.get("red") == "\033[31m"
 

--- a/koan/tests/test_run_log.py
+++ b/koan/tests/test_run_log.py
@@ -1,0 +1,143 @@
+"""Tests for app.run_log — colored logging module."""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test: _init_colors
+# ---------------------------------------------------------------------------
+
+class TestInitColors:
+    def test_tty_enables_colors(self, monkeypatch):
+        monkeypatch.delenv("KOAN_FORCE_COLOR", raising=False)
+        import app.run_log as mod
+        mod._COLORS = {}
+        with patch.object(mod.sys.stdout, "isatty", return_value=True):
+            mod._init_colors()
+        assert mod._COLORS.get("reset") == "\033[0m"
+        assert mod._COLORS.get("red") == "\033[31m"
+
+    def test_no_tty_disables_colors(self, monkeypatch):
+        monkeypatch.delenv("KOAN_FORCE_COLOR", raising=False)
+        import app.run_log as mod
+        mod._COLORS = {}
+        with patch.object(mod.sys.stdout, "isatty", return_value=False):
+            mod._init_colors()
+        assert mod._COLORS.get("reset") == ""
+        assert mod._COLORS.get("red") == ""
+
+    def test_force_color_overrides_tty(self, monkeypatch):
+        monkeypatch.setenv("KOAN_FORCE_COLOR", "1")
+        import app.run_log as mod
+        mod._COLORS = {}
+        with patch.object(mod.sys.stdout, "isatty", return_value=False):
+            mod._init_colors()
+        assert mod._COLORS.get("reset") == "\033[0m"
+
+
+# ---------------------------------------------------------------------------
+# Test: log
+# ---------------------------------------------------------------------------
+
+class TestLog:
+    def test_outputs_category_and_message(self, capsys):
+        from app.run_log import log, _init_colors
+        _init_colors()
+        log("koan", "hello world")
+        out = capsys.readouterr().out
+        assert "[koan]" in out
+        assert "hello world" in out
+
+    def test_unknown_category_uses_white(self, capsys):
+        from app.run_log import log, _init_colors
+        _init_colors()
+        log("custom_cat", "msg")
+        out = capsys.readouterr().out
+        assert "[custom_cat]" in out
+
+    def test_lazy_init(self):
+        """log() should auto-initialize colors if empty."""
+        import app.run_log as mod
+        mod._COLORS = {}
+        mod.log("test", "auto-init")
+        assert mod._COLORS  # Should be populated now
+
+
+# ---------------------------------------------------------------------------
+# Test: _styled
+# ---------------------------------------------------------------------------
+
+class TestStyled:
+    def test_applies_styles(self):
+        import app.run_log as mod
+        mod._COLORS = {}
+        mod._init_colors()
+        result = mod._styled("text", "bold", "cyan")
+        assert "text" in result
+
+    def test_empty_colors(self):
+        """With no TTY, styled text should still contain the text."""
+        import app.run_log as mod
+        mod._COLORS = {k: "" for k in [
+            "reset", "bold", "dim", "red", "green", "yellow",
+            "blue", "magenta", "cyan", "white",
+        ]}
+        result = mod._styled("hello", "bold", "cyan")
+        assert "hello" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: bold_cyan, bold_green
+# ---------------------------------------------------------------------------
+
+class TestBoldHelpers:
+    def test_bold_cyan(self):
+        from app.run_log import bold_cyan, _init_colors
+        _init_colors()
+        result = bold_cyan("test")
+        assert "test" in result
+
+    def test_bold_green(self):
+        from app.run_log import bold_green, _init_colors
+        _init_colors()
+        result = bold_green("test")
+        assert "test" in result
+
+
+# ---------------------------------------------------------------------------
+# Test: _reset_terminal
+# ---------------------------------------------------------------------------
+
+class TestResetTerminal:
+    def test_writes_reset_sequence(self, capsys):
+        from app.run_log import _reset_terminal
+        _reset_terminal()
+        out = capsys.readouterr().out
+        assert "\033[0m" in out
+
+    def test_handles_os_error(self):
+        """Should not raise when stdout is gone."""
+        from app.run_log import _reset_terminal
+        with patch("app.run_log.sys.stdout") as mock_stdout:
+            mock_stdout.write.side_effect = OSError("fd closed")
+            _reset_terminal()  # Should not raise
+
+
+# ---------------------------------------------------------------------------
+# Test: _CATEGORY_COLORS
+# ---------------------------------------------------------------------------
+
+class TestCategoryColors:
+    def test_all_categories_defined(self):
+        from app.run_log import _CATEGORY_COLORS
+        expected = {"koan", "error", "init", "health", "git", "github",
+                    "mission", "quota", "pause", "warning", "warn"}
+        assert expected.issubset(set(_CATEGORY_COLORS.keys()))
+
+    def test_warning_and_warn_both_exist(self):
+        from app.run_log import _CATEGORY_COLORS
+        assert "warning" in _CATEGORY_COLORS
+        assert "warn" in _CATEGORY_COLORS

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -1,0 +1,555 @@
+"""Tests for app.startup_manager — decomposed startup steps."""
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch, call
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def koan_root(tmp_path):
+    """Create a minimal koan root with instance directory."""
+    instance = tmp_path / "instance"
+    instance.mkdir()
+    (instance / "missions.md").write_text(
+        "# Missions\n\n## Pending\n\n## In Progress\n\n## Done\n"
+    )
+    (instance / "config.yaml").write_text("max_runs: 5\ninterval: 10\n")
+    return tmp_path
+
+
+@pytest.fixture
+def instance(koan_root):
+    return str(koan_root / "instance")
+
+
+@pytest.fixture
+def projects(tmp_path):
+    p1 = tmp_path / "proj1"
+    p1.mkdir()
+    return [("proj1", str(p1))]
+
+
+# ---------------------------------------------------------------------------
+# Test: recover_crashed_missions
+# ---------------------------------------------------------------------------
+
+class TestRecoverCrashedMissions:
+    @patch("app.recover.recover_missions")
+    def test_calls_recover_missions(self, mock_recover, instance):
+        from app.startup_manager import recover_crashed_missions
+        recover_crashed_missions(instance)
+        mock_recover.assert_called_once_with(instance)
+
+    @patch("app.recover.recover_missions", side_effect=FileNotFoundError("no missions"))
+    def test_propagates_exceptions(self, mock_recover, instance):
+        from app.startup_manager import recover_crashed_missions
+        with pytest.raises(FileNotFoundError):
+            recover_crashed_missions(instance)
+
+
+# ---------------------------------------------------------------------------
+# Test: run_migrations
+# ---------------------------------------------------------------------------
+
+class TestRunMigrations:
+    @patch("app.projects_migration.run_migration", return_value=[])
+    def test_no_migrations(self, mock_migrate, capsys):
+        from app.startup_manager import run_migrations
+        run_migrations("/tmp/koan")
+        mock_migrate.assert_called_once_with("/tmp/koan")
+
+    @patch("app.projects_migration.run_migration", return_value=["migrated X", "migrated Y"])
+    def test_logs_migration_messages(self, mock_migrate, capsys):
+        from app.startup_manager import run_migrations
+        run_migrations("/tmp/koan")
+        out = capsys.readouterr().out
+        assert "[migration] migrated X" in out
+        assert "[migration] migrated Y" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: populate_github_urls
+# ---------------------------------------------------------------------------
+
+class TestPopulateGithubUrls:
+    @patch("app.projects_config.ensure_github_urls", return_value=[])
+    def test_no_urls(self, mock_ensure):
+        from app.startup_manager import populate_github_urls
+        populate_github_urls("/tmp/koan")
+        mock_ensure.assert_called_once_with("/tmp/koan")
+
+    @patch("app.projects_config.ensure_github_urls", return_value=["added url for proj1"])
+    def test_logs_messages(self, mock_ensure, capsys):
+        from app.startup_manager import populate_github_urls
+        populate_github_urls("/tmp/koan")
+        out = capsys.readouterr().out
+        assert "[github-urls] added url for proj1" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: discover_workspace
+# ---------------------------------------------------------------------------
+
+class TestDiscoverWorkspace:
+    @patch("app.projects_merged.get_warnings", return_value=[])
+    @patch("app.projects_merged.populate_workspace_github_urls", return_value=0)
+    @patch("app.projects_merged.get_yaml_project_names", return_value={"proj1"})
+    @patch("app.projects_merged.refresh_projects", return_value=[("proj1", "/path/proj1")])
+    def test_no_workspace_projects(self, mock_refresh, mock_yaml, mock_pop, mock_warn, capsys):
+        from app.startup_manager import discover_workspace
+        result = discover_workspace("/tmp/koan", [])
+        assert result == [("proj1", "/path/proj1")]
+        out = capsys.readouterr().out
+        assert "[workspace]" not in out  # No workspace projects logged
+
+    @patch("app.projects_merged.get_warnings", return_value=[])
+    @patch("app.projects_merged.populate_workspace_github_urls", return_value=2)
+    @patch("app.projects_merged.get_yaml_project_names", return_value={"proj1"})
+    @patch("app.projects_merged.refresh_projects", return_value=[
+        ("proj1", "/p1"), ("ws-proj", "/p2"), ("ws-proj2", "/p3"),
+    ])
+    def test_workspace_projects_logged(self, mock_refresh, mock_yaml, mock_pop, mock_warn, capsys):
+        from app.startup_manager import discover_workspace
+        result = discover_workspace("/tmp/koan", [])
+        assert len(result) == 3
+        out = capsys.readouterr().out
+        assert "Discovered 2 project(s) from workspace/" in out
+        assert "Cached 2 github_url(s)" in out
+
+    @patch("app.projects_merged.get_warnings", return_value=["path conflict for X"])
+    @patch("app.projects_merged.populate_workspace_github_urls", return_value=0)
+    @patch("app.projects_merged.get_yaml_project_names", return_value=set())
+    @patch("app.projects_merged.refresh_projects", return_value=[])
+    def test_warnings_logged(self, mock_refresh, mock_yaml, mock_pop, mock_warn, capsys):
+        from app.startup_manager import discover_workspace
+        discover_workspace("/tmp/koan", [])
+        out = capsys.readouterr().out
+        assert "path conflict for X" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: run_sanity_checks
+# ---------------------------------------------------------------------------
+
+class TestRunSanityChecks:
+    @patch("sanity.run_all", return_value=[])
+    def test_no_changes(self, mock_run_all, capsys):
+        from app.startup_manager import run_sanity_checks
+        run_sanity_checks("/tmp/instance")
+        out = capsys.readouterr().out
+        assert "Running sanity checks" in out
+
+    @patch("sanity.run_all", return_value=[
+        ("missions", True, ["Fixed header"]),
+        ("config", False, []),
+    ])
+    def test_logs_modified_checks(self, mock_run_all, capsys):
+        from app.startup_manager import run_sanity_checks
+        run_sanity_checks("/tmp/instance")
+        out = capsys.readouterr().out
+        assert "[missions] Fixed header" in out
+        assert "[config]" not in out  # Not modified
+
+
+# ---------------------------------------------------------------------------
+# Test: cleanup_memory
+# ---------------------------------------------------------------------------
+
+class TestCleanupMemory:
+    @patch("app.memory_manager.run_cleanup")
+    def test_calls_run_cleanup(self, mock_cleanup, capsys):
+        from app.startup_manager import cleanup_memory
+        cleanup_memory("/tmp/instance")
+        mock_cleanup.assert_called_once_with("/tmp/instance")
+        out = capsys.readouterr().out
+        assert "Running memory cleanup" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: cleanup_mission_history
+# ---------------------------------------------------------------------------
+
+class TestCleanupMissionHistory:
+    @patch("app.mission_history.cleanup_old_entries")
+    def test_calls_cleanup(self, mock_cleanup):
+        from app.startup_manager import cleanup_mission_history
+        cleanup_mission_history("/tmp/instance")
+        mock_cleanup.assert_called_once_with("/tmp/instance")
+
+
+# ---------------------------------------------------------------------------
+# Test: check_health
+# ---------------------------------------------------------------------------
+
+class TestCheckHealth:
+    @patch("app.health_check.check_and_alert")
+    def test_default_max_age(self, mock_check, capsys):
+        from app.startup_manager import check_health
+        check_health("/tmp/koan")
+        mock_check.assert_called_once_with("/tmp/koan", max_age=120)
+
+    @patch("app.health_check.check_and_alert")
+    def test_custom_max_age(self, mock_check):
+        from app.startup_manager import check_health
+        check_health("/tmp/koan", max_age=60)
+        mock_check.assert_called_once_with("/tmp/koan", max_age=60)
+
+
+# ---------------------------------------------------------------------------
+# Test: check_self_reflection
+# ---------------------------------------------------------------------------
+
+class TestCheckSelfReflection:
+    @patch("app.self_reflection.should_reflect", return_value=False)
+    def test_not_due(self, mock_should, capsys):
+        from app.startup_manager import check_self_reflection
+        check_self_reflection("/tmp/instance")
+        mock_should.assert_called_once()
+
+    @patch("app.self_reflection.notify_outbox")
+    @patch("app.self_reflection.save_reflection")
+    @patch("app.self_reflection.run_reflection", return_value="Some observations")
+    @patch("app.self_reflection.should_reflect", return_value=True)
+    def test_triggers_reflection(self, mock_should, mock_run, mock_save, mock_notify):
+        from app.startup_manager import check_self_reflection
+        check_self_reflection("/tmp/instance")
+        mock_run.assert_called_once()
+        mock_save.assert_called_once()
+        mock_notify.assert_called_once()
+
+    @patch("app.self_reflection.run_reflection", return_value="")
+    @patch("app.self_reflection.should_reflect", return_value=True)
+    def test_empty_observations_skips_save(self, mock_should, mock_run):
+        from app.startup_manager import check_self_reflection
+        with patch("app.self_reflection.save_reflection") as mock_save:
+            check_self_reflection("/tmp/instance")
+            mock_save.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test: handle_start_on_pause
+# ---------------------------------------------------------------------------
+
+class TestHandleStartOnPause:
+    @patch("app.utils.get_start_on_pause", return_value=False)
+    def test_disabled(self, mock_config, koan_root):
+        from app.startup_manager import handle_start_on_pause
+        handle_start_on_pause(str(koan_root))
+        assert not (koan_root / ".koan-pause").exists()
+
+    @patch("app.utils.get_start_on_pause", return_value=True)
+    def test_creates_pause_file(self, mock_config, koan_root, capsys):
+        from app.startup_manager import handle_start_on_pause
+        handle_start_on_pause(str(koan_root))
+        assert (koan_root / ".koan-pause").exists()
+        out = capsys.readouterr().out
+        assert "start_on_pause=true" in out
+
+    @patch("app.utils.get_start_on_pause", return_value=True)
+    def test_preserves_manual_pause(self, mock_config, koan_root):
+        from app.startup_manager import handle_start_on_pause
+        (koan_root / ".koan-pause").touch()
+        (koan_root / ".koan-pause-reason").write_text("manual\n")
+        handle_start_on_pause(str(koan_root))
+        # Manual pause reason preserved
+        assert (koan_root / ".koan-pause-reason").exists()
+
+    @patch("app.utils.get_start_on_pause", return_value=True)
+    def test_removes_quota_reason(self, mock_config, koan_root):
+        from app.startup_manager import handle_start_on_pause
+        (koan_root / ".koan-pause-reason").write_text("quota\n1234567890\nresets 10am")
+        handle_start_on_pause(str(koan_root))
+        assert not (koan_root / ".koan-pause-reason").exists()
+
+    @patch("app.utils.get_start_on_pause", return_value=True)
+    def test_removes_max_runs_reason(self, mock_config, koan_root):
+        from app.startup_manager import handle_start_on_pause
+        (koan_root / ".koan-pause-reason").write_text("max_runs\n")
+        handle_start_on_pause(str(koan_root))
+        assert not (koan_root / ".koan-pause-reason").exists()
+
+    @patch("app.utils.get_start_on_pause", return_value=True)
+    def test_noop_if_already_paused(self, mock_config, koan_root, capsys):
+        from app.startup_manager import handle_start_on_pause
+        (koan_root / ".koan-pause").touch()
+        handle_start_on_pause(str(koan_root))
+        out = capsys.readouterr().out
+        # No log about entering pause (already paused)
+        assert "start_on_pause=true" not in out
+
+
+# ---------------------------------------------------------------------------
+# Test: setup_git_identity
+# ---------------------------------------------------------------------------
+
+class TestSetupGitIdentity:
+    def test_sets_git_env(self, monkeypatch):
+        monkeypatch.setenv("KOAN_EMAIL", "koan@example.com")
+        from app.startup_manager import setup_git_identity
+        setup_git_identity()
+        assert os.environ["GIT_AUTHOR_NAME"] == "Kōan"
+        assert os.environ["GIT_AUTHOR_EMAIL"] == "koan@example.com"
+        assert os.environ["GIT_COMMITTER_NAME"] == "Kōan"
+        assert os.environ["GIT_COMMITTER_EMAIL"] == "koan@example.com"
+
+    def test_noop_without_env(self, monkeypatch):
+        monkeypatch.delenv("KOAN_EMAIL", raising=False)
+        monkeypatch.delenv("GIT_AUTHOR_NAME", raising=False)
+        from app.startup_manager import setup_git_identity
+        setup_git_identity()
+        assert "GIT_AUTHOR_NAME" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# Test: setup_github_auth
+# ---------------------------------------------------------------------------
+
+class TestSetupGithubAuth:
+    def test_noop_without_github_user(self, monkeypatch):
+        monkeypatch.delenv("GITHUB_USER", raising=False)
+        from app.startup_manager import setup_github_auth
+        # Should not raise
+        setup_github_auth()
+
+    @patch("app.github_auth.setup_github_auth", return_value=True)
+    def test_success(self, mock_auth, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_USER", "testuser")
+        from app.startup_manager import setup_github_auth
+        setup_github_auth()
+        out = capsys.readouterr().out
+        assert "authenticated as testuser" in out
+
+    @patch("app.github_auth.setup_github_auth", return_value=False)
+    def test_failure(self, mock_auth, monkeypatch, capsys):
+        monkeypatch.setenv("GITHUB_USER", "testuser")
+        from app.startup_manager import setup_github_auth
+        setup_github_auth()
+        out = capsys.readouterr().out
+        assert "Warning: GitHub auth failed" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: run_git_sync
+# ---------------------------------------------------------------------------
+
+class TestRunGitSync:
+    @patch("app.git_sync.GitSync")
+    def test_syncs_all_projects(self, mock_gs_cls, capsys):
+        from app.startup_manager import run_git_sync
+        projects = [("proj1", "/p1"), ("proj2", "/p2")]
+        run_git_sync("/tmp/instance", projects)
+        assert mock_gs_cls.call_count == 2
+        mock_gs_cls.assert_any_call("/tmp/instance", "proj1", "/p1")
+        mock_gs_cls.assert_any_call("/tmp/instance", "proj2", "/p2")
+
+    @patch("app.git_sync.GitSync")
+    def test_continues_on_error(self, mock_gs_cls, capsys):
+        """One project failing should not stop sync of others."""
+        from app.startup_manager import run_git_sync
+        mock_inst = MagicMock()
+        mock_inst.sync_and_report.side_effect = [Exception("fail"), None]
+        mock_gs_cls.return_value = mock_inst
+        run_git_sync("/tmp/instance", [("proj1", "/p1"), ("proj2", "/p2")])
+        out = capsys.readouterr().out
+        assert "Git sync failed for proj1" in out
+        # Second project still attempted
+        assert mock_inst.sync_and_report.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: run_daily_report
+# ---------------------------------------------------------------------------
+
+class TestRunDailyReport:
+    @patch("app.daily_report.send_daily_report")
+    def test_calls_report(self, mock_report):
+        from app.startup_manager import run_daily_report
+        run_daily_report()
+        mock_report.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Test: run_morning_ritual
+# ---------------------------------------------------------------------------
+
+class TestRunMorningRitual:
+    @patch("app.rituals.run_ritual")
+    def test_calls_morning_ritual(self, mock_ritual, capsys):
+        from app.startup_manager import run_morning_ritual
+        run_morning_ritual("/tmp/instance")
+        mock_ritual.assert_called_once_with("morning", Path("/tmp/instance"))
+        out = capsys.readouterr().out
+        assert "Running morning ritual" in out
+
+
+# ---------------------------------------------------------------------------
+# Test: _safe_run
+# ---------------------------------------------------------------------------
+
+class TestSafeRun:
+    def test_returns_result(self):
+        from app.startup_manager import _safe_run
+        result = _safe_run("test", lambda: 42)
+        assert result == 42
+
+    def test_catches_exception(self, capsys):
+        from app.startup_manager import _safe_run
+        result = _safe_run("step X", lambda: 1 / 0)
+        assert result is None
+        out = capsys.readouterr().out
+        assert "step X failed" in out
+
+    def test_passes_args(self):
+        from app.startup_manager import _safe_run
+        result = _safe_run("test", lambda x, y: x + y, 3, 4)
+        assert result == 7
+
+    def test_passes_kwargs(self):
+        from app.startup_manager import _safe_run
+        result = _safe_run("test", lambda *, x: x * 2, x=5)
+        assert result == 10
+
+
+# ---------------------------------------------------------------------------
+# Test: run_startup (orchestrator)
+# ---------------------------------------------------------------------------
+
+class TestRunStartup:
+    @patch("app.startup_manager.run_morning_ritual")
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks")
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_returns_config(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual,
+    ):
+        from app.startup_manager import run_startup
+        result = run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+        assert result == (10, 60, "koan/")
+
+    @patch("app.startup_manager.run_morning_ritual")
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks")
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_calls_all_steps(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual,
+    ):
+        from app.startup_manager import run_startup
+        run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+
+        # Verify all steps were called
+        mock_recover.assert_called_once()
+        mock_migrate.assert_called_once()
+        mock_gh_urls.assert_called_once()
+        mock_workspace.assert_called_once()
+        mock_sanity.assert_called_once()
+        mock_memory.assert_called_once()
+        mock_history.assert_called_once()
+        mock_health.assert_called_once()
+        mock_reflection.assert_called_once()
+        mock_pause.assert_called_once()
+        mock_git_id.assert_called_once()
+        mock_gh_auth.assert_called_once()
+        mock_git_sync.assert_called_once()
+        mock_daily.assert_called_once()
+        mock_ritual.assert_called_once()
+
+    @patch("app.startup_manager.run_morning_ritual")
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks", side_effect=Exception("sanity boom"))
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_survives_step_failure(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual,
+        capsys,
+    ):
+        """A failing step should not prevent other steps from running."""
+        from app.startup_manager import run_startup
+        result = run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+        assert result == (10, 60, "koan/")
+        # Sanity failed but memory cleanup still ran
+        mock_memory.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Sanity checks failed" in out


### PR DESCRIPTION
## What
Extract logging and startup orchestration from the 2006-line `run.py` into two focused, testable modules.

## Why
`run.py` was the biggest God module at 55% coverage. The 201-line `run_startup()` function had ~0% coverage because it orchestrated 12+ concerns in a single monolith. Breaking it into independently testable steps brings coverage to 97%.

## How
- **`run_log.py`** (122 lines): All logging/ANSI functions (`log`, `_styled`, `bold_cyan`, `bold_green`, `_reset_terminal`, `_init_colors`). No app dependencies.
- **`startup_manager.py`** (288 lines): 16 decomposed startup steps, each independently testable. `_safe_run()` helper for error isolation (replaces 12 identical try/except blocks). Lazy imports from `run.py` for `protected_phase` and notification helpers to avoid circular deps.
- **`run.py`** re-exports logging functions for backward compat — zero test breakage.

## Testing
- 54 new tests: 40 for `startup_manager.py`, 14 for `run_log.py`
- `startup_manager.py`: 97% coverage
- `run_log.py`: 97% coverage  
- `run.py`: 55% → 62% (+7 points)
- Full suite: 7226 → 7280 tests, 0 failures