### PR TITLE
feat: separate GitHub reply auth from command auth

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -235,6 +235,10 @@ usage:
 #   reply_enabled: false             # AI replies to non-command @mentions (default: false)
 #                                    # When enabled, the bot replies to questions/requests
 #                                    # from authorized users with contextual AI-generated answers.
+#   reply_authorized_users: ["*"]    # Optional override for reply permissions.
+#                                    # If omitted, falls back to authorized_users.
+#                                    # Unlike command auth, ["*"] here means any commenter.
+#   reply_rate_limit: 5              # Max replies per user per hour (default: 5, min: 1)
 #   natural_language: false           # NLP intent parsing for @mentions (default: false)
 #                                    # When enabled, unrecognized commands are sent to Claude
 #                                    # for intent classification before falling back to error.

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -21,14 +21,17 @@ Reply flow (when reply_enabled=true and command not recognized):
 
 import logging
 import re
-from typing import List, Optional, Tuple
+import time
+from typing import Dict, List, Optional, Tuple
 
 from app.bounded_set import BoundedSet
 from app.github_config import (
     get_github_authorized_users,
     get_github_natural_language,
     get_github_nickname,
+    get_github_reply_authorized_users,
     get_github_reply_enabled,
+    get_github_reply_rate_limit,
     get_github_subscribe_enabled,
     get_github_subscribe_max_per_cycle,
 )
@@ -52,6 +55,24 @@ log = logging.getLogger(__name__)
 # Bounded: FIFO eviction when limit is reached (oldest entries removed first).
 _MAX_TRACKED_ENTRIES = 10000
 _error_replies: BoundedSet = BoundedSet(maxlen=_MAX_TRACKED_ENTRIES)
+_reply_timestamps: Dict[str, List[float]] = {}
+
+
+def _is_reply_rate_limited(comment_author: str, config: dict) -> bool:
+    """Check and update per-user reply rate limits (max replies per hour)."""
+    now = time.time()
+    window_start = now - 3600
+    timestamps = _reply_timestamps.get(comment_author, [])
+    timestamps = [ts for ts in timestamps if ts >= window_start]
+
+    limit = get_github_reply_rate_limit(config)
+    if len(timestamps) >= limit:
+        _reply_timestamps[comment_author] = timestamps
+        return True
+
+    timestamps.append(now)
+    _reply_timestamps[comment_author] = timestamps
+    return False
 
 
 def _quarantine_github_mission(text: str, reason: str, author: str):
