### PR TITLE
feat: auto-cleanup remote branches + configurable branch cleanup

### DIFF
--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -285,6 +285,15 @@ usage:
 #                                    # for intent classification before falling back to error.
 #                                    # Per-project override available in projects.yaml.
 
+# Branch cleanup — auto-delete merged branches during git sync
+# When enabled, branches matching the agent prefix (e.g. koan/*) are deleted
+# after being confirmed merged (via git ancestry or GitHub API).
+# Local branches are cleaned up by default; set remote: true to also delete
+# the corresponding remote tracking branches on origin.
+# branch_cleanup:
+#   enabled: true           # Auto-cleanup merged branches (default: true)
+#   remote: true            # Also delete remote branches (default: true)
+
 # Review concurrency — parallel GitHub API calls during code reviews
 # When enabled, PR context and comment fetching run concurrently using a
 # ThreadPoolExecutor. The LLM call (Claude CLI) is always sequential.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -633,3 +633,27 @@ def get_review_concurrency_config() -> dict:
         "enabled": bool(review_cfg.get("enabled", True)),
         "github_workers": _safe_int(review_cfg.get("github_workers", 4), 4),
     }
+
+
+def get_branch_cleanup_config() -> dict:
+    """Get branch cleanup configuration from config.yaml.
+
+    Controls automatic deletion of merged branches during git sync.
+
+    Config key: branch_cleanup
+      - enabled (bool): Enable auto-cleanup of merged branches (default: True)
+      - remote (bool): Also delete remote tracking branches (default: True)
+
+    Returns:
+        Dict with keys:
+          - enabled (bool): Whether cleanup runs during sync.
+          - remote (bool): Whether to delete remote branches too.
+    """
+    config = _load_config()
+    cleanup_cfg = config.get("branch_cleanup", {})
+    if not isinstance(cleanup_cfg, dict):
+        cleanup_cfg = {}
+    return {
+        "enabled": bool(cleanup_cfg.get("enabled", True)),
+        "remote": bool(cleanup_cfg.get("remote", True)),
+    }

--- a/koan/app/git_sync.py
+++ b/koan/app/git_sync.py
@@ -328,8 +328,49 @@ class GitSync:
 
         return deleted
 
+    def cleanup_remote_branches(self, branches: List[str]) -> List[str]:
+        """Delete remote tracking branches on origin for confirmed-merged branches.
+
+        Only deletes branches matching the agent prefix. Failures are
+        silently skipped (branch may already be gone on remote).
+
+        Args:
+            branches: Branch names to delete from origin.
+
+        Returns:
+            List of successfully deleted remote branch names.
+        """
+        prefix = _get_prefix()
+        deleted = []
+        for branch in branches:
+            if not branch.startswith(prefix):
+                continue
+            result = run_git(
+                self.project_path, "push", "origin", "--delete", branch
+            )
+            if result:
+                deleted.append(branch)
+                log.debug("Deleted remote branch: origin/%s", branch)
+        return deleted
+
+    def _get_remote_branches(self, prefix: str) -> List[str]:
+        """List remote branches matching prefix on origin."""
+        output = run_git(
+            self.project_path, "branch", "-r", "--list", f"origin/{prefix}*"
+        )
+        branches = []
+        for line in output.splitlines():
+            name = line.strip()
+            if name.startswith("origin/"):
+                name = name[len("origin/"):]
+            if name.startswith(prefix):
+                branches.append(name)
+        return branches
+
     def build_sync_report(self) -> str:
         """Build a human-readable git sync report."""
+        from app.config import get_branch_cleanup_config
+
         run_git(self.project_path, "fetch", "--prune")
 
         merged = self.get_merged_branches()
@@ -337,8 +378,26 @@ class GitSync:
         unmerged = self.get_unmerged_branches()
         recent = self.get_recent_main_commits(since_hours=12)
 
-        # Auto-cleanup merged local branches (git + GitHub-detected)
-        cleaned = self.cleanup_merged_branches(merged, github_merged)
+        cleanup_cfg = get_branch_cleanup_config()
+
+        # Auto-cleanup merged branches (local + optionally remote)
+        cleaned = []
+        remote_cleaned = []
+        if cleanup_cfg["enabled"]:
+            cleaned = self.cleanup_merged_branches(merged, github_merged)
+
+            if cleanup_cfg["remote"]:
+                # Find remote branches that are confirmed merged
+                all_confirmed = set(merged or [])
+                all_confirmed.update(github_merged or [])
+                prefix = _get_prefix()
+                remote_branches = set(self._get_remote_branches(prefix))
+                # Only delete remote branches that are confirmed merged
+                to_delete_remote = sorted(all_confirmed & remote_branches)
+                if to_delete_remote:
+                    remote_cleaned = self.cleanup_remote_branches(to_delete_remote)
+        else:
+            cleaned = []
 
         # Branches cleaned via GitHub detection should be removed from
         # the unmerged list (they were unmerged per git but merged per GitHub)
