### PR TITLE
feat: add per-Jira-project target branch for PRs

### DIFF
--- a/docs/jira-integration.md
+++ b/docs/jira-integration.md
@@ -2,7 +2,7 @@
 
 Control Koan directly from Jira issue comments using `@mention` commands.
 
-> **Introduced in**: commit `fd3ccf8` — Jira @mention integration mirroring the GitHub notification pipeline.
+> **Introduced in**: commit `fd3ccf8`. Enhanced with Jira URL support in skills, comment acknowledgment, and per-project target branches.
 
 ## Overview
 
@@ -53,9 +53,16 @@ Tell Koan which Jira project keys correspond to which Koan projects:
 ```yaml
 jira:
   projects:
+    # Simple format — project name only:
     FOO: myproject        # FOO-123 → project "myproject"
-    BAR: anotherproject   # BAR-456 → project "anotherproject"
+
+    # Extended format — with optional target branch for PRs:
+    BAR:
+      project: anotherproject   # BAR-456 → project "anotherproject"
+      branch: "11.126"          # PRs target branch "11.126" instead of repo default
 ```
+
+Both formats can be mixed. The `branch` field is optional — when omitted, PRs target the repository's default branch as usual.
 
 ### 4. Post a command in a Jira issue comment
 
@@ -67,8 +74,9 @@ Koan will:
 1. Detect the @mention during its next polling cycle
 2. Validate the command and user permissions
 3. Create a pending mission: `- [project:myproject] /plan https://myorg.atlassian.net/browse/FOO-123 🎫`
-4. Send a Telegram notification confirming the mission was queued
-5. Execute it in the next agent loop iteration
+4. Post a `👍 Mission queued: /plan` acknowledgment reply on the Jira comment
+5. Send a Telegram notification confirming the mission was queued
+6. Execute it in the next agent loop iteration — fetching the full Jira issue context (title, description, and all comments)
 
 ## Configuration Reference
 
@@ -86,7 +94,7 @@ All settings live under the `jira:` key in `instance/config.yaml`.
 | `max_age_hours` | int | `24` | Ignore comments older than this (stale protection) |
 | `check_interval_seconds` | int | `60` | Base polling interval in seconds (min: 10) |
 | `max_check_interval_seconds` | int | `180` | Maximum backoff interval when idle (min: 30) |
-| `projects` | dict | `{}` | Jira project key to Koan project name mapping |
+| `projects` | dict | `{}` | Jira project key mapping. Simple: `FOO: myproject`. Extended: `FOO: {project: myproject, branch: "11.126"}` |
 
 ### Environment variables
 
@@ -141,38 +149,58 @@ You can override the default project mapping using the `repo:` token:
 
 This routes the mission to `other-project` instead of the project mapped to the Jira issue's project key.
 
+### Branch override with `branch:`
+
+You can override the target branch for PRs using the `branch:` token:
+
+```
+@koan-bot fix branch:main
+```
+
+This takes highest priority — overriding both the per-project `branch` configured in `jira.projects` and the repository's default branch. Useful for one-off requests targeting a different release branch.
+
+When a target branch is set (via config or override), the feature branch is created from it and the PR targets it with `--base`.
+
 ## How It Works
 
 ### Architecture
 
 ```
-loop_manager.py              ← Polls during sleep cycle (throttled, after GitHub check)
+run.py                       ← Pre-iteration check (before plan_iteration)
+loop_manager.py              ← Also polls during sleep cycle (throttled, after GitHub check)
   ↓
 jira_notifications.py        ← Fetches & filters Jira comments, parses @mentions
   ↓
 jira_command_handler.py      ← Validates commands, checks permissions, creates missions
   ↓
-jira_config.py               ← Reads jira: config from config.yaml
+jira_config.py               ← Reads jira: config (project map + branch map)
   ↓
 skills.py                    ← Skill flags: github_enabled (reused for Jira)
 ```
 
 ### Notification processing flow
 
