### PR TITLE
fix: decouple chat cwd from project directory (#1180)

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -350,7 +350,7 @@ def handle_chat(text: str):
             result = run_cli(
                 cmd,
                 capture_output=True, text=True, timeout=CHAT_TIMEOUT,
-                cwd=PROJECT_PATH or str(KOAN_ROOT),
+                cwd=str(KOAN_ROOT),
             )
             response = _clean_chat_response(result.stdout.strip(), text)
             if response:
@@ -362,7 +362,7 @@ def handle_chat(text: str):
                 )
                 log("chat", f"Chat reply: {response[:80]}...")
             elif result.returncode != 0:
-                log("error", f"Claude error: {result.stderr[:200]}")
+                log("error", f"Claude error (exit {result.returncode}): {result.stderr[:200]}")
                 error_msg = "⚠️ Hmm, I couldn't formulate a response. Try again?"
                 send_telegram(error_msg)
                 save_conversation_message(CONVERSATION_HISTORY_FILE, "assistant", error_msg)
@@ -389,7 +389,7 @@ def handle_chat(text: str):
                 result = run_cli(
                     lite_cmd,
                     capture_output=True, text=True, timeout=retry_timeout,
-                    cwd=PROJECT_PATH or str(KOAN_ROOT),
+                    cwd=str(KOAN_ROOT),
                 )
                 response = _clean_chat_response(result.stdout.strip(), text)
                 if response:

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -707,6 +707,39 @@ class TestHandleChat:
     @patch("app.awake.format_conversation_history", return_value="")
     @patch("app.awake.get_tools_description", return_value="")
     @patch("app.awake.get_chat_tools", return_value="")
+    @patch("app.awake.send_telegram", return_value=True)
+    @patch("app.awake.subprocess.run")
+    def test_chat_cwd_is_koan_root_not_project_path(
+        self, mock_run, mock_send, mock_tools,
+        mock_tools_desc, mock_fmt, mock_hist, mock_save, tmp_path,
+    ):
+        """Chat CLI must run from KOAN_ROOT, not PROJECT_PATH, to avoid
+        session conflicts with concurrent mission execution."""
+        mock_run.return_value = MagicMock(stdout="reply", returncode=0)
+        koan_root = tmp_path / "koan-root"
+        project_path = tmp_path / "project"
+        koan_root.mkdir()
+        project_path.mkdir()
+        journal_dir = tmp_path / "journal" / "2026-02-01"
+        journal_dir.mkdir(parents=True)
+        with patch("app.awake.INSTANCE_DIR", tmp_path), \
+             patch("app.awake.KOAN_ROOT", koan_root), \
+             patch("app.awake.PROJECT_PATH", str(project_path)), \
+             patch("app.awake.CONVERSATION_HISTORY_FILE", tmp_path / "history.jsonl"), \
+             patch("app.awake.SOUL", "soul"), \
+             patch("app.awake.SUMMARY", "summary"):
+            handle_chat("hello")
+        assert mock_run.call_count >= 1
+        cwd_used = mock_run.call_args_list[0].kwargs.get("cwd")
+        assert cwd_used == str(koan_root), (
+            f"Chat cwd should be KOAN_ROOT ({koan_root}), not PROJECT_PATH ({project_path}). Got: {cwd_used}"
+        )
+
+    @patch("app.awake.save_conversation_message")
+    @patch("app.awake.load_recent_history", return_value=[])
+    @patch("app.awake.format_conversation_history", return_value="")
+    @patch("app.awake.get_tools_description", return_value="")
+    @patch("app.awake.get_chat_tools", return_value="")
     @patch("app.awake.send_telegram")
     @patch("app.awake.subprocess.run")
     def test_chat_timeout(self, mock_run, mock_send, mock_tools,


### PR DESCRIPTION
## Summary

Chat CLI calls (`handle_chat` in `awake.py`) now use `KOAN_ROOT` instead of `PROJECT_PATH` as the working directory. This prevents Claude CLI session conflicts when a mission is running concurrently in the same project directory, which caused "couldn't formulate a response" errors.

Closes https://github.com/Anantys-oss/koan/issues/1180

## Changes

- Changed `cwd` argument in both `run_cli()` calls inside `handle_chat()` from `PROJECT_PATH or str(KOAN_ROOT)` to `str(KOAN_ROOT)`
- Added exit code to the chat error log message for easier debugging
- Added regression test verifying chat always uses `KOAN_ROOT` as cwd, not `PROJECT_PATH`

## Test plan

- All 243 tests in `test_awake.py` pass
- New test `test_chat_cwd_is_koan_root_not_project_path` verifies the fix and will fail if reverted
- Manual verification: send a Telegram chat message while a mission is running — should get a response instead of the error

---
*Generated by Kōan /implement*