@@ -364,8 +423,15 @@ class GitSync:
                 suffix = " (cleaned up)" if b in (cleaned or []) else ""
                 parts.append(f"  ✓ {b}{suffix}")
 
-        if cleaned:
-            parts.append(f"\nCleaned up {len(cleaned)} merged local branch(es).")
+        if cleaned or remote_cleaned:
+            local_count = len(cleaned) if cleaned else 0
+            remote_count = len(remote_cleaned) if remote_cleaned else 0
+            cleanup_parts = []
+            if local_count:
+                cleanup_parts.append(f"{local_count} local")
+            if remote_count:
+                cleanup_parts.append(f"{remote_count} remote")
+            parts.append(f"\nCleaned up {' + '.join(cleanup_parts)} branch(es).")
 
         if unmerged:
             recent_branches, stale_branches = self._split_branches_by_recency(unmerged)

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -734,6 +734,36 @@ class TestDashboardConfig:
             assert get_dashboard_port() == 8080
 
 
+class TestBranchCleanupConfig:
+    """Tests for get_branch_cleanup_config()."""
+
+    def test_defaults(self):
+        from app.config import get_branch_cleanup_config
+        with _mock_config({}):
+            cfg = get_branch_cleanup_config()
+        assert cfg == {"enabled": True, "remote": True}
+
+    def test_disabled(self):
+        from app.config import get_branch_cleanup_config
+        with _mock_config({"branch_cleanup": {"enabled": False}}):
+            cfg = get_branch_cleanup_config()
+        assert cfg["enabled"] is False
+        assert cfg["remote"] is True
+
+    def test_remote_disabled(self):
+        from app.config import get_branch_cleanup_config
+        with _mock_config({"branch_cleanup": {"remote": False}}):
+            cfg = get_branch_cleanup_config()
+        assert cfg["enabled"] is True
+        assert cfg["remote"] is False
+
+    def test_non_dict_value(self):
+        from app.config import get_branch_cleanup_config
+        with _mock_config({"branch_cleanup": "yes"}):
+            cfg = get_branch_cleanup_config()
+        assert cfg == {"enabled": True, "remote": True}
+
+
 class TestBackwardCompat:
     """Verify that importing from app.utils still works."""
 

--- a/koan/tests/test_git_sync.py
+++ b/koan/tests/test_git_sync.py
@@ -771,6 +771,170 @@ class TestWriteSyncToJournal:
         assert "New sync" in content
 
 
