### PR TITLE
fix: detect GitHub Enterprise SSO auth failures and alert via Telegram

### DIFF
--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -12,6 +12,30 @@ from typing import Dict, Optional
 
 from app.retry import retry_with_backoff, is_gh_transient
 
+
+class SSOAuthRequired(RuntimeError):
+    """Raised when a GitHub API call fails due to missing SSO authorization.
+
+    The token is valid but not authorized for the target organization's
+    SAML SSO policy.  The user must re-authorize with:
+        gh auth refresh -h github.com -s read:org
+    """
+
+    def __init__(self, stderr_text: str):
+        remediation = "gh auth refresh -h github.com -s read:org"
+        super().__init__(
+            f"GitHub API 403: SSO/SAML authorization required. "
+            f"Run: {remediation}\n"
+            f"Details: {stderr_text[:300]}"
+        )
+        self.stderr_text = stderr_text
+
+
+def _is_sso_error(stderr: str) -> bool:
+    """Check if a gh CLI stderr message indicates an SSO/SAML auth failure."""
+    upper = stderr.upper()
+    return "SSO" in upper or "SAML" in upper
+
 # Cached GitHub username (from gh api user fallback).
 # None = not yet queried, "" = query failed.
 _cached_gh_username = None
@@ -41,6 +65,8 @@ def run_gh(*args, cwd=None, timeout=30, stdin_data=None):
             capture_output=True, text=True, timeout=timeout, cwd=cwd,
         )
         if result.returncode != 0:
+            if _is_sso_error(result.stderr):
+                raise SSOAuthRequired(result.stderr)
             raise RuntimeError(
                 f"gh failed: {' '.join(cmd[:4])}... — {result.stderr[:300]}"
             )

--- a/koan/app/github_notifications.py
+++ b/koan/app/github_notifications.py
@@ -18,9 +18,36 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional, Set, Tuple
 
 from app.bounded_set import BoundedSet
-from app.github import api
+from app.github import SSOAuthRequired, api
 
 log = logging.getLogger(__name__)
+
+# Count of SSO failures observed during the current processing cycle.
+# Reset at the start of each cycle by the caller (loop_manager).
+_sso_failure_count: int = 0
+
+
+def reset_sso_failure_count() -> None:
+    """Reset the per-cycle SSO failure counter."""
+    global _sso_failure_count
+    _sso_failure_count = 0
+
+
+def get_sso_failure_count() -> int:
+    """Return the number of SSO failures observed in the current cycle."""
+    return _sso_failure_count
+
+
+def _record_sso_failure(context: str) -> None:
+    """Record an SSO failure and log a warning (once per context)."""
+    global _sso_failure_count
+    _sso_failure_count += 1
+    if _sso_failure_count == 1:
+        log.warning(
+            "GitHub SSO auth failure detected (%s). "
+            "Token needs re-authorization: gh auth refresh -h github.com -s read:org",
+            context,
+        )
 
 # In-memory set of processed comment IDs (resets on restart).
 # Bounded: FIFO eviction when limit is reached (oldest entries removed first).
@@ -239,6 +266,9 @@ def get_comment_from_notification(notification: dict) -> Optional[dict]:
     try:
         raw = api(endpoint)
         return json.loads(raw) if raw else None
+    except SSOAuthRequired:
+        _record_sso_failure(f"get_comment endpoint={endpoint[:80]}")
+        return None
     except (RuntimeError, json.JSONDecodeError, subprocess.TimeoutExpired):
         return None
 
