### PR TITLE
refactor: extract quarantine append into shared helper

### DIFF
--- a/koan/app/command_handlers.py
+++ b/koan/app/command_handlers.py
@@ -717,15 +717,10 @@ def _handle_start():
 
 def _quarantine_mission(text: str, reason: str, source: str = "unknown"):
     """Write a blocked/flagged mission to the quarantine file for human review."""
-    from datetime import datetime
+    from app.missions import quarantine_mission
 
-    quarantine_path = INSTANCE_DIR / "missions-quarantine.md"
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-    entry = f"- 🛡️ [{timestamp}] ({source}) {reason}: {text[:500]}\n"
-    try:
-        with open(quarantine_path, "a") as f:
-            f.write(entry)
-    except OSError:
+    ok = quarantine_mission(INSTANCE_DIR / "missions-quarantine.md", text, reason, source)
+    if not ok:
         log("guard", f"Failed to write quarantine entry: {reason}")
 
 

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -63,19 +63,16 @@ _reply_timestamps: Dict[str, List[float]] = {}
 def _quarantine_github_mission(text: str, reason: str, author: str):
     """Write a flagged GitHub mission to the quarantine file."""
     import os
-    from datetime import datetime
     from pathlib import Path
+
+    from app.missions import quarantine_mission
 
     koan_root = os.environ.get("KOAN_ROOT", "")
     if not koan_root:
         return
     quarantine_path = Path(koan_root) / "instance" / "missions-quarantine.md"
-    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
-    entry = f"- 🛡️ [{timestamp}] (github/@{author}) {reason}: {text[:500]}\n"
-    try:
-        with open(quarantine_path, "a") as f:
-            f.write(entry)
-    except OSError:
+    ok = quarantine_mission(quarantine_path, text, reason, source=f"github/@{author}")
+    if not ok:
         log.warning("GitHub: failed to write quarantine entry: %s", reason)
 
 

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1532,3 +1532,59 @@ def count_in_progress(content: str) -> int:
     """Count the number of missions currently in progress."""
     sections = parse_sections(content)
     return len(sections.get("in_progress", []))