@@ -623,11 +644,28 @@ def _try_reply(
     comment_author = comment.get("user", {}).get("login", "")
     comment_id = str(comment.get("id", ""))
 
-    # Check permissions — same authorized_users as commands
-    allowed_users = get_github_authorized_users(config, project_name, projects_config)
-    if not check_user_permission(owner, repo, comment_author, allowed_users):
+    reply_allowed_users = get_github_reply_authorized_users(
+        config, project_name, projects_config
+    )
+    if reply_allowed_users is None:
+        # Backward compatibility: default to command-level authorization.
+        allowed_users = get_github_authorized_users(config, project_name, projects_config)
+    else:
+        allowed_users = reply_allowed_users
+
+    # Explicit ["*"] for replies means anyone can ask a question.
+    if allowed_users != ["*"] and not check_user_permission(
+        owner, repo, comment_author, allowed_users
+    ):
         log.debug(
             "GitHub reply: permission denied for @%s on %s/%s",
+            comment_author, owner, repo,
+        )
+        return False
+
+    if _is_reply_rate_limited(comment_author, config):
+        log.warning(
+            "GitHub reply: rate limit exceeded for @%s on %s/%s",
             comment_author, owner, repo,
         )
         return False

--- a/koan/app/github_config.py
+++ b/koan/app/github_config.py
@@ -8,6 +8,8 @@ Config schema in config.yaml:
       nickname: "koan-bot"
       commands_enabled: true
       authorized_users: ["*"]
+      reply_authorized_users: ["alice", "bob"]  # optional
+      reply_rate_limit: 5
       max_age_hours: 24
       reply_enabled: false
       check_interval_seconds: 60
@@ -17,6 +19,7 @@ Per-project override in projects.yaml:
       myproject:
         github:
           authorized_users: ["alice", "bob"]
+          reply_authorized_users: ["alice", "bob"]
 """
 
 from typing import List, Optional
@@ -90,6 +93,47 @@ def get_github_reply_enabled(config: dict) -> bool:
     """
     github = config.get("github") or {}
     return bool(github.get("reply_enabled", False))
+
+
+def get_github_reply_authorized_users(
+    config: dict,
+    project_name: Optional[str] = None,
+    projects_config: Optional[dict] = None,
+) -> Optional[List[str]]:
+    """Get the list of authorized GitHub users for reply generation.
+
+    Checks per-project github.reply_authorized_users first, then global
+    github.reply_authorized_users. Returns None when not configured so callers
+    can fall back to command-level authorized_users for backward compatibility.
+    """
+    # Check per-project override first
+    if project_name and projects_config:
+        from app.projects_config import get_project_github_reply_authorized_users
+        project_users = get_project_github_reply_authorized_users(
+            projects_config, project_name
+        )
+        if project_users is not None:
+            return project_users
+
+    # Fall back to global config.yaml
+    github = config.get("github") or {}
+    users = github.get("reply_authorized_users")
+    if users is None:
+        return None
+    return users if isinstance(users, list) else None
+
+
+def get_github_reply_rate_limit(config: dict) -> int:
+    """Get max replies per user per hour for GitHub reply flow.
+
+    Default: 5. Values below 1 are floored to 1.
+    """
+    github = config.get("github") or {}
+    try:
+        val = int(github.get("reply_rate_limit", 5))
+        return max(1, val)
+    except (ValueError, TypeError):
+        return 5
 
 
 def get_github_max_age_hours(config: dict) -> int:

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -11,6 +11,7 @@ Provides:
 - get_project_exploration(config, name) -> bool: Get exploration flag for a project
 - get_project_max_open_prs(config, name) -> int: Get max open PRs limit for a project
 - get_project_github_authorized_users(config, name) -> list: Get GitHub authorized users
+- get_project_github_reply_authorized_users(config, name) -> Optional[list]: Get GitHub reply-authorized users
 
 File location: projects.yaml at KOAN_ROOT (next to .env).
 """
@@ -345,6 +346,25 @@ def get_project_github_natural_language(config: dict, project_name: str) -> Opti
     if value is None:
         return None
     return bool(value)
+
+
+def get_project_github_reply_authorized_users(
+    config: dict, project_name: str
+) -> Optional[list]:
+    """Get GitHub reply-authorized users for a project from projects.yaml.
+
+    Per-project github.reply_authorized_users overrides global config.
+    Returns:
+    - list of usernames (or ["*"]) when explicitly configured
+    - [] when explicitly configured as empty
+    - None when not configured (caller should fall back to command auth list)
+    """
+    project_cfg = get_project_config(config, project_name)
+    github = project_cfg.get("github", {}) or {}
+    users = github.get("reply_authorized_users")
+    if users is None:
+        return None
+    return users if isinstance(users, list) else None
 
 
 def get_project_submit_to_repository(config: dict, project_name: str) -> dict:

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.github_command_handler import (
     _error_replies,
+    _reply_timestamps,
     _extract_url_from_context,
     _fetch_and_filter_comment,
     _handle_help_command,
@@ -88,6 +89,14 @@ def sample_notification():
             "latest_comment_url": "https://api.github.com/repos/sukria/koan/issues/comments/99999",
         },
     }
+
+
+@pytest.fixture(autouse=True)
+def clear_reply_rate_state():
+    """Keep in-memory reply rate tracking isolated between tests."""
+    _reply_timestamps.clear()
+    yield
+    _reply_timestamps.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -746,6 +755,89 @@ class TestTryReply:
             "bot", "sukria", "koan", "koan", "what?",
         )
         assert result is False
+
+    @patch("app.github_command_handler.check_user_permission", return_value=False)
+    def test_falls_back_to_command_authorized_users_when_reply_list_unset(
+        self, mock_perm, reply_notification, reply_comment
+    ):
+        config = {
+            "github": {
+                "nickname": "bot",
+                "reply_enabled": True,
+                "authorized_users": ["maintainer"],
+            }
+        }
+        _try_reply(
+            reply_notification, reply_comment, config, None,
+            "bot", "sukria", "koan", "koan", "what?",
+        )
+        mock_perm.assert_called_once_with("sukria", "koan", "alice", ["maintainer"])
+
+    @patch("app.github_command_handler.check_user_permission")
+    def test_reply_wildcard_skips_permission_check(
+        self, mock_perm, reply_comment
+    ):
+        notif = {"id": "1", "subject": {"url": ""}, "repository": {"full_name": "o/r"}}
+        config = {
+            "github": {
+                "nickname": "bot",
+                "reply_enabled": True,
+                "authorized_users": ["maintainer"],
+                "reply_authorized_users": ["*"],
+            }
+        }
+        result = _try_reply(
+            notif, reply_comment, config, None,
+            "bot", "o", "r", "koan", "what?",
+        )
+        assert result is False
+        mock_perm.assert_not_called()
+
+    @patch("app.github_command_handler.check_user_permission", return_value=False)
+    def test_reply_empty_authorized_users_disables_replies(
+        self, mock_perm, reply_notification, reply_comment
+    ):
+        config = {
+            "github": {
+                "nickname": "bot",
+                "reply_enabled": True,
+                "authorized_users": ["*"],
+                "reply_authorized_users": [],
+            }
+        }
+        result = _try_reply(
+            reply_notification, reply_comment, config, None,
+            "bot", "sukria", "koan", "koan", "what?",
+        )
+        assert result is False
+        mock_perm.assert_called_once_with("sukria", "koan", "alice", [])
+
+    @patch("app.github_command_handler.check_user_permission")
+    @patch("app.github_command_handler.extract_issue_number_from_notification")
+    def test_reply_rate_limit_applies_per_user_per_hour(
+        self, mock_issue, mock_perm, reply_notification, reply_comment
+    ):
+        mock_issue.return_value = "42"
+        mock_perm.return_value = True
+        config = {
+            "github": {
+                "nickname": "bot",
+                "reply_enabled": True,
+                "authorized_users": ["*"],
+                "reply_rate_limit": 1,
+            }
+        }
+
+        _try_reply(
+            reply_notification, reply_comment, config, None,
+            "bot", "sukria", "koan", "koan", "first?",
+        )
+        _try_reply(
+            reply_notification, reply_comment, config, None,
+            "bot", "sukria", "koan", "koan", "second?",
+        )
+
+        assert mock_issue.call_count == 1
 
     @patch("app.github_command_handler._notify_github_reply")
     @patch("app.github_command_handler._notify_github_question")

--- a/koan/tests/test_github_config.py
+++ b/koan/tests/test_github_config.py
@@ -9,7 +9,9 @@ from app.github_config import (
     get_github_max_age_hours,
     get_github_natural_language,
     get_github_nickname,
+    get_github_reply_authorized_users,
     get_github_reply_enabled,
+    get_github_reply_rate_limit,
     validate_github_config,
 )
 
@@ -160,6 +162,68 @@ class TestGetGithubReplyEnabled:
 
     def test_missing_key(self):
         assert get_github_reply_enabled({"github": {}}) is False
+
+
+class TestGetGithubReplyAuthorizedUsers:
+    def test_default_none_when_missing(self):
+        assert get_github_reply_authorized_users({}) is None
+
+    def test_global_explicit_list(self):
+        config = {"github": {"reply_authorized_users": ["alice", "bob"]}}
+        assert get_github_reply_authorized_users(config) == ["alice", "bob"]
+
+    def test_global_wildcard(self):
+        config = {"github": {"reply_authorized_users": ["*"]}}
+        assert get_github_reply_authorized_users(config) == ["*"]
+
+    def test_global_empty_list(self):
+        config = {"github": {"reply_authorized_users": []}}
+        assert get_github_reply_authorized_users(config) == []
+
+    def test_per_project_override(self):
+        config = {"github": {"reply_authorized_users": ["alice"]}}
+        projects_config = {
+            "defaults": {},
+            "projects": {
+                "myapp": {
+                    "path": "/tmp/myapp",
+                    "github": {"reply_authorized_users": ["bob"]},
+                }
+            },
+        }
+        result = get_github_reply_authorized_users(
+            config, project_name="myapp", projects_config=projects_config
+        )
+        assert result == ["bob"]
+
+    def test_per_project_fallback_to_global(self):
+        config = {"github": {"reply_authorized_users": ["alice"]}}
+        projects_config = {
+            "defaults": {},
+            "projects": {"myapp": {"path": "/tmp/myapp"}},
+        }
+        result = get_github_reply_authorized_users(
+            config, project_name="myapp", projects_config=projects_config
+        )
+        assert result == ["alice"]
+
+    def test_invalid_global_type_returns_none(self):
+        config = {"github": {"reply_authorized_users": "alice"}}
+        assert get_github_reply_authorized_users(config) is None
+
+
+class TestGetGithubReplyRateLimit:
+    def test_default(self):
+        assert get_github_reply_rate_limit({}) == 5
+
+    def test_custom(self):
+        assert get_github_reply_rate_limit({"github": {"reply_rate_limit": 9}}) == 9
+
+    def test_floor_at_1(self):
+        assert get_github_reply_rate_limit({"github": {"reply_rate_limit": 0}}) == 1
+
+    def test_invalid_returns_default(self):
+        assert get_github_reply_rate_limit({"github": {"reply_rate_limit": "bad"}}) == 5
 
 
 class TestGetGithubMaxAgeHours:

--- a/koan/tests/test_projects_config.py
+++ b/koan/tests/test_projects_config.py
@@ -13,6 +13,7 @@ from app.projects_config import (
     get_project_exploration,
     get_project_max_open_prs,
     get_project_models,
+    get_project_github_reply_authorized_users,
     get_project_submit_to_repository,
     get_project_tools,
     resolve_base_branch,
@@ -587,6 +588,59 @@ class TestGetProjectMaxOpenPrs:
             "projects": {"app": None},
         }
         assert get_project_max_open_prs(config, "app") == 8
+
+
+# ---------------------------------------------------------------------------
+# get_project_github_reply_authorized_users
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectGithubReplyAuthorizedUsers:
+    """Tests for get_project_github_reply_authorized_users()."""
+
+    def test_returns_none_when_unset(self):
+        config = {"projects": {"app": {"path": "/app", "github": {}}}}
+        assert get_project_github_reply_authorized_users(config, "app") is None
+
+    def test_returns_list_when_set(self):
+        config = {
+            "projects": {
+                "app": {
+                    "path": "/app",
+                    "github": {"reply_authorized_users": ["alice", "bob"]},
+                }
+            }
+        }
+        assert get_project_github_reply_authorized_users(config, "app") == ["alice", "bob"]
+
+    def test_returns_empty_list_when_explicitly_empty(self):
+        config = {
+            "projects": {
+                "app": {
+                    "path": "/app",
+                    "github": {"reply_authorized_users": []},
+                }
+            }
+        }
+        assert get_project_github_reply_authorized_users(config, "app") == []
+
+    def test_defaults_inherited_via_get_project_config(self):
+        config = {
+            "defaults": {"github": {"reply_authorized_users": ["team"]}},
+            "projects": {"app": {"path": "/app"}},
+        }
+        assert get_project_github_reply_authorized_users(config, "app") == ["team"]
+
+    def test_invalid_type_returns_none(self):
+        config = {
+            "projects": {
+                "app": {
+                    "path": "/app",
+                    "github": {"reply_authorized_users": "alice"},
+                }
+            }
+        }
+        assert get_project_github_reply_authorized_users(config, "app") is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
Add dedicated GitHub reply authorization and per-user reply rate limiting, without changing command permissions.

## Why
Issue #969 asks for responding to non-command questions from broader audiences while keeping command execution restricted. Reusing command `authorized_users` blocked this.

## How
- Added `github.reply_authorized_users` (global + per-project override) with fallback to existing `authorized_users` for backward compatibility.
- Updated `_try_reply()` to use reply-specific auth and treat explicit `reply_authorized_users: ["*"]` as allow-any-commenter for read-only replies.
- Added `github.reply_rate_limit` (per user, per hour; default 5) and in-memory enforcement in reply flow.
- Documented new config keys in `instance.example/config.yaml`.

## Testing
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_github_config.py koan/tests/test_projects_config.py koan/tests/test_github_command_handler.py -q`
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/ -q` *(environment had 1 unrelated failure: missing `tzdata` for `ZoneInfo("US/Eastern")` in `test_reset_parser.py`)*
