### PR TITLE
docs: generalize provider and include codex

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -19,7 +19,11 @@ To run Koan in a Docker container (for server deployment or local isolation), se
 
 ## Prerequisites
 
-- [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code) installed and authenticated
+- At least one supported CLI provider installed and authenticated:
+  - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
+  - [OpenAI Codex CLI](https://github.com/openai/codex)
+  - [GitHub Copilot CLI](https://docs.github.com/en/copilot/github-copilot-in-the-cli)
+  - Local provider dependencies (see [docs/provider-local.md](docs/provider-local.md))
 - Python 3.8+
 - A Telegram account or a Slack workspace (for messaging)
 
@@ -30,12 +34,13 @@ To run Koan in a Docker container (for server deployment or local isolation), se
 ## LLM Providers
 
 Koan supports multiple LLM providers. Claude Code CLI is the default and
-most capable option. You can also use GitHub Copilot or a local LLM
-server.
+most capable option. You can also use OpenAI Codex, GitHub Copilot, or a
+local LLM server.
 
 | Provider | Setup Guide | Best For |
 |----------|------------|----------|
 | **Claude Code** (default) | [docs/provider-claude.md](docs/provider-claude.md) | Full-featured agent with best reasoning |
+| **OpenAI Codex** | [docs/provider-codex.md](docs/provider-codex.md) | ChatGPT users who want Codex models |
 | **GitHub Copilot** | [docs/provider-copilot.md](docs/provider-copilot.md) | Teams with existing Copilot subscriptions |
 | **Local LLM** | [docs/provider-local.md](docs/provider-local.md) | Offline use, privacy, zero API cost |
 
@@ -498,13 +503,25 @@ Your `missions.md` file references a project name that doesn't match your config
 2. Check that the bot is invited to the channel (`/invite @koan`)
 3. Review the logs for connection errors (`make logs`)
 
-### Claude CLI errors
+### CLI provider errors
 
-Make sure Claude Code CLI is installed and authenticated:
+Make sure your configured provider CLI is installed and authenticated.
+
+**Claude Code:**
 ```bash
 claude --version   # Should show version
 claude             # Should start interactive mode (exit with /exit)
 ```
+
+**OpenAI Codex:**
+```bash
+codex --version    # Should show version
+codex login --device-auth
+```
+
+For Copilot and local setups, see:
+- [docs/provider-copilot.md](docs/provider-copilot.md)
+- [docs/provider-local.md](docs/provider-local.md)
 
 ## Preventing macOS sleep
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@
 
 ## What Is This?
 
-You pay for Claude Max. You use it 8 hours a day. The other 16? Wasted quota.
+You pay for AI coding quota. You use it 8 hours a day. The other 16? Wasted quota.
 
-Koan fixes that. It's a background agent that runs on your machine, pulls tasks from a shared mission queue, executes them via [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code), and reports back through Telegram or Slack. It writes code in isolated branches, never touches `main`, and waits for your review before anything ships.
+Koan fixes that. It's a background agent that runs on your machine, pulls tasks from a shared mission queue, executes them via your configured CLI provider (Claude Code, Codex, Copilot, or local), and reports back through Telegram or Slack. It writes code in isolated branches, never touches `main`, and waits for your review before anything ships.
 
 **The agent proposes. The human decides.**
 
@@ -126,7 +126,7 @@ OpenClaw and ZeroClaw are general-purpose autonomous agents that can do *anythin
 Two processes run in parallel:
 
 - **Bridge** (`make awake`) — Polls your messaging platform. Classifies incoming messages as *chat* (instant reply) or *mission* (queued for deep work). Formats outgoing messages through Claude with personality context.
-- **Agent loop** (`make run`) — Picks the next mission, executes it via Claude Code CLI, writes journal entries, pushes branches, creates draft PRs. Adapts its work intensity based on remaining API quota.
+- **Agent loop** (`make run`) — Picks the next mission, executes it via the configured CLI provider, writes journal entries, pushes branches, creates draft PRs. Adapts its work intensity based on remaining API quota.
 
 Communication happens through shared markdown files in `instance/` — atomic writes, file locks, no database needed.
 
@@ -288,10 +288,15 @@ Koan isn't locked to Claude. Swap the backend per-project:
 | Provider | Best for |
 |----------|----------|
 | **Claude Code** (default) | Full-featured agent, best reasoning |
+| **OpenAI Codex** | ChatGPT users (Plus/Pro/Business/Edu/Enterprise) |
 | **GitHub Copilot** | Teams with existing Copilot licenses |
 | **Local LLM** | Offline, privacy, zero API cost |
 
-See provider guides in [docs/](docs/).
+See provider guides:
+- [docs/provider-claude.md](docs/provider-claude.md)
+- [docs/provider-codex.md](docs/provider-codex.md)
+- [docs/provider-copilot.md](docs/provider-copilot.md)
+- [docs/provider-local.md](docs/provider-local.md)
 
 ## Architecture
 
@@ -307,7 +312,9 @@ koan/
     usage_tracker.py      #   Budget tracking & mode selection
     provider/             #   CLI provider abstraction
       claude.py           #     Claude Code CLI
+      codex.py            #     OpenAI Codex CLI
       copilot.py          #     GitHub Copilot CLI
+      local.py            #     Local LLM backends
   skills/                 # Pluggable command system (44 core skills)
   system-prompts/         # All LLM prompts (20 files, no inline prompts)
   templates/              # Dashboard Jinja2 templates

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -93,7 +93,7 @@ Pending  →  In Progress  →  Done ✓
 ```
 
 1. **Pending** — Queued and waiting. Kōan picks missions from the top of the queue.
-2. **In Progress** — Kōan is actively working on it via Claude Code CLI.
+2. **In Progress** — Kōan is actively working on it via the configured CLI provider.
 3. **Done** — Completed successfully. Code is in a `koan/*` branch, often with a draft PR.
 4. **Failed** — Something went wrong. Kōan logs the reason and moves on.
 
@@ -789,7 +789,7 @@ projects:
 ```
 
 Key per-project settings:
-- **`cli_provider`** — `claude`, `copilot`, or `local`
+- **`cli_provider`** — `claude`, `codex`, `copilot`, `local`, or `ollama-launch`
 - **`models`** — Override model selection per role
 - **`tools`** — Restrict available tools
 - **`git_auto_merge`** — Auto-merge completed PRs (strategy: squash/merge/rebase)
@@ -872,6 +872,7 @@ Kōan supports multiple CLI backends. Configure globally via `KOAN_CLI_PROVIDER`
 | Provider | Best for | Docs |
 |----------|----------|------|
 | **Claude Code** (default) | Full-featured agent, best reasoning | [provider-claude.md](provider-claude.md) |
+| **OpenAI Codex** | ChatGPT users who want Codex models | [provider-codex.md](provider-codex.md) |
 | **GitHub Copilot** | Teams with existing Copilot licenses | [provider-copilot.md](provider-copilot.md) |
 | **Local LLM** | Offline, privacy, zero API cost | [provider-local.md](provider-local.md) |
 


### PR DESCRIPTION
This PR ports the docs-only extraction from mateu/koan#17 into upstream review.\n\nIncluded:\n- INSTALL.md\n- README.md\n- docs/user-manual.md\n\nIntentionally excluded:\n- docs/provider-codex.md (kept with runtime/landlock-related changes in separate work)\n\nSource branch: `mateu:koan/docs-split-exclude-provider-codex`\n