+
+
+# ---------------------------------------------------------------------------
+# Quarantine helpers
+# ---------------------------------------------------------------------------
+
+# Max quarantine file size in bytes. Once exceeded, the oldest half of
+# entries is pruned to make room.  100 KB is ~200 entries at ~500 bytes each.
+QUARANTINE_MAX_BYTES = 100_000
+
+
+def quarantine_mission(
+    quarantine_path: "Path",
+    text: str,
+    reason: str,
+    source: str = "unknown",
+) -> bool:
+    """Append a flagged mission to the quarantine file.
+
+    Args:
+        quarantine_path: Path to missions-quarantine.md.
+        text: The mission text (truncated to 500 chars).
+        reason: Why it was quarantined.
+        source: Origin label (e.g. "telegram", "github/@user").
+
+    Returns:
+        True if the entry was written, False on error.
+    """
+    from pathlib import Path  # local to avoid top-level import
+
+    quarantine_path = Path(quarantine_path)
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M")
+    entry = f"- \U0001f6e1\ufe0f [{timestamp}] ({source}) {reason}: {text[:500]}\n"
+    try:
+        _enforce_quarantine_cap(quarantine_path)
+        with open(quarantine_path, "a") as f:
+            f.write(entry)
+        return True
+    except OSError:
+        return False
+
+
+def _enforce_quarantine_cap(path: "Path") -> None:
+    """If the quarantine file exceeds QUARANTINE_MAX_BYTES, prune oldest half."""
+    from pathlib import Path
+
+    path = Path(path)
+    if not path.exists():
+        return
+    size = path.stat().st_size
+    if size <= QUARANTINE_MAX_BYTES:
+        return
+    lines = path.read_text().splitlines(keepends=True)
+    # Keep the newer half
+    half = len(lines) // 2
+    path.write_text("".join(lines[half:]))

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -27,6 +27,8 @@ from app.missions import (
     normalize_content,
     promote_all_ideas,
     promote_idea,
+    quarantine_mission,
+    QUARANTINE_MAX_BYTES,
     reorder_mission,
     sanitize_mission_text,
     stamp_queued,
@@ -34,6 +36,7 @@ from app.missions import (
     start_mission,
     strip_timestamps,
     prune_done_section,
+    _enforce_quarantine_cap,
     _flush_in_progress_to_done,
     DEFAULT_SKELETON,
 )
@@ -2691,3 +2694,86 @@ class TestInsertMissionNewlineSanitization:
         for line in result.split("\n"):
             if "fix" in line and "bug" in line:
                 assert "\n" not in line.replace("\n", "")  # trivially true per line
+
+
+# ---------------------------------------------------------------------------
+# quarantine_mission shared helper
+# ---------------------------------------------------------------------------
+
+class TestQuarantineMission:
+
+    def test_writes_entry(self, tmp_path):
+        qpath = tmp_path / "missions-quarantine.md"
+        ok = quarantine_mission(qpath, "bad text", "injection", source="telegram")
+        assert ok is True
+        content = qpath.read_text()
+        assert "injection" in content
+        assert "bad text" in content
+        assert "telegram" in content
+        assert "\U0001f6e1\ufe0f" in content  # shield emoji
+
+    def test_appends_multiple(self, tmp_path):
+        qpath = tmp_path / "missions-quarantine.md"
+        quarantine_mission(qpath, "first", "reason1", source="telegram")
+        quarantine_mission(qpath, "second", "reason2", source="github/@alice")
+        content = qpath.read_text()
+        assert "first" in content
+        assert "second" in content
+        assert "github/@alice" in content
+
+    def test_truncates_long_text(self, tmp_path):
+        qpath = tmp_path / "missions-quarantine.md"
+        long_text = "x" * 1000
+        quarantine_mission(qpath, long_text, "too long")
+        content = qpath.read_text()
+        # Entry should contain at most 500 chars of the text
+        assert "x" * 500 in content
+        assert "x" * 501 not in content
+
+    def test_returns_false_on_oserror(self, tmp_path):
+        # Non-existent parent → OSError
+        qpath = tmp_path / "no" / "such" / "dir" / "quarantine.md"
+        ok = quarantine_mission(qpath, "text", "reason")
+        assert ok is False
+
+    def test_default_source(self, tmp_path):
+        qpath = tmp_path / "missions-quarantine.md"
+        quarantine_mission(qpath, "text", "reason")
+        assert "unknown" in qpath.read_text()
+
+
+class TestQuarantineSizeCap:
+
+    def test_no_prune_under_limit(self, tmp_path):
+        qpath = tmp_path / "quarantine.md"
+        qpath.write_text("- entry 1\n- entry 2\n")
+        _enforce_quarantine_cap(qpath)
+        assert "entry 1" in qpath.read_text()
+        assert "entry 2" in qpath.read_text()
+
+    def test_prunes_when_over_limit(self, tmp_path):
+        qpath = tmp_path / "quarantine.md"
+        # Write enough data to exceed the cap
+        lines = [f"- entry {i}: {'x' * 200}\n" for i in range(600)]
+        qpath.write_text("".join(lines))
+        assert qpath.stat().st_size > QUARANTINE_MAX_BYTES
+        _enforce_quarantine_cap(qpath)
+        remaining = qpath.read_text()
+        # Older half was pruned
+        assert "entry 0" not in remaining
+        assert "entry 1" not in remaining
+        # Newer half is kept
+        assert "entry 599" in remaining
+        # File is smaller now
+        assert qpath.stat().st_size < QUARANTINE_MAX_BYTES * 0.7
+
+    def test_cap_enforced_on_write(self, tmp_path):
+        qpath = tmp_path / "quarantine.md"
+        lines = [f"- old entry {i}: {'y' * 200}\n" for i in range(600)]
+        qpath.write_text("".join(lines))
+        quarantine_mission(qpath, "new entry", "reason", source="test")
+        content = qpath.read_text()
+        # Old entries pruned
+        assert "old entry 0" not in content
+        # New entry present
+        assert "new entry" in content


### PR DESCRIPTION
## What
Consolidate duplicated quarantine file append logic into a single `quarantine_mission()` helper in `missions.py`.

## Why
`command_handlers.py` and `github_command_handler.py` had nearly identical private functions for appending to `missions-quarantine.md`. Beyond duplication, the quarantine file had no size limit — it could grow indefinitely.

## How
- Added `quarantine_mission(path, text, reason, source)` to `missions.py` with a 100KB size cap
- When the cap is exceeded, `_enforce_quarantine_cap()` prunes the oldest half of entries
- Both callers now delegate to the shared helper, keeping their thin wrappers for logging

## Testing
- 8 new tests: writes, appends, truncation, error handling, size cap enforcement
- Existing `TestQuarantine` in `test_prompt_guard.py` still passes (wrapper behavior unchanged)
- Full suite: 10665 passed