### PR TITLE
fix: log error instead of silencing exception in resolve_base_branch

### DIFF
--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -15,6 +15,7 @@ Provides:
 File location: projects.yaml at KOAN_ROOT (next to .env).
 """
 
+import sys
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -229,8 +230,8 @@ def resolve_base_branch(
             detected = detect_remote_default_branch(remote, project_path)
             if detected:
                 return detected
-        except Exception:
-            pass
+        except Exception as e:
+            print(f"[projects_config] default branch detection failed for {project_name}: {e}", file=sys.stderr)
 
     return config_branch
 


### PR DESCRIPTION
Add diagnostic output to the broad except clause in
resolve_base_branch() so failures during remote default branch
detection are visible on stderr. The silent catch violated the
project's no-silent-broad-exception lint enforced by
test_silent_exceptions.py, breaking CI.
