### PR TITLE
feat: add strict_missions mode to gate autonomous work (#1175)

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -279,6 +279,37 @@ Kōan can manage multiple projects simultaneously. It rotates between them based
 - `/active` — "I'm done, you can work again"
 </details>
 
+### Strict Missions Mode
+
+**Strict missions** is a config-level switch that turns Kōan into a pure mission executor. When enabled, the agent only runs missions you explicitly queue — it never picks up GitHub issues autonomously, never runs contemplative reflection, and never enters DEEP mode. The loop keeps polling Telegram, GitHub notifications, and recurring schedules, so it still wakes up the moment you queue something.
+
+- **Enable in `instance/config.yaml`:**
+  ```yaml
+  strict_missions: true
+  ```
+- **Or via environment variable:** `KOAN_STRICT_MISSIONS=1` (takes precedence over `config.yaml`).
+- **Disable:** set back to `false`, or `KOAN_STRICT_MISSIONS=0`.
+
+What continues to run under strict mode:
+
+- Missions queued via `/mission`, GitHub `@mention` commands, and recurring schedules.
+- Heartbeat, auto-update, Telegram polling, GitHub notification polling, CI queue drain.
+
+What is disabled:
+
+- DEEP mode (capped at `implement`).
+- Contemplative sessions (random reflection rolls are skipped).
+- Autonomous exploration (`strict_wait` replaces `exploration_wait` when no mission is pending).
+- The agent prompt's `GitHub Issue Selection` section is replaced with an explicit "do not pick up issues" instruction.
+
+**How it differs from `/passive`:** passive mode blocks all execution (missions sit as Pending until you `/active`). Strict missions mode keeps the executor running for any mission you queue — it only gates *autonomous work selection*.
+
+**When to use:**
+
+- You want Kōan to act strictly on demand, no surprises on the PR list.
+- You're handing off mission dispatch to another system (CI, a team workflow) and want Kōan to be a quiet executor.
+- Multi-bot setups where only one instance should pick up issues autonomously.
+
 ---
 
 ## Intermediate — Productivity Workflows

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -279,18 +279,28 @@ Kōan can manage multiple projects simultaneously. It rotates between them based
 - `/active` — "I'm done, you can work again"
 </details>
 
-### Strict Missions Mode
+### Permanent Focus Mode
 
-**Strict missions** is a config-level switch that turns Kōan into a pure mission executor. When enabled, the agent only runs missions you explicitly queue — it never picks up GitHub issues autonomously, never runs contemplative reflection, and never enters DEEP mode. The loop keeps polling Telegram, GitHub notifications, and recurring schedules, so it still wakes up the moment you queue something.
+Focus mode can be made permanent via config, turning Kōan into a pure mission executor. When enabled, the agent only runs missions you explicitly queue — it never picks up GitHub issues autonomously, never runs contemplative reflection, and never enters DEEP mode. The loop keeps polling Telegram, GitHub notifications, and recurring schedules, so it still wakes up the moment you queue something.
 
-- **Enable in `instance/config.yaml`:**
+This extends the `/focus` Telegram command (which is time-bounded) into a permanent config-level switch.
+
+- **Enable globally in `instance/config.yaml`:**
   ```yaml
-  strict_missions: true
+  focus: true
   ```
-- **Or via environment variable:** `KOAN_STRICT_MISSIONS=1` (takes precedence over `config.yaml`).
-- **Disable:** set back to `false`, or `KOAN_STRICT_MISSIONS=0`.
+- **Or via environment variable:** `KOAN_FOCUS=1` (takes precedence over `config.yaml`).
+- **Per-project in `projects.yaml`:**
+  ```yaml
+  defaults:
+    focus: true          # All projects focused by default
+  projects:
+    myapp:
+      focus: false       # Override: allow autonomous work on myapp
+  ```
+- **Disable:** set back to `false`, or `KOAN_FOCUS=0`.
 
-What continues to run under strict mode:
+What continues to run under focus mode:
 
 - Missions queued via `/mission`, GitHub `@mention` commands, and recurring schedules.
 - Heartbeat, auto-update, Telegram polling, GitHub notification polling, CI queue drain.
@@ -299,16 +309,17 @@ What is disabled:
 
 - DEEP mode (capped at `implement`).
 - Contemplative sessions (random reflection rolls are skipped).
-- Autonomous exploration (`strict_wait` replaces `exploration_wait` when no mission is pending).
+- Autonomous exploration (the loop idles with wake-on-mission when no mission is pending).
 - The agent prompt's `GitHub Issue Selection` section is replaced with an explicit "do not pick up issues" instruction.
 
-**How it differs from `/passive`:** passive mode blocks all execution (missions sit as Pending until you `/active`). Strict missions mode keeps the executor running for any mission you queue — it only gates *autonomous work selection*.
+**How it differs from `/passive`:** passive mode blocks all execution (missions sit as Pending until you `/active`). Focus mode keeps the executor running for any mission you queue — it only gates *autonomous work selection*.
 
 **When to use:**
 
 - You want Kōan to act strictly on demand, no surprises on the PR list.
 - You're handing off mission dispatch to another system (CI, a team workflow) and want Kōan to be a quiet executor.
 - Multi-bot setups where only one instance should pick up issues autonomously.
+- Per-project: focus some repos while allowing exploration on others.
 
 ---
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -25,18 +25,25 @@
 # autonomous work. Use /active to resume normal execution.
 # start_passive: false
 
-# Strict missions mode — only run explicitly queued missions
+# Focus mode (permanent) — only run explicitly queued missions
 # When true, Kōan becomes a pure "mission executor": no DEEP mode, no
 # contemplative sessions, no autonomous exploration. Only missions queued
 # via /mission (Telegram), recurring missions, and GitHub @mention commands
 # are executed. The loop idles (wake-on-mission) whenever the queue is empty.
 #
-# Differs from passive mode:
-#   - passive        = no execution at all (missions stay Pending)
-#   - strict_missions = autonomous work disabled, but missions still run
+# This is the config-level permanent switch. The /focus Telegram command
+# provides time-bounded focus (e.g. /focus 3h). Both produce the same
+# runtime behavior.
 #
-# Env override: KOAN_STRICT_MISSIONS=1 (truthy values)
-# strict_missions: false
+# Per-project override: set focus: true/false in projects.yaml under
+# defaults or individual projects. Config.yaml sets the global default.
+#
+# Differs from passive mode:
+#   - passive = no execution at all (missions stay Pending)
+#   - focus   = autonomous work disabled, but missions still run
+#
+# Env override: KOAN_FOCUS=1 (truthy values)
+# focus: false
 
 # Startup reflection — run self-reflection check on startup
 # When true, Kōan checks whether periodic self-reflection is due (every N

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -25,6 +25,19 @@
 # autonomous work. Use /active to resume normal execution.
 # start_passive: false
 
+# Strict missions mode — only run explicitly queued missions
+# When true, Kōan becomes a pure "mission executor": no DEEP mode, no
+# contemplative sessions, no autonomous exploration. Only missions queued
+# via /mission (Telegram), recurring missions, and GitHub @mention commands
+# are executed. The loop idles (wake-on-mission) whenever the queue is empty.
+#
+# Differs from passive mode:
+#   - passive        = no execution at all (missions stay Pending)
+#   - strict_missions = autonomous work disabled, but missions still run
+#
+# Env override: KOAN_STRICT_MISSIONS=1 (truthy values)
+# strict_missions: false
+
 # Startup reflection — run self-reflection check on startup
 # When true, Kōan checks whether periodic self-reflection is due (every N
 # sessions) and, if so, invokes Claude to generate observations. Disabled by

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -223,29 +223,33 @@ def get_start_on_pause() -> bool:
     return bool(config.get("start_on_pause", False))
 
 
-def is_strict_missions() -> bool:
-    """Check if strict_missions mode is enabled.
+def is_focus_mode() -> bool:
+    """Check if permanent focus mode is enabled via config.
 
-    Strict missions mode disables all autonomous work so Kōan only runs
-    missions that were explicitly queued (via Telegram, recurring, or
-    GitHub @mention). No contemplative sessions, no DEEP mode, no
-    exploration fallback.
+    Focus mode disables all autonomous work so Kōan only runs missions
+    that were explicitly queued (via Telegram, recurring, or GitHub
+    @mention). No contemplative sessions, no DEEP mode, no exploration
+    fallback.
+
+    This is the config-level permanent switch. The ``/focus`` Telegram
+    command provides time-bounded focus via ``.koan-focus`` file — both
+    mechanisms produce the same runtime behavior.
 
     Resolution order:
-    1. ``KOAN_STRICT_MISSIONS`` env var (truthy: ``1``, ``true``, ``yes``, ``on``)
-    2. ``strict_missions`` key in ``config.yaml``
+    1. ``KOAN_FOCUS`` env var (truthy: ``1``, ``true``, ``yes``, ``on``)
+    2. ``focus`` key in ``config.yaml``
     3. Default: ``False``
 
     Returns:
-        True when strict missions mode is active.
+        True when permanent focus mode is active.
     """
-    env_value = os.environ.get("KOAN_STRICT_MISSIONS", "").strip().lower()
+    env_value = os.environ.get("KOAN_FOCUS", "").strip().lower()
     if env_value in ("1", "true", "yes", "on"):
         return True
     if env_value in ("0", "false", "no", "off"):
         return False
     config = _load_config()
-    return bool(config.get("strict_missions", False))
+    return bool(config.get("focus", False))
 
 
 def get_start_passive() -> bool:

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -223,6 +223,31 @@ def get_start_on_pause() -> bool:
     return bool(config.get("start_on_pause", False))
 
 
+def is_strict_missions() -> bool:
+    """Check if strict_missions mode is enabled.
+
+    Strict missions mode disables all autonomous work so Kōan only runs
+    missions that were explicitly queued (via Telegram, recurring, or
+    GitHub @mention). No contemplative sessions, no DEEP mode, no
+    exploration fallback.
+
+    Resolution order:
+    1. ``KOAN_STRICT_MISSIONS`` env var (truthy: ``1``, ``true``, ``yes``, ``on``)
+    2. ``strict_missions`` key in ``config.yaml``
+    3. Default: ``False``
+
+    Returns:
+        True when strict missions mode is active.
+    """
+    env_value = os.environ.get("KOAN_STRICT_MISSIONS", "").strip().lower()
+    if env_value in ("1", "true", "yes", "on"):
+        return True
+    if env_value in ("0", "false", "no", "off"):
+        return False
+    config = _load_config()
+    return bool(config.get("strict_missions", False))
+
+
 def get_start_passive() -> bool:
     """Check if start_passive is enabled in config.yaml.
 

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -301,10 +301,12 @@ def _get_known_project_names(projects: List[Tuple[str, str]]) -> list:
 
 def _should_contemplate(autonomous_mode: str, focus_active: bool,
                         contemplative_chance: int,
-                        schedule_state=None) -> bool:
+                        schedule_state=None,
+                        strict_missions: bool = False) -> bool:
     """Check if this iteration should be a contemplative session.
 
     Contemplative sessions only trigger when:
+    - Strict missions mode is NOT active
     - Mode is deep or implement (need budget for Claude call)
     - Focus mode is NOT active
     - Schedule is not in work_hours
@@ -313,6 +315,9 @@ def _should_contemplate(autonomous_mode: str, focus_active: bool,
     Returns:
         True if should run a contemplative session
     """
