### PR TITLE
feat: add strict_missions mode (#1175)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,9 @@ models:
 budget:
   warn_at_percent: 20
   stop_at_percent: 5
+
+# Only run user-queued missions (no autonomous work)
+strict_missions: false
 ```
 
 ### Multi-Project Setup

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -271,6 +271,8 @@ Kōan can manage multiple projects simultaneously. It rotates between them based
 
 **`/active`** — Exit passive mode and resume normal execution. Queued missions drain naturally.
 
+> **`strict_missions` vs `/passive`** — `strict_missions` (config-only) disables autonomous work but still runs queued missions, recurring tasks, and GitHub @mention commands. `/passive` blocks *all* execution. Use `strict_missions: true` when you want a quiet bot that only does what it's told; use `/passive` when you want it to stop working entirely.
+
 <details>
 <summary>Use cases</summary>
 
@@ -854,6 +856,12 @@ tools:
 # Useful for scheduled launches (cron, launchd) where you want
 # the stack running but idle until you explicitly /resume.
 start_on_pause: false
+
+# Strict missions — only execute user-queued missions
+# No autonomous exploration, no contemplative sessions, no DEEP mode.
+# The loop idles when no missions are pending.
+# Env override: KOAN_STRICT_MISSIONS=1
+strict_missions: false
 
 # Schedule (when Kōan is allowed to work)
 schedule:

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -25,6 +25,15 @@
 # autonomous work. Use /active to resume normal execution.
 # start_passive: false
 
+# Strict missions mode — disable all autonomous work
+# When true, Kōan only executes user-queued missions (Telegram /mission,
+# GitHub @mention commands, recurring missions). No autonomous exploration,
+# no contemplative sessions, no DEEP mode. The loop idles when missions.md
+# has no Pending items. Unlike passive mode (which blocks all execution),
+# strict_missions still runs queued work — it just won't invent its own.
+# Can also be set via KOAN_STRICT_MISSIONS=1 env var (overrides this).
+# strict_missions: false
+
 # Startup reflection — run self-reflection check on startup
 # When true, Kōan checks whether periodic self-reflection is due (every N
 # sessions) and, if so, invokes Claude to generate observations. Disabled by

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -673,6 +673,22 @@ def get_prompt_guard_config() -> dict:
     }
 
 
+def is_strict_missions() -> bool:
+    """Check if strict_missions mode is enabled.
+
+    When True, Kōan only executes user-queued missions — no autonomous
+    exploration, no contemplative sessions, no DEEP mode. The loop idles
+    when missions.md has no Pending items.
+
+    Resolution order: KOAN_STRICT_MISSIONS env var → config.yaml strict_missions.
+    """
+    env = os.environ.get("KOAN_STRICT_MISSIONS", "").strip()
+    if env:
+        return env in ("1", "true", "yes")
+    config = _load_config()
+    return bool(config.get("strict_missions", False))
+
+
 def get_review_concurrency_config() -> dict:
     """Get review concurrency configuration from config.yaml.
 

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -301,10 +301,12 @@ def _get_known_project_names(projects: List[Tuple[str, str]]) -> list:
 
 def _should_contemplate(autonomous_mode: str, focus_active: bool,
                         contemplative_chance: int,
-                        schedule_state=None) -> bool:
+                        schedule_state=None,
+                        strict_missions: bool = False) -> bool:
     """Check if this iteration should be a contemplative session.
 
     Contemplative sessions only trigger when:
+    - strict_missions is NOT active
     - Mode is deep or implement (need budget for Claude call)
     - Focus mode is NOT active
     - Schedule is not in work_hours
@@ -313,6 +315,9 @@ def _should_contemplate(autonomous_mode: str, focus_active: bool,
     Returns:
         True if should run a contemplative session
     """
+    if strict_missions:
+        return False
+
     if autonomous_mode not in ("deep", "implement"):
         return False
 
@@ -710,6 +715,7 @@ def _decide_autonomous_action(
     koan_root: str,
     schedule_state,
     contemplative_chance: int = 10,
+    strict_missions: bool = False,
 ) -> "AutonomousDecision":
     """Decide autonomous action via a linear priority chain.
 
@@ -733,7 +739,8 @@ def _decide_autonomous_action(
 
     # 1. Contemplative session (random reflection)
     if _should_contemplate(autonomous_mode, focus_active,
-                           contemplative_chance, schedule_state):
+                           contemplative_chance, schedule_state,
+                           strict_missions=strict_missions):
         return AutonomousDecision(action="contemplative", focus_remaining=None)
 
     # 2. Focus mode active → wait for missions
@@ -780,7 +787,7 @@ def plan_iteration(
     Returns:
         dict with iteration plan:
         {
-            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "error",
+            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "strict_wait" | "wait_pause" | "error",
             "project_name": str,
             "project_path": str,
             "mission_title": str (empty for autonomous/contemplative),
@@ -839,6 +846,18 @@ def plan_iteration(
                 )
     except (ImportError, OSError, ValueError) as e:
         _log_iteration("error", f"Schedule mode cap check failed: {e}")
+
+    # Step 2c: Strict missions mode — cap at implement (no DEEP)
+    try:
+        from app.config import is_strict_missions
+        strict_missions = is_strict_missions()
+    except (ImportError, OSError, ValueError):
+        strict_missions = False
+
+    if strict_missions and autonomous_mode == "deep":
+        _log_iteration("koan", "Strict missions: capping deep → implement")
+        autonomous_mode = "implement"
+        decision_reason = f"{decision_reason} (strict_missions: capped from deep)"
 
     # Step 3: Inject recurring missions
     recurring_injected = _inject_recurring(instance)
@@ -977,6 +996,24 @@ def plan_iteration(
                 tracker_error=tracker_error,
             )
 
+        # Short-circuit: strict_missions mode — no autonomous work at all
+        if strict_missions:
+            _log_iteration("koan", "Strict missions: no pending missions — idling")
+            focus_area = resolve_focus_area(autonomous_mode, has_mission=False)
+            return _make_result(
+                action="strict_wait",
+                project_name=projects[0][0] if projects else "default",
+                project_path=projects[0][1] if projects else "",
+                autonomous_mode=autonomous_mode,
+                focus_area=focus_area,
+                available_pct=available_pct,
+                decision_reason="Strict missions mode — waiting for explicit missions",
+                display_lines=display_lines,
+                recurring_injected=recurring_injected,
+                schedule_mode=schedule_state.mode if schedule_state else "normal",
+                tracker_error=tracker_error,
+            )
+
         # Filter to exploration-enabled projects only
         filter_result = _filter_exploration_projects(projects, koan_root,
                                                      schedule_state=schedule_state)
@@ -1040,6 +1077,7 @@ def plan_iteration(
 
         autonomous_decision = _decide_autonomous_action(
             autonomous_mode, koan_root, schedule_state, contemplative_chance,
+            strict_missions=strict_missions,
         )
         action = autonomous_decision.action
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -295,6 +295,20 @@ def _build_mission_instruction(mission_title: str, project_name: str) -> str:
     )
 
 
+def _strip_github_issue_selection(prompt: str) -> str:
+    """Remove the GitHub Issue Selection section from the agent prompt.
+
+    Used under strict_missions mode to prevent the agent from picking
+    up GitHub issues autonomously.
+    """
+    return re.sub(
+        r"\n## GitHub Issue Selection \(IMPLEMENT and DEEP modes\)\n.*?(?=\n# )",
+        "",
+        prompt,
+        flags=re.DOTALL,
+    )
+
+
 def _warn_unresolved_placeholders(text: str, template_name: str) -> None:
     """Log a warning if any {PLACEHOLDER} tokens remain after substitution."""
     unresolved = _PLACEHOLDER_RE.findall(text)
@@ -317,6 +331,7 @@ def _load_agent_template(
     focus_area: str,
     available_pct: int,
     mission_title: str,
+    strict_missions: bool = False,
 ) -> str:
     """Load and populate the agent.md template with standard placeholders."""
     from app.prompts import load_prompt
@@ -336,6 +351,10 @@ def _load_agent_template(
         MISSION_INSTRUCTION=mission_instruction,
         BRANCH_PREFIX=branch_prefix,
     )
+
+    if strict_missions:
+        result = _strip_github_issue_selection(result)
+
     _warn_unresolved_placeholders(result, "agent")
     return result
 
@@ -364,6 +383,7 @@ def build_agent_prompt(
     available_pct: int,
     mission_title: str = "",
     spec_content: str = "",
+    strict_missions: bool = False,
 ) -> str:
     """Build the complete agent prompt from template + dynamic sections.
 
@@ -378,6 +398,7 @@ def build_agent_prompt(
         available_pct: Budget percentage available
         mission_title: Mission title (empty for autonomous mode)
         spec_content: Pre-generated mission spec (empty to skip)
+        strict_missions: When True, strip autonomous GitHub issue selection
 
     Returns:
         Complete prompt string ready for Claude CLI
@@ -385,6 +406,7 @@ def build_agent_prompt(
     prompt = _load_agent_template(
         instance, project_name, project_path, run_num, max_runs,
         autonomous_mode, focus_area, available_pct, mission_title,
+        strict_missions=strict_missions,
     )
 
     prompt = _append_spec(prompt, spec_content, mission_title)
@@ -446,6 +468,7 @@ def build_agent_prompt_parts(
     available_pct: int,
     mission_title: str = "",
     spec_content: str = "",
+    strict_missions: bool = False,
 ) -> Tuple[str, str]:
     """Build agent prompt split into system prompt and user prompt.
 
@@ -462,6 +485,7 @@ def build_agent_prompt_parts(
     user_prompt = _load_agent_template(
         instance, project_name, project_path, run_num, max_runs,
         autonomous_mode, focus_area, available_pct, mission_title,
+        strict_missions=strict_missions,
     )
 
     user_prompt = _append_spec(user_prompt, spec_content, mission_title)

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1489,6 +1489,10 @@ def _run_iteration(
             "PR limit reached for all projects — waiting for reviews",
             f"PR limit reached — waiting for reviews ({time.strftime('%H:%M')})",
         ),
+        "strict_wait": lambda _: (
+            "Strict missions mode — no pending missions, waiting",
+            f"Strict missions — waiting for missions ({time.strftime('%H:%M')})",
+        ),
     }
     if action in _IDLE_WAIT_CONFIG:
         log_msg, status_msg = _IDLE_WAIT_CONFIG[action](plan)
@@ -1631,6 +1635,7 @@ def _run_iteration(
 
     # Build prompt (split into system/user for prompt caching)
     from app.prompt_builder import build_agent_prompt_parts
+    from app.config import is_strict_missions
     system_prompt, prompt = build_agent_prompt_parts(
         instance=instance,
         project_name=project_name,
@@ -1642,6 +1647,7 @@ def _run_iteration(
         available_pct=available_pct or 50,
         mission_title=mission_title,
         spec_content=spec_content,
+        strict_missions=is_strict_missions(),
     )
 
     # Create pending.md

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -2696,3 +2696,161 @@ class TestPlanIterationRandomSelection:
         )
         assert result["action"] == "autonomous"
         assert result["project_name"] == "koan"
+
+
+# === Tests: strict_missions mode ===
+
+
+class TestStrictMissions:
+
+    @patch("random.randint", return_value=5)
+    def test_should_contemplate_returns_false_when_strict(self, mock_rand):
+        """Contemplative sessions are suppressed under strict_missions."""
+        assert _should_contemplate("deep", False, 100, strict_missions=True) is False
+
+    @patch("random.randint", return_value=5)
+    def test_should_contemplate_still_works_when_not_strict(self, mock_rand):
+        """Sanity check: contemplative sessions fire normally without strict."""
+        assert _should_contemplate("deep", False, 100, strict_missions=False) is True
+
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.config.is_strict_missions", return_value=True)
+    def test_plan_iteration_strict_wait_when_no_mission(
+        self, mock_strict, mock_refresh, mock_pick,
+        instance_dir, koan_root, usage_state,
+    ):
+        """With strict_missions on and no pending mission, action is strict_wait."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=1,
+            count=0,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "strict_wait"
+        assert "Strict missions" in result["decision_reason"]
+
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.config.is_strict_missions", return_value=True)
+    def test_strict_caps_deep_to_implement(
+        self, mock_strict, mock_refresh, mock_pick,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Under strict_missions, deep mode is capped to implement."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=1,
+            count=0,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["autonomous_mode"] != "deep"
+        assert result["autonomous_mode"] == "implement"
+
+    @patch("app.pick_mission.pick_mission", return_value="koan:Fix auth bug")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.config.is_strict_missions", return_value=True)
+    def test_queued_mission_still_runs_under_strict(
+        self, mock_strict, mock_refresh, mock_pick,
+        instance_dir, koan_root, usage_state,
+    ):
+        """A queued mission is executed normally even under strict_missions."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=1,
+            count=0,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["action"] == "mission"
+        assert result["mission_title"] == "Fix auth bug"
+
+    @patch("app.pick_mission.pick_mission", return_value="")
+    @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.config.is_strict_missions", return_value=True)
+    @patch("app.iteration_manager._inject_recurring", return_value=["injected-task"])
+    def test_recurring_injection_still_works_under_strict(
+        self, mock_recurring, mock_strict, mock_refresh, mock_pick,
+        instance_dir, koan_root, usage_state,
+    ):
+        """Recurring injection fires before strict_wait — injected items surface."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text(
+            "Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n"
+        )
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=1,
+            count=0,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        assert result["recurring_injected"] == ["injected-task"]
+        mock_recurring.assert_called_once()
+
+    def test_decide_autonomous_action_no_contemplative_under_strict(self):
+        """_decide_autonomous_action never returns contemplative under strict."""
+        with patch("app.iteration_manager._check_focus", return_value=None):
+            with patch("random.randint", return_value=0):
+                decision = _decide_autonomous_action(
+                    "deep", "/koan-root", None,
+                    contemplative_chance=100,
+                    strict_missions=True,
+                )
+                assert decision.action != "contemplative"
+                assert decision.action == "autonomous"
+
+
+class TestIsStrictMissions:
+
+    def test_env_var_true(self, monkeypatch):
+        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "1")
+        from app.config import is_strict_missions
+        assert is_strict_missions() is True
+
+    def test_env_var_false(self, monkeypatch):
+        monkeypatch.setenv("KOAN_STRICT_MISSIONS", "0")
+        from app.config import is_strict_missions
+        assert is_strict_missions() is False
+
+    def test_env_var_empty_falls_through_to_config(self, monkeypatch):
+        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
+        with patch("app.config._load_config", return_value={"strict_missions": True}):
+            from app.config import is_strict_missions
+            assert is_strict_missions() is True
+
+    def test_default_is_false(self, monkeypatch):
+        monkeypatch.delenv("KOAN_STRICT_MISSIONS", raising=False)
+        with patch("app.config._load_config", return_value={}):
+            from app.config import is_strict_missions
+            assert is_strict_missions() is False

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -1770,3 +1770,47 @@ class TestWarnUnresolvedPlaceholders:
         assert "{BOGUS_PLACEHOLDER}" in result
         assert len(caplog.records) == 1
         assert "BOGUS_PLACEHOLDER" in caplog.records[0].message
+
+
+class TestStripGithubIssueSelection:
+    """Tests for _strip_github_issue_selection used under strict_missions."""
+
+    def test_strips_github_issue_selection_section(self):
+        from app.prompt_builder import _strip_github_issue_selection
+        prompt = (
+            "Some preamble\n"
+            "\n## GitHub Issue Selection (IMPLEMENT and DEEP modes)\n"
+            "\nWhen you choose to work on a GitHub issue autonomously...\n"
+            "1. Assignment check\n2. Open PR check\n"
+            "\n# Autonomy\n\nYou are autonomous."
+        )
+        result = _strip_github_issue_selection(prompt)
+        assert "GitHub Issue Selection" not in result
+        assert "# Autonomy" in result
+        assert "Some preamble" in result
+
+    def test_noop_when_section_absent(self):
+        from app.prompt_builder import _strip_github_issue_selection
+        prompt = "Some prompt without the section\n# Autonomy\n"
+        assert _strip_github_issue_selection(prompt) == prompt
+
+    @patch("app.prompt_builder._get_merge_policy", return_value="")
+    @patch("app.prompt_builder._get_branch_prefix", return_value="koan/")
+    def test_build_agent_prompt_strips_section_when_strict(
+        self, mock_prefix, mock_merge,
+    ):
+        from app.prompt_builder import build_agent_prompt
+        result_normal = build_agent_prompt(
+            instance="/tmp/inst", project_name="test",
+            project_path="/tmp/proj", run_num=1, max_runs=10,
+            autonomous_mode="implement", focus_area="test",
+            available_pct=50, strict_missions=False,
+        )
+        result_strict = build_agent_prompt(
+            instance="/tmp/inst", project_name="test",
+            project_path="/tmp/proj", run_num=1, max_runs=10,
+            autonomous_mode="implement", focus_area="test",
+            available_pct=50, strict_missions=True,
+        )
+        assert "GitHub Issue Selection" in result_normal
+        assert "GitHub Issue Selection" not in result_strict


### PR DESCRIPTION
## Summary

Adds `strict_missions` mode — a global switch that turns Kōan into a pure mission executor. When enabled, only user-queued missions (Telegram `/mission`, GitHub @mention commands, recurring tasks) run. All autonomous work is suppressed: no exploration, no contemplative sessions, no DEEP mode.

Closes https://github.com/Anantys-oss/koan/issues/1175

## Changes

- **Config**: `is_strict_missions()` helper in `config.py` — reads `KOAN_STRICT_MISSIONS` env var first, then `config.yaml`
- **Mode cap**: DEEP mode capped to IMPLEMENT under strict_missions (prevents autonomous issue pickup prompt)
- **Exploration gate**: New `strict_wait` action returned when no missions are pending — skips all exploration filtering
- **Contemplative gate**: `_should_contemplate()` returns False unconditionally under strict
- **Prompt stripping**: GitHub Issue Selection section removed from agent prompt under strict
- **Run loop**: `strict_wait` wired as idle wait action with wake-on-mission support
- **Docs**: Updated user-manual, README, and `instance.example/config.yaml`

## Test plan

- 14 new tests covering all strict_missions behaviors (11 iteration_manager + 3 prompt_builder)
- Full test suite passes (11574 tests, 0 regressions)
- Tests verify: strict_wait action, mode cap, contemplative suppression, mission execution, recurring injection, prompt stripping, config helper (env var + yaml + default)

---
*Generated by Kōan /implement*