### PR TITLE
feat: max_pending_branches per-project limit to cap unreviewed work

### DIFF
--- a/koan/app/branch_limiter.py
+++ b/koan/app/branch_limiter.py
@@ -1,0 +1,103 @@
+"""Branch saturation limiter — caps unreviewed work per project.
+
+Counts "pending branches" as the union (deduplicated by branch name) of:
+1. Local unmerged koan/* branches (via GitSync)
+2. Open PR branches on GitHub (via gh CLI)
+
+When the count reaches ``max_pending_branches``, the project is
+considered branch-saturated: no new missions are picked up and
+exploration is blocked until branches are reviewed/merged.
+
+Provides:
+- count_pending_branches(project_path, github_urls, author) -> int
+- is_project_branch_saturated(config, project_name, ...) -> bool
+"""
+
+import logging
+from typing import List, Set
+
+log = logging.getLogger(__name__)
+
+
+def _get_local_unmerged_branches(instance_dir: str, project_name: str,
+                                  project_path: str) -> Set[str]:
+    """Return set of local unmerged koan/* branch names."""
+    try:
+        from app.git_sync import GitSync
+        sync = GitSync(instance_dir, project_name, project_path)
+        return set(sync.get_unmerged_branches())
+    except Exception as e:
+        log.debug("Failed to get local unmerged branches for %s: %s",
+                  project_name, e)
+        return set()
+
+
+def _get_open_pr_branches(github_urls: List[str], author: str) -> Set[str]:
+    """Return set of branch names from open PRs across all GitHub URLs."""
+    if not author or not github_urls:
+        return set()
+
+    from app.github import list_open_pr_branches
+
+    pr_branches: Set[str] = set()
+    for url in github_urls:
+        try:
+            branches = list_open_pr_branches(url, author)
+            pr_branches.update(branches)
+        except Exception as e:
+            log.debug("Failed to list open PR branches for %s: %s", url, e)
+    return pr_branches
+
+
+def count_pending_branches(
+    instance_dir: str,
+    project_name: str,
+    project_path: str,
+    github_urls: List[str],
+    author: str,
+) -> int:
+    """Count pending (unreviewed) branches for a project.
+
+    Returns the size of the union of local unmerged branches and open
+    PR branches, deduplicated by branch name.
+
+    On GitHub API errors, falls back to local-only count.
+    """
+    local_branches = _get_local_unmerged_branches(
+        instance_dir, project_name, project_path,
+    )
+    pr_branches = _get_open_pr_branches(github_urls, author)
+
+    # Union: a branch with both a local copy and an open PR counts once
+    return len(local_branches | pr_branches)
+
+
+def is_project_branch_saturated(
+    config: dict,
+    project_name: str,
+    instance_dir: str,
+    project_path: str,
+    github_urls: List[str],
+    author: str,
+) -> bool:
+    """Check if a project has reached its max_pending_branches limit.
+
+    Returns False if the limit is 0 (unlimited) or if the count is
+    below the limit.
+    """
+    from app.projects_config import get_project_max_pending_branches
+
+    limit = get_project_max_pending_branches(config, project_name)
+    if limit == 0:
+        return False
+
+    count = count_pending_branches(
+        instance_dir, project_name, project_path, github_urls, author,
+    )
+    if count >= limit:
+        log.info(
+            "Project '%s' branch-saturated (%d/%d pending branches)",
+            project_name, count, limit,
+        )
+        return True
+    return False

--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -9,7 +9,7 @@ import json
 import re
 import subprocess
 import time
-from typing import Dict, Optional
+from typing import Dict, List, Optional
 
 from app.retry import (
     retry_with_backoff,
@@ -444,6 +444,43 @@ def batch_count_open_prs(repos: list, author: str) -> Dict[str, int]:
     except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError,
             OSError, TypeError, KeyError):
         return {}