+    if strict_missions:
+        return False
+
     if autonomous_mode not in ("deep", "implement"):
         return False
 
@@ -710,6 +715,7 @@ def _decide_autonomous_action(
     koan_root: str,
     schedule_state,
     contemplative_chance: int = 10,
+    strict_missions: bool = False,
 ) -> "AutonomousDecision":
     """Decide autonomous action via a linear priority chain.
 
@@ -722,6 +728,9 @@ def _decide_autonomous_action(
     3. Schedule wait — work_hours active, skip exploration
     4. Autonomous exploration — default fallback
 
+    When ``strict_missions`` is True, contemplation and exploration are
+    disabled — the loop idles via ``strict_wait``.
+
     Returns:
         AutonomousDecision(action, focus_remaining)
     """
@@ -729,11 +738,13 @@ def _decide_autonomous_action(
     focus_active = focus_state is not None
     _log_iteration("koan",
         f"Evaluating autonomous action "
-        f"(mode={autonomous_mode}, focus_active={focus_active})")
+        f"(mode={autonomous_mode}, focus_active={focus_active}, "
+        f"strict_missions={strict_missions})")
 
     # 1. Contemplative session (random reflection)
     if _should_contemplate(autonomous_mode, focus_active,
-                           contemplative_chance, schedule_state):
+                           contemplative_chance, schedule_state,
+                           strict_missions=strict_missions):
         return AutonomousDecision(action="contemplative", focus_remaining=None)
 
     # 2. Focus mode active → wait for missions