+Jira notifications are checked in two places:
+- **Pre-iteration**: At the start of each agent loop iteration (so `plan_iteration()` sees Jira missions immediately)
+- **During sleep**: Between iterations (same as GitHub, with exponential backoff)
+
 ```
-1. Sleep cycle tick → process_jira_notifications()
-2. Build JQL query: issues updated in mapped projects since last check
-3. Fetch recent comments on matching issues
-4. For each comment containing @nickname:
+1. process_jira_notifications()
+2. Build JQL query (POST /rest/api/3/search/jql): issues updated in mapped projects since last check
+3. Paginate results using cursor-based nextPageToken
+4. Fetch recent comments on matching issues
+5. For each comment containing @nickname:
    a. Skip if already processed (in-memory set + .jira-processed.json)
    b. Skip if stale (> max_age_hours)
    c. Parse @mention → extract (command, context)
    d. Handle repo: override if present
-   e. Validate command → skill must have github_enabled: true
-   f. Check user permission → allowlist of Jira account emails
-   g. Insert mission into missions.md
-   h. Mark comment as processed (in-memory + persistent tracker)
-   i. Notify via Telegram (🎫 emoji prefix)
+   e. Handle branch: override if present (or use per-project config default)
+   f. Validate command → skill must have github_enabled: true
+   g. Check user permission → allowlist of Jira account emails
+   h. Insert mission into missions.md (with branch:X token if set)
+   i. Mark comment as processed (in-memory + persistent tracker)
+   j. Post 👍 acknowledgment reply on the Jira comment
+   k. Notify via Telegram (🎫 emoji prefix)
 ```
 
 ### ADF (Atlassian Document Format) handling
@@ -198,6 +226,23 @@ Two-tier approach matching the GitHub integration pattern:
 | 3+ consecutive empty | `max_check_interval_seconds` cap (default: 180s) |
 
 Backoff resets immediately when any mention is found.
+
+## Jira Issue Context in Skills
+
+When a mission originates from a Jira URL (e.g. `/fix https://myorg.atlassian.net/browse/FOO-123`), the skill runners (`/fix`, `/plan`, `/implement`) automatically detect the Jira URL and fetch full issue context from the Jira REST API:
+
+- **Title**: Issue summary
+- **Description**: Full issue body (converted from ADF to plain text)
+- **All comments**: Every comment with author attribution (ADF to plain text)
+
+This context is fed to Claude the same way GitHub issue context would be — the agent sees the complete Jira issue when working on the fix or plan.
+
+Skills that accept GitHub issue/PR URLs also accept Jira browse URLs:
+- `/fix https://myorg.atlassian.net/browse/FOO-123`
+- `/plan https://myorg.atlassian.net/browse/FOO-123`
+- `/implement https://myorg.atlassian.net/browse/FOO-123`
+
+When the source is Jira, GitHub-specific steps (closed-state check, PR submission) are adjusted — PR submission still works if the Koan project has a `github_url` configured in `projects.yaml`.
 
 ## Security Model
 
@@ -254,8 +299,10 @@ jira:
   nickname: "koan-bot"
   authorized_users: ["*"]
   projects:
-    PROJ: myproject
-    INFRA: infrastructure
+    PROJ: myproject              # Simple format
+    INFRA:                       # Extended format with target branch
+      project: infrastructure
+      branch: "11.126"
 ```
 
 ```bash
@@ -283,9 +330,12 @@ Both can trigger the same set of commands. The difference is the context URL att
 4. **Check polling**: Look for `[jira]` log entries in `make logs`. If you see "no recently-updated issues found", the JQL query isn't matching.
 5. **Verify API access**: Test manually:
    ```bash
-   curl -u "email@example.com:YOUR_API_TOKEN" \
-     "https://myorg.atlassian.net/rest/api/3/search?jql=project=FOO&maxResults=1"
+   curl -X POST -u "email@example.com:YOUR_API_TOKEN" \
+     -H "Content-Type: application/json" \
+     "https://myorg.atlassian.net/rest/api/3/search/jql" \
+     -d '{"jql": "project = FOO", "maxResults": 1}'
    ```
+   > **Note**: Jira Cloud deprecated `GET /rest/api/3/search` (returns HTTP 410). Koan uses `POST /rest/api/3/search/jql` with cursor-based pagination.
 
 ### Mission queued but not executed
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -336,8 +336,10 @@ usage:
 #   check_interval_seconds: 60           # Base polling interval (default: 60, min: 10)
 #   max_check_interval_seconds: 180      # Backoff cap when idle (default: 180, min: 30)
 #   projects:                            # Jira project key → Kōan project name mapping
