### PR TITLE
fix: use full SHA-256 digest in review hash

### DIFF
--- a/koan/app/pr_review_learning.py
+++ b/koan/app/pr_review_learning.py
@@ -274,7 +274,7 @@ def _compute_review_hash(prs: List[dict]) -> str:
         for comment in pr.get("review_comments", []):
             parts.append(comment.get("body") or "")
     content = "|".join(parts)
-    return hashlib.sha256(content.encode()).hexdigest()[:16]
+    return hashlib.sha256(content.encode()).hexdigest()
 
 
 def _get_cache_path(instance_dir: str) -> Path:

--- a/koan/tests/test_pr_review_learning.py
+++ b/koan/tests/test_pr_review_learning.py
@@ -138,6 +138,13 @@ class TestComputeReviewHash:
         ]
         assert _compute_review_hash(prs_a) == _compute_review_hash(prs_b)
 
+    def test_returns_full_sha256_hex_digest(self):
+        """Hash must be a full 64-char SHA-256 hex digest to prevent cache collisions."""
+        prs = [{"number": 1, "reviews": [{"body": "lgtm"}], "review_comments": []}]
+        h = _compute_review_hash(prs)
+        assert len(h) == 64
+        assert all(c in "0123456789abcdef" for c in h)
+
 
 # ─── cache ───────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What

Use the full 64-char SHA-256 hex digest in `_compute_review_hash()` instead of truncating to 16 characters.

## Why

A 16-char prefix (64 bits) has a non-trivial collision probability on long-running instances processing many PR reviews over time. The birthday paradox means ~2^32 (~4 billion) distinct inputs give a 50% collision chance — unlikely but unnecessary when the full digest is free.

## How

Removed `[:16]` from `hashlib.sha256(content.encode()).hexdigest()[:16]` at `pr_review_learning.py:277`. Added a test asserting the hash is exactly 64 hex characters.

## Testing

All 37 tests in `test_pr_review_learning.py` pass, including the new `test_returns_full_sha256_hex_digest`.

Note: existing cache files with 16-char hashes will simply be treated as stale (hash mismatch), triggering one re-analysis — no migration needed.