### PR TITLE
Add MCP server config and GitHub notification tracker

### DIFF
--- a/docs/provider-claude.md
+++ b/docs/provider-claude.md
@@ -122,12 +122,86 @@ projects:
 ### MCP (Model Context Protocol) Servers
 
 Claude Code supports MCP servers for extended capabilities (browser,
-databases, APIs):
+databases, APIs). Add MCP config file paths to `config.yaml`:
 
 ```yaml
+# config.yaml — global MCP servers for all projects
 mcp:
   - "/path/to/mcp-config.json"
 ```
+
+Per-project overrides are supported in `projects.yaml` — a project-level
+`mcp` list replaces the global list entirely:
+
+```yaml
+# projects.yaml — project-specific MCP servers
+projects:
+  my-project:
+    path: "/home/user/my-project"
+    mcp:
+      - "/path/to/project-specific-mcp.json"
+```
+
+The MCP config files use the standard Claude Code JSON format (same as
+`~/.claude/mcp.json` or `--mcp-config` flag).
+
+#### Permissions for MCP Tools
+
+When Koan runs as a systemd service (or any non-interactive context),
+Claude CLI cannot prompt for tool approval. MCP tools will be
+**silently denied** unless pre-approved.
+
+> **Note:** `skip_permissions: true` does **not** work when Koan runs
+> as root — Claude CLI rejects `--dangerously-skip-permissions` with
+> root/sudo privileges. You must use the allowlist approach below.
+
+To pre-approve MCP tools, create a `.claude/settings.local.json` file
+**in the target project's root directory** (the `path` from
+`projects.yaml`). This file is loaded by Claude CLI when it runs with
+that project as its working directory.
+
+Example — allowlisting the Atlassian MCP server's Jira tools:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__atlassian__getAccessibleAtlassianResources",
+      "mcp__atlassian__getJiraIssue",
+      "mcp__atlassian__searchJiraIssuesUsingJql",
+      "mcp__atlassian__getVisibleJiraProjects",
+      "mcp__atlassian__getJiraIssueTypeMetaWithFields",
+      "mcp__atlassian__getJiraProjectIssueTypesMetadata",
+      "mcp__atlassian__createJiraIssue",
+      "mcp__atlassian__editJiraIssue",
+      "mcp__atlassian__addCommentToJiraIssue",
+      "mcp__atlassian__getTransitionsForJiraIssue",
+      "mcp__atlassian__transitionJiraIssue",
+      "mcp__atlassian__lookupJiraAccountId",
+      "mcp__atlassian__getIssueLinkTypes",
+      "mcp__atlassian__createIssueLink",
+      "mcp__atlassian__getJiraIssueRemoteIssueLinks",
+      "mcp__atlassian__searchAtlassian",
+      "mcp__atlassian__fetchAtlassian",
+      "mcp__atlassian__atlassianUserInfo"
+    ]
+  }
+}
+```
+
+The tool name format is `mcp__<server-name>__<toolName>` where
+`<server-name>` matches the key in your MCP config JSON (e.g.,
+`"atlassian"` in `~/.claude.json`). To find the exact tool names,
+run Claude CLI interactively once — denied tools appear in the JSON
+output under `permission_denials`.
+
+**Setup checklist for each project using MCP:**
+
+1. Add the MCP config path to `projects.yaml` (under the project's
+   `mcp:` key) or globally in `config.yaml`
+2. Create `<project-path>/.claude/settings.local.json` with the
+   tool allowlist
+3. Restart Koan (`systemctl restart koan.service`)
 
 ### Max Turns
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -94,9 +94,19 @@ tools:
 # Can also be set via KOAN_CLI_PROVIDER env var (overrides this)
 cli_provider: "claude"
 
-# Skip permission prompts — required for MCP tools to work in autonomous mode.
-# Only enable this if you understand the security implications.
+# Skip permission prompts — adds --dangerously-skip-permissions to Claude CLI.
+# WARNING: Does NOT work when Koan runs as root (Claude CLI rejects it).
+# For MCP tools, use .claude/settings.local.json allowlists instead.
+# See docs/provider-claude.md for details.
 # skip_permissions: false
+
+# MCP server configuration — paths to MCP config JSON files.
+# Passed as --mcp-config to the Claude CLI.
+# For autonomous mode, pre-approve MCP tools in the project's
+# .claude/settings.local.json (see docs/provider-claude.md).
+# Per-project overrides available in projects.yaml (replaces global list).
+# mcp:
+#   - "/path/to/mcp-servers.json"
 
 # Local LLM configuration (used when cli_provider: "local")
 # Connects to any OpenAI-compatible API server:

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -178,6 +178,34 @@ def get_model_config(project_name: str = "") -> dict:
     return result
 
 
+def get_mcp_configs(project_name: str = "") -> List[str]:
+    """Get MCP server config file paths from config.yaml with per-project overrides.
+
+    Resolution order:
+    1. projects.yaml mcp list for the project (replaces global if set)
+    2. config.yaml mcp list
+    3. Empty list (no MCP servers)
+
+    Args:
+        project_name: Optional project name for per-project overrides.
+
+    Returns:
+        List of file paths to MCP config JSON files.
+    """
+    config = _load_config()
+    result = config.get("mcp", [])
+    if not isinstance(result, list):
+        result = []
+
+    # Per-project override replaces global list entirely
+    project_overrides = _load_project_overrides(project_name)
+    project_mcp = project_overrides.get("mcp")
+    if project_mcp is not None:
+        result = project_mcp if isinstance(project_mcp, list) else []
+
+    return [entry for entry in result if isinstance(entry, str) and entry]
+
+
 def _safe_int(value, default: int) -> int:
     """Safely convert a config value to int, returning default on failure."""
     try:

--- a/koan/app/contemplative_runner.py
+++ b/koan/app/contemplative_runner.py
@@ -55,14 +55,16 @@ def build_contemplative_command(
     )
 
     from app.cli_provider import build_full_command
-    from app.config import get_contemplative_tools
+    from app.config import get_contemplative_tools, get_mcp_configs
 
     tools_str = get_contemplative_tools(project_name=project_name)
     allowed_tools = [t.strip() for t in tools_str.split(",") if t.strip()]
+    mcp_configs = get_mcp_configs(project_name)
 
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=allowed_tools,
+        mcp_configs=mcp_configs,
         max_turns=10,
     )
     if extra_flags:

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -424,7 +424,7 @@ def _fetch_and_filter_comment(notification: dict, bot_username: str, max_age_hou
             repo_name,
         )
         need_thread_search = True
-    elif f"@{bot_username}".lower() not in comment.get("body", "").lower():
+    elif f"@{bot_username}".lower() not in (comment.get("body") or "").lower():
         # latest_comment_url shifted to a comment that doesn't mention the bot
         # (e.g., CI bot commented after the @mention, or PR body was returned)
         comment_author = comment.get("user", {}).get("login", "?")
@@ -873,6 +873,11 @@ def process_single_notification(
     comment_id = str(comment.get("id", ""))
     comment_api_url = comment.get("url", "")
     add_reaction(owner, repo, comment_id, comment_api_url=comment_api_url)
+
+    # Persist locally so restarts don't re-queue if reaction API failed
+    from app.github_notification_tracker import track_comment
+    instance_dir = str(Path(koan_root) / "instance")
+    track_comment(instance_dir, comment_id)
 
     # Mark notification as read
     mark_notification_read(str(notification.get("id", "")))

--- a/koan/app/github_notification_tracker.py
+++ b/koan/app/github_notification_tracker.py
@@ -1,0 +1,80 @@
+"""Persistent tracker for processed GitHub notification comments.
+
+Survives process restarts — prevents duplicate mission queueing when
+GitHub reaction API fails (SSO, rate limits, network errors).
+
+File location: ``instance/.koan-github-processed.json``
+Format: ``{"<comment_id>": <epoch_timestamp>, ...}``
+"""
+
+import fcntl
+import json
+import time
+from pathlib import Path
+
+
+_TRACKER_FILE = ".koan-github-processed.json"
+_LOCK_FILE = ".koan-github-processed.lock"
+_TTL_SECONDS = 7 * 86400  # 7 days
+_MAX_ENTRIES = 5000
+
+
+def _tracker_path(instance_dir: str) -> Path:
+    return Path(instance_dir) / _TRACKER_FILE
+
+
+def _lock_path(instance_dir: str) -> Path:
+    return Path(instance_dir) / _LOCK_FILE
+
+
+def _load(instance_dir: str) -> dict:
+    """Load tracker data, pruning expired entries."""
+    path = _tracker_path(instance_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    # Prune expired
+    now = time.time()
+    return {k: v for k, v in data.items() if now - v < _TTL_SECONDS}
+
+
+def _save(instance_dir: str, data: dict) -> None:
+    from app.utils import atomic_write
+
+    path = _tracker_path(instance_dir)
+    atomic_write(path, json.dumps(data) + "\n")
+
+
+def is_comment_tracked(instance_dir: str, comment_id: str) -> bool:
+    """Check if a comment ID has been persistently recorded."""
+    if not comment_id:
+        return False
+    data = _load(instance_dir)
+    return comment_id in data
+
+
+def track_comment(instance_dir: str, comment_id: str) -> None:
+    """Record a comment ID as processed (with file lock for thread safety)."""
+    if not comment_id:
+        return
+    lock = _lock_path(instance_dir)
+    try:
+        with open(lock, "a") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                data = _load(instance_dir)
+                data[comment_id] = time.time()
+                # Cap entries — evict oldest beyond limit
+                if len(data) > _MAX_ENTRIES:
+                    sorted_items = sorted(data.items(), key=lambda x: x[1])
+                    data = dict(sorted_items[-_MAX_ENTRIES:])
+                _save(instance_dir, data)
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
+    except OSError:
+        pass  # Best-effort — don't break notification processing

--- a/koan/app/github_notifications.py
+++ b/koan/app/github_notifications.py
@@ -433,6 +433,15 @@ def check_already_processed(comment_id: str, bot_username: str,
     if comment_id in _processed_comments:
         return True
 
+    # Check persistent file tracker (survives restarts)
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if koan_root:
+        from app.github_notification_tracker import is_comment_tracked
+        instance_dir = os.path.join(koan_root, "instance")
+        if is_comment_tracked(instance_dir, comment_id):
+            _processed_comments.add(comment_id)
+            return True
+
     # Check GitHub reactions — any reaction from the bot means processed
     endpoint = _reactions_endpoint(comment_api_url, owner, repo, comment_id)
     try:

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -151,7 +151,7 @@ def build_mission_command(
     Returns:
         Complete command list ready for subprocess.
     """
-    from app.config import get_mission_tools, get_model_config
+    from app.config import get_mission_tools, get_model_config, get_mcp_configs
     from app.cli_provider import build_full_command
 
     # Get mission tools (comma-separated list)
@@ -169,6 +169,9 @@ def build_mission_command(
         model = models["review_mode"]
     fallback = models["fallback"]
 
+    # Get MCP server configs
+    mcp_configs = get_mcp_configs(project_name)
+
     # Build provider-specific command
     cmd = build_full_command(
         prompt=prompt,
@@ -176,6 +179,7 @@ def build_mission_command(
         model=model,
         fallback=fallback,
         output_format="json",
+        mcp_configs=mcp_configs,
         plugin_dirs=plugin_dirs,
         system_prompt=system_prompt,
     )

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -278,6 +278,19 @@ def get_project_tools(config: dict, project_name: str) -> dict:
     return tools
 
 
+def get_project_mcp(config: dict, project_name: str) -> list:
+    """Get MCP config file paths for a project from projects.yaml.
+
+    Returns a list of file path strings. Only includes entries explicitly
+    set — caller should fall back to global config.yaml mcp list.
+    """
+    project_cfg = get_project_config(config, project_name)
+    mcp = project_cfg.get("mcp", [])
+    if not isinstance(mcp, list):
+        return []
+    return mcp
+
+
 def get_project_exploration(config: dict, project_name: str) -> bool:
     """Get exploration flag for a project from projects.yaml.
 

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -650,6 +650,74 @@ class TestDashboardConfig:
             assert get_dashboard_port() == 8080
 
 
+# --- get_mcp_configs ---
+
+
+class TestGetMcpConfigs:
+    def test_default_empty(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs() == []
+
+    def test_global_list(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": ["/path/to/mcp.json"]}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs() == ["/path/to/mcp.json"]
+
+    def test_global_multiple(self):
+        from app.config import get_mcp_configs
+
+        configs = ["/path/a.json", "/path/b.json"]
+        with _mock_config({"mcp": configs}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs() == configs
+
+    def test_non_list_returns_empty(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": "not-a-list"}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs() == []
+
+    def test_filters_non_string_entries(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": ["/valid.json", 42, "", None]}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs() == ["/valid.json"]
+
+    def test_project_override_replaces_global(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": ["/global.json"]}):
+            with patch(
+                "app.config._load_project_overrides",
+                return_value={"mcp": ["/project.json"]},
+            ):
+                assert get_mcp_configs("myproject") == ["/project.json"]
+
+    def test_project_override_absent_uses_global(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": ["/global.json"]}):
+            with patch("app.config._load_project_overrides", return_value={}):
+                assert get_mcp_configs("myproject") == ["/global.json"]
+
+    def test_project_override_empty_list_clears_global(self):
+        from app.config import get_mcp_configs
+
+        with _mock_config({"mcp": ["/global.json"]}):
+            with patch(
+                "app.config._load_project_overrides",
+                return_value={"mcp": []},
+            ):
+                assert get_mcp_configs("myproject") == []
+
+
 class TestBackwardCompat:
     """Verify that importing from app.utils still works."""
 

--- a/koan/tests/test_github_notification_tracker.py
+++ b/koan/tests/test_github_notification_tracker.py
@@ -1,0 +1,82 @@
+"""Tests for github_notification_tracker — persistent comment dedup."""
+
+import json
+import time
+
+import pytest
+
+from app.github_notification_tracker import (
+    _MAX_ENTRIES,
+    _TTL_SECONDS,
+    _tracker_path,
+    is_comment_tracked,
+    track_comment,
+)
+
+
+@pytest.fixture()
+def instance_dir(tmp_path):
+    return str(tmp_path)
+
+
+def test_track_and_check(instance_dir):
+    assert not is_comment_tracked(instance_dir, "123")
+    track_comment(instance_dir, "123")
+    assert is_comment_tracked(instance_dir, "123")
+
+
+def test_empty_comment_id(instance_dir):
+    track_comment(instance_dir, "")
+    assert not is_comment_tracked(instance_dir, "")
+
+
+def test_survives_reload(instance_dir):
+    """Simulates process restart — data persists on disk."""
+    track_comment(instance_dir, "abc")
+    # Read directly from file to confirm persistence
+    data = json.loads(_tracker_path(instance_dir).read_text())
+    assert "abc" in data
+
+
+def test_ttl_expiry(instance_dir):
+    """Expired entries are pruned on load."""
+    path = _tracker_path(instance_dir)
+    old_ts = time.time() - _TTL_SECONDS - 1
+    path.write_text(json.dumps({"old": old_ts, "fresh": time.time()}))
+
+    assert not is_comment_tracked(instance_dir, "old")
+    assert is_comment_tracked(instance_dir, "fresh")
+
+
+def test_max_entries_cap(instance_dir):
+    """Oldest entries are evicted when cap is exceeded."""
+    now = time.time()
+    data = {str(i): now - (_MAX_ENTRIES - i) for i in range(_MAX_ENTRIES)}
+    _tracker_path(instance_dir).write_text(json.dumps(data))
+
+    # Adding one more should evict the oldest
+    track_comment(instance_dir, "new_entry")
+    result = json.loads(_tracker_path(instance_dir).read_text())
+    assert len(result) == _MAX_ENTRIES
+    assert "new_entry" in result
+    # Entry "0" had the oldest timestamp, should be evicted
+    assert "0" not in result
+
+
+def test_corrupt_file_handled(instance_dir):
+    """Corrupt JSON is treated as empty tracker."""
+    _tracker_path(instance_dir).write_text("not json{{{")
+    assert not is_comment_tracked(instance_dir, "123")
+    # Can still write
+    track_comment(instance_dir, "123")
+    assert is_comment_tracked(instance_dir, "123")
+
+
+def test_multiple_comments(instance_dir):
+    track_comment(instance_dir, "a")
+    track_comment(instance_dir, "b")
+    track_comment(instance_dir, "c")
+    assert is_comment_tracked(instance_dir, "a")
+    assert is_comment_tracked(instance_dir, "b")
+    assert is_comment_tracked(instance_dir, "c")
+    assert not is_comment_tracked(instance_dir, "d")

--- a/projects.example.yaml
+++ b/projects.example.yaml
@@ -51,6 +51,11 @@ defaults:
   #   mission: ["Read", "Glob", "Grep", "Edit", "Write", "Bash"]
   #   chat: ["Read", "Glob", "Grep"]
 
+  # MCP server configuration — paths to MCP config JSON files.
+  # Replaces the global mcp list from config.yaml when set.
+  # mcp:
+  #   - "/path/to/project-specific-mcp.json"
+
   # Exploration — controls autonomous work on this project.
   #
   # When enabled, the agent may autonomously:


### PR DESCRIPTION
Add per-project and global MCP server configuration support. MCP config file paths can be set globally in config.yaml or overridden per-project in projects.yaml. The mcp_configs are passed through to both mission runner and contemplative runner via build_full_command().

Add persistent GitHub notification tracker that survives process restarts. Previously, processed comment IDs were only tracked in memory, so a restart could re-queue duplicate missions when the GitHub reaction API failed (SSO, rate limits, network errors). The tracker persists comment IDs to instance/.koan-github-processed.json with file locking, TTL-based expiry (7 days), and max entry cap (5000).

Also fix a minor None-safety bug in github_command_handler.py where comment body could be None, and update docs/provider-claude.md with MCP permissions guidance for autonomous/systemd deployments.