-#     FOO: myproject                     # e.g. FOO-123 → project "myproject"
-#     BAR: anotherproject
+#     FOO: myproject                     # Simple: FOO-123 → project "myproject"
+#     BAR:                               # Extended: with optional target branch
+#       project: anotherproject          #   BAR-456 → project "anotherproject"
+#       branch: "11.126"                 #   PRs target branch "11.126" instead of default
 
 # Review concurrency — parallel GitHub API calls during code reviews
 # When enabled, PR context and comment fetching run concurrently using a

--- a/koan/app/jira_command_handler.py
+++ b/koan/app/jira_command_handler.py
@@ -29,6 +29,7 @@ from app.jira_notifications import (
     check_jira_already_processed,
     mark_jira_comment_processed,
     parse_jira_mention_command,
+    resolve_branch_from_jira_key,
 )
 from app.skills import SkillRegistry
 
@@ -59,6 +60,28 @@ def _extract_repo_override(context: str) -> Tuple[Optional[str], str]:
     # Remove the repo: token from context
     cleaned = (context[:match.start()] + context[match.end():]).strip()
     return project_name, cleaned
+
+
+def _extract_branch_override(context: str) -> Tuple[Optional[str], str]:
+    """Parse a 'branch:name' token from comment context.
+
+    When a commenter writes "@bot fix branch:11.126", the branch: token
+    overrides the default branch mapping from jira.projects.
+
+    Args:
+        context: The context string after the command word.
+
+    Returns:
+        Tuple of (branch_name_or_None, cleaned_context).
+        The branch: token is removed from the cleaned context.
+    """
+    match = re.search(r'\bbranch:(\S+)', context, re.IGNORECASE)
+    if not match:
+        return None, context
+
+    branch_name = match.group(1)
+    cleaned = (context[:match.start()] + context[match.end():]).strip()
+    return branch_name, cleaned
 
 
 def validate_command(command_name: str, registry: SkillRegistry) -> Optional[object]:
@@ -106,6 +129,7 @@ def build_jira_mission(
     issue_key: str,
     issue_url: str,
     project_name: str,
+    target_branch: Optional[str] = None,
 ) -> str:
     """Construct a mission string from a Jira @mention.
 
@@ -116,6 +140,7 @@ def build_jira_mission(
         issue_key: Jira issue key (e.g. "FOO-123").
         issue_url: Full URL to the Jira issue (for missions.md).
         project_name: The resolved Kōan project name.
+        target_branch: Optional target branch for PRs (from config or override).
 
     Returns:
         A mission entry string like "- [project:X] /command url context 🎫"
@@ -127,6 +152,8 @@ def build_jira_mission(
     parts = [f"/{command_name}"]
     if issue_url:
         parts.append(issue_url)
+    if target_branch:
+        parts.append(f"branch:{target_branch}")
     if context and skill.github_context_aware:
         parts.append(context)
 
@@ -140,6 +167,7 @@ def process_jira_mention(
     registry: SkillRegistry,
     config: dict,
     processed_set: Set[str],
+    branch_map: Optional[Dict[str, str]] = None,
 ) -> Tuple[bool, Optional[str]]:
     """Process a single Jira @mention and create a mission if valid.
 
