### PR TITLE
fix: add startup delay to prevent /pause race condition

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -26,6 +26,11 @@
 max_runs_per_day: 20
 interval_seconds: 300
 
+# Startup delay — seconds to wait before the first mission after boot.
+# Gives you time to send /pause before any mission runs.
+# Set to 0 to disable. Skipped automatically if already paused at startup.
+# startup_delay: 30
+
 # Auto-pause — automatically pause after max_runs or idle timeout.
 # When false, Kōan keeps running indefinitely (quota and error pauses still apply).
 # Useful when you have scheduled recurring tasks that must fire reliably.

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -50,6 +50,7 @@ from app.signals import (
     CYCLE_FILE,
     PAUSE_FILE,
     PROJECT_FILE,
+    RESTART_FILE,
     SHUTDOWN_FILE,
     ABORT_FILE,
     STATUS_FILE,
@@ -483,6 +484,60 @@ def _notify_mission_end(
 
 
 # ---------------------------------------------------------------------------
+# Startup delay (#1039)
+# ---------------------------------------------------------------------------
+
+DEFAULT_STARTUP_DELAY = 30  # seconds
+
+
+def _startup_delay(koan_root: str) -> None:
+    """Wait before the first iteration so /pause can be processed.
+
+    When ``make start`` launches koan, the first mission can be picked up
+    before the Telegram bridge has time to process a /pause command.  This
+    interruptible delay (default 30 s, configurable via ``startup_delay``
+    in config.yaml) closes the race window.
+
+    The delay is skipped when:
+    - The agent is already paused (.koan-pause exists).
+    - ``startup_delay`` is set to ``0``.
+
+    The delay is interrupted early if any lifecycle signal appears
+    (.koan-pause, .koan-stop, .koan-shutdown, .koan-restart).
+    """
+    from app.utils import load_config
+
+    delay = load_config().get("startup_delay", DEFAULT_STARTUP_DELAY)
+    if delay <= 0:
+        return
+
+    # Already paused — skip directly into the main loop's pause handler
+    if Path(koan_root, PAUSE_FILE).exists():
+        log("koan", "Already paused at startup — skipping startup delay.")
+        return
+
+    log(
+        "koan",
+        f"Startup delay: waiting {delay}s before first mission "
+        f"(send /pause now if needed).",
+    )
+
+    tick = 2  # check signals every 2 s
+    elapsed = 0
+    while elapsed < delay:
+        time.sleep(min(tick, delay - elapsed))
+        elapsed += tick
+
+        # Any lifecycle signal → break out
+        for sig in (PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE, RESTART_FILE):
+            if Path(koan_root, sig).exists():
+                log("koan", f"Signal detected during startup delay ({sig}), proceeding.")
+                return
+
+    log("koan", "Startup delay complete — entering main loop.")
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 
@@ -664,6 +719,12 @@ def main_loop():
         max_runs, interval, branch_prefix = run_startup(koan_root, instance, projects)
 
         git_sync_interval = int(os.environ.get("KOAN_GIT_SYNC_INTERVAL", "5"))
+
+        # --- Startup delay (#1039) ---
+        # Give the user a window to send /pause before the first mission runs.
+        # Without this, a mission can be picked up immediately after startup,
+        # racing with the Telegram bridge processing of /pause.
+        _startup_delay(koan_root)
 
         while True:
             # --- Stop check ---

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -18,6 +18,18 @@ pytestmark = pytest.mark.slow
 # Fixtures
 # ---------------------------------------------------------------------------
 
+@pytest.fixture(autouse=True)
+def _skip_startup_delay():
+    """Disable _startup_delay for all tests in this module.
+
+    The startup delay sleeps for 30 s by default, which causes timeouts
+    in tests that invoke main_loop().  Tests for the delay itself live
+    in test_startup_delay.py.
+    """
+    with patch("app.run._startup_delay"):
+        yield
+
+
 @pytest.fixture
 def koan_root(tmp_path):
     """Create a minimal koan root with instance directory."""

--- a/koan/tests/test_startup_delay.py
+++ b/koan/tests/test_startup_delay.py
@@ -1,0 +1,173 @@
+"""Tests for the startup delay feature (#1039).
+
+The startup delay prevents the race condition where a mission starts
+before the Telegram bridge can process a /pause command sent right
+after ``make start``.
+"""
+
+import time
+from pathlib import Path
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.signals import PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE, RESTART_FILE
+
+
+@pytest.fixture
+def koan_root(tmp_path):
+    """Create a minimal koan root directory."""
+    (tmp_path / "instance").mkdir()
+    return str(tmp_path)
+
+
+class TestStartupDelay:
+    """Tests for app.run._startup_delay()."""
+
+    def _import_fn(self):
+        from app.run import _startup_delay
+        return _startup_delay
+
+    def test_default_delay_waits(self, koan_root):
+        """With default config, the delay waits approximately 30s."""
+        fn = self._import_fn()
+        with patch("app.utils.load_config", return_value={}), \
+             patch("time.sleep") as mock_sleep:
+            fn(koan_root)
+
+        # Should have slept in 2s ticks for ~30s
+        total = sum(call.args[0] for call in mock_sleep.call_args_list)
+        assert total == pytest.approx(30, abs=1)
+
+    def test_zero_delay_skips(self, koan_root):
+        """startup_delay: 0 disables the delay entirely."""
+        fn = self._import_fn()
+        with patch("app.utils.load_config", return_value={"startup_delay": 0}), \
+             patch("time.sleep") as mock_sleep:
+            fn(koan_root)
+
+        mock_sleep.assert_not_called()
+
+    def test_negative_delay_skips(self, koan_root):
+        """Negative values are treated like zero."""
+        fn = self._import_fn()
+        with patch("app.utils.load_config", return_value={"startup_delay": -5}), \
+             patch("time.sleep") as mock_sleep:
+            fn(koan_root)
+
+        mock_sleep.assert_not_called()
+
+    def test_custom_delay(self, koan_root):
+        """Custom startup_delay value is respected."""
+        fn = self._import_fn()
+        with patch("app.utils.load_config", return_value={"startup_delay": 10}), \
+             patch("time.sleep") as mock_sleep:
+            fn(koan_root)
+
+        total = sum(call.args[0] for call in mock_sleep.call_args_list)
+        assert total == pytest.approx(10, abs=1)
+
+    def test_already_paused_skips(self, koan_root):
+        """If .koan-pause exists at startup, skip the delay."""
+        fn = self._import_fn()
+        Path(koan_root, PAUSE_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={}), \
+             patch("time.sleep") as mock_sleep:
+            fn(koan_root)
+
+        mock_sleep.assert_not_called()
+
+    def test_pause_signal_interrupts(self, koan_root):
+        """If .koan-pause appears during the delay, it stops early."""
+        fn = self._import_fn()
+        call_count = 0
+
+        def sleep_then_pause(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 3:
+                Path(koan_root, PAUSE_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={"startup_delay": 30}), \
+             patch("time.sleep", side_effect=sleep_then_pause):
+            fn(koan_root)
+
+        # Should have stopped after 3 ticks (6s), not the full 30s
+        assert call_count == 3
+
+    def test_stop_signal_interrupts(self, koan_root):
+        """If .koan-stop appears during the delay, it stops early."""
+        fn = self._import_fn()
+        call_count = 0
+
+        def sleep_then_stop(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                Path(koan_root, STOP_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={"startup_delay": 30}), \
+             patch("time.sleep", side_effect=sleep_then_stop):
+            fn(koan_root)
+
+        assert call_count == 2
+
+    def test_shutdown_signal_interrupts(self, koan_root):
+        """If .koan-shutdown appears during the delay, it stops early."""
+        fn = self._import_fn()
+        call_count = 0
+
+        def sleep_then_shutdown(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                Path(koan_root, SHUTDOWN_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={"startup_delay": 30}), \
+             patch("time.sleep", side_effect=sleep_then_shutdown):
+            fn(koan_root)
+
+        assert call_count == 1
+
+    def test_restart_signal_interrupts(self, koan_root):
+        """If .koan-restart appears during the delay, it stops early."""
+        fn = self._import_fn()
+        call_count = 0
+
+        def sleep_then_restart(seconds):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 2:
+                Path(koan_root, RESTART_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={"startup_delay": 30}), \
+             patch("time.sleep", side_effect=sleep_then_restart):
+            fn(koan_root)
+
+        assert call_count == 2
+
+    def test_logs_delay_start_and_end(self, koan_root):
+        """Verify that log messages are emitted for delay start and end."""
+        fn = self._import_fn()
+        with patch("app.utils.load_config", return_value={"startup_delay": 4}), \
+             patch("time.sleep"), \
+             patch("app.run.log") as mock_log:
+            fn(koan_root)
+
+        messages = [call.args[1] for call in mock_log.call_args_list]
+        assert any("waiting 4s" in m for m in messages)
+        assert any("complete" in m.lower() for m in messages)
+
+    def test_logs_skip_when_paused(self, koan_root):
+        """When already paused, log that the delay is skipped."""
+        fn = self._import_fn()
+        Path(koan_root, PAUSE_FILE).touch()
+
+        with patch("app.utils.load_config", return_value={}), \
+             patch("time.sleep"), \
+             patch("app.run.log") as mock_log:
+            fn(koan_root)
+
+        messages = [call.args[1] for call in mock_log.call_args_list]
+        assert any("skipping" in m.lower() for m in messages)


### PR DESCRIPTION
## What
Adds a configurable interruptible delay (default 30s) between startup and the first iteration loop cycle.

## Why
When `make start` launches koan, the first mission could be picked up before the Telegram bridge processes a `/pause` command sent right after boot. This race condition meant `/pause` was acknowledged but didn't prevent the first mission from running (#1039).

## How
- `_startup_delay()` in `run.py` sleeps in 2s ticks, checking for lifecycle signals each tick
- Delay is skipped if already paused, configurable to 0 via `startup_delay` in `config.yaml`
- Interrupted early by `.koan-pause`, `.koan-stop`, `.koan-shutdown`, `.koan-restart`
- Autouse fixture in `test_run.py` patches out the delay so existing tests aren't affected

## Testing
- 11 dedicated tests in `test_startup_delay.py` (delay, skip, interruption, logging)
- 313 tests pass in `test_run.py` + `test_startup_delay.py`

Closes #1039