@@ -331,6 +361,9 @@ def find_mention_in_thread(
     try:
         raw = api(issue_endpoint)
         comments = json.loads(raw) if raw else []
+    except SSOAuthRequired:
+        _record_sso_failure(f"find_mention issue_comments {owner}/{repo}#{number}")
+        comments = []
     except (RuntimeError, json.JSONDecodeError, subprocess.TimeoutExpired):
         comments = []
 
@@ -348,6 +381,9 @@ def find_mention_in_thread(
         try:
             raw = api(review_endpoint)
             review_comments = json.loads(raw) if raw else []
+        except SSOAuthRequired:
+            _record_sso_failure(f"find_mention review_comments {owner}/{repo}#{number}")
+            review_comments = []
         except (RuntimeError, json.JSONDecodeError, subprocess.TimeoutExpired):
             review_comments = []
 
@@ -443,6 +479,8 @@ def check_already_processed(comment_id: str, bot_username: str,
                 if reaction.get("user", {}).get("login") == bot_username:
                     _processed_comments.add(comment_id)
                     return True
+    except SSOAuthRequired:
+        _record_sso_failure(f"check_already_processed comment={comment_id}")
     except (RuntimeError, json.JSONDecodeError):
         pass
 
@@ -501,6 +539,9 @@ def check_user_permission(owner: str, repo: str, username: str,
         data = json.loads(raw) if raw else {}
         permission = data.get("permission", "none")
         return permission in ("admin", "write")
+    except SSOAuthRequired:
+        _record_sso_failure(f"check_user_permission {owner}/{repo}")
+        return False
     except (RuntimeError, json.JSONDecodeError):
         return False
 

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -209,6 +209,10 @@ _NOTIF_CACHE_MAX = 2000
 _notif_cache: dict = {}
 _notif_cache_lock = threading.Lock()
 
+# SSO alert cooldown: only send one Telegram alert per hour.
+_SSO_ALERT_COOLDOWN = 3600  # 1 hour
+_last_sso_alert: float = 0
+
 # Lock protecting all module-level mutable GitHub state above.
 # Acquired for short state reads/writes only — never held during API calls.
 _github_state_lock = threading.Lock()
@@ -457,10 +461,42 @@ def _get_effective_check_interval() -> int:
         return _get_effective_check_interval_locked()
 
 
+def _check_sso_failures() -> None:
+    """After a notification cycle, check for SSO failures and alert once per cooldown."""
+    global _last_sso_alert
+
+    from app.github_notifications import get_sso_failure_count
+
+    count = get_sso_failure_count()
+    if count == 0:
+        return
+
+    now = time.time()
+    with _github_state_lock:
+        if now - _last_sso_alert < _SSO_ALERT_COOLDOWN:
+            return
+        _last_sso_alert = now
+
+    _github_log(
+        f"SSO auth failure: {count} API call(s) returned 403 — "
+        "run: gh auth refresh -h github.com -s read:org",
+        "warning",
+    )
+    try:
+        from app.notify import send_telegram
+        send_telegram(
+            "⚠️ GitHub API returning 403 for enterprise org repos — "
+            "SSO token needs re-authorization.\n"
+            "Run: gh auth refresh -h github.com -s read:org"
+        )
+    except (ImportError, OSError) as e:
+        log.debug("Failed to send SSO alert: %s", e)
+
+
 def reset_github_backoff() -> None:
     """Reset backoff state. Useful for tests and when external events suggest activity."""
     global _last_github_check, _last_github_check_iso, _consecutive_empty_checks, _github_config_logged, _github_interval_loaded
-    global _github_config_cache, _github_config_cache_mtime
+    global _github_config_cache, _github_config_cache_mtime, _last_sso_alert
     with _github_state_lock:
         _last_github_check = 0
         _last_github_check_iso = ""
@@ -469,6 +505,7 @@ def reset_github_backoff() -> None:
         _github_interval_loaded = False
         _github_config_cache = _GITHUB_CONFIG_UNSET
         _github_config_cache_mtime = 0
+        _last_sso_alert = 0
     with _notif_cache_lock:
         _notif_cache.clear()
 
@@ -538,7 +575,8 @@ def process_github_notifications(
         projects_config = load_projects_config(koan_root)
 
         # Fetch and process notifications
-        from app.github_notifications import fetch_unread_notifications, mark_notification_read
+        from app.github_notifications import fetch_unread_notifications, mark_notification_read, reset_sso_failure_count
+        reset_sso_failure_count()
         from app.github_command_handler import (
             process_single_notification,
             post_error_reply,
@@ -625,6 +663,9 @@ def process_github_notifications(
         drained = _drain_notifications(result.drain)
         if drained > 0:
             log.debug("GitHub: drained %d non-actionable notification(s)", drained)
+
+        # Check for SSO failures and alert if needed
+        _check_sso_failures()
 
         # Update backoff state
         with _github_state_lock:

--- a/koan/tests/test_github.py
+++ b/koan/tests/test_github.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from app.github import (
+    SSOAuthRequired, _is_sso_error,
     run_gh, pr_create, issue_create, api,
     get_gh_username, count_open_prs, cached_count_open_prs,
     batch_count_open_prs, fetch_issue_with_comments, detect_parent_repo,
@@ -93,6 +94,68 @@ class TestRunGh:
             run_gh("api", "repos/o/r")
         assert mock_run.call_count == 3
         assert mock_sleep.call_count == 2
+
+    @patch("app.github.subprocess.run")
+    def test_raises_sso_auth_required_on_sso_error(self, mock_run):
+        """SSO/SAML errors raise SSOAuthRequired instead of RuntimeError."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="Resource protected by organization SAML enforcement. "
+                   "You must grant your OAuth token access to this organization.",
+        )
+        with pytest.raises(SSOAuthRequired, match="SSO/SAML authorization required"):
+            run_gh("api", "repos/enterprise-org/repo")
+
+    @patch("app.retry.time.sleep")
+    @patch("app.github.subprocess.run")
+    def test_sso_error_not_retried(self, mock_run, mock_sleep):
+        """SSO errors are not transient — should not be retried."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stderr="SSO authorization required for this resource",
+        )
+        with pytest.raises(SSOAuthRequired):
+            run_gh("api", "repos/org/repo")
+        assert mock_run.call_count == 1
+        mock_sleep.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _is_sso_error
+# ---------------------------------------------------------------------------
+
+class TestIsSsoError:
+    def test_detects_sso_keyword(self):
+        assert _is_sso_error("You must grant your SSO token access") is True
+
+    def test_detects_saml_keyword(self):
+        assert _is_sso_error("Resource protected by organization SAML enforcement") is True
+
+    def test_case_insensitive(self):
+        assert _is_sso_error("sso authorization required") is True
+        assert _is_sso_error("saml enforcement") is True
+
+    def test_non_sso_error(self):
+        assert _is_sso_error("not found") is False
+        assert _is_sso_error("auth required") is False
+
+
+# ---------------------------------------------------------------------------
+# SSOAuthRequired
+# ---------------------------------------------------------------------------
+
+class TestSSOAuthRequired:
+    def test_is_runtime_error_subclass(self):
+        exc = SSOAuthRequired("test stderr")
+        assert isinstance(exc, RuntimeError)
+
+    def test_includes_remediation(self):
+        exc = SSOAuthRequired("SAML enforcement error")
+        assert "gh auth refresh" in str(exc)
+
+    def test_stores_stderr(self):
+        exc = SSOAuthRequired("original stderr")
+        assert exc.stderr_text == "original stderr"
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_github_notifications.py
+++ b/koan/tests/test_github_notifications.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.github import SSOAuthRequired
 from app.github_notifications import (
     FetchResult,
     _processed_comments,
@@ -20,9 +21,11 @@ from app.github_notifications import (
     fetch_unread_notifications,
     find_mention_in_thread,
     get_comment_from_notification,
+    get_sso_failure_count,
     is_notification_stale,
     is_self_mention,
     parse_mention_command,
+    reset_sso_failure_count,
 )
 
 
@@ -901,3 +904,71 @@ class TestSearchCommentsForMention:
         ]
         result = _search_comments_for_mention(comments, "bot", "owner", "repo")
         assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# SSO failure tracking
+# ---------------------------------------------------------------------------
+
+class TestSSOFailureTracking:
+    def setup_method(self):
+        reset_sso_failure_count()
+
+    def teardown_method(self):
+        reset_sso_failure_count()
+
+    @patch("app.github_notifications.api")
+    def test_get_comment_sso_failure_records_count(self, mock_api):
+        mock_api.side_effect = SSOAuthRequired("SAML enforcement")
+        notif = {
+            "subject": {
+                "latest_comment_url": "https://api.github.com/repos/org/repo/issues/comments/1"
+            }
+        }
+        result = get_comment_from_notification(notif)
+        assert result is None
+        assert get_sso_failure_count() == 1
+
+    @patch("app.github_notifications.api")
+    def test_find_mention_sso_failure_records_count(self, mock_api):
+        mock_api.side_effect = SSOAuthRequired("SSO required")
+        notif = {
+            "subject": {
+                "url": "https://api.github.com/repos/org/repo/issues/42"
+            }
+        }
+        result = find_mention_in_thread(notif, "bot")
+        assert result is None
+        assert get_sso_failure_count() >= 1
+
+    @patch("app.github_notifications.api")
+    def test_check_already_processed_sso_failure(self, mock_api):
+        mock_api.side_effect = SSOAuthRequired("SAML enforcement")
+        result = check_already_processed("123", "bot", "org", "repo")
+        assert result is False
+        assert get_sso_failure_count() == 1
+
+    @patch("app.github_notifications.api")
+    def test_check_user_permission_sso_failure(self, mock_api):
+        mock_api.side_effect = SSOAuthRequired("SSO required")
+        result = check_user_permission("org", "repo", "alice", ["*"])
+        assert result is False
+        assert get_sso_failure_count() == 1
+
+    def test_reset_clears_count(self):
+        # Manually bump the count
+        from app.github_notifications import _record_sso_failure
+        _record_sso_failure("test")
+        assert get_sso_failure_count() > 0
+        reset_sso_failure_count()
+        assert get_sso_failure_count() == 0
+
+    @patch("app.github_notifications.api")
+    def test_multiple_sso_failures_aggregate(self, mock_api):
+        mock_api.side_effect = SSOAuthRequired("SAML enforcement")
+        # Call multiple functions that each record SSO failures
+        get_comment_from_notification({
+            "subject": {"latest_comment_url": "https://api.github.com/repos/o/r/issues/comments/1"}
+        })
+        check_already_processed("123", "bot", "org", "repo")
+        assert get_sso_failure_count() == 2

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -2149,3 +2149,55 @@ class TestThreadSafety:
             t.join(timeout=5)
 
         assert not errors, f"Thread-safety errors: {errors}"
+
+
+# ---------------------------------------------------------------------------
+# SSO alert detection (_check_sso_failures)
+# ---------------------------------------------------------------------------
+
+class TestCheckSSOFailures:
+    def setup_method(self):
+        from app.loop_manager import reset_github_backoff
+        from app.github_notifications import reset_sso_failure_count
+        reset_github_backoff()
+        reset_sso_failure_count()
+
+    def teardown_method(self):
+        from app.loop_manager import reset_github_backoff
+        from app.github_notifications import reset_sso_failure_count
+        reset_github_backoff()
+        reset_sso_failure_count()
+
+    @patch("app.loop_manager.log")
+    def test_no_alert_when_no_sso_failures(self, mock_log):
+        from app.loop_manager import _check_sso_failures
+        _check_sso_failures()
+        # Should not log any warning
+        mock_log.warning.assert_not_called()
+
+    def test_sends_telegram_on_sso_failure(self):
+        from app.loop_manager import _check_sso_failures
+        from app.github_notifications import _record_sso_failure
+        _record_sso_failure("test")
+
+        with patch("app.notify.send_telegram") as mock_tg:
+            _check_sso_failures()
+            mock_tg.assert_called_once()
+            msg = mock_tg.call_args[0][0]
+            assert "SSO" in msg
+            assert "gh auth refresh" in msg
+
+    def test_cooldown_prevents_repeated_alerts(self):
+        from app.loop_manager import _check_sso_failures
+        from app.github_notifications import _record_sso_failure, reset_sso_failure_count
+
+        with patch("app.notify.send_telegram") as mock_tg:
+            _record_sso_failure("test1")
+            _check_sso_failures()
+            assert mock_tg.call_count == 1
+
+            # Second call within cooldown — should not alert again
+            reset_sso_failure_count()
+            _record_sso_failure("test2")
+            _check_sso_failures()
+            assert mock_tg.call_count == 1


### PR DESCRIPTION
GitHub Enterprise SSO token expiry causes silent 403/404 errors that look like "no notifications" rather than auth failures. Add SSOAuthRequired exception and _is_sso_error() detection in run_gh(), per-cycle SSO failure counting in github_notifications.py, and a cooldown-based Telegram alert in loop_manager.py so operators know to re-authorize.