### PR TITLE
fix: use --onto rebase for cross-fork PRs

### DIFF
--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -38,13 +38,14 @@ def _rebase_onto_target(
     base: str,
     project_path: str,
     preferred_remote: Optional[str] = None,
+    head_remote: Optional[str] = None,
 ) -> Optional[str]:
     """Rebase onto target branch, trying *preferred_remote* first.
 
     When *preferred_remote* is given (e.g. the remote matching the PR's
     target repository), it is tried before the default ``origin`` /
-    ``upstream`` fallbacks.  This avoids rebasing onto a stale fork main
-    when the PR targets an upstream repo.
+    ``upstream`` fallbacks.  When *head_remote* is known and differs from
+    the target remote, uses ``--onto`` to replay only the PR's commits.
 
     Returns:
         Remote name used (e.g. "origin" or "upstream") on success, None on failure.
@@ -58,6 +59,33 @@ def _rebase_onto_target(
     for remote in remotes:
         try:
             _run_git(["git", "fetch", remote, base], cwd=project_path)
+        except (RuntimeError, subprocess.TimeoutExpired, OSError) as e:
+            print(f"[claude_step] Fetch {remote}/{base} failed: {e}", file=sys.stderr)
+            continue
+
+        # When head_remote differs from target, use --onto to limit
+        # replay to only the PR's commits.
+        if head_remote and head_remote != remote:
+            try:
+                _run_git(["git", "fetch", head_remote, base], cwd=project_path)
+                _run_git(
+                    ["git", "rebase", "--onto", f"{remote}/{base}",
+                     f"{head_remote}/{base}", "--autostash"],
+                    cwd=project_path,
+                )
+                return remote
+            except (RuntimeError, subprocess.TimeoutExpired, OSError) as e:
+                print(f"[claude_step] --onto rebase failed: {e}", file=sys.stderr)
+                subprocess.run(
+                    ["git", "rebase", "--abort"],
+                    stdin=subprocess.DEVNULL,
+                    capture_output=True, cwd=project_path,
+                    timeout=30,
+                )
+                # Fall through to plain rebase
+
+        # Fallback: plain rebase
+        try:
             _run_git(
                 ["git", "rebase", "--autostash", f"{remote}/{base}"],
                 cwd=project_path,

--- a/koan/app/pr_review.py
+++ b/koan/app/pr_review.py
@@ -214,6 +214,10 @@ def run_pr_review(
     # Determine which local remote corresponds to the PR's target repo
     base_remote = _find_remote_for_repo(owner, repo, project_path)
 
+    # Determine which remote hosts the PR's head branch (the fork)
+    head_owner = context.get("head_owner", "")
+    head_remote = _find_remote_for_repo(head_owner, repo, project_path) if head_owner else None
+
     # ── Step 2: Checkout and rebase onto target branch ────────────────
     notify_fn(f"Rebasing `{branch}` onto `{base}`...")
     try:
@@ -224,7 +228,10 @@ def run_pr_review(
         return False, f"Failed to checkout branch {branch}: {e}"
 
     # Rebase onto the upstream target branch (prefers the matched remote)
-    rebase_remote = _rebase_onto_target(base, project_path, preferred_remote=base_remote)
+    rebase_remote = _rebase_onto_target(
+        base, project_path, preferred_remote=base_remote,
+        head_remote=head_remote,
+    )
     if rebase_remote:
         actions_log.append(f"Rebased `{branch}` onto `{rebase_remote}/{base}`")
     else:

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -43,7 +43,7 @@ def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
     # Fetch PR metadata
     pr_json = run_gh(
         "pr", "view", pr_number, "--repo", full_repo, "--json",
-        "title,body,headRefName,baseRefName,state,author,url",
+        "title,body,headRefName,baseRefName,state,author,url,headRepositoryOwner",
     )
 
     # Fetch PR diff (may fail for very large PRs — GitHub HTTP 406)
@@ -94,6 +94,7 @@ def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
         "base": metadata.get("baseRefName", "main"),
         "state": metadata.get("state", ""),
         "author": metadata.get("author", {}).get("login", ""),
+        "head_owner": metadata.get("headRepositoryOwner", {}).get("login", ""),
         "url": metadata.get("url", ""),
         "diff": truncate_text(diff, 8000),
         "review_comments": truncate_text(comments_json, 4000),
@@ -222,6 +223,10 @@ def run_rebase(
     # so we rebase against the correct upstream, not a stale fork.
     base_remote = _find_remote_for_repo(owner, repo, project_path)
 
+    # Determine which remote hosts the PR's head branch (the fork)
+    head_owner = context.get("head_owner", "")
+    head_remote = _find_remote_for_repo(head_owner, repo, project_path) if head_owner else None
+
     # Log comment summary for awareness
     comment_summary = build_comment_summary(context)
     if comment_summary and "No comments" not in comment_summary:
@@ -234,9 +239,12 @@ def run_rebase(
     original_branch = _get_current_branch(project_path)
 
     try:
-        _checkout_pr_branch(branch, project_path)
+        fetch_remote = _checkout_pr_branch(branch, project_path)
     except Exception as e:
         return False, f"Failed to checkout branch `{branch}`: {e}"
+
+    # Use API-discovered head_remote, fall back to checkout's fetch_remote
+    effective_head_remote = head_remote or fetch_remote
 
     # ── Step 3: Rebase onto target branch ─────────────────────────────
     notify_fn(f"Rebasing `{branch}` onto `{base}`...")
@@ -244,6 +252,7 @@ def run_rebase(
         base, project_path, context, actions_log,
         notify_fn=notify_fn, skill_dir=skill_dir,
         preferred_remote=base_remote,
+        head_remote=effective_head_remote,
     )
     if rebase_remote:
         actions_log.append(f"Rebased `{branch}` onto `{rebase_remote}/{base}`")
@@ -281,7 +290,8 @@ def run_rebase(
     # ── Step 6: Push the result ───────────────────────────────────────
     notify_fn(f"Pushing `{branch}`...")
     push_result = _push_with_fallback(
-        branch, base, full_repo, pr_number, context, project_path
+        branch, base, full_repo, pr_number, context, project_path,
+        head_remote=effective_head_remote,
     )
     actions_log.extend(push_result["actions"])
 
@@ -332,14 +342,19 @@ def _rebase_with_conflict_resolution(
     skill_dir: Optional[Path] = None,
     max_conflict_rounds: int = 5,
     preferred_remote: Optional[str] = None,
+    head_remote: Optional[str] = None,
 ) -> Optional[str]:
     """Rebase onto target branch, resolving conflicts via Claude if needed.
 
     Tries the *preferred_remote* first (matched from the PR's target repo),
-    then falls back to ``origin`` and ``upstream``.  When ``git rebase`` hits
-    conflicts, Claude is invoked to resolve the conflicted files, they are
-    staged, and the rebase is continued.  This loop repeats for up to
-    *max_conflict_rounds* per remote (one round per conflicting commit).
+    then falls back to ``origin`` and ``upstream``.  When *head_remote* is
+    known and differs from the target remote, uses ``--onto`` to replay only
+    the PR's commits (between ``head_remote/base`` and HEAD) onto the target.
+
+    When ``git rebase`` hits conflicts, Claude is invoked to resolve the
+    conflicted files, they are staged, and the rebase is continued.  This
+    loop repeats for up to *max_conflict_rounds* per remote (one round per
+    conflicting commit).
 
     Returns:
         Remote name used (e.g. "origin") on success, None on total failure.
@@ -351,7 +366,33 @@ def _rebase_with_conflict_resolution(
             print(f"[rebase_pr] fetch {remote}/{base} failed: {e}", file=sys.stderr)
             continue
 
-        # Attempt rebase
+        # When head_remote differs from the target remote, use --onto to
+        # limit replay to only the PR's commits (avoids replaying upstream
+        # history when the fork has diverged).
+        if head_remote and head_remote != remote:
+            try:
+                _run_git(["git", "fetch", head_remote, base], cwd=project_path)
+                _run_git(
+                    ["git", "rebase", "--onto", f"{remote}/{base}",
+                     f"{head_remote}/{base}", "--autostash"],
+                    cwd=project_path,
+                )
+                return remote  # Clean --onto rebase
+            except Exception as e:
+                print(f"[rebase_pr] --onto rebase failed: {e}", file=sys.stderr)
+                # Check if we're in a conflicted rebase state from --onto
+                if _has_rebase_in_progress(project_path):
+                    resolved = _resolve_rebase_conflicts(
+                        base, remote, project_path, context, actions_log,
+                        notify_fn=notify_fn, skill_dir=skill_dir,
+                        max_rounds=max_conflict_rounds,
+                    )
+                    if resolved:
+                        return remote
+                    _abort_rebase(project_path)
+                # Fall through to plain rebase
+
+        # Fallback: plain rebase (same repo PR, or --onto failed)
         try:
             _run_git(
                 ["git", "rebase", "--autostash", f"{remote}/{base}"],
@@ -569,12 +610,15 @@ def _apply_review_feedback(
 
 
 
-def _checkout_pr_branch(branch: str, project_path: str) -> None:
+def _checkout_pr_branch(branch: str, project_path: str) -> str:
     """Checkout the PR branch, fetching from origin or upstream.
 
     Uses ``git checkout -B`` to create or reset the local branch,
     ensuring a stale local branch with the same name never blocks
     the checkout.
+
+    Returns:
+        The remote name used for the fetch (e.g. ``"origin"`` or ``"upstream"``).
     """
     # Try origin first, then upstream (for cross-repo PRs)
     fetch_remote = "origin"
@@ -596,6 +640,7 @@ def _checkout_pr_branch(branch: str, project_path: str) -> None:
         ["git", "checkout", "-B", branch, f"{fetch_remote}/{branch}"],
         cwd=project_path,
     )
+    return fetch_remote
 
 
 def _push_with_fallback(
@@ -605,17 +650,26 @@ def _push_with_fallback(
     pr_number: str,
     context: dict,
     project_path: str,
+    head_remote: Optional[str] = None,
 ) -> dict:
     """Push rebased branch, always reusing the existing PR branch.
 
     Rebase never creates a new branch or PR — it always pushes to the
-    same branch to recycle the existing pull request.  Tries
-    ``--force-with-lease`` first, then plain ``--force`` as fallback.
+    same branch to recycle the existing pull request.  Tries *head_remote*
+    first (where the PR branch lives), then ``origin`` and ``upstream``.
+    Uses ``--force-with-lease`` first, then plain ``--force`` as fallback.
     """
     actions: List[str] = []
 
+    remotes: List[str] = []
+    if head_remote:
+        remotes.append(head_remote)
+    for r in ("origin", "upstream"):
+        if r not in remotes:
+            remotes.append(r)
+
     last_error = ""
-    for remote in ("origin", "upstream"):
+    for remote in remotes:
         # Try safe force-push first
         try:
             _run_git(

--- a/koan/tests/test_claude_step.py
+++ b/koan/tests/test_claude_step.py
@@ -166,7 +166,15 @@ class TestRebaseOntoTarget:
     @patch("app.cli_exec.subprocess.run")
     @patch("app.claude_step._run_git")
     def test_rebase_abort_called_on_failure(self, mock_git, mock_subprocess):
-        mock_git.side_effect = RuntimeError("conflict")
+        call_count = 0
+        def selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            # Odd calls are fetch (succeed), even calls are rebase (fail)
+            if call_count % 2 == 0:
+                raise RuntimeError("conflict")
+            return ""
+        mock_git.side_effect = selective_fail
         _rebase_onto_target("main", "/project")
         # Should call rebase --abort for each failed remote
         abort_calls = [
@@ -180,7 +188,14 @@ class TestRebaseOntoTarget:
     @patch("app.claude_step._run_git")
     def test_rebase_abort_called_with_timeout(self, mock_git, mock_subprocess):
         """git rebase --abort must have a timeout to prevent hangs in cleanup."""
-        mock_git.side_effect = RuntimeError("conflict")
+        call_count = 0
+        def selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise RuntimeError("conflict")
+            return ""
+        mock_git.side_effect = selective_fail
         _rebase_onto_target("main", "/project")
         abort_calls = [
             c
@@ -195,7 +210,14 @@ class TestRebaseOntoTarget:
     @patch("app.claude_step._run_git")
     def test_timeout_caught_and_logged(self, mock_git, mock_subprocess, capsys):
         """TimeoutExpired should be caught (not just Exception) and logged."""
-        mock_git.side_effect = subprocess.TimeoutExpired("git", 60)
+        call_count = 0
+        def selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise subprocess.TimeoutExpired("git", 60)
+            return ""
+        mock_git.side_effect = selective_fail
         result = _rebase_onto_target("main", "/project")
         assert result is None
         captured = capsys.readouterr()
@@ -206,7 +228,14 @@ class TestRebaseOntoTarget:
     @patch("app.claude_step._run_git")
     def test_os_error_caught_and_logged(self, mock_git, mock_subprocess, capsys):
         """OSError (e.g. git not found) should be caught and logged."""
-        mock_git.side_effect = OSError("No such file or directory: 'git'")
+        call_count = 0
+        def selective_fail(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count % 2 == 0:
+                raise OSError("No such file or directory: 'git'")
+            return ""
+        mock_git.side_effect = selective_fail
         result = _rebase_onto_target("main", "/project")
         assert result is None
         captured = capsys.readouterr()

--- a/koan/tests/test_pr_review.py
+++ b/koan/tests/test_pr_review.py
@@ -355,8 +355,6 @@ class TestRebaseOntoTarget:
         mock_git.side_effect = RuntimeError("conflict")
         result = _rebase_onto_target("main", "/tmp/p")
         assert result is None
-        # Should have called rebase --abort twice (once per remote)
-        assert mock_subproc.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -23,6 +23,7 @@ from app.rebase_pr import (
     _is_conflict_failure,
     _ordered_remotes,
     _push_with_fallback,
+    _rebase_with_conflict_resolution,
     _safe_checkout,
 )
 from app.claude_step import _is_permission_error
@@ -144,8 +145,9 @@ class TestCheckoutPrBranch:
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("app.claude_step.subprocess.run", side_effect=mock_run):
-            _checkout_pr_branch("koan/fix", "/project")
+            result = _checkout_pr_branch("koan/fix", "/project")
 
+        assert result == "origin"
         cmds = [c[:3] for c in calls]
         assert ["git", "fetch", "origin"] in cmds
         # Must use -B, not -b or plain checkout
@@ -171,7 +173,7 @@ class TestCheckoutPrBranch:
         assert "-B" in checkout_cmds[0]
 
     def test_falls_back_to_upstream(self):
-        """If origin fetch fails, tries upstream."""
+        """If origin fetch fails, tries upstream and returns 'upstream'."""
         calls = []
         def mock_run(cmd, **kwargs):
             calls.append(cmd)
@@ -182,8 +184,9 @@ class TestCheckoutPrBranch:
             return result
 
         with patch("app.claude_step.subprocess.run", side_effect=mock_run):
-            _checkout_pr_branch("feat/upstream-only", "/project")
+            result = _checkout_pr_branch("feat/upstream-only", "/project")
 
+        assert result == "upstream"
         fetch_cmds = [c for c in calls if c[:2] == ["git", "fetch"]]
         assert ["git", "fetch", "origin", "feat/upstream-only"] in fetch_cmds
         assert ["git", "fetch", "upstream", "feat/upstream-only"] in fetch_cmds
@@ -1204,3 +1207,273 @@ class TestMain:
 
     def test_rejects_empty(self):
         assert _is_conflict_failure("") is False
+
+
+# ---------------------------------------------------------------------------
+# --onto rebase (cross-fork PR support)
+# ---------------------------------------------------------------------------
+
+class TestRebaseOntoTarget_OntoMode:
+    """Tests for --onto rebase when head_remote differs from target remote."""
+
+    def test_uses_onto_when_head_remote_differs(self):
+        """--onto should be used when head_remote != target remote."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_onto_target(
+                "main", "/project",
+                preferred_remote="upstream",
+                head_remote="origin",
+            )
+
+        assert result == "upstream"
+        # Should have fetched both remotes' base branches
+        fetch_cmds = [c for c in calls if c[:2] == ["git", "fetch"]]
+        assert ["git", "fetch", "upstream", "main"] in fetch_cmds
+        assert ["git", "fetch", "origin", "main"] in fetch_cmds
+        # Should use --onto
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert len(rebase_cmds) == 1
+        assert "--onto" in rebase_cmds[0]
+        assert "upstream/main" in rebase_cmds[0]
+        assert "origin/main" in rebase_cmds[0]
+
+    def test_plain_rebase_when_head_remote_same_as_target(self):
+        """When head_remote == target remote, use plain rebase (same-repo PR)."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_onto_target(
+                "main", "/project",
+                preferred_remote="origin",
+                head_remote="origin",
+            )
+
+        assert result == "origin"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert len(rebase_cmds) == 1
+        assert "--onto" not in rebase_cmds[0]
+
+    def test_plain_rebase_when_head_remote_is_none(self):
+        """When head_remote is None, use plain rebase."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_onto_target("main", "/project", head_remote=None)
+
+        assert result == "origin"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert len(rebase_cmds) == 1
+        assert "--onto" not in rebase_cmds[0]
+
+    def test_onto_failure_falls_back_to_plain_rebase(self):
+        """If --onto rebase fails, fall back to plain rebase."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "rebase" in cmd and "--onto" in cmd:
+                raise RuntimeError("onto rebase conflict")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_onto_target(
+                "main", "/project",
+                preferred_remote="upstream",
+                head_remote="origin",
+            )
+
+        assert result == "upstream"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        # Should have tried --onto first, then plain rebase
+        assert len(rebase_cmds) == 2
+        assert "--onto" in rebase_cmds[0]
+        assert "--onto" not in rebase_cmds[1]
+
+    def test_onto_head_remote_fetch_failure_falls_back(self):
+        """If fetching head_remote/base fails, fall back to plain rebase."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            # head_remote fetch fails
+            if cmd[:3] == ["git", "fetch", "origin"] and "main" in cmd:
+                raise RuntimeError("fetch failed")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_onto_target(
+                "main", "/project",
+                preferred_remote="upstream",
+                head_remote="origin",
+            )
+
+        assert result == "upstream"
+        # Should have fallen back to plain rebase
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert len(rebase_cmds) == 1
+        assert "--onto" not in rebase_cmds[0]
+
+
+class TestRebaseWithConflictResolution_OntoMode:
+    """Tests for --onto rebase in _rebase_with_conflict_resolution."""
+
+    def _base_context(self):
+        return {
+            "title": "Fix", "body": "", "branch": "feat",
+            "base": "main", "diff": "", "review_comments": "",
+            "reviews": "", "issue_comments": "",
+        }
+
+    def test_uses_onto_when_head_remote_differs(self):
+        """--onto should be used when head_remote != preferred_remote."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_with_conflict_resolution(
+                "main", "/project", self._base_context(), [],
+                preferred_remote="upstream",
+                head_remote="origin",
+            )
+
+        assert result == "upstream"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert any("--onto" in c for c in rebase_cmds)
+
+    def test_plain_rebase_when_same_remote(self):
+        """Same-repo PR: head_remote == target, no --onto."""
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _rebase_with_conflict_resolution(
+                "main", "/project", self._base_context(), [],
+                preferred_remote="origin",
+                head_remote="origin",
+            )
+
+        assert result == "origin"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        assert all("--onto" not in c for c in rebase_cmds)
+
+    def test_onto_failure_falls_back_to_plain_rebase(self):
+        """If --onto fails (non-conflict), should fall back to plain rebase."""
+        calls = []
+        rebase_dir = MagicMock()
+        rebase_dir.exists.return_value = False
+
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "rebase" in cmd and "--onto" in cmd:
+                raise RuntimeError("onto failed")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.rebase_pr._has_rebase_in_progress", return_value=False):
+            result = _rebase_with_conflict_resolution(
+                "main", "/project", self._base_context(), [],
+                preferred_remote="upstream",
+                head_remote="origin",
+            )
+
+        assert result == "upstream"
+        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
+        plain_rebases = [c for c in rebase_cmds if "--onto" not in c]
+        assert len(plain_rebases) >= 1
+
+
+class TestFetchPrContextHeadOwner:
+    """Tests that fetch_pr_context extracts head_owner."""
+
+    @patch("app.github.subprocess.run")
+    def test_extracts_head_owner(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "Fix",
+                "headRefName": "feat",
+                "baseRefName": "main",
+                "state": "OPEN",
+                "author": {"login": "contributor"},
+                "headRepositoryOwner": {"login": "contributor"},
+                "url": "https://github.com/upstream/repo/pull/1",
+            })),
+            MagicMock(returncode=0, stdout=""),  # diff
+            MagicMock(returncode=0, stdout=""),  # review comments
+            MagicMock(returncode=0, stdout=""),  # reviews
+            MagicMock(returncode=0, stdout=""),  # issue comments
+        ]
+
+        context = fetch_pr_context("upstream", "repo", "1")
+        assert context["head_owner"] == "contributor"
+
+    @patch("app.github.subprocess.run")
+    def test_head_owner_missing_defaults_empty(self, mock_run):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "Fix",
+                "headRefName": "feat",
+                "baseRefName": "main",
+            })),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+
+        context = fetch_pr_context("o", "r", "1")
+        assert context["head_owner"] == ""
+
+
+class TestPushWithFallbackHeadRemote:
+    """Tests that _push_with_fallback tries head_remote first."""
+
+    def test_tries_head_remote_first(self):
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _push_with_fallback(
+                "feat", "main", "upstream/repo", "1",
+                {"title": "Fix"}, "/project",
+                head_remote="myfork",
+            )
+
+        assert result["success"] is True
+        # First push attempt should be to head_remote
+        push_cmds = [c for c in calls if "push" in c]
+        assert push_cmds[0][2] == "myfork"
+
+    def test_falls_back_to_origin_when_head_remote_fails(self):
+        calls = []
+        def mock_run(cmd, **kwargs):
+            calls.append(cmd)
+            if "push" in cmd and cmd[2] == "myfork":
+                raise RuntimeError("push rejected")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+            result = _push_with_fallback(
+                "feat", "main", "upstream/repo", "1",
+                {"title": "Fix"}, "/project",
+                head_remote="myfork",
+            )
+
+        assert result["success"] is True
+        push_cmds = [c for c in calls if "push" in c]
+        # Should have tried myfork first (both lease and force), then origin
+        assert any(c[2] == "origin" for c in push_cmds)


### PR DESCRIPTION
When rebasing a cross-fork PR, `git rebase upstream/main` replays all
commits between merge-base(HEAD, upstream/main) and HEAD. If the fork's
main has diverged from upstream, this replays upstream history as new PR
commits (e.g. PR #83 on cpan-authors/Crypt-OpenSSL-RSA ended up with
57 commits instead of ~1).

Fix by using `git rebase --onto target/base fork/base` when the PR's
head remote differs from the target remote. This limits replay to only
the PR's actual commits. Falls back to plain rebase for same-repo PRs
or when --onto fails.

Changes:
- fetch_pr_context() now queries headRepositoryOwner to identify fork
- _checkout_pr_branch() returns the fetch remote name
- _rebase_with_conflict_resolution() and _rebase_onto_target() accept
  head_remote param and use --onto when it differs from target
- _push_with_fallback() tries head_remote first (where the PR branch
  lives)
- pr_review.py passes head_remote through to _rebase_onto_target()

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
