### PR TITLE
fix: anchor branch glob pattern to prefix start

### DIFF
--- a/koan/app/git_sync.py
+++ b/koan/app/git_sync.py
@@ -84,7 +84,7 @@ class GitSync:
     def get_koan_branches(self) -> List[str]:
         """List all agent branches (local and remote)."""
         prefix = _get_prefix()
-        glob_pattern = f"*{prefix}*"
+        glob_pattern = f"{prefix}*"
         output = run_git(self.project_path, "branch", "-a", "--list", glob_pattern)
         branches = []
         for line in output.splitlines():
@@ -116,7 +116,7 @@ class GitSync:
     def get_merged_branches(self) -> List[str]:
         """List agent branches merged into any target branch."""
         prefix = _get_prefix()
-        glob_pattern = f"*{prefix}*"
+        glob_pattern = f"{prefix}*"
         targets = self._get_target_branches()
         merged = set()
         for target in targets:

--- a/koan/tests/test_git_sync.py
+++ b/koan/tests/test_git_sync.py
@@ -64,6 +64,22 @@ class TestGetKoanBranches:
         with patch("app.git_sync.run_git", return_value=""):
             assert _sync().get_koan_branches() == []
 
+    def test_glob_pattern_uses_prefix_start(self):
+        """Glob pattern must match prefix at start, not anywhere in the name.
+
+        Bug: the old pattern f"*{prefix}*" would cause git branch --list to
+        scan branches like "feature/fix-koan/stuff" that merely contain the
+        prefix. The correct pattern is f"{prefix}*" (prefix-anchored).
+        """
+        with patch("app.git_sync.run_git", return_value="") as mock_git:
+            _sync().get_koan_branches()
+        # Verify the glob pattern passed to git branch --list
+        call_args = mock_git.call_args
+        assert call_args is not None
+        git_args = call_args[0]  # positional args: (cwd, "branch", "-a", "--list", pattern)
+        glob_pattern = git_args[-1]  # last argument is the pattern
+        assert glob_pattern == "koan/*", f"Expected 'koan/*' but got '{glob_pattern}'"
+
 
 class TestGetMergedBranches:
     def test_parses_merged(self):
@@ -72,6 +88,20 @@ class TestGetMergedBranches:
             merged = _sync().get_merged_branches()
         assert "koan/done-feature" in merged
         assert "koan/old-fix" in merged
+
+
+    def test_glob_pattern_uses_prefix_start(self):
+        """Glob pattern must match prefix at start for merged branches too."""
+        with patch("app.git_sync.run_git", return_value="") as mock_git:
+            _sync().get_merged_branches()
+        # Find the call that includes "--list" (the branch listing call)
+        list_calls = [
+            c for c in mock_git.call_args_list
+            if len(c[0]) >= 4 and "--list" in c[0]
+        ]
+        assert list_calls, "Expected at least one git branch --list call"
+        glob_pattern = list_calls[0][0][-1]
+        assert glob_pattern == "koan/*", f"Expected 'koan/*' but got '{glob_pattern}'"
 
 
 class TestGetUnmergedBranches:


### PR DESCRIPTION
## What

Fix glob pattern in `get_koan_branches()` and `get_merged_branches()` from `*{prefix}*` to `{prefix}*`.

## Why

The wildcard-wrapped pattern `*koan/*` matches any branch containing the prefix anywhere in its name (e.g., `feature/fix-koan/thing`). On large repos with many branches, this causes unnecessary scanning and potential false matches. The pattern should be prefix-anchored like `_get_local_branches()` already does.

## How

Changed `glob_pattern` from `f"*{prefix}*"` to `f"{prefix}*"` in both methods (lines 87 and 119 of `git_sync.py`).

## Testing

- Added 2 tests verifying the glob pattern passed to `git branch --list` is prefix-anchored
- All 58 tests in `test_git_sync.py` pass

---
Generated with [Claude Code](https://claude.com/claude-code)

---
### Quality Report

**Changes**: 2 files changed, 32 insertions(+), 2 deletions(-)

**Code scan**: clean

**Tests**: passed (10 PASSED)

**Branch hygiene**: clean

*Generated by Kōan post-mission quality pipeline*