### PR TITLE
feat: drift detection for smarter project selection

### DIFF
--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -300,6 +300,15 @@ def _select_random_exploration_project(
         except (ImportError, OSError, ValueError) as e:
             _log_iteration("error", f"Freshness lookup failed: {e}")
 
+    # Get drift scores (commits since last session)
+    drift = None
+    if instance_dir:
+        try:
+            from app.session_tracker import get_project_drift
+            drift = get_project_drift(instance_dir, projects)
+        except (ImportError, OSError, ValueError) as e:
+            _log_iteration("error", f"Drift detection failed: {e}")
+
     # Filter out last project when possible
     candidates = projects
     if last_project and len(projects) > 1:
@@ -307,18 +316,37 @@ def _select_random_exploration_project(
         if filtered:
             candidates = filtered
 
-    # Weighted random selection if we have weights
-    if weights and len(candidates) > 1:
-        candidate_weights = [weights.get(n, 10) for n, _ in candidates]
+    # Weighted random selection combining freshness and drift
+    if (weights or drift) and len(candidates) > 1:
+        candidate_weights = []
+        for name, _ in candidates:
+            base = weights.get(name, 10) if weights else 10
+            # Drift boost: projects with significant new commits get a bonus
+            if drift:
+                d = drift.get(name, 0)
+                if d >= 15:
+                    base += 6  # High drift — strong pull
+                elif d >= 5:
+                    base += 3  # Moderate drift
+                elif d >= 3:
+                    base += 1  # Minor drift
+            candidate_weights.append(base)
+
         total = sum(candidate_weights)
         if total > 0:
             selected = random.choices(candidates, weights=candidate_weights, k=1)[0]
-            stale_info = ""
-            score = 10 - weights.get(selected[0], 10)
-            if score > 0:
-                stale_info = f" (staleness={score})"
+            extra_info = []
+            if weights:
+                staleness = 10 - weights.get(selected[0], 10)
+                if staleness > 0:
+                    extra_info.append(f"staleness={staleness}")
+            if drift:
+                d = drift.get(selected[0], 0)
+                if d > 0:
+                    extra_info.append(f"drift={d} commits")
+            suffix = f" ({', '.join(extra_info)})" if extra_info else ""
             _log_iteration("koan",
-                f"Weighted selection: '{selected[0]}'{stale_info} "
+                f"Weighted selection: '{selected[0]}'{suffix} "
                 f"from {len(candidates)} candidate(s)")
             return selected
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -145,6 +145,22 @@ def _get_pr_feedback_section(project_path: str) -> str:
     return ""
 
 
+def _get_drift_section(instance: str, project_name: str, project_path: str) -> str:
+    """Get drift summary for the current project.
+
+    Checks how many commits landed on main since the agent's last session
+    on this project. Helps the agent avoid conflicts and stale assumptions.
+    """
+    try:
+        from app.session_tracker import get_drift_summary
+        summary = get_drift_summary(instance, project_name, project_path)
+        if summary:
+            return f"\n\n# Codebase Drift\n\n{summary}\n"
+    except Exception as e:
+        print(f"[prompt_builder] Drift check failed: {e}", file=sys.stderr)
+    return ""
+
+
 def _get_verbose_section(instance: str) -> str:
     """Build the verbose mode section if .koan-verbose exists."""
     koan_root = str(Path(instance).parent)
@@ -225,6 +241,10 @@ def build_agent_prompt(
     # Append staleness warning (all autonomous modes — cheap local read)
     if not mission_title:
         prompt += _get_staleness_section(instance, project_name)
+
+    # Append drift detection (autonomous only — shows what changed on main)
+    if not mission_title:
+        prompt += _get_drift_section(instance, project_name, project_path)
 
     # Append PR merge feedback (autonomous only — helps topic alignment)
     if not mission_title and autonomous_mode in ("deep", "implement"):

--- a/koan/app/session_tracker.py
+++ b/koan/app/session_tracker.py
@@ -15,10 +15,11 @@ Integration points:
 
 import json
 import re
+import subprocess
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 
 # Maximum entries to keep in session_outcomes.json (rolling window)
@@ -370,3 +371,160 @@ def get_project_freshness(
             weights[name] = 1  # Heavily deprioritized
 
     return weights
+
+
+def get_last_session_timestamp(instance_dir: str, project: str) -> Optional[str]:
+    """Get the ISO timestamp of the most recent session for a project.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project: Project name.
+
+    Returns:
+        ISO timestamp string, or None if no sessions found.
+    """
+    recent = get_recent_outcomes(instance_dir, project, limit=1)
+    if not recent:
+        return None
+    return recent[-1].get("timestamp")
+
+
+def _count_commits_since(project_path: str, since_iso: str) -> int:
+    """Count commits on the default branch since a given ISO timestamp.
+
+    Uses ``git log --oneline --since`` to count new commits. Runs in
+    the project directory. Returns -1 on error (missing repo, bad path).
+
+    Args:
+        project_path: Path to the project's git repository.
+        since_iso: ISO 8601 timestamp (e.g. "2026-03-01T10:00:00").
+
+    Returns:
+        Number of commits since the timestamp, or -1 on error.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "log", "--oneline", f"--since={since_iso}"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            return -1
+        lines = [l for l in result.stdout.strip().splitlines() if l.strip()]
+        return len(lines)
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return -1
+
+
+def get_project_drift(
+    instance_dir: str,
+    projects: List[Tuple[str, str]],
+) -> Dict[str, int]:
+    """Measure how much each project has drifted since the agent's last session.
+
+    For each project, finds the last session timestamp and counts commits
+    on the default branch since then. Projects with no prior sessions get
+    drift = 0 (no baseline to compare against).
+
+    Args:
+        instance_dir: Path to instance directory.
+        projects: List of (name, path) tuples.
+
+    Returns:
+        Dict mapping project name to commit count since last session.
+        Values are >= 0 (errors mapped to 0).
+    """
+    drift = {}
+    for name, path in projects:
+        ts = get_last_session_timestamp(instance_dir, name)
+        if not ts or not path:
+            drift[name] = 0
+            continue
+        count = _count_commits_since(path, ts)
+        drift[name] = max(0, count)
+    return drift
+
+
+def get_drift_summary(
+    instance_dir: str,
+    project_name: str,
+    project_path: str,
+) -> str:
+    """Generate a human-readable drift summary for a single project.
+
+    Used by prompt_builder to inject context about how much the project
+    has changed since the agent last worked on it.
+
+    Args:
+        instance_dir: Path to instance directory.
+        project_name: Project name.
+        project_path: Path to the project directory.
+
+    Returns:
+        Summary string, or empty string if no significant drift.
+    """
+    ts = get_last_session_timestamp(instance_dir, project_name)
+    if not ts or not project_path:
+        return ""
+
+    count = _count_commits_since(project_path, ts)
+    if count <= 0:
+        return ""
+
+    # Only report meaningful drift (3+ commits)
+    if count < 3:
+        return ""
+
+    # Parse the timestamp for display
+    try:
+        dt = datetime.fromisoformat(ts)
+        days_ago = (datetime.now() - dt).days
+        if days_ago == 0:
+            time_desc = "today"
+        elif days_ago == 1:
+            time_desc = "yesterday"
+        else:
+            time_desc = f"{days_ago} days ago"
+    except (ValueError, TypeError):
+        time_desc = "recently"
+
+    # Get brief log of recent changes
+    recent_log = ""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--oneline", f"--since={ts}", "-5"],
+            cwd=project_path,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            lines = result.stdout.strip().splitlines()[:5]
+            recent_log = "\n".join(f"  - {l.strip()}" for l in lines)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+    summary_lines = [
+        f"### Project Drift Detected",
+        "",
+        f"**{count} commits** landed on main since your last session ({time_desc}).",
+        "Review recent changes before starting work to avoid conflicts or duplication.",
+    ]
+
+    if recent_log:
+        summary_lines.extend([
+            "",
+            "Recent commits:",
+            recent_log,
+        ])
+
+    if count >= 15:
+        summary_lines.extend([
+            "",
+            "**High drift** — consider reading CLAUDE.md and key files again "
+            "before starting work. The codebase may have changed significantly.",
+        ])
+
+    return "\n".join(summary_lines)

--- a/koan/tests/test_session_tracker.py
+++ b/koan/tests/test_session_tracker.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 import pytest
 
+from unittest.mock import patch
+
 from app.session_tracker import (
     classify_session,
     record_outcome,
@@ -12,6 +14,10 @@ from app.session_tracker import (
     get_staleness_score,
     get_staleness_warning,
     get_project_freshness,
+    get_last_session_timestamp,
+    get_project_drift,
+    get_drift_summary,
+    _count_commits_since,
     _extract_summary,
     _load_outcomes,
     MAX_OUTCOMES,
@@ -639,3 +645,123 @@ class TestLoadOutcomesValidation:
         outcomes_path.write_text('[{"a": 1}]')
         result = _load_outcomes(outcomes_path)
         assert len(result) == 1
+
+
+# --- Drift detection ---
+
+class TestGetLastSessionTimestamp:
+
+    def test_returns_none_when_no_sessions(self, tracker_env):
+        assert get_last_session_timestamp(tracker_env, "koan") is None
+
+    def test_returns_timestamp_of_last_session(self, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        ts = get_last_session_timestamp(tracker_env, "koan")
+        assert ts is not None
+        assert "T" in ts  # ISO format
+
+    def test_returns_none_for_different_project(self, tracker_env):
+        record_outcome(tracker_env, "other", "deep", 10, "branch pushed")
+        assert get_last_session_timestamp(tracker_env, "koan") is None
+
+
+class TestCountCommitsSince:
+
+    def test_returns_negative_for_nonexistent_path(self):
+        result = _count_commits_since("/nonexistent/path", "2026-01-01T00:00:00")
+        assert result == -1
+
+    @patch("app.session_tracker.subprocess.run")
+    def test_counts_git_log_lines(self, mock_run):
+        mock_run.return_value = type("R", (), {
+            "returncode": 0,
+            "stdout": "abc123 first commit\ndef456 second commit\nghi789 third\n",
+        })()
+        result = _count_commits_since("/some/path", "2026-01-01T00:00:00")
+        assert result == 3
+        mock_run.assert_called_once()
+        args = mock_run.call_args
+        assert "--since=2026-01-01T00:00:00" in args[0][0]
+
+    @patch("app.session_tracker.subprocess.run")
+    def test_returns_negative_on_git_error(self, mock_run):
+        mock_run.return_value = type("R", (), {
+            "returncode": 128,
+            "stdout": "",
+        })()
+        assert _count_commits_since("/path", "2026-01-01T00:00:00") == -1
+
+    @patch("app.session_tracker.subprocess.run")
+    def test_returns_zero_for_empty_log(self, mock_run):
+        mock_run.return_value = type("R", (), {
+            "returncode": 0,
+            "stdout": "",
+        })()
+        assert _count_commits_since("/path", "2026-01-01T00:00:00") == 0
+
+
+class TestGetProjectDrift:
+
+    def test_no_sessions_returns_zero_drift(self, tracker_env):
+        projects = [("koan", "/some/path"), ("other", "/other")]
+        drift = get_project_drift(tracker_env, projects)
+        assert drift == {"koan": 0, "other": 0}
+
+    @patch("app.session_tracker._count_commits_since", return_value=12)
+    def test_returns_commit_count(self, mock_count, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        projects = [("koan", "/some/path")]
+        drift = get_project_drift(tracker_env, projects)
+        assert drift["koan"] == 12
+        mock_count.assert_called_once()
+
+    @patch("app.session_tracker._count_commits_since", return_value=-1)
+    def test_error_maps_to_zero(self, mock_count, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        projects = [("koan", "/some/path")]
+        drift = get_project_drift(tracker_env, projects)
+        assert drift["koan"] == 0
+
+    def test_empty_path_returns_zero(self, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        projects = [("koan", "")]
+        drift = get_project_drift(tracker_env, projects)
+        assert drift["koan"] == 0
+
+
+class TestGetDriftSummary:
+
+    def test_no_sessions_returns_empty(self, tracker_env):
+        assert get_drift_summary(tracker_env, "koan", "/path") == ""
+
+    @patch("app.session_tracker._count_commits_since", return_value=1)
+    def test_low_drift_returns_empty(self, mock_count, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        assert get_drift_summary(tracker_env, "koan", "/path") == ""
+
+    @patch("app.session_tracker.subprocess.run")
+    @patch("app.session_tracker._count_commits_since", return_value=5)
+    def test_moderate_drift_returns_summary(self, mock_count, mock_run, tracker_env):
+        mock_run.return_value = type("R", (), {
+            "returncode": 0,
+            "stdout": "abc fix: something\ndef feat: other\n",
+        })()
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        summary = get_drift_summary(tracker_env, "koan", "/path")
+        assert "5 commits" in summary
+        assert "Project Drift Detected" in summary
+
+    @patch("app.session_tracker.subprocess.run")
+    @patch("app.session_tracker._count_commits_since", return_value=20)
+    def test_high_drift_includes_warning(self, mock_count, mock_run, tracker_env):
+        mock_run.return_value = type("R", (), {
+            "returncode": 0,
+            "stdout": "abc fix\n" * 5,
+        })()
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        summary = get_drift_summary(tracker_env, "koan", "/path")
+        assert "High drift" in summary
+
+    def test_empty_path_returns_empty(self, tracker_env):
+        record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
+        assert get_drift_summary(tracker_env, "koan", "") == ""


### PR DESCRIPTION
## What
Adds drift detection — the agent now knows how much a project's main branch has evolved since its last session.

## Why
When picking a project for autonomous work, the agent had no awareness of codebase churn. A project with 20 new commits since the last session was treated the same as one with zero. This led to stale assumptions and potential conflicts.

## How
- **`session_tracker.py`**: New functions `get_project_drift()` and `get_drift_summary()` that count commits on main since the agent's last session timestamp (already stored in `session_outcomes.json`).
- **`iteration_manager.py`**: `_select_random_exploration_project()` now combines freshness weights with drift boost — projects with 5+ new commits get higher selection weight.
- **`prompt_builder.py`**: Injects a "Codebase Drift" section into the agent prompt for autonomous sessions, listing recent commits and warning about high drift (15+ commits).

## Testing
16 new tests covering all drift detection functions. Full suite: 7638 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)