+
+
+def list_open_pr_branches(repo: str, author: str, cwd: str = None) -> List[str]:
+    """List branch names of open PRs by a specific author in a repository.
+
+    Args:
+        repo: Repository in ``owner/repo`` format.
+        author: GitHub username to filter by. If empty, returns ``[]``.
+        cwd: Optional working directory.
+
+    Returns:
+        Sorted list of branch names (headRefName) for open PRs.
+        Returns empty list on error.
+    """
+    if not author:
+        return []
+
+    try:
+        output = run_gh(
+            "pr", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--author", author,
+            "--json", "headRefName",
+            cwd=cwd, timeout=15,
+        )
+        prs = json.loads(output) if output else []
+        if not isinstance(prs, list):
+            return []
+        return sorted({
+            pr["headRefName"]
+            for pr in prs
+            if isinstance(pr, dict) and pr.get("headRefName")
+        })
+    except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError,
+            TypeError, KeyError):
+        return []
 
 
 def count_open_prs(repo: str, author: str, cwd: str = None) -> int:

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -458,7 +458,8 @@ def _select_random_exploration_project(
     return random.choice(candidates)
 
 
-FilterResult = namedtuple("FilterResult", ["projects", "pr_limited"])
+FilterResult = namedtuple("FilterResult", ["projects", "pr_limited", "branch_saturated"],
+                         defaults=[[]])
 AutonomousDecision = namedtuple("AutonomousDecision", ["action", "focus_remaining"])
 
 
@@ -468,13 +469,16 @@ def _filter_exploration_projects(
 ) -> FilterResult:
     """Filter projects to only those eligible for exploration.
 
-    Checks two gates in order:
+    Checks three gates in order:
     1. ``exploration`` flag — projects with ``exploration: false`` are excluded.
     2. ``max_open_prs`` limit — projects at or over their PR limit are excluded.
+    3. ``max_pending_branches`` limit — projects at or over their branch limit
+       are excluded.
 
     Returns a FilterResult with:
     - ``projects``: list of (name, path) tuples eligible for exploration
     - ``pr_limited``: list of project names excluded due to PR limit
+    - ``branch_saturated``: list of project names excluded due to branch limit
     """
     from app.projects_config import (
         load_projects_config, get_project_exploration,
@@ -542,46 +546,86 @@ def _filter_exploration_projects(
 
         projects_needing_check[name] = (path, limit, urls_to_check)
 
-    if not projects_needing_check:
-        return FilterResult(projects=filtered, pr_limited=pr_limited)
+    if projects_needing_check:
+        # Phase 2: Batch-fetch PR counts for all repos in one GraphQL call
+        all_repos = []
+        for _, (_, _, urls) in projects_needing_check.items():
+            all_repos.extend(urls)
+        all_repos = list(dict.fromkeys(all_repos))  # deduplicate, preserve order
 
-    # Phase 2: Batch-fetch PR counts for all repos in one GraphQL call
-    all_repos = []
-    for _, (_, _, urls) in projects_needing_check.items():
-        all_repos.extend(urls)
-    all_repos = list(dict.fromkeys(all_repos))  # deduplicate, preserve order
+        batch_results = batch_count_open_prs(all_repos, author)
 
-    batch_results = batch_count_open_prs(all_repos, author)
+        # Phase 3: Evaluate limits using batch results (fall back to sequential on miss)
+        for name, (path, limit, urls_to_check) in projects_needing_check.items():
+            total_open = 0
+            any_error = False
 
-    # Phase 3: Evaluate limits using batch results (fall back to sequential on miss)
-    for name, (path, limit, urls_to_check) in projects_needing_check.items():
-        total_open = 0
-        any_error = False
+            for url in urls_to_check:
+                if url in batch_results:
+                    count = batch_results[url]
+                else:
+                    # Batch missed this repo — fall back to individual query
+                    count = cached_count_open_prs(url, author)
+                if count >= 0:
+                    total_open += count
+                else:
+                    any_error = True
 
-        for url in urls_to_check:
-            if url in batch_results:
-                count = batch_results[url]
+            if any_error and total_open == 0:
+                # All URLs errored — conservative: treat as PR-limited
+                pr_limited.append(name)
+                continue
+
+            if total_open >= limit:
+                _log_iteration("koan",
+                    f"Project '{name}' at PR limit ({total_open}/{limit}) — excluding from exploration")
+                pr_limited.append(name)
             else:
-                # Batch missed this repo — fall back to individual query
-                count = cached_count_open_prs(url, author)
-            if count >= 0:
-                total_open += count
-            else:
-                any_error = True
+                filtered.append((name, path))
 
-        if any_error and total_open == 0:
-            # All URLs errored — conservative: treat as PR-limited
-            pr_limited.append(name)
+    # Gate 3: max_pending_branches limit
+    from app.projects_config import get_project_max_pending_branches
+
+    instance_dir = str(Path(koan_root) / "instance")
+    branch_saturated = []
+    final_filtered = []
+
+    for name, path in filtered:
+        branch_limit = get_project_max_pending_branches(config, name)
+        if branch_limit == 0:
+            final_filtered.append((name, path))
             continue
 
-        if total_open >= limit:
-            _log_iteration("koan",
-                f"Project '{name}' at PR limit ({total_open}/{limit}) — excluding from exploration")
-            pr_limited.append(name)
-        else:
-            filtered.append((name, path))
+        project_cfg = config.get("projects", {}).get(name, {}) or {}
+        urls = set()
+        primary = project_cfg.get("github_url", "")
+        if primary:
+            urls.add(primary)
+        for u in project_cfg.get("github_urls", []):
+            if u:
+                urls.add(u)
 
-    return FilterResult(projects=filtered, pr_limited=pr_limited)
+        try:
+            from app.branch_limiter import count_pending_branches
+            count = count_pending_branches(
+                instance_dir, name, path, list(urls), author,
+            )
+        except Exception as e:
+            _log_iteration("debug",
+                f"Branch count failed for '{name}': {e} — allowing")
+            final_filtered.append((name, path))
+            continue
+
+        if count >= branch_limit:
+            _log_iteration("koan",
+                f"Project '{name}' branch-saturated ({count}/{branch_limit}) "
+                f"— excluding from exploration")
+            branch_saturated.append(name)
+        else:
+            final_filtered.append((name, path))
+
+    return FilterResult(projects=final_filtered, pr_limited=pr_limited,
+                        branch_saturated=branch_saturated)
 
 
 def _check_schedule():
@@ -824,6 +868,57 @@ def plan_iteration(
                 error=f"Unknown project '{project_name}'. Known: {', '.join(known)}",
                 tracker_error=tracker_error,
             )
+
+        # Step 5b: Branch saturation gate — skip mission if project is at limit
+        # Direct skill dispatch (/plan, /implement) bypasses this via skill_dispatch.py
+        try:
+            from app.projects_config import load_projects_config, get_project_max_pending_branches
+            branch_config = load_projects_config(koan_root)
+            if branch_config is not None:
+                branch_limit = get_project_max_pending_branches(branch_config, project_name)
+                if branch_limit > 0:
+                    from app.github import get_gh_username
+                    from app.branch_limiter import count_pending_branches
+
+                    branch_author = get_gh_username()
+                    project_cfg = branch_config.get("projects", {}).get(project_name, {}) or {}
+                    branch_urls = set()
+                    primary = project_cfg.get("github_url", "")
+                    if primary:
+                        branch_urls.add(primary)
+                    for u in project_cfg.get("github_urls", []):
+                        if u:
+                            branch_urls.add(u)
+
+                    instance_dir_str = str(instance)
+                    pending_count = count_pending_branches(
+                        instance_dir_str, project_name, project_path,
+                        list(branch_urls), branch_author,
+                    )
+                    if pending_count >= branch_limit:
+                        _log_iteration("koan",
+                            f"Project '{project_name}' branch-saturated "
+                            f"({pending_count}/{branch_limit}) — skipping mission")
+                        return _make_result(
+                            action="branch_saturated_wait",
+                            project_name=project_name,
+                            project_path=project_path,
+                            mission_title="",
+                            autonomous_mode=autonomous_mode,
+                            focus_area=f"Branch-saturated: {pending_count}/{branch_limit} pending branches",
+                            available_pct=available_pct,
+                            decision_reason=(
+                                f"Project '{project_name}' at branch limit "
+                                f"({pending_count}/{branch_limit}) — mission stays Pending"
+                            ),
+                            display_lines=display_lines,
+                            recurring_injected=recurring_injected,
+                            schedule_mode=schedule_state.mode if schedule_state else "normal",
+                            tracker_error=tracker_error,
+                        )
+        except (ImportError, OSError, ValueError) as e:
+            _log_iteration("debug", f"Branch saturation check failed: {e} — proceeding")
+
     else:
         # No mission — autonomous mode
         mission_title = ""
@@ -851,8 +946,15 @@ def plan_iteration(
                                                      schedule_state=schedule_state)
         exploration_projects = filter_result.projects
         if not exploration_projects:
-            # Determine whether this is exploration-disabled or PR-limited
-            if filter_result.pr_limited:
+            # Determine whether this is exploration-disabled, PR-limited, or branch-saturated
+            if filter_result.branch_saturated:
+                _log_iteration("koan", "All exploration projects branch-saturated — waiting for reviews")
+                wait_action = "branch_saturated_wait"
+                wait_reason = (
+                    f"Branch limit reached for: {', '.join(filter_result.branch_saturated)} "
+                    f"— waiting for reviews/merges"
+                )
+            elif filter_result.pr_limited:
                 _log_iteration("koan", "All exploration projects at PR limit — waiting for reviews")
                 wait_action = "pr_limit_wait"
                 wait_reason = (

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -10,6 +10,7 @@ Provides:
 - get_project_tools(config, name) -> dict: Get tool restrictions for a project
 - get_project_exploration(config, name) -> bool: Get exploration flag for a project
 - get_project_max_open_prs(config, name) -> int: Get max open PRs limit for a project
+- get_project_max_pending_branches(config, name) -> int: Get max pending branches limit
 - get_project_github_authorized_users(config, name) -> list: Get GitHub authorized users
 
 File location: projects.yaml at KOAN_ROOT (next to .env).
@@ -323,6 +324,28 @@ def get_project_max_open_prs(config: dict, project_name: str) -> int:
     """
     project_cfg = get_project_config(config, project_name)
     value = project_cfg.get("max_open_prs", 0)
+
+    # Coerce to int; invalid values map to 0 (unlimited)
+    try:
+        result = int(value)
+    except (TypeError, ValueError):
+        return 0
+
+    # Negative or zero → unlimited
+    return result if result > 0 else 0
+
+
+def get_project_max_pending_branches(config: dict, project_name: str) -> int:
+    """Get max pending branches limit for a project from projects.yaml.
+
+    Controls the maximum number of pending branches (open PRs ∪ local
+    unmerged branches) allowed before mission pickup and exploration are
+    blocked for this project.
+
+    Returns 10 by default. Returns 0 for unlimited (no limit).
+    """
+    project_cfg = get_project_config(config, project_name)
+    value = project_cfg.get("max_pending_branches", 10)
 
     # Coerce to int; invalid values map to 0 (unlimited)
     try:

--- a/koan/tests/test_branch_limiter.py
+++ b/koan/tests/test_branch_limiter.py
@@ -1,0 +1,114 @@
+"""Tests for koan/app/branch_limiter.py — branch saturation limiter."""
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from app.branch_limiter import (
+    count_pending_branches,
+    is_project_branch_saturated,
+)
+
+
+class TestCountPendingBranches:
+    """Tests for count_pending_branches() — union of local + PR branches."""
+
+    @patch("app.branch_limiter._get_open_pr_branches")
+    @patch("app.branch_limiter._get_local_unmerged_branches")
+    def test_union_deduplicates(self, mock_local, mock_pr):
+        """Branch with both local copy and open PR counted once."""
+        mock_local.return_value = {"koan/fix-a", "koan/fix-b"}
+        mock_pr.return_value = {"koan/fix-b", "koan/fix-c"}
+
+        count = count_pending_branches(
+            "/instance", "myapp", "/code/myapp", ["owner/myapp"], "bot",
+        )
+        assert count == 3  # fix-a, fix-b, fix-c
+
+    @patch("app.branch_limiter._get_open_pr_branches")
+    @patch("app.branch_limiter._get_local_unmerged_branches")
+    def test_local_only(self, mock_local, mock_pr):
+        """No GitHub URLs — count only local branches."""
+        mock_local.return_value = {"koan/fix-a", "koan/fix-b"}
+        mock_pr.return_value = set()
+
+        count = count_pending_branches(
+            "/instance", "myapp", "/code/myapp", [], "bot",
+        )
+        assert count == 2
+
+    @patch("app.branch_limiter._get_open_pr_branches")
+    @patch("app.branch_limiter._get_local_unmerged_branches")
+    def test_pr_only(self, mock_local, mock_pr):
+        """No local branches — count only PR branches."""
+        mock_local.return_value = set()
+        mock_pr.return_value = {"koan/fix-a"}
+
+        count = count_pending_branches(
+            "/instance", "myapp", "/code/myapp", ["owner/myapp"], "bot",
+        )
+        assert count == 1
+
+    @patch("app.branch_limiter._get_open_pr_branches")
+    @patch("app.branch_limiter._get_local_unmerged_branches")
+    def test_empty_both(self, mock_local, mock_pr):
+        """No branches at all."""
+        mock_local.return_value = set()
+        mock_pr.return_value = set()
+
+        count = count_pending_branches(
+            "/instance", "myapp", "/code/myapp", ["owner/myapp"], "bot",
+        )
+        assert count == 0
+
+    @patch("app.branch_limiter._get_open_pr_branches")
+    @patch("app.branch_limiter._get_local_unmerged_branches")
+    def test_github_error_falls_back_to_local(self, mock_local, mock_pr):
+        """GitHub API error → local-only count."""
+        mock_local.return_value = {"koan/fix-a", "koan/fix-b"}
+        mock_pr.return_value = set()  # Empty on error (handled internally)
+
+        count = count_pending_branches(
+            "/instance", "myapp", "/code/myapp", ["owner/myapp"], "bot",
+        )
+        assert count == 2
+
+
+class TestIsProjectBranchSaturated:
+    """Tests for is_project_branch_saturated()."""
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=10)
+    def test_saturated_at_limit(self, mock_count):
+        config = {
+            "defaults": {"max_pending_branches": 10},
+            "projects": {"myapp": {"path": "/code/myapp"}},
+        }
+        assert is_project_branch_saturated(
+            config, "myapp", "/instance", "/code/myapp", ["owner/myapp"], "bot",
+        ) is True
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=11)
+    def test_saturated_over_limit(self, mock_count):
+        config = {
+            "projects": {"myapp": {"path": "/code/myapp", "max_pending_branches": 5}},
+        }
+        assert is_project_branch_saturated(
+            config, "myapp", "/instance", "/code/myapp", ["owner/myapp"], "bot",
+        ) is True
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=4)
+    def test_not_saturated_under_limit(self, mock_count):
+        config = {
+            "projects": {"myapp": {"path": "/code/myapp", "max_pending_branches": 5}},
+        }
+        assert is_project_branch_saturated(
+            config, "myapp", "/instance", "/code/myapp", ["owner/myapp"], "bot",
+        ) is False
+
+    def test_unlimited_returns_false(self):
+        """max_pending_branches: 0 means unlimited — never saturated."""
+        config = {
+            "projects": {"myapp": {"path": "/code/myapp", "max_pending_branches": 0}},
+        }
+        assert is_project_branch_saturated(
+            config, "myapp", "/instance", "/code/myapp", ["owner/myapp"], "bot",
+        ) is False

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -1831,6 +1831,98 @@ projects:
         assert set(repos_arg) == {"owner/koan", "owner/backend"}
 
 
+# === Tests: _filter_exploration_projects with branch saturation ===
+
+
+class TestFilterExplorationProjectsBranchSaturation:
+
+    def setup_method(self):
+        self._batch_patcher = patch("app.github.batch_count_open_prs", return_value={})
+        self._batch_patcher.start()
+
+    def teardown_method(self):
+        self._batch_patcher.stop()
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=5)
+    @patch("app.github.get_gh_username", return_value="koan-bot")
+    def test_under_limit_included(self, mock_user, mock_count, koan_root):
+        """Project under branch limit is included."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 10
+""")
+        result = _filter_exploration_projects(
+            [("koan", "/path/to/koan")], str(koan_root),
+        )
+        assert len(result.projects) == 1
+        assert result.branch_saturated == []
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=10)
+    @patch("app.github.get_gh_username", return_value="koan-bot")
+    def test_at_limit_excluded(self, mock_user, mock_count, koan_root):
+        """Project at branch limit is excluded."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 10
+""")
+        result = _filter_exploration_projects(
+            [("koan", "/path/to/koan")], str(koan_root),
+        )
+        assert result.projects == []
+        assert result.branch_saturated == ["koan"]
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=15)
+    @patch("app.github.get_gh_username", return_value="koan-bot")
+    def test_over_limit_excluded(self, mock_user, mock_count, koan_root):
+        """Project over branch limit is excluded."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 10
+""")
+        result = _filter_exploration_projects(
+            [("koan", "/path/to/koan")], str(koan_root),
+        )
+        assert result.projects == []
+        assert result.branch_saturated == ["koan"]
+
+    @patch("app.github.get_gh_username", return_value="koan-bot")
+    def test_zero_limit_means_unlimited(self, mock_user, koan_root):
+        """max_pending_branches: 0 means unlimited — no branch count check."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 0
+""")
+        result = _filter_exploration_projects(
+            [("koan", "/path/to/koan")], str(koan_root),
+        )
+        assert len(result.projects) == 1
+        assert result.branch_saturated == []
+
+    @patch("app.branch_limiter.count_pending_branches", side_effect=Exception("git error"))
+    @patch("app.github.get_gh_username", return_value="koan-bot")
+    def test_error_allows_project(self, mock_user, mock_count, koan_root):
+        """Branch count error → project allowed (fail-open)."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 5
+""")
+        result = _filter_exploration_projects(
+            [("koan", "/path/to/koan")], str(koan_root),
+        )
+        assert len(result.projects) == 1
+        assert result.branch_saturated == []
+
+
 # === Tests: _filter_exploration_projects with deep_hours PR limit relaxation ===
 
 
@@ -2243,6 +2335,104 @@ class TestPlanIterationPrLimit:
         )
 
         assert result["action"] == "exploration_wait"
+
+
+# === Tests: plan_iteration with branch saturation ===
+
+
+class TestPlanIterationBranchSaturation:
+
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.iteration_manager._filter_exploration_projects")
+    @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("random.randint", return_value=99)
+    def test_all_branch_saturated_returns_branch_saturated_wait(
+        self, mock_rand, mock_focus, mock_filter, mock_refresh, mock_pick,
+        instance_dir, koan_root, usage_state,
+    ):
+        """When all projects are branch-saturated, action is branch_saturated_wait."""
+        mock_filter.return_value = FilterResult(
+            projects=[], pr_limited=[], branch_saturated=["koan", "backend"],
+        )
+
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "branch_saturated_wait"
+        assert "Branch limit" in result["decision_reason"]
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=10)
+    @patch("app.pick_mission.pick_mission", return_value="koan:fix a bug")
+    @patch("app.usage_estimator.cmd_refresh")
+    def test_mission_blocked_when_branch_saturated(
+        self, mock_refresh, mock_pick, mock_count,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Mission is skipped when project is branch-saturated."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 5
+""")
+
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "branch_saturated_wait"
+        assert result["project_name"] == "koan"
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=3)
+    @patch("app.pick_mission.pick_mission", return_value="koan:fix a bug")
+    @patch("app.usage_estimator.cmd_refresh")
+    def test_mission_allowed_when_under_limit(
+        self, mock_refresh, mock_pick, mock_count,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Mission proceeds when project is under branch limit."""
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 10
+""")
+
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "mission"
+        assert result["project_name"] == "koan"
 
 
 # === Tests: CLI interface ===

--- a/koan/tests/test_projects_config.py
+++ b/koan/tests/test_projects_config.py
@@ -12,6 +12,7 @@ from app.projects_config import (
     get_project_cli_provider,
     get_project_exploration,
     get_project_max_open_prs,
+    get_project_max_pending_branches,
     get_project_models,
     get_project_submit_to_repository,
     get_project_tools,
@@ -587,6 +588,79 @@ class TestGetProjectMaxOpenPrs:
             "projects": {"app": None},
         }
         assert get_project_max_open_prs(config, "app") == 8
+
+
+# ---------------------------------------------------------------------------
+# get_project_max_pending_branches
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectMaxPendingBranches:
+    """Tests for get_project_max_pending_branches() — per-project branch limit."""
+
+    def test_defaults_to_ten_when_key_missing(self):
+        config = {"projects": {"app": {"path": "/app"}}}
+        assert get_project_max_pending_branches(config, "app") == 10
+
+    def test_explicit_zero_returns_zero(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": 0}}}
+        assert get_project_max_pending_branches(config, "app") == 0
+
+    def test_positive_int_returns_value(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": 5}}}
+        assert get_project_max_pending_branches(config, "app") == 5
+
+    def test_string_int_coerced(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": "7"}}}
+        assert get_project_max_pending_branches(config, "app") == 7
+
+    def test_negative_returns_zero(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": -1}}}
+        assert get_project_max_pending_branches(config, "app") == 0
+
+    def test_none_returns_zero(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": None}}}
+        assert get_project_max_pending_branches(config, "app") == 0
+
+    def test_invalid_string_returns_zero(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": "abc"}}}
+        assert get_project_max_pending_branches(config, "app") == 0
+
+    def test_float_coerced_to_int(self):
+        config = {"projects": {"app": {"path": "/app", "max_pending_branches": 3.7}}}
+        assert get_project_max_pending_branches(config, "app") == 3
+
+    def test_defaults_section_applies(self):
+        config = {
+            "defaults": {"max_pending_branches": 15},
+            "projects": {"app": {"path": "/app"}},
+        }
+        assert get_project_max_pending_branches(config, "app") == 15
+
+    def test_project_overrides_defaults(self):
+        config = {
+            "defaults": {"max_pending_branches": 15},
+            "projects": {"app": {"path": "/app", "max_pending_branches": 3}},
+        }
+        assert get_project_max_pending_branches(config, "app") == 3
+
+    def test_unknown_project_returns_default_ten(self):
+        config = {"projects": {"app": {"path": "/app"}}}
+        assert get_project_max_pending_branches(config, "unknown") == 10
+
+    def test_unknown_project_inherits_defaults(self):
+        config = {
+            "defaults": {"max_pending_branches": 20},
+            "projects": {"app": {"path": "/app"}},
+        }
+        assert get_project_max_pending_branches(config, "unknown") == 20
+
+    def test_none_project_config_returns_default(self):
+        config = {
+            "defaults": {"max_pending_branches": 8},
+            "projects": {"app": None},
+        }
+        assert get_project_max_pending_branches(config, "app") == 8
 
 
 # ---------------------------------------------------------------------------

--- a/projects.example.yaml
+++ b/projects.example.yaml
@@ -83,6 +83,17 @@ defaults:
   # Default: 0 (unlimited)
   max_open_prs: 10
 
+  # Max pending branches — limit total unreviewed work per project.
+  # Counts the union of local unmerged koan/* branches and open PRs
+  # (deduplicated by branch name). When the limit is reached, both
+  # mission pickup AND exploration are blocked for this project until
+  # existing branches are reviewed/merged.
+  # More comprehensive than max_open_prs (which only gates exploration
+  # and only counts GitHub PRs).
+  # Set to 0 for unlimited.
+  # Default: 10
+  max_pending_branches: 10
+
 projects:
   # Example: your main project (minimal config — inherits all defaults)
   myapp:
@@ -136,6 +147,7 @@ projects:
   # oss-lib:
   #   path: "/Users/yourname/workspace/oss-lib"
   #   max_open_prs: 3                        # Keep max 3 open PRs for this repo
+  #   max_pending_branches: 5                # Cap total unreviewed branches
 
   # Example: a project using GitHub Copilot instead of Claude
   # copilot-project:


### PR DESCRIPTION
## Summary

Add a `max_pending_branches` setting (default: 10) per project that prevents kōan from creating new branches when too much unreviewed work is pending. When the limit is reached, both mission pickup and exploration are blocked for the project until existing branches are reviewed/merged.

Closes https://github.com/Anantys-oss/koan/issues/1076

## Changes

- New `koan/app/branch_limiter.py` — counts pending branches as the union of local unmerged branches + open PR branches (deduplicated by name), with graceful fallback on GitHub API errors
- `projects_config.py` — added `get_project_max_pending_branches()` (default: 10, 0 = unlimited)
- `github.py` — added `list_open_pr_branches()` helper for fetching open PR branch names
- `iteration_manager.py` — Gate 3 in `_filter_exploration_projects()` for branch saturation + Step 5b mission pickup gate
- `projects.example.yaml` — documented the new setting with inline comments
- Full test coverage: `test_branch_limiter.py`, plus new test classes in `test_projects_config.py` and `test_iteration_manager.py`

## Test plan

- 11122 tests pass (full suite)
- Unit tests for `count_pending_branches()` with mocked git/gh calls
- Unit tests for `get_project_max_pending_branches()` (all edge cases)
- Integration tests for exploration filtering with branch saturation
- Integration tests for mission pickup gate (blocked and allowed)
- Deduplication test: branch with both local copy and PR counted once
- Fallback test: GitHub error → local-only count
- Zero limit test: `0` = unlimited (no gate)

---
*Generated by Kōan /implement*