### PR TITLE
fix: invalid pipeline tracker status + unbound vars in error retry

### DIFF
--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -868,6 +868,8 @@ def _post_error_for_notification(notif: dict, error: str) -> None:
 
     _, owner, repo = project_info
 
+    comment_id = ""
+    comment_api_url = ""
     try:
         comment = get_comment_from_notification(notif)
         if not comment:

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -802,7 +802,7 @@ def run_post_mission(
         if quota_result is QUOTA_CHECK_UNRELIABLE:
             log(f"⚠️  Quota check unreliable for {project_name} — "
                 "could not read log files, skipping quota detection")
-            tracker.record("quota_check", "warning", "unreliable — log files unreadable")
+            tracker.record("quota_check", "skipped", "unreliable — log files unreadable")
         elif quota_result is not None:
             result["quota_exhausted"] = True
             result["quota_info"] = quota_result

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -2266,6 +2266,41 @@ class TestErrorReplyRetryQueue:
             assert entry["comment_id"] == "999"
             assert entry["attempts"] == 1
 
+    def test_error_reply_queued_when_get_comment_raises(self):
+        """Regression: NameError when get_comment_from_notification raises.
+
+        If get_comment_from_notification raises an OSError (or similar),
+        comment_id and comment_api_url were unbound, causing NameError in
+        the except block. The fix initializes them before the try block.
+        """
+        import app.loop_manager as lm
+
+        notif = {
+            "id": "2",
+            "updated_at": "2026-03-27T10:00:00Z",
+            "subject": {"url": "https://api.github.com/repos/o/r/issues/5"},
+            "repository": {"full_name": "o/r"},
+        }
+
+        with lm._pending_error_replies_lock:
+            lm._pending_error_replies.clear()
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                    return_value=("proj", "o", "r")), \
+             patch("app.github_command_handler.extract_issue_number_from_notification",
+                    return_value=5), \
+             patch("app.github_notifications.get_comment_from_notification",
+                    side_effect=OSError("network timeout")):
+            # Before the fix, this raised NameError: name 'comment_id' is not defined
+            lm._post_error_for_notification(notif, "dispatch failed")
+
+        with lm._pending_error_replies_lock:
+            assert len(lm._pending_error_replies) == 1
+            entry = lm._pending_error_replies[0]
+            assert entry["comment_id"] == ""
+            assert entry["comment_api_url"] == ""
+            assert entry["error"] == "dispatch failed"
+
     def test_retry_succeeds_clears_queue(self):
         """Successful retry removes entry from the queue."""
         import app.loop_manager as lm

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -2266,6 +2266,23 @@ class TestPipelineTracker:
         assert result is None
         assert tracker.steps["timed_out"]["status"] == "timeout"
 
+    def test_skipped_status_for_unreliable_quota_check(self):
+        """Regression: quota_check used 'warning' status which is not in VALID_STATUSES.
+
+        The unreliable quota check path in run_post_mission must use 'skipped'
+        (a valid status) instead of 'warning' (which raises ValueError).
+        """
+        from app.mission_runner import _PipelineTracker
+
+        tracker = _PipelineTracker()
+        # This must not raise — 'skipped' is valid
+        tracker.record("quota_check", "skipped", "unreliable — log files unreadable")
+        assert tracker.steps["quota_check"]["status"] == "skipped"
+
+        # Confirm 'warning' is still invalid
+        with pytest.raises(ValueError, match="Invalid status"):
+            tracker.record("other", "warning", "not a valid status")
+
 
 class TestPipelineStepsInResult:
     """Test that run_post_mission includes pipeline_steps in result."""


### PR DESCRIPTION
## What
Fixes two bugs in the post-mission pipeline and GitHub error reply handler.

## Why
Bug 1: When CLI log files are unreadable, `run_post_mission` records `"warning"` as a pipeline tracker status — but `_PipelineTracker` only accepts `success/fail/skipped/timeout`. This raises `ValueError`, crashing the entire post-mission pipeline and incrementing `consecutive_errors` (which eventually triggers auto-pause).

Bug 2: When `get_comment_from_notification()` raises an exception in `_post_error_for_notification`, `comment_id` and `comment_api_url` are never assigned. The `except` block then immediately hits `NameError`, silently dropping the retry entry — the error reply is permanently lost.

## How
- Bug 1: Changed `"warning"` → `"skipped"` (semantically correct: we're skipping quota detection, not warning about it).
- Bug 2: Initialize `comment_id = ""` and `comment_api_url = ""` before the `try` block.

## Testing
- Added regression test for each bug (both verify the fix and confirm the original behavior was broken)
- Full suite: 10995 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)