@@ -154,6 +182,9 @@ def process_jira_mention(
         config: Global config dict (from config.yaml).
         processed_set: Set of already-processed comment IDs (mutated in-place
                        when a new comment is processed).
+        branch_map: Optional mapping of Jira project keys to target branches
+                    (from jira_config.get_jira_branch_map()). When set, the
+                    resolved branch is injected into the mission context.
 
     Returns:
         Tuple of (success, error_message). error_message is None on success.
@@ -215,6 +246,24 @@ def process_jira_mention(
         )
         project_name = repo_override
 
+    # Handle branch: override in context (highest priority)
+    branch_override, context = _extract_branch_override(context)
+    if branch_override:
+        target_branch = branch_override
+        log.debug(
+            "Jira: branch: override '%s' for comment %s",
+            target_branch, comment_id,
+        )
+    elif branch_map:
+        target_branch = resolve_branch_from_jira_key(issue_key, branch_map)
+        if target_branch:
+            log.debug(
+                "Jira: config branch '%s' for %s",
+                target_branch, issue_key,
+            )
+    else:
+        target_branch = None
+
     # Validate command
     skill = validate_command(command_name, registry)
     if not skill:
@@ -236,6 +285,7 @@ def process_jira_mention(
     # Build mission entry
     mission_entry = build_jira_mission(
         skill, command_name, context, issue_key, issue_url, project_name,
+        target_branch=target_branch,
     )
     log.info(
         "Jira: inserting mission from %s (%s): %s",

--- a/koan/app/jira_config.py
+++ b/koan/app/jira_config.py
@@ -120,11 +120,19 @@ def get_jira_max_check_interval(config: dict) -> int:
 def get_jira_project_map(config: dict) -> Dict[str, str]:
     """Get the mapping of Jira project keys to Kōan project names.
 
-    Example config:
+    Supports both simple and extended formats:
+
+        # Simple (string value):
         jira:
           projects:
             FOO: myproject
-            BAR: anotherproject
+
+        # Extended (object value with optional branch):
+        jira:
+          projects:
+            FOO:
+              project: myproject
+              branch: "11.126"
 
     Returns:
         Dict of {jira_project_key: koan_project_name}.
@@ -133,7 +141,42 @@ def get_jira_project_map(config: dict) -> Dict[str, str]:
     projects = jira.get("projects") or {}
     if not isinstance(projects, dict):
         return {}
-    return {str(k): str(v) for k, v in projects.items()}
+    result = {}
+    for k, v in projects.items():
+        if isinstance(v, dict):
+            result[str(k)] = str(v.get("project", ""))
+        else:
+            result[str(k)] = str(v)
+    return result
+
+
+def get_jira_branch_map(config: dict) -> Dict[str, str]:
+    """Get the mapping of Jira project keys to target branches.
+
+    Only returns entries that have an explicit branch configured
+    via the extended format:
+
+        jira:
+          projects:
+            FOO:
+              project: myproject
+              branch: "11.126"
+
+    Returns:
+        Dict of {jira_project_key: branch_name}. Keys without a branch
+        are omitted.
+    """
+    jira = config.get("jira") or {}
+    projects = jira.get("projects") or {}
+    if not isinstance(projects, dict):
+        return {}
+    result = {}
+    for k, v in projects.items():
+        if isinstance(v, dict):
+            branch = v.get("branch")
+            if branch:
+                result[str(k)] = str(branch)
+    return result
 
 
 def validate_jira_config(config: dict) -> Optional[str]:

--- a/koan/app/jira_notifications.py
+++ b/koan/app/jira_notifications.py
@@ -384,6 +384,22 @@ def resolve_project_from_jira_key(issue_key: str, project_map: Dict[str, str]) -
     return project_map.get(jira_project_key)
 
 
+def resolve_branch_from_jira_key(issue_key: str, branch_map: Dict[str, str]) -> Optional[str]:
+    """Map a Jira issue key to a configured target branch.
+
+    Args:
+        issue_key: Full Jira issue key like "FOO-123".
+        branch_map: Dict from jira_config.get_jira_branch_map().
+
+    Returns:
+        Branch name or None if no branch is configured for this project key.
+    """
+    if not issue_key or "-" not in issue_key:
+        return None
+    jira_project_key = issue_key.split("-")[0].upper()
+    return branch_map.get(jira_project_key)
+
+
 def _search_issues_with_comments(
     base_url: str,
     auth_header: str,

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -1069,6 +1069,8 @@ def process_jira_notifications(
 
         nickname = get_jira_nickname(config)
         project_map = get_jira_project_map(config)
+        from app.jira_config import get_jira_branch_map
+        branch_map = get_jira_branch_map(config)
 
         with _jira_state_lock:
             if not _jira_config_logged:
@@ -1125,6 +1127,7 @@ def process_jira_notifications(
         for mention in mentions:
             success, error_msg = process_jira_mention(
                 mention, registry, config, processed_set,
+                branch_map=branch_map,
             )
             if success:
                 missions_created += 1

--- a/koan/app/pr_submit.py
+++ b/koan/app/pr_submit.py
@@ -96,6 +96,7 @@ def submit_draft_pr(
     pr_title: str,
     pr_body: str,
     issue_url: Optional[str] = None,
+    base_branch: Optional[str] = None,
 ) -> Optional[str]:
     """Push branch and create a draft PR.
 
@@ -116,6 +117,9 @@ def submit_draft_pr(
         pr_title: Full PR title string (caller builds it).
         pr_body: Full PR body markdown (caller builds it).
         issue_url: Optional issue URL for the cross-link comment.
+        base_branch: Optional target branch for the PR (e.g. "11.126").
+            When set, overrides the auto-resolved base branch for both
+            commit diffing and the PR's --base flag.
 
     Returns:
         PR URL on success, or None on failure.
@@ -138,8 +142,8 @@ def submit_draft_pr(
         logger.debug("No existing PR found (or check failed): %s", e)
 
     # Verify we have commits to submit
-    base_branch = resolve_base_branch(project_name, project_path)
-    commits = get_commit_subjects(project_path, base_branch=base_branch)
+    effective_base = base_branch or resolve_base_branch(project_name, project_path)
+    commits = get_commit_subjects(project_path, base_branch=effective_base)
     if not commits:
         logger.info("No commits on branch — skipping PR creation")
         return None
@@ -163,6 +167,9 @@ def submit_draft_pr(
         "draft": True,
         "cwd": project_path,
     }
+
+    if base_branch:
+        pr_kwargs["base"] = base_branch
 
     if target["is_fork"]:
         pr_kwargs["repo"] = target["repo"]

--- a/koan/app/skill_dispatch.py
+++ b/koan/app/skill_dispatch.py
@@ -415,13 +415,35 @@ def _build_plan_cmd(
     url_and_context = _extract_pr_or_issue_url_and_context(args)
     if url_and_context:
         issue_url, context = url_and_context
+
+        # Extract branch: token before passing context to runner
+        base_branch, context = _extract_branch_token(context)
+
         cmd.extend(["--issue-url", issue_url])
+        if base_branch:
+            cmd.extend(["--base-branch", base_branch])
         if context:
             cmd.extend(["--context", context])
     else:
         cmd.extend(["--idea", args])
 
     return cmd
+
+
+_BRANCH_TOKEN_RE = re.compile(r'\bbranch:(\S+)', re.IGNORECASE)
+
+
+def _extract_branch_token(context: str) -> Tuple[Optional[str], str]:
+    """Extract a branch:NAME token from context text.
+
+    Returns (branch_name, cleaned_context) or (None, context).
+    """
+    match = _BRANCH_TOKEN_RE.search(context)
+    if not match:
+        return None, context
+    branch = match.group(1)
+    cleaned = (context[:match.start()] + context[match.end():]).strip()
+    return branch, cleaned
 
 
 def _build_implement_cmd(
@@ -436,13 +458,19 @@ def _build_implement_cmd(
     url_and_context = _extract_pr_or_issue_url_and_context(args)
     if not url_and_context:
         return None
-    
+
     issue_url, context = url_and_context
+
+    # Extract branch: token before passing context to runner
+    base_branch, context = _extract_branch_token(context)
+
     cmd = base_cmd + [
         "--project-path", project_path,
         "--issue-url", issue_url,
     ]
 
+    if base_branch:
+        cmd.extend(["--base-branch", base_branch])
     if context:
         cmd.extend(["--context", context])
 

--- a/koan/skills/core/fix/fix_runner.py
+++ b/koan/skills/core/fix/fix_runner.py
@@ -33,10 +33,11 @@ def run_fix(
     context: Optional[str] = None,
     notify_fn=None,
     skill_dir: Optional[Path] = None,
+    base_branch: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """Execute the fix pipeline.
 
-    Fetches the GitHub issue, builds a fix prompt, and invokes Claude to
+    Fetches the GitHub or Jira issue, builds a fix prompt, and invokes Claude to
     understand, plan, test, and fix the issue.
 
     Args:
@@ -135,6 +136,7 @@ def run_fix(
             issue_number=str(issue_number),
             issue_title=title,
             issue_url=issue_url,
+            base_branch=base_branch,
         )
 
     # Build notification and summary
@@ -255,14 +257,15 @@ def _submit_fix_pr(
     issue_number: str,
     issue_title: str,
     issue_url: str,
+    base_branch: Optional[str] = None,
 ) -> Optional[str]:
     """Build fix-specific PR title/body and delegate to shared submit."""
     from app.pr_submit import get_commit_subjects
     from app.projects_config import resolve_base_branch
 
     project_name = guess_project_name(project_path)
-    base_branch = resolve_base_branch(project_name, project_path)
-    commits = get_commit_subjects(project_path, base_branch=base_branch)
+    effective_base = base_branch or resolve_base_branch(project_name, project_path)
+    commits = get_commit_subjects(project_path, base_branch=effective_base)
     commits_text = "\n".join(f"- {s}" for s in commits)
 
     pr_title = f"fix: {issue_title}"[:70]
@@ -283,6 +286,7 @@ def _submit_fix_pr(
             pr_title=pr_title,
             pr_body=pr_body,
             issue_url=issue_url,
+            base_branch=base_branch,
         )
     except Exception as e:
         logger.warning("PR submission failed: %s", e)
@@ -313,6 +317,11 @@ def main(argv=None):
         help="Additional context (e.g. 'backend only')",
         default=None,
     )
+    parser.add_argument(
+        "--base-branch",
+        help="Target branch for the PR (e.g. '11.126')",
+        default=None,
+    )
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent
@@ -322,6 +331,7 @@ def main(argv=None):
         issue_url=cli_args.issue_url,
         context=cli_args.context,
         skill_dir=skill_dir,
+        base_branch=cli_args.base_branch,
     )
     print(summary)
     return 0 if success else 1

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -41,6 +41,7 @@ def run_implement(
     context: Optional[str] = None,
     notify_fn=None,
     skill_dir: Optional[Path] = None,
+    base_branch: Optional[str] = None,
 ) -> Tuple[bool, str]:
     """Execute the implement pipeline.
 
@@ -139,6 +140,7 @@ def run_implement(
                 issue_title=title,
                 issue_url=issue_url,
                 skill_dir=skill_dir,
+                base_branch=base_branch,
             )
         except Exception as e:
             logger.warning("PR submission failed: %s", e)
@@ -319,14 +321,15 @@ def _submit_implement_pr(
     issue_title: str,
     issue_url: str,
     skill_dir: Optional[Path] = None,
+    base_branch: Optional[str] = None,
 ) -> Optional[str]:
     """Build implement-specific PR title/body and delegate to shared submit."""
     from app.pr_submit import get_commit_subjects
     from app.projects_config import resolve_base_branch
 
     project_name = guess_project_name(project_path)
-    base_branch = resolve_base_branch(project_name, project_path)
-    commits = get_commit_subjects(project_path, base_branch=base_branch)
+    effective_base = base_branch or resolve_base_branch(project_name, project_path)
+    commits = get_commit_subjects(project_path, base_branch=effective_base)
 
     summary = _generate_pr_summary(
         project_path, issue_title, issue_url, commits, skill_dir,
@@ -349,6 +352,7 @@ def _submit_implement_pr(
             pr_title=pr_title,
             pr_body=pr_body,
             issue_url=issue_url,
+            base_branch=base_branch,
         )
     except Exception as e:
         logger.warning("PR submission failed: %s", e)
@@ -379,6 +383,11 @@ def main(argv=None):
         help="Additional context (e.g. 'Phase 1 to 3')",
         default=None,
     )
+    parser.add_argument(
+        "--base-branch",
+        help="Target branch for the PR (e.g. '11.126')",
+        default=None,
+    )
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent
@@ -388,6 +397,7 @@ def main(argv=None):
         issue_url=cli_args.issue_url,
         context=cli_args.context,
         skill_dir=skill_dir,
+        base_branch=cli_args.base_branch,
     )
     print(summary)
     return 0 if success else 1

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -1119,8 +1119,8 @@ class TestDrainNotifications:
         assert result == 1  # 1 actionable processed
         # Both actionable and drain notifications should be marked as read
         assert mock_mark.call_count == 2
-        mock_mark.assert_any_call("1")
-        mock_mark.assert_any_call("400")
+        mock_mark.assert_any_call("1")    # actionable
+        mock_mark.assert_any_call("400")  # drain
 
 
 # --- Test _normalize_github_url ---


### PR DESCRIPTION
Extend jira.projects config to support an optional target branch per Jira project key. When set, PRs from Jira-originated missions (/fix, /implement) target the configured branch instead of the repo default. Affects both checkout (feature branch based on target) and PR creation (--base flag).

Config format is backward-compatible — simple string values still work, extended objects add the optional branch field:

```
  jira:
    projects:
      XTRA:
        project: myrepo
        branch: "staging"
```

Users can also override inline via branch:NAME in Jira comments (e.g. "@bot fix branch:main"), which takes highest priority.

Flow: jira_config parses branch_map -> jira_command_handler resolves branch (comment override > config default) -> injects branch:X token into mission text -> skill_dispatch extracts it and passes --base-branch to runner CLI -> runner threads it through to submit_draft_pr() which passes --base to gh pr create.