+class TestCleanupRemoteBranches:
+    """Tests for GitSync.cleanup_remote_branches()."""
+
+    def test_deletes_remote_branches(self):
+        """Successfully deletes remote branches on origin."""
+        def side_effect(cwd, *args):
+            if args[0] == "push" and args[2] == "--delete":
+                return f"deleted branch {args[3]}"
+            return ""
+
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git", side_effect=side_effect):
+                deleted = _sync().cleanup_remote_branches(
+                    ["koan/merged-one", "koan/merged-two"]
+                )
+        assert deleted == ["koan/merged-one", "koan/merged-two"]
+
+    def test_skips_non_prefixed_branches(self):
+        """Ignores branches that don't match the agent prefix."""
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git") as mock_git:
+                deleted = _sync().cleanup_remote_branches(
+                    ["feature/unrelated", "main"]
+                )
+        assert deleted == []
+        mock_git.assert_not_called()
+
+    def test_handles_delete_failure(self):
+        """Branch not in result if git push --delete fails."""
+        def side_effect(cwd, *args):
+            if args[0] == "push" and args[3] == "koan/gone":
+                return ""  # failure
+            if args[0] == "push" and args[3] == "koan/exists":
+                return "deleted"
+            return ""
+
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git", side_effect=side_effect):
+                deleted = _sync().cleanup_remote_branches(
+                    ["koan/gone", "koan/exists"]
+                )
+        assert deleted == ["koan/exists"]
+
+    def test_empty_list(self):
+        """No-op for empty input."""
+        deleted = _sync().cleanup_remote_branches([])
+        assert deleted == []
+
+
+class TestGetRemoteBranches:
+    """Tests for GitSync._get_remote_branches()."""
+
+    def test_parses_remote_branches(self):
+        output = "  origin/koan/fix-bug\n  origin/koan/add-feature\n"
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git", return_value=output):
+                branches = _sync()._get_remote_branches("koan/")
+        assert branches == ["koan/fix-bug", "koan/add-feature"]
+
+    def test_filters_by_prefix(self):
+        output = "  origin/koan/mine\n  origin/feature/other\n"
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git", return_value=output):
+                branches = _sync()._get_remote_branches("koan/")
+        assert branches == ["koan/mine"]
+
+    def test_empty_output(self):
+        with patch("app.git_sync._get_prefix", return_value="koan/"):
+            with patch("app.git_sync.run_git", return_value=""):
+                branches = _sync()._get_remote_branches("koan/")
+        assert branches == []
+
+
+class TestBranchCleanupConfig:
+    """Tests for config-gated cleanup behavior in build_sync_report."""
+
+    def test_cleanup_disabled_skips_all_cleanup(self):
+        """When branch_cleanup.enabled=False, no branches are cleaned."""
+        sync = _sync()
+        with patch.object(
+            GitSync, "get_merged_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "get_github_merged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "get_unmerged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "_split_branches_by_recency", return_value=([], []),
+        ), patch.object(
+            GitSync, "get_recent_main_commits", return_value=[],
+        ), patch.object(
+            GitSync, "cleanup_merged_branches",
+        ) as mock_local, patch.object(
+            GitSync, "cleanup_remote_branches",
+        ) as mock_remote, patch(
+            "app.git_sync.run_git", return_value=""
+        ), patch(
+            "app.config.get_branch_cleanup_config",
+            return_value={"enabled": False, "remote": True},
+        ):
+            report = sync.build_sync_report()
+
+        mock_local.assert_not_called()
+        mock_remote.assert_not_called()
+        assert "cleaned up" not in report.lower()
+
+    def test_remote_disabled_skips_remote_cleanup(self):
+        """When branch_cleanup.remote=False, only local cleanup runs."""
+        sync = _sync()
+        with patch.object(
+            GitSync, "get_merged_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "get_github_merged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "get_unmerged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "_split_branches_by_recency", return_value=([], []),
+        ), patch.object(
+            GitSync, "get_recent_main_commits", return_value=[],
+        ), patch.object(
+            GitSync, "cleanup_merged_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "cleanup_remote_branches",
+        ) as mock_remote, patch(
+            "app.git_sync.run_git", return_value=""
+        ), patch(
+            "app.config.get_branch_cleanup_config",
+            return_value={"enabled": True, "remote": False},
+        ):
+            report = sync.build_sync_report()
+
+        mock_remote.assert_not_called()
+        assert "1 local" in report
+
+    def test_remote_cleanup_included_in_report(self):
+        """Report shows both local and remote cleanup counts."""
+        sync = _sync()
+        with patch.object(
+            GitSync, "get_merged_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "get_github_merged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "get_unmerged_branches", return_value=[],
+        ), patch.object(
+            GitSync, "_split_branches_by_recency", return_value=([], []),
+        ), patch.object(
+            GitSync, "get_recent_main_commits", return_value=[],
+        ), patch.object(
+            GitSync, "cleanup_merged_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "_get_remote_branches", return_value=["koan/done"],
+        ), patch.object(
+            GitSync, "cleanup_remote_branches", return_value=["koan/done"],
+        ), patch(
+            "app.git_sync.run_git", return_value=""
+        ), patch(
+            "app.config.get_branch_cleanup_config",
+            return_value={"enabled": True, "remote": True},
+        ):
+            report = sync.build_sync_report()
+
+        assert "1 local" in report
+        assert "1 remote" in report
+
+
 class TestGitSyncCLI:
     """Tests for git_sync.py __main__ block."""
 


### PR DESCRIPTION
## What
Extends git sync to also delete remote tracking branches and adds a `branch_cleanup` config section.

## Why
Issue #1086 — merged branches accumulate locally and on origin, cluttering `git branch` output and `/branches` listings. Local cleanup existed but remote refs remained, and the behavior wasn't configurable.

## How
- **`cleanup_remote_branches()`** — new method on `GitSync` that runs `git push origin --delete` for confirmed-merged agent-prefixed branches
- **`_get_remote_branches()`** — lists remote branches matching the agent prefix to intersect with confirmed-merged set
- **`get_branch_cleanup_config()`** in `config.py` — reads `branch_cleanup.enabled` (default: true) and `branch_cleanup.remote` (default: true) from config.yaml
- **`build_sync_report()`** — gates all cleanup behind config, runs remote cleanup after local, reports "N local + M remote branch(es)" in sync output
- Safety: only agent-prefixed branches, never current branch, failures silently skipped

## Testing
- 14 new tests: `TestCleanupRemoteBranches` (4), `TestGetRemoteBranches` (3), `TestBranchCleanupConfig` (3+4)
- All 68 git_sync tests pass, all config tests pass

Closes #1086

🤖 Generated with [Claude Code](https://claude.com/claude-code)