@@ -780,7 +791,7 @@ def plan_iteration(
     Returns:
         dict with iteration plan:
         {
-            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "error",
+            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "strict_wait" | "error",
             "project_name": str,
             "project_path": str,
             "mission_title": str (empty for autonomous/contemplative),
@@ -805,6 +816,14 @@ def plan_iteration(
     # Convert projects to string format for downstream functions
     projects_str = _projects_to_str(projects)
 
+    # Step 0: Detect strict_missions mode (disables autonomous work)
+    try:
+        from app.config import is_strict_missions
+        strict_missions = is_strict_missions()
+    except (ImportError, OSError, ValueError) as e:
+        _log_iteration("error", f"Strict missions config lookup failed: {e}")
+        strict_missions = False
+
     # Step 1: Refresh usage
     _refresh_usage(usage_state, usage_md, count)
 
@@ -817,6 +836,17 @@ def plan_iteration(
     tracker_error = decision.get("tracker_error")
     cost_today = decision.get("cost_today", 0.0)
     _log_iteration("koan", f"Usage decision: mode={autonomous_mode}, available={available_pct}%")
+
+    # Step 2a: Cap mode at implement when strict_missions is active.
+    # DEEP mode encourages autonomous GitHub issue pickup, which strict
+    # missions explicitly forbids — missions only, no autonomous work.
+    if strict_missions and autonomous_mode == "deep":
+        decision_reason = (
+            f"{decision_reason} (capped from deep: strict_missions active)"
+        )
+        autonomous_mode = "implement"
+        _log_iteration("koan",
+            "Strict missions: capped mode deep → implement")
 
     # Step 2b: Check schedule and cap mode based on deep_hours config.
     # This runs early (before mission pick) so the capped mode affects
@@ -977,6 +1007,30 @@ def plan_iteration(
                 tracker_error=tracker_error,
             )
 
+        # Short-circuit: strict_missions mode means no autonomous work.
+        # Skip exploration filtering, contemplative rolls, and any gh calls —
+        # idle with wake-on-mission like exploration_wait.
+        if strict_missions:
+            _log_iteration("koan",
+                "Strict missions: no pending mission — entering strict_wait")
+            focus_area = resolve_focus_area(autonomous_mode, has_mission=False)
+            return _make_result(
+                action="strict_wait",
+                project_name=projects[0][0] if projects else "default",
+                project_path=projects[0][1] if projects else "",
+                autonomous_mode=autonomous_mode,
+                focus_area=focus_area,
+                available_pct=available_pct,
+                decision_reason=(
+                    "Strict missions mode — no autonomous work, "
+                    "waiting for queued missions"
+                ),
+                display_lines=display_lines,
+                recurring_injected=recurring_injected,
+                schedule_mode=schedule_state.mode if schedule_state else "normal",
+                tracker_error=tracker_error,
+            )
+
         # Filter to exploration-enabled projects only
         filter_result = _filter_exploration_projects(projects, koan_root,
                                                      schedule_state=schedule_state)
@@ -1040,6 +1094,7 @@ def plan_iteration(
 
         autonomous_decision = _decide_autonomous_action(
             autonomous_mode, koan_root, schedule_state, contemplative_chance,
+            strict_missions=strict_missions,
         )
         action = autonomous_decision.action
 

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -302,20 +302,19 @@ def _get_known_project_names(projects: List[Tuple[str, str]]) -> list:
 def _should_contemplate(autonomous_mode: str, focus_active: bool,
                         contemplative_chance: int,
                         schedule_state=None,
-                        strict_missions: bool = False) -> bool:
+                        focus_mode: bool = False) -> bool:
     """Check if this iteration should be a contemplative session.
 
     Contemplative sessions only trigger when:
-    - Strict missions mode is NOT active
+    - Focus mode is NOT active (neither config-level nor file-based)
     - Mode is deep or implement (need budget for Claude call)
-    - Focus mode is NOT active
     - Schedule is not in work_hours
     - Random roll succeeds (chance boosted during deep_hours)
 
     Returns:
         True if should run a contemplative session
     """
-    if strict_missions:
+    if focus_mode:
         return False
 
     if autonomous_mode not in ("deep", "implement"):
@@ -715,7 +714,7 @@ def _decide_autonomous_action(
     koan_root: str,
     schedule_state,
     contemplative_chance: int = 10,
-    strict_missions: bool = False,
+    focus_mode: bool = False,
 ) -> "AutonomousDecision":
     """Decide autonomous action via a linear priority chain.
 
@@ -728,26 +727,26 @@ def _decide_autonomous_action(
     3. Schedule wait — work_hours active, skip exploration
     4. Autonomous exploration — default fallback
 
-    When ``strict_missions`` is True, contemplation and exploration are
-    disabled — the loop idles via ``strict_wait``.
+    When ``focus_mode`` is True (config-level or file-based), contemplation
+    and exploration are disabled — the loop idles via ``focus_wait``.
 
     Returns:
         AutonomousDecision(action, focus_remaining)
     """
     focus_state = _check_focus(koan_root)
-    focus_active = focus_state is not None
+    focus_active = focus_state is not None or focus_mode
     _log_iteration("koan",
         f"Evaluating autonomous action "
         f"(mode={autonomous_mode}, focus_active={focus_active}, "
-        f"strict_missions={strict_missions})")
+        f"focus_mode={focus_mode})")
 
     # 1. Contemplative session (random reflection)
     if _should_contemplate(autonomous_mode, focus_active,
                            contemplative_chance, schedule_state,
-                           strict_missions=strict_missions):
+                           focus_mode=focus_mode):
         return AutonomousDecision(action="contemplative", focus_remaining=None)
 
-    # 2. Focus mode active → wait for missions
+    # 2. Focus mode active → wait for missions (file-based or config-level)
     if focus_state is not None:
         try:
             focus_remaining = focus_state.remaining_display()
@@ -756,6 +755,11 @@ def _decide_autonomous_action(
             focus_remaining = "unknown"
         return AutonomousDecision(action="focus_wait",
                                  focus_remaining=focus_remaining)
+
+    # 2b. Config-level focus mode (permanent, no remaining time)
+    if focus_mode:
+        return AutonomousDecision(action="focus_wait",
+                                 focus_remaining="permanent")
 
     # 3. Schedule work_hours → suppress exploration
     if schedule_state is not None and schedule_state.in_work_hours:
@@ -791,7 +795,7 @@ def plan_iteration(
     Returns:
         dict with iteration plan:
         {
-            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "strict_wait" | "error",
+            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "error",
             "project_name": str,
             "project_path": str,
             "mission_title": str (empty for autonomous/contemplative),
@@ -816,13 +820,13 @@ def plan_iteration(
     # Convert projects to string format for downstream functions
     projects_str = _projects_to_str(projects)
 
-    # Step 0: Detect strict_missions mode (disables autonomous work)
+    # Step 0: Detect config-level focus mode (disables autonomous work)
     try:
-        from app.config import is_strict_missions
-        strict_missions = is_strict_missions()
+        from app.config import is_focus_mode
+        focus_mode = is_focus_mode()
     except (ImportError, OSError, ValueError) as e:
-        _log_iteration("error", f"Strict missions config lookup failed: {e}")
-        strict_missions = False
+        _log_iteration("error", f"Focus mode config lookup failed: {e}")
+        focus_mode = False
 
     # Step 1: Refresh usage
     _refresh_usage(usage_state, usage_md, count)
@@ -837,16 +841,16 @@ def plan_iteration(
     cost_today = decision.get("cost_today", 0.0)
     _log_iteration("koan", f"Usage decision: mode={autonomous_mode}, available={available_pct}%")
 
-    # Step 2a: Cap mode at implement when strict_missions is active.
-    # DEEP mode encourages autonomous GitHub issue pickup, which strict
-    # missions explicitly forbids — missions only, no autonomous work.
-    if strict_missions and autonomous_mode == "deep":
+    # Step 2a: Cap mode at implement when focus mode is active.
+    # DEEP mode encourages autonomous GitHub issue pickup, which focus
+    # mode explicitly forbids — missions only, no autonomous work.
+    if focus_mode and autonomous_mode == "deep":
         decision_reason = (
-            f"{decision_reason} (capped from deep: strict_missions active)"
+            f"{decision_reason} (capped from deep: focus mode active)"
         )
         autonomous_mode = "implement"
         _log_iteration("koan",
-            "Strict missions: capped mode deep → implement")
+            "Focus mode: capped mode deep → implement")
 
     # Step 2b: Check schedule and cap mode based on deep_hours config.
     # This runs early (before mission pick) so the capped mode affects
@@ -1007,22 +1011,22 @@ def plan_iteration(
                 tracker_error=tracker_error,
             )
 
-        # Short-circuit: strict_missions mode means no autonomous work.
+        # Short-circuit: config-level focus mode means no autonomous work.
         # Skip exploration filtering, contemplative rolls, and any gh calls —
         # idle with wake-on-mission like exploration_wait.
-        if strict_missions:
+        if focus_mode:
             _log_iteration("koan",
-                "Strict missions: no pending mission — entering strict_wait")
+                "Focus mode: no pending mission — entering focus_wait")
             focus_area = resolve_focus_area(autonomous_mode, has_mission=False)
             return _make_result(
-                action="strict_wait",
+                action="focus_wait",
                 project_name=projects[0][0] if projects else "default",
                 project_path=projects[0][1] if projects else "",
                 autonomous_mode=autonomous_mode,
                 focus_area=focus_area,
                 available_pct=available_pct,
                 decision_reason=(
-                    "Strict missions mode — no autonomous work, "
+                    "Focus mode — no autonomous work, "
                     "waiting for queued missions"
                 ),
                 display_lines=display_lines,
@@ -1094,7 +1098,7 @@ def plan_iteration(
 
         autonomous_decision = _decide_autonomous_action(
             autonomous_mode, koan_root, schedule_state, contemplative_chance,
-            strict_missions=strict_missions,
+            focus_mode=focus_mode,
         )
         action = autonomous_decision.action
 

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -307,6 +307,32 @@ def get_project_mcp(config: dict, project_name: str) -> list:
     return mcp
 
 
+def get_project_focus(config: dict, project_name: str) -> bool:
+    """Get focus flag for a project from projects.yaml.
+
+    When True, the agent only works on explicitly queued missions for this
+    project — no contemplative sessions, no DEEP mode, no autonomous
+    exploration. Equivalent to ``exploration: false`` but unified under the
+    focus concept.
+
+    Supports defaults-level and per-project overrides. Common patterns:
+      - ``defaults: { focus: true }`` + ``myapp: { focus: false }``
+        → all projects focused except myapp
+      - ``defaults: { focus: false }`` + ``vendor: { focus: true }``
+        → only vendor is focused
+
+    Returns False by default (focus not enforced).
+    """
+    project_cfg = get_project_config(config, project_name)
+    value = project_cfg.get("focus", False)
+
+    # Handle string values like "true", "yes", "1"
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "yes", "1")
+
+    return bool(value)
+
+
 def get_project_exploration(config: dict, project_name: str) -> bool:
     """Get exploration flag for a project from projects.yaml.
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -307,18 +307,30 @@ def _warn_unresolved_placeholders(text: str, template_name: str) -> None:
         )
 
 
-def _is_strict_missions() -> bool:
-    """Return True if strict_missions mode is enabled.
+def _is_focus_mode() -> bool:
+    """Return True if focus mode is enabled (config-level or file-based).
 
-    Strict mode disables autonomous GitHub issue pickup — the agent prompt
+    Focus mode disables autonomous GitHub issue pickup — the agent prompt
     replaces the ``GitHub Issue Selection`` section with an explicit
     instruction to only act on explicitly-queued missions.
+
+    Checks both config.yaml/env (permanent) and .koan-focus file (temporary).
     """
     try:
-        from app.config import is_strict_missions
-        return is_strict_missions()
+        from app.config import is_focus_mode
+        if is_focus_mode():
+            return True
     except (ImportError, OSError, ValueError):
-        return False
+        pass
+    # Also check file-based focus (.koan-focus from /focus command)
+    try:
+        koan_root = os.environ.get("KOAN_ROOT", "")
+        if koan_root:
+            from app.focus_manager import check_focus
+            return check_focus(koan_root) is not None
+    except (ImportError, OSError, ValueError):
+        pass
+    return False
 
 
 _GITHUB_ISSUE_SECTION_RE = re.compile(
@@ -327,9 +339,9 @@ _GITHUB_ISSUE_SECTION_RE = re.compile(
 )
 
 
-_STRICT_MISSIONS_REPLACEMENT = (
-    "## Strict Missions Mode (autonomous GitHub pickup disabled)\n\n"
-    "Kōan is running in **strict missions** mode. You MUST NOT pick up "
+_FOCUS_MODE_REPLACEMENT = (
+    "## Focus Mode (autonomous GitHub pickup disabled)\n\n"
+    "Kōan is running in **focus mode**. You MUST NOT pick up "
     "GitHub issues on your own.\n\n"
     "- Only work on the explicit mission assigned above (if any).\n"
     "- If no mission is assigned, do nothing autonomously — exit gracefully.\n"
@@ -340,12 +352,12 @@ _STRICT_MISSIONS_REPLACEMENT = (
 )
 
 
-def _apply_strict_missions_override(prompt: str) -> str:
-    """Replace the GitHub Issue Selection section when strict mode is active."""
-    if not _is_strict_missions():
+def _apply_focus_mode_override(prompt: str) -> str:
+    """Replace the GitHub Issue Selection section when focus mode is active."""
+    if not _is_focus_mode():
         return prompt
     return _GITHUB_ISSUE_SECTION_RE.sub(
-        _STRICT_MISSIONS_REPLACEMENT.rstrip(),
+        _FOCUS_MODE_REPLACEMENT.rstrip(),
         prompt,
         count=1,
     )
@@ -380,7 +392,7 @@ def _load_agent_template(
         MISSION_INSTRUCTION=mission_instruction,
         BRANCH_PREFIX=branch_prefix,
     )
-    result = _apply_strict_missions_override(result)
+    result = _apply_focus_mode_override(result)
     _warn_unresolved_placeholders(result, "agent")
     return result
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -307,6 +307,50 @@ def _warn_unresolved_placeholders(text: str, template_name: str) -> None:
         )
 
 
+def _is_strict_missions() -> bool:
+    """Return True if strict_missions mode is enabled.
+
+    Strict mode disables autonomous GitHub issue pickup — the agent prompt
+    replaces the ``GitHub Issue Selection`` section with an explicit
+    instruction to only act on explicitly-queued missions.
+    """
+    try:
+        from app.config import is_strict_missions
+        return is_strict_missions()
+    except (ImportError, OSError, ValueError):
+        return False
+
+
+_GITHUB_ISSUE_SECTION_RE = re.compile(
+    r"## GitHub Issue Selection.*?(?=\n# Autonomy\b|\n## |\Z)",
+    re.DOTALL,
+)
+
+
+_STRICT_MISSIONS_REPLACEMENT = (
+    "## Strict Missions Mode (autonomous GitHub pickup disabled)\n\n"
+    "Kōan is running in **strict missions** mode. You MUST NOT pick up "
+    "GitHub issues on your own.\n\n"
+    "- Only work on the explicit mission assigned above (if any).\n"
+    "- If no mission is assigned, do nothing autonomously — exit gracefully.\n"
+    "- Do not browse open issues, do not create branches for unassigned work,\n"
+    "  do not open speculative PRs.\n"
+    "- If the assigned mission references a specific GitHub issue, you may\n"
+    "  work on that issue only.\n\n"
+)
+
+
+def _apply_strict_missions_override(prompt: str) -> str:
+    """Replace the GitHub Issue Selection section when strict mode is active."""
+    if not _is_strict_missions():
+        return prompt
+    return _GITHUB_ISSUE_SECTION_RE.sub(
+        _STRICT_MISSIONS_REPLACEMENT.rstrip(),
+        prompt,
+        count=1,
+    )
+
+
 def _load_agent_template(
     instance: str,
     project_name: str,
@@ -336,6 +380,7 @@ def _load_agent_template(
         MISSION_INSTRUCTION=mission_instruction,
         BRANCH_PREFIX=branch_prefix,
     )
+    result = _apply_strict_missions_override(result)
     _warn_unresolved_placeholders(result, "agent")
     return result
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1474,8 +1474,8 @@ def _run_iteration(
             f"👁️ Passive — read-only ({p.get('passive_remaining', 'indefinite')})",
         ),
         "focus_wait": lambda p: (
-            f"Focus mode active ({p.get('focus_remaining', 'unknown')} remaining) — no missions pending, sleeping",
-            f"Focus mode — waiting for missions ({p.get('focus_remaining', 'unknown')} remaining)",
+            f"Focus mode active ({p.get('focus_remaining', 'permanent')}) — no missions pending, sleeping",
+            f"Focus mode — waiting for missions ({p.get('focus_remaining', 'permanent')})",
         ),
         "schedule_wait": lambda _: (
             "Work hours active — waiting for missions (exploration suppressed)",
@@ -1488,10 +1488,6 @@ def _run_iteration(
         "pr_limit_wait": lambda _: (
             "PR limit reached for all projects — waiting for reviews",
             f"PR limit reached — waiting for reviews ({time.strftime('%H:%M')})",
-        ),
-        "strict_wait": lambda _: (
-            "Strict missions mode — waiting for queued missions (no autonomous work)",
-            f"Strict missions — waiting for /mission ({time.strftime('%H:%M')})",
         ),
     }
     if action in _IDLE_WAIT_CONFIG:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1489,6 +1489,10 @@ def _run_iteration(
             "PR limit reached for all projects — waiting for reviews",
             f"PR limit reached — waiting for reviews ({time.strftime('%H:%M')})",
         ),
+        "strict_wait": lambda _: (
+            "Strict missions mode — waiting for queued missions (no autonomous work)",
+            f"Strict missions — waiting for /mission ({time.strftime('%H:%M')})",
+        ),
     }
     if action in _IDLE_WAIT_CONFIG:
         log_msg, status_msg = _IDLE_WAIT_CONFIG[action](plan)

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -2698,45 +2698,45 @@ class TestPlanIterationRandomSelection:
         assert result["project_name"] == "koan"
 
 
-# === Tests: strict_missions mode ===
+# === Tests: focus mode (config-level permanent focus) ===
 
 
-class TestStrictMissionsContemplate:
-    """_should_contemplate should return False under strict mode."""
+class TestFocusModeContemplate:
+    """_should_contemplate should return False under focus mode."""
 
     @patch("random.randint", return_value=0)  # roll would otherwise succeed
-    def test_strict_skips_contemplation_with_ample_budget(self, mock_rand):
+    def test_focus_skips_contemplation_with_ample_budget(self, mock_rand):
         assert _should_contemplate(
-            "deep", False, 100, strict_missions=True,
+            "deep", False, 100, focus_mode=True,
         ) is False
 
     @patch("random.randint", return_value=0)
-    def test_strict_skips_contemplation_in_implement(self, mock_rand):
+    def test_focus_skips_contemplation_in_implement(self, mock_rand):
         assert _should_contemplate(
-            "implement", False, 100, strict_missions=True,
+            "implement", False, 100, focus_mode=True,
         ) is False
 
     @patch("random.randint", return_value=0)
-    def test_non_strict_still_contemplates(self, mock_rand):
-        """Sanity check: non-strict path still rolls."""
+    def test_non_focus_still_contemplates(self, mock_rand):
+        """Sanity check: non-focus path still rolls."""
         assert _should_contemplate(
-            "deep", False, 100, strict_missions=False,
+            "deep", False, 100, focus_mode=False,
         ) is True
 
 
-class TestStrictMissionsPlanIteration:
-    """plan_iteration behavior under strict_missions mode."""
+class TestFocusModePlanIteration:
+    """plan_iteration behavior under config-level focus mode."""
 
-    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.config.is_focus_mode", return_value=True)
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
     @patch("app.iteration_manager._check_schedule", return_value=None)
-    def test_no_mission_returns_strict_wait(
-        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+    def test_no_mission_returns_focus_wait(
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_focus_mode,
         instance_dir, koan_root, usage_state,
     ):
-        """Strict mode + no pending mission → strict_wait action."""
+        """Focus mode + no pending mission → focus_wait action."""
         usage_md = instance_dir / "usage.md"
         usage_md.write_text(
             "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
@@ -2752,23 +2752,23 @@ class TestStrictMissionsPlanIteration:
             usage_state_path=str(usage_state),
         )
 
-        assert result["action"] == "strict_wait"
+        assert result["action"] == "focus_wait"
         assert result["mission_title"] == ""
-        # DEEP is capped to implement under strict mode
+        # DEEP is capped to implement under focus mode
         assert result["autonomous_mode"] == "implement"
-        assert "strict" in result["decision_reason"].lower()
+        assert "focus" in result["decision_reason"].lower()
 
     @patch("app.iteration_manager._filter_exploration_projects")
-    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.config.is_focus_mode", return_value=True)
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
     @patch("app.iteration_manager._check_schedule", return_value=None)
-    def test_strict_mode_skips_exploration_filter(
-        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+    def test_focus_mode_skips_exploration_filter(
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_focus_mode,
         mock_filter, instance_dir, koan_root, usage_state,
     ):
-        """Strict mode should short-circuit before calling exploration filter."""
+        """Focus mode should short-circuit before calling exploration filter."""
         usage_md = instance_dir / "usage.md"
         usage_md.write_text(
             "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
@@ -2784,17 +2784,17 @@ class TestStrictMissionsPlanIteration:
             usage_state_path=str(usage_state),
         )
 
-        assert result["action"] == "strict_wait"
+        assert result["action"] == "focus_wait"
         mock_filter.assert_not_called()
 
-    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.config.is_focus_mode", return_value=True)
     @patch("app.pick_mission.pick_mission", return_value="koan:Fix auth bug")
     @patch("app.usage_estimator.cmd_refresh")
-    def test_queued_mission_still_runs_under_strict(
-        self, mock_refresh, mock_pick, mock_strict,
+    def test_queued_mission_still_runs_under_focus(
+        self, mock_refresh, mock_pick, mock_focus_mode,
         instance_dir, koan_root, usage_state,
     ):
-        """Strict mode never blocks an already-queued mission."""
+        """Focus mode never blocks an already-queued mission."""
         usage_md = instance_dir / "usage.md"
         usage_md.write_text(
             "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
@@ -2816,17 +2816,17 @@ class TestStrictMissionsPlanIteration:
         # Mode still capped at implement (ample budget)
         assert result["autonomous_mode"] == "implement"
 
-    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.config.is_focus_mode", return_value=True)
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
     @patch("app.iteration_manager._check_schedule", return_value=None)
     @patch("random.randint", return_value=0)  # contemplation would normally fire
-    def test_strict_mode_blocks_contemplative(
+    def test_focus_mode_blocks_contemplative(
         self, mock_rand, mock_schedule, mock_focus, mock_refresh, mock_pick,
-        mock_strict, instance_dir, koan_root, usage_state,
+        mock_focus_mode, instance_dir, koan_root, usage_state,
     ):
-        """Strict mode prevents contemplative action even on a 0-roll."""
+        """Focus mode prevents contemplative action even on a 0-roll."""
         usage_md = instance_dir / "usage.md"
         usage_md.write_text(
             "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
@@ -2842,19 +2842,19 @@ class TestStrictMissionsPlanIteration:
             usage_state_path=str(usage_state),
         )
 
-        assert result["action"] == "strict_wait"
+        assert result["action"] == "focus_wait"
 
     @patch("app.iteration_manager._inject_recurring")
-    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.config.is_focus_mode", return_value=True)
     @patch("app.pick_mission.pick_mission", return_value="")
     @patch("app.usage_estimator.cmd_refresh")
     @patch("app.iteration_manager._check_focus", return_value=None)
     @patch("app.iteration_manager._check_schedule", return_value=None)
     def test_recurring_injection_still_runs(
-        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_focus_mode,
         mock_recurring, instance_dir, koan_root, usage_state,
     ):
-        """Recurring missions are still injected under strict mode."""
+        """Recurring missions are still injected under focus mode."""
         mock_recurring.return_value = ["recurring: Daily housekeeping"]
         usage_md = instance_dir / "usage.md"
         usage_md.write_text(
@@ -2875,39 +2875,39 @@ class TestStrictMissionsPlanIteration:
         assert result["recurring_injected"] == ["recurring: Daily housekeeping"]
 
 
-class TestStrictMissionsConfigHelper:
-    """Tests for app.config.is_strict_missions()."""
+class TestFocusModeConfigHelper:
+    """Tests for app.config.is_focus_mode()."""
 
     def test_env_var_true(self, monkeypatch):
-        from app.config import is_strict_missions
-        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "1")
-        assert is_strict_missions() is True
+        from app.config import is_focus_mode
+        monkeypatch.setenv("KOAN_FOCUS", "1")
+        assert is_focus_mode() is True
 
     def test_env_var_false_overrides_config(self, monkeypatch):
         """Env var false should override config.yaml = true."""
-        from app.config import is_strict_missions
-        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "0")
-        with patch("app.config._load_config", return_value={"strict_missions": True}):
-            assert is_strict_missions() is False
+        from app.config import is_focus_mode
+        monkeypatch.setenv("KOAN_FOCUS", "0")
+        with patch("app.config._load_config", return_value={"focus": True}):
+            assert is_focus_mode() is False
 
     def test_config_true_when_env_unset(self, monkeypatch):
-        from app.config import is_strict_missions
-        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
-        with patch("app.config._load_config", return_value={"strict_missions": True}):
-            assert is_strict_missions() is True
+        from app.config import is_focus_mode
+        monkeypatch.delenv("KOAN_FOCUS", raising=False)
+        with patch("app.config._load_config", return_value={"focus": True}):
+            assert is_focus_mode() is True
 
     def test_default_false(self, monkeypatch):
-        from app.config import is_strict_missions
-        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
+        from app.config import is_focus_mode
+        monkeypatch.delenv("KOAN_FOCUS", raising=False)
         with patch("app.config._load_config", return_value={}):
-            assert is_strict_missions() is False
+            assert is_focus_mode() is False
 
 
-class TestStrictMissionsPromptOverride:
-    """Tests for prompt_builder strict_missions override."""
+class TestFocusModePromptOverride:
+    """Tests for prompt_builder focus mode override."""
 
-    def test_github_section_replaced_when_strict(self):
-        from app.prompt_builder import _apply_strict_missions_override
+    def test_github_section_replaced_when_focus(self):
+        from app.prompt_builder import _apply_focus_mode_override
         sample = (
             "# Mission\n\n"
             "## GitHub Issue Selection (IMPLEMENT and DEEP modes)\n\n"
@@ -2916,19 +2916,19 @@ class TestStrictMissionsPromptOverride:
             "# Autonomy\n\n"
             "some autonomy content\n"
         )
-        with patch("app.prompt_builder._is_strict_missions", return_value=True):
-            result = _apply_strict_missions_override(sample)
-        assert "Strict Missions Mode" in result
+        with patch("app.prompt_builder._is_focus_mode", return_value=True):
+            result = _apply_focus_mode_override(sample)
+        assert "Focus Mode" in result
         assert "GitHub Issue Selection" not in result
         assert "# Autonomy" in result  # downstream content preserved
 
-    def test_github_section_intact_when_not_strict(self):
-        from app.prompt_builder import _apply_strict_missions_override
+    def test_github_section_intact_when_not_focus(self):
+        from app.prompt_builder import _apply_focus_mode_override
         sample = (
             "## GitHub Issue Selection (IMPLEMENT and DEEP modes)\n\n"
             "content\n\n"
             "# Autonomy\n"
         )
-        with patch("app.prompt_builder._is_strict_missions", return_value=False):
-            result = _apply_strict_missions_override(sample)
+        with patch("app.prompt_builder._is_focus_mode", return_value=False):
+            result = _apply_focus_mode_override(sample)
         assert result == sample

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -2696,3 +2696,239 @@ class TestPlanIterationRandomSelection:
         )
         assert result["action"] == "autonomous"
         assert result["project_name"] == "koan"
+
+
+# === Tests: strict_missions mode ===
+
+
+class TestStrictMissionsContemplate:
+    """_should_contemplate should return False under strict mode."""
+
+    @patch("random.randint", return_value=0)  # roll would otherwise succeed
+    def test_strict_skips_contemplation_with_ample_budget(self, mock_rand):
+        assert _should_contemplate(
+            "deep", False, 100, strict_missions=True,
+        ) is False
+
+    @patch("random.randint", return_value=0)
+    def test_strict_skips_contemplation_in_implement(self, mock_rand):
+        assert _should_contemplate(
+            "implement", False, 100, strict_missions=True,
+        ) is False
+
+    @patch("random.randint", return_value=0)
+    def test_non_strict_still_contemplates(self, mock_rand):
+        """Sanity check: non-strict path still rolls."""
+        assert _should_contemplate(
+            "deep", False, 100, strict_missions=False,
+        ) is True
+
+
+class TestStrictMissionsPlanIteration:
+    """plan_iteration behavior under strict_missions mode."""
+
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
+    def test_no_mission_returns_strict_wait(
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Strict mode + no pending mission → strict_wait action."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "strict_wait"
+        assert result["mission_title"] == ""
+        # DEEP is capped to implement under strict mode
+        assert result["autonomous_mode"] == "implement"
+        assert "strict" in result["decision_reason"].lower()
+
+    @patch("app.iteration_manager._filter_exploration_projects")
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
+    def test_strict_mode_skips_exploration_filter(
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+        mock_filter, instance_dir, koan_root, usage_state,
+    ):
+        """Strict mode should short-circuit before calling exploration filter."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "strict_wait"
+        mock_filter.assert_not_called()
+
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.pick_mission.pick_mission", return_value="koan:Fix auth bug")
+    @patch("app.usage_estimator.cmd_refresh")
+    def test_queued_mission_still_runs_under_strict(
+        self, mock_refresh, mock_pick, mock_strict,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Strict mode never blocks an already-queued mission."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "mission"
+        assert result["mission_title"] == "Fix auth bug"
+        assert result["project_name"] == "koan"
+        # Mode still capped at implement (ample budget)
+        assert result["autonomous_mode"] == "implement"
+
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
+    @patch("random.randint", return_value=0)  # contemplation would normally fire
+    def test_strict_mode_blocks_contemplative(
+        self, mock_rand, mock_schedule, mock_focus, mock_refresh, mock_pick,
+        mock_strict, instance_dir, koan_root, usage_state,
+    ):
+        """Strict mode prevents contemplative action even on a 0-roll."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "strict_wait"
+
+    @patch("app.iteration_manager._inject_recurring")
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.iteration_manager._check_focus", return_value=None)
+    @patch("app.iteration_manager._check_schedule", return_value=None)
+    def test_recurring_injection_still_runs(
+        self, mock_schedule, mock_focus, mock_refresh, mock_pick, mock_strict,
+        mock_recurring, instance_dir, koan_root, usage_state,
+    ):
+        """Recurring missions are still injected under strict mode."""
+        mock_recurring.return_value = ["recurring: Daily housekeeping"]
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        mock_recurring.assert_called_once()
+        assert result["recurring_injected"] == ["recurring: Daily housekeeping"]
+
+
+class TestStrictMissionsConfigHelper:
+    """Tests for app.config.is_strict_missions()."""
+
+    def test_env_var_true(self, monkeypatch):
+        from app.config import is_strict_missions
+        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "1")
+        assert is_strict_missions() is True
+
+    def test_env_var_false_overrides_config(self, monkeypatch):
+        """Env var false should override config.yaml = true."""
+        from app.config import is_strict_missions
+        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "0")
+        with patch("app.config._load_config", return_value={"strict_missions": True}):
+            assert is_strict_missions() is False
+
+    def test_config_true_when_env_unset(self, monkeypatch):
+        from app.config import is_strict_missions
+        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
+        with patch("app.config._load_config", return_value={"strict_missions": True}):
+            assert is_strict_missions() is True
+
+    def test_default_false(self, monkeypatch):
+        from app.config import is_strict_missions
+        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
+        with patch("app.config._load_config", return_value={}):
+            assert is_strict_missions() is False
+
+
+class TestStrictMissionsPromptOverride:
+    """Tests for prompt_builder strict_missions override."""
+
+    def test_github_section_replaced_when_strict(self):
+        from app.prompt_builder import _apply_strict_missions_override
+        sample = (
+            "# Mission\n\n"
+            "## GitHub Issue Selection (IMPLEMENT and DEEP modes)\n\n"
+            "When you choose to work on a GitHub issue...\n"
+            "more text here\n\n"
+            "# Autonomy\n\n"
+            "some autonomy content\n"
+        )
+        with patch("app.prompt_builder._is_strict_missions", return_value=True):
+            result = _apply_strict_missions_override(sample)
+        assert "Strict Missions Mode" in result
+        assert "GitHub Issue Selection" not in result
+        assert "# Autonomy" in result  # downstream content preserved
+
+    def test_github_section_intact_when_not_strict(self):
+        from app.prompt_builder import _apply_strict_missions_override
+        sample = (
+            "## GitHub Issue Selection (IMPLEMENT and DEEP modes)\n\n"
+            "content\n\n"
+            "# Autonomy\n"
+        )
+        with patch("app.prompt_builder._is_strict_missions", return_value=False):
+            result = _apply_strict_missions_override(sample)
+        assert result == sample

--- a/projects.example.yaml
+++ b/projects.example.yaml
@@ -56,6 +56,21 @@ defaults:
   # mcp:
   #   - "/path/to/project-specific-mcp.json"
 
+  # Focus mode — disable autonomous work for this project.
+  #
+  # When enabled, the agent ONLY works on explicitly queued missions for
+  # this project — no contemplative sessions, no DEEP mode, no autonomous
+  # exploration. This is the per-project equivalent of the global
+  # config.yaml `focus: true` setting.
+  #
+  # Set at defaults level to control the global policy, then override
+  # per-project. Common patterns:
+  #   - defaults: true + myapp: false → all focused except myapp
+  #   - defaults: false + vendor: true → only vendor is focused
+  #
+  # Default: false
+  # focus: false
+
   # Exploration — controls autonomous work on this project.
   #
   # When enabled, the agent may autonomously:
@@ -147,6 +162,12 @@ projects:
   # my-main-app:
   #   path: "/Users/yourname/workspace/my-main-app"
   #   exploration: true                    # Override global false default
+
+  # Example: focus mode — missions only, no autonomous work
+  # Use when you want Kōan to be a quiet executor for a project.
+  # quiet-repo:
+  #   path: "/Users/yourname/workspace/quiet-repo"
+  #   focus: true                           # Only run queued missions
 
   # Example: a project with a lower PR limit (overrides default of 10)
   # oss-lib:


### PR DESCRIPTION
## Summary

Closes #1175.

Adds a single global switch — `strict_missions` — that turns Kōan into a pure mission executor. When enabled, only missions that were explicitly queued (via `/mission`, recurring schedules, or GitHub @mention commands) ever run. All autonomous work is gated off.

## What this changes

- **New config helper** `is_strict_missions()` in `koan/app/config.py`, resolving from `KOAN_STRICT_MISSIONS` env var first, then `strict_missions:` in `config.yaml` (default: `false`).
- **Mode cap** — `plan_iteration()` caps `decide_mode()` at `implement` when strict is on, so the agent prompt never gets the "ample budget, pick an issue" framing of DEEP mode.
- **`strict_wait` action** — when no mission is pending, `plan_iteration()` short-circuits to a new `strict_wait` result *before* exploration filtering, skipping `_filter_exploration_projects()` entirely (avoids wasted `gh` calls). It idles with wake-on-mission like `exploration_wait`.
- **Contemplative gate** — `_should_contemplate()` unconditionally returns `False` under strict mode.
- **Agent prompt override** — `prompt_builder._apply_strict_missions_override()` replaces the `## GitHub Issue Selection` section with a `## Strict Missions Mode` block that explicitly forbids autonomous GitHub pickup.
- **Run loop** — `run.py` handles `strict_wait` via the idle-wait config map with a clear status message.
- **Recurring, Telegram polling, GitHub notification polling, CI queue drain, auto-update, heartbeat** — all continue to run. Strict mode gates *work selection*, not the bridge.

## What it is NOT

- Not a replacement for `/passive` — passive blocks all execution (missions sit as Pending). Strict mode keeps running queued missions.
- Not a weakening of the per-project `exploration:` flag — that's still the finer-grained override.
- No Telegram `/strict` toggle yet — v1 is config-only, as specified in the issue.

## Tests

Added 14 new tests in `koan/tests/test_iteration_manager.py`:

- `TestStrictMissionsContemplate` — `_should_contemplate()` returns False under strict even with ample budget / deep mode / implement mode.
- `TestStrictMissionsPlanIteration` — covers:
  - no-mission → `strict_wait` (DEEP capped to implement)
  - exploration filter is never called
  - queued missions still run
  - contemplative rolls are blocked
  - recurring injection still fires
- `TestStrictMissionsConfigHelper` — env-var truthy, env-var false overrides yaml, yaml fallback, default false.
- `TestStrictMissionsPromptOverride` — GitHub section replaced when strict; intact when not.

Full suite (**11,530 tests**) passes locally.

## Docs

- `instance.example/config.yaml` — new commented `strict_missions: false` block explaining the option and env override, and contrasting it with passive mode.
- `docs/user-manual.md` — new "Strict Missions Mode" section under the passive mode docs with enable/disable instructions, what continues vs what's gated, and when to use it.

## Test plan

- [x] Unit tests pass (`KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_iteration_manager.py`)
- [x] Full suite passes (`KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/`)
- [ ] Manual smoke: set `strict_missions: true`, start run loop, verify `/status` reports `strict_wait`, queue a mission via `/mission`, verify it runs, remove config, verify normal autonomous behavior returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)