### PR TITLE
feat: direct API path for lightweight LLM tasks

### DIFF
--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -176,8 +176,23 @@ def format_message(raw_content: str, soul: str, prefs: str,
 
     try:
         from app.cli_exec import run_cli
+        from app.llm_client import try_complete_with_api
+        from app.text_utils import strip_markdown
 
         models = get_model_config()
+
+        # Direct API path for lightweight formatting (with system prompt cache hint).
+        api_output = try_complete_with_api(
+            prompt,
+            model=models["lightweight"],
+            timeout=30,
+            max_tokens=1200,
+        )
+        if api_output:
+            formatted = strip_markdown(api_output)
+            cache.put(cache_key, formatted, ttl=900)
+            return formatted
+
         cmd = build_full_command(prompt=prompt, model=models["lightweight"])
         result = run_cli(
             cmd,
@@ -189,8 +204,6 @@ def format_message(raw_content: str, soul: str, prefs: str,
         )
 
         if result.returncode == 0 and result.stdout.strip():
-            from app.text_utils import strip_markdown
-
             formatted = result.stdout.strip()
 
             # Safety check: remove any remaining markdown artifacts

--- a/koan/app/llm_client.py
+++ b/koan/app/llm_client.py
@@ -1,0 +1,108 @@
+"""Direct API helper for lightweight text-only LLM operations.
+
+Uses Anthropic's Messages API when available and enabled, with graceful
+fallback to existing CLI paths in callers.
+"""
+
+import os
+import sys
+from functools import lru_cache
+from typing import Optional
+
+
+_MODEL_ALIASES = {
+    "haiku": "claude-3-5-haiku-latest",
+    "sonnet": "claude-3-7-sonnet-latest",
+    "opus": "claude-3-opus-latest",
+}
+
+
+def _is_enabled() -> bool:
+    """Return whether direct API lightweight calls are enabled."""
+    raw = os.environ.get("KOAN_DIRECT_API_LIGHTWEIGHT", "1").strip().lower()
+    return raw not in {"0", "false", "off", "no"}
+
+
+def _resolve_model(model: str) -> str:
+    """Map shorthand model names to Anthropic model IDs."""
+    candidate = (model or "").strip()
+    if not candidate:
+        return _MODEL_ALIASES["haiku"]
+    if candidate.startswith("claude-"):
+        return candidate
+    return _MODEL_ALIASES.get(candidate.lower(), candidate)
+
+
+@lru_cache(maxsize=1)
+def _load_system_prompt(name: str) -> str:
+    from app.prompts import load_prompt
+
+    try:
+        return load_prompt(name).strip()
+    except Exception as e:
+        print(f"[llm_client] System prompt load failed ({name}): {e}", file=sys.stderr)
+        return ""
+
+
+def try_complete_with_api(
+    user_prompt: str,
+    *,
+    model: str = "haiku",
+    timeout: int = 30,
+    max_tokens: int = 1024,
+    temperature: float = 0.0,
+    system_prompt_name: str = "lightweight-api-system",
+) -> Optional[str]:
+    """Try a direct Anthropic API completion and return text or ``None``.
+
+    Callers should treat ``None`` as "use existing CLI path".
+    """
+    if not _is_enabled():
+        return None
+
+    api_key = os.environ.get("ANTHROPIC_API_KEY", "").strip()
+    if not api_key:
+        return None
+
+    try:
+        from anthropic import Anthropic
+    except ImportError:
+        return None
+
+    system_text = _load_system_prompt(system_prompt_name) if system_prompt_name else ""
+    system_blocks = []
+    if system_text:
+        system_blocks.append(
+            {
+                "type": "text",
+                "text": system_text,
+                "cache_control": {"type": "ephemeral"},
+            }
+        )
+
+    try:
+        client = Anthropic(api_key=api_key)
+        response = client.messages.create(
+            model=_resolve_model(model),
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system_blocks if system_blocks else None,
+            messages=[{"role": "user", "content": user_prompt}],
+            timeout=timeout,
+        )
+    except Exception as e:
+        print(f"[llm_client] Direct API call failed: {e}", file=sys.stderr)
+        return None
+
+    parts = []
+    for block in getattr(response, "content", []) or []:
+        if getattr(block, "type", "") == "text":
+            text = getattr(block, "text", "")
+            if text:
+                parts.append(text)
+
+    merged = "\n".join(parts).strip()
+    if not merged:
+        print("[llm_client] Direct API returned empty text output", file=sys.stderr)
+        return None
+    return merged

--- a/koan/app/pr_review_learning.py
+++ b/koan/app/pr_review_learning.py
@@ -216,7 +216,7 @@ def analyze_reviews_with_cli(
     review_text: str,
     project_path: str,
 ) -> str:
-    """Use Claude CLI (lightweight model) to extract lessons from review text.
+    """Use lightweight LLM path to extract lessons from review text.
 
     Args:
         review_text: Formatted review text from format_reviews_for_analysis().
@@ -227,10 +227,21 @@ def analyze_reviews_with_cli(
     """
     from app.cli_provider import build_full_command
     from app.config import get_model_config
+    from app.llm_client import try_complete_with_api
     from app.prompts import load_prompt
 
     prompt = load_prompt("review-learning", REVIEW_DATA=review_text)
     models = get_model_config()
+
+    # Direct API path first for lower latency/cost on pure text analysis.
+    api_output = try_complete_with_api(
+        prompt,
+        model=models.get("lightweight", "haiku"),
+        timeout=60,
+        max_tokens=1400,
+    )
+    if api_output:
+        return api_output.strip()
 
     cmd = build_full_command(
         prompt=prompt,

--- a/koan/system-prompts/lightweight-api-system.md
+++ b/koan/system-prompts/lightweight-api-system.md
@@ -1,0 +1,5 @@
+You are Kōan, a practical engineering assistant.
+
+Produce concise, actionable text with no filler.
+Follow the user's language and style instructions from the provided prompt.
+If uncertain, prefer a short, explicit caveat over speculation.

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -24,6 +24,12 @@ def _clear_format_cache():
     _format_cache.clear()
 
 
+@pytest.fixture(autouse=True)
+def _disable_direct_api(monkeypatch):
+    """Keep tests deterministic: default to CLI path unless explicitly mocked."""
+    monkeypatch.setenv("KOAN_DIRECT_API_LIGHTWEIGHT", "0")
+
+
 class TestLoadSoul:
     def test_returns_content_when_file_exists(self, instance_dir):
         result = load_soul(instance_dir)
@@ -80,8 +86,18 @@ class TestFallbackFormat:
 
 
 class TestFormatForTelegram:
+    @patch("app.llm_client.try_complete_with_api")
     @patch("app.cli_exec.run_cli")
-    def test_returns_claude_output_on_success(self, mock_run):
+    def test_prefers_direct_api_output_when_available(self, mock_run, mock_api):
+        mock_api.return_value = "**API** result"
+        result = format_message("raw content", "soul", "prefs")
+        assert result == "API result"
+        mock_run.assert_not_called()
+
+    @patch("app.llm_client.try_complete_with_api")
+    @patch("app.cli_exec.run_cli")
+    def test_returns_claude_output_on_success(self, mock_run, mock_api):
+        mock_api.return_value = None
         mock_run.return_value = MagicMock(
             returncode=0, stdout="Voici le résumé formaté.\n", stderr=""
         )

--- a/koan/tests/test_llm_client.py
+++ b/koan/tests/test_llm_client.py
@@ -1,0 +1,39 @@
+"""Tests for llm_client lightweight direct API helper."""
+
+import sys
+from types import SimpleNamespace
+
+from app.llm_client import try_complete_with_api
+
+
+class _FakeClient:
+    def __init__(self, *_args, **_kwargs):
+        self.messages = self
+
+    def create(self, **_kwargs):
+        block = SimpleNamespace(type="text", text="hello from api")
+        return SimpleNamespace(content=[block])
+
+
+class _FakeAnthropicModule:
+    Anthropic = _FakeClient
+
+
+def test_returns_none_when_disabled(monkeypatch):
+    monkeypatch.setenv("KOAN_DIRECT_API_LIGHTWEIGHT", "0")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    assert try_complete_with_api("ping") is None
+
+
+def test_returns_none_without_api_key(monkeypatch):
+    monkeypatch.setenv("KOAN_DIRECT_API_LIGHTWEIGHT", "1")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    assert try_complete_with_api("ping") is None
+
+
+def test_returns_text_on_success(monkeypatch):
+    monkeypatch.setenv("KOAN_DIRECT_API_LIGHTWEIGHT", "1")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "x")
+    monkeypatch.setitem(sys.modules, "anthropic", _FakeAnthropicModule)
+    result = try_complete_with_api("ping", system_prompt_name="")
+    assert result == "hello from api"

--- a/koan/tests/test_pr_review_learning.py
+++ b/koan/tests/test_pr_review_learning.py
@@ -20,6 +20,12 @@ from app.pr_review_learning import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _disable_direct_api(monkeypatch):
+    """Keep tests deterministic: default to CLI path unless explicitly mocked."""
+    monkeypatch.setenv("KOAN_DIRECT_API_LIGHTWEIGHT", "0")
+
+
 # ─── _parse_iso ──────────────────────────────────────────────────────────
 
 
@@ -231,6 +237,23 @@ class TestAppendLessonsToLearnings:
 
 
 class TestAnalyzeReviewsWithCli:
+    @patch("app.cli_exec.run_cli_with_retry")
+    @patch("app.cli_provider.build_full_command")
+    @patch("app.llm_client.try_complete_with_api")
+    @patch("app.config.get_model_config")
+    @patch("app.prompts.load_prompt")
+    def test_returns_api_output_without_cli(
+        self, mock_prompt, mock_models, mock_api, mock_build, mock_run
+    ):
+        mock_prompt.return_value = "analysis prompt"
+        mock_models.return_value = {"lightweight": "haiku", "fallback": "sonnet"}
+        mock_api.return_value = "- Direct API lesson"
+
+        result = analyze_reviews_with_cli("some review text", "/fake/path")
+        assert "Direct API lesson" in result
+        mock_build.assert_not_called()
+        mock_run.assert_not_called()
+
     @patch("app.cli_exec.run_cli_with_retry")
     @patch("app.cli_provider.build_full_command")
     @patch("app.config.get_model_config")


### PR DESCRIPTION
## What
Add a shared direct-API lightweight LLM client and use it for outbox formatting and PR-review learning before falling back to CLI.

## Why
Lightweight text-only tasks were paying full CLI startup overhead and missing prompt-cache opportunities. This reduces latency/cost when Anthropic API is available while keeping existing CLI behavior as a safe fallback.

## How
- Added `app/llm_client.py` with Anthropic Messages API support, shorthand model alias resolution, and a `cache_control` system prompt block.
- Added `system-prompts/lightweight-api-system.md` to keep lightweight API system context in prompt files.
- Wired API-first behavior into `format_outbox.format_message()` and `pr_review_learning.analyze_reviews_with_cli()`; both now transparently fall back to existing CLI paths.
- Added deterministic test guards (`KOAN_DIRECT_API_LIGHTWEIGHT=0`) plus new tests for API success/fallback behavior.

## Testing
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_llm_client.py koan/tests/test_format_outbox.py koan/tests/test_pr_review_learning.py -q`
- Result: `84 passed`
