### PR TITLE
fix: handle branch_saturated_wait in idle wait dispatcher

### DIFF
--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -846,12 +846,17 @@ def plan_iteration(
     # Step 3b: Drain CI queue (one entry per iteration, non-blocking)
     ci_drain_msg = _drain_ci_queue(instance)
 
-    # Step 4: Pick mission
+    # Step 4: Pick mission. Manual missions (queued in missions.md or via
+    # notifications) are always eligible regardless of branch saturation —
+    # max_pending_branches is a self-throttle for autonomous exploration,
+    # not a gate on human instructions. Saturation is enforced by
+    # _filter_exploration_projects in the no-mission path only.
     mission_project, mission_title = _pick_mission(
         instance, projects_str, run_num, autonomous_mode, last_project,
     )
     if mission_project and mission_title:
-        _log_iteration("mission", f"Mission picked: [{mission_project}] {mission_title[:80]}")
+        _log_iteration("mission",
+            f"Mission picked: [{mission_project}] {mission_title[:80]}")
     else:
         _log_iteration("koan", "No pending mission — entering autonomous mode")
 
@@ -878,9 +883,8 @@ def plan_iteration(
             passive_remaining=remaining,
         )
 
-    # Step 5: Resolve project
+    # Step 5: Resolve project for the picked mission.
     if mission_project and mission_title:
-        # Mission picked — resolve project path (case-insensitive)
         resolved = _resolve_project_path(mission_project, projects)
 
         if resolved is None:
@@ -904,56 +908,6 @@ def plan_iteration(
                 error=f"Unknown project '{project_name}'. Known: {', '.join(known)}",
                 tracker_error=tracker_error,
             )
-
-        # Step 5b: Branch saturation gate — skip mission if project is at limit
-        # Direct skill dispatch (/plan, /implement) bypasses this via skill_dispatch.py
-        try:
-            from app.projects_config import load_projects_config, get_project_max_pending_branches
-            branch_config = load_projects_config(koan_root)
-            if branch_config is not None:
-                branch_limit = get_project_max_pending_branches(branch_config, project_name)
-                if branch_limit > 0:
-                    from app.github import get_gh_username
-                    from app.branch_limiter import count_pending_branches
-
-                    branch_author = get_gh_username()
-                    project_cfg = branch_config.get("projects", {}).get(project_name, {}) or {}
-                    branch_urls = set()
-                    primary = project_cfg.get("github_url", "")
-                    if primary:
-                        branch_urls.add(primary)
-                    for u in project_cfg.get("github_urls", []):
-                        if u:
-                            branch_urls.add(u)
-
-                    instance_dir_str = str(instance)
-                    pending_count = count_pending_branches(
-                        instance_dir_str, project_name, project_path,
-                        list(branch_urls), branch_author,
-                    )
-                    if pending_count >= branch_limit:
-                        _log_iteration("koan",
-                            f"Project '{project_name}' branch-saturated "
-                            f"({pending_count}/{branch_limit}) — skipping mission")
-                        return _make_result(
-                            action="branch_saturated_wait",
-                            project_name=project_name,
-                            project_path=project_path,
-                            mission_title="",
-                            autonomous_mode=autonomous_mode,
-                            focus_area=f"Branch-saturated: {pending_count}/{branch_limit} pending branches",
-                            available_pct=available_pct,
-                            decision_reason=(
-                                f"Project '{project_name}' at branch limit "
-                                f"({pending_count}/{branch_limit}) — mission stays Pending"
-                            ),
-                            display_lines=display_lines,
-                            recurring_injected=recurring_injected,
-                            schedule_mode=schedule_state.mode if schedule_state else "normal",
-                            tracker_error=tracker_error,
-                        )
-        except (ImportError, OSError, ValueError) as e:
-            _log_iteration("debug", f"Branch saturation check failed: {e} — proceeding")
 
     else:
         # No mission — autonomous mode

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -1186,6 +1186,7 @@ def interruptible_sleep(
     koan_root: str,
     instance_dir: str,
     check_interval: int = 10,
+    wake_on_mission: bool = True,
 ) -> str:
     """Sleep for a given interval, waking early on events.
 
@@ -1197,6 +1198,11 @@ def interruptible_sleep(
         koan_root: Path to koan root directory.
         instance_dir: Path to instance directory.
         check_interval: How often to check for wake events (seconds).
+        wake_on_mission: When True (default), return early if pending
+            missions or GitHub/Jira mission-inducing notifications appear.
+            Set False for wait states where pending missions are the
+            blocker (e.g. branch-saturated) and waking would just tight-
+            loop back into the same blocked state.
 
     Returns:
         Reason for waking: "timeout", "mission", "stop", "pause", "restart", "shutdown".
@@ -1204,7 +1210,7 @@ def interruptible_sleep(
     elapsed = 0
     while elapsed < interval:
         # Check signals BEFORE sleeping so events are detected immediately.
-        if check_pending_missions(instance_dir):
+        if wake_on_mission and check_pending_missions(instance_dir):
             return "mission"
         if _check_signal_file(koan_root, ".koan-stop"):
             return "stop"
@@ -1236,13 +1242,15 @@ def interruptible_sleep(
         # Check GitHub notifications (throttled to once per 60s).
         # Track wall time: API calls can be slow and should count toward elapsed.
         t0 = time.monotonic()
-        if process_github_notifications(koan_root, instance_dir) > 0:
+        gh_new = process_github_notifications(koan_root, instance_dir)
+        if wake_on_mission and gh_new > 0:
             return "mission"
         elapsed += time.monotonic() - t0
 
         # Check Jira notifications (throttled to once per 60s).
         t0 = time.monotonic()
-        if process_jira_notifications(koan_root, instance_dir) > 0:
+        jira_new = process_jira_notifications(koan_root, instance_dir)
+        if wake_on_mission and jira_new > 0:
             return "mission"
         elapsed += time.monotonic() - t0
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1489,15 +1489,31 @@ def _run_iteration(
             "PR limit reached for all projects — waiting for reviews",
             f"PR limit reached — waiting for reviews ({time.strftime('%H:%M')})",
         ),
+        "branch_saturated_wait": lambda p: (
+            p.get("decision_reason") or "Project branch-saturated — waiting for reviews/merges",
+            f"Branch-saturated — waiting ({time.strftime('%H:%M')})",
+        ),
     }
     if action in _IDLE_WAIT_CONFIG:
         log_msg, status_msg = _IDLE_WAIT_CONFIG[action](plan)
         log("koan", log_msg)
         set_status(koan_root, status_msg)
+        # branch_saturated_wait: the pending missions ARE the blocker
+        # (the picked mission's project is over its PR limit), so waking
+        # on pending missions would just tight-loop back into the same
+        # blocked state. Wait the full interval for PR count to change.
+        wake_on_mission = action != "branch_saturated_wait"
         with protected_phase(status_msg):
-            wake = interruptible_sleep(interval, koan_root, instance)
+            wake = interruptible_sleep(
+                interval, koan_root, instance,
+                wake_on_mission=wake_on_mission,
+            )
         if wake == "mission":
             log("koan", f"New mission detected during {action} — waking up")
+        # branch_saturated_wait is a human-unblock state (review PRs),
+        # not an idle state — don't accumulate toward auto-pause.
+        if action == "branch_saturated_wait":
+            return False  # blocked on external action — not idle, not productive
         return "idle"  # idle wait — not productive, trackable
 
     if action == "wait_pause":

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -450,6 +450,21 @@ def _notify(instance: str, message: str):
         log("error", f"Notification failed: {e}")
 
 
+def _notify_raw(instance: str, message: str):
+    """Send a notification straight to Telegram, skipping the Claude-CLI
+    personality reformatter (notify.format_and_send → format_outbox.
+    format_message). Use this for terse status updates (startup progress,
+    auto-update restarts) where the verbatim text and emoji matter and the
+    extra Claude CLI call would defeat the point. send_telegram still
+    handles priority filtering, flood protection, and retries.
+    """
+    try:
+        from app.notify import send_telegram
+        send_telegram(message)
+    except Exception as e:
+        log("error", f"Raw notification failed: {e}")
+
+
 def _notify_mission_end(
     instance: str,
     project_name: str,
@@ -1390,7 +1405,7 @@ def _run_iteration(
     # so plan_iteration() sees them immediately instead of waiting for sleep)
     log("koan", "Checking GitHub notifications...")
     if is_first_iteration:
-        _notify(instance, "🔍 Scanning GitHub notifications (cold start, may take ~1 min)...")
+        _notify_raw(instance, "🔍 Scanning GitHub notifications (cold start, may take ~1 min)...")
     from app.loop_manager import process_github_notifications
     gh_missions = 0
     try:
@@ -1407,9 +1422,9 @@ def _run_iteration(
     log("koan", "Checking Jira notifications...")
     if is_first_iteration:
         if gh_missions > 0:
-            _notify(instance, f"📋 GitHub: {gh_missions} new mission(s) queued. Scanning Jira...")
+            _notify_raw(instance, f"📋 GitHub: {gh_missions} new mission(s) queued. Scanning Jira...")
         else:
-            _notify(instance, "📋 GitHub: scanned, no new missions. Scanning Jira...")
+            _notify_raw(instance, "📋 GitHub: scanned, no new missions. Scanning Jira...")
     from app.loop_manager import process_jira_notifications
     jira_missions = 0
     try:
@@ -1423,9 +1438,9 @@ def _run_iteration(
 
     if is_first_iteration:
         if jira_missions > 0:
-            _notify(instance, f"🎯 Jira: {jira_missions} new mission(s) queued. Picking first mission from queue...")
+            _notify_raw(instance, f"🎯 Jira: {jira_missions} new mission(s) queued. Picking first mission from queue...")
         else:
-            _notify(instance, "🎯 Notifications clear. Picking first mission from queue...")
+            _notify_raw(instance, "🎯 Notifications clear. Picking first mission from queue...")
 
     # Plan iteration (delegated to iteration_manager)
     log("koan", "Planning iteration...")

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1378,10 +1378,21 @@ def _run_iteration(
         if valid:
             projects = valid
 
+    # Per-phase Telegram visibility for the first iteration only. After
+    # process start or /resume, count is 0 and the first iteration runs
+    # several slow steps (GH cold-start, Jira scan, plan_iteration) that
+    # together take ~30-90s before any mission notification fires. Surface
+    # progress to Telegram so the human knows what's happening. count>=1
+    # iterations stay quiet to avoid steady-state spam.
+    is_first_iteration = (count == 0)
+
     # Check GitHub notifications before planning (converts @mentions to missions
     # so plan_iteration() sees them immediately instead of waiting for sleep)
     log("koan", "Checking GitHub notifications...")
+    if is_first_iteration:
+        _notify(instance, "🔍 Scanning GitHub notifications (cold start, may take ~1 min)...")
     from app.loop_manager import process_github_notifications
+    gh_missions = 0
     try:
         gh_missions = process_github_notifications(koan_root, instance)
         if gh_missions > 0:
@@ -1394,7 +1405,13 @@ def _run_iteration(
     # Check Jira notifications before planning (converts @mentions to missions
     # so plan_iteration() sees them immediately instead of waiting for sleep)
     log("koan", "Checking Jira notifications...")
+    if is_first_iteration:
+        if gh_missions > 0:
+            _notify(instance, f"📋 GitHub: {gh_missions} new mission(s) queued. Scanning Jira...")
+        else:
+            _notify(instance, "📋 GitHub: scanned, no new missions. Scanning Jira...")
     from app.loop_manager import process_jira_notifications
+    jira_missions = 0
     try:
         jira_missions = process_jira_notifications(koan_root, instance)
         if jira_missions > 0:
@@ -1403,6 +1420,12 @@ def _run_iteration(
             log("koan", "No new Jira notifications")
     except Exception as e:
         log("error", f"Pre-iteration Jira notification check failed: {e}")
+
+    if is_first_iteration:
+        if jira_missions > 0:
+            _notify(instance, f"🎯 Jira: {jira_missions} new mission(s) queued. Picking first mission from queue...")
+        else:
+            _notify(instance, "🎯 Notifications clear. Picking first mission from queue...")
 
     # Plan iteration (delegated to iteration_manager)
     log("koan", "Planning iteration...")

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -429,7 +429,7 @@ def run_startup(koan_root: str, instance: str, projects: list):
     log("init", f"Starting. Max runs: {max_runs}, interval: {interval}s")
 
     # Import status/notify helpers lazily from run
-    from app.run import set_status, _build_startup_status, _notify
+    from app.run import set_status, _build_startup_status, _notify, _notify_raw
 
     project_list = "\n".join(f"  • {n}" for n, _ in sorted(projects))
     current_project = projects[0][0] if projects else "none"
@@ -450,7 +450,9 @@ def run_startup(koan_root: str, instance: str, projects: list):
     if updated:
         # Restart signal has been set — notify so the human knows the agent
         # is restarting under newer code, then exit to let wrapper restart us.
-        _notify(instance, "🔄 Auto-update pulled new commits — restarting under updated code...")
+        # Use _notify_raw so the verbatim text + 🔄 marker survive (skipping
+        # the Claude-CLI personality reformatter).
+        _notify_raw(instance, "🔄 Auto-update pulled new commits — restarting under updated code...")
         import sys
         from app.restart_manager import RESTART_EXIT_CODE
         sys.exit(RESTART_EXIT_CODE)
@@ -458,13 +460,15 @@ def run_startup(koan_root: str, instance: str, projects: list):
     # Daily report
     _safe_run("Daily report", run_daily_report)
 
-    _notify(instance, "🌅 Running morning ritual (Claude CLI, up to ~90s)...")
+    # Startup-status pings use _notify_raw so the 🌅/⚠️ markers and exact
+    # wording reach Telegram intact (no Claude CLI rewrite).
+    _notify_raw(instance, "🌅 Running morning ritual (Claude CLI, up to ~90s)...")
     with protected_phase("Morning ritual"):
         ritual_ok = _safe_run("Morning ritual", run_morning_ritual, instance)
     if ritual_ok:
-        _notify(instance, "🌅 Morning ritual complete — preparing first iteration.")
+        _notify_raw(instance, "🌅 Morning ritual complete — preparing first iteration.")
     else:
-        _notify(instance, "⚠️ Morning ritual skipped/failed — preparing first iteration anyway.")
+        _notify_raw(instance, "⚠️ Morning ritual skipped/failed — preparing first iteration anyway.")
 
     # Initialize hook system and fire session_start
     from app.hooks import fire_hook, init_hooks

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -344,11 +344,11 @@ def check_auto_update(koan_root: str, instance: str) -> bool:
     return perform_auto_update(koan_root, instance)
 
 
-def run_morning_ritual(instance: str):
-    """Execute the morning ritual."""
+def run_morning_ritual(instance: str) -> bool:
+    """Execute the morning ritual. Returns True on success, False otherwise."""
     log("init", "Running morning ritual...")
     from app.rituals import run_ritual
-    run_ritual("morning", Path(instance))
+    return run_ritual("morning", Path(instance))
 
 
 # ---------------------------------------------------------------------------
@@ -448,7 +448,9 @@ def run_startup(koan_root: str, instance: str, projects: list):
     # Auto-update check (before daily report / morning ritual)
     updated = _safe_run("Auto-update check", check_auto_update, koan_root, instance)
     if updated:
-        # Restart signal has been set — exit to let wrapper restart us
+        # Restart signal has been set — notify so the human knows the agent
+        # is restarting under newer code, then exit to let wrapper restart us.
+        _notify(instance, "🔄 Auto-update pulled new commits — restarting under updated code...")
         import sys
         from app.restart_manager import RESTART_EXIT_CODE
         sys.exit(RESTART_EXIT_CODE)
@@ -456,8 +458,13 @@ def run_startup(koan_root: str, instance: str, projects: list):
     # Daily report
     _safe_run("Daily report", run_daily_report)
 
+    _notify(instance, "🌅 Running morning ritual (Claude CLI, up to ~90s)...")
     with protected_phase("Morning ritual"):
-        _safe_run("Morning ritual", run_morning_ritual, instance)
+        ritual_ok = _safe_run("Morning ritual", run_morning_ritual, instance)
+    if ritual_ok:
+        _notify(instance, "🌅 Morning ritual complete — preparing first iteration.")
+    else:
+        _notify(instance, "⚠️ Morning ritual skipped/failed — preparing first iteration anyway.")
 
     # Initialize hook system and fire session_start
     from app.hooks import fire_hook, init_hooks

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -2373,37 +2373,6 @@ class TestPlanIterationBranchSaturation:
         assert result["action"] == "branch_saturated_wait"
         assert "Branch limit" in result["decision_reason"]
 
-    @patch("app.branch_limiter.count_pending_branches", return_value=10)
-    @patch("app.pick_mission.pick_mission", return_value="koan:fix a bug")
-    @patch("app.usage_estimator.cmd_refresh")
-    def test_mission_blocked_when_branch_saturated(
-        self, mock_refresh, mock_pick, mock_count,
-        instance_dir, koan_root, usage_state,
-    ):
-        """Mission is skipped when project is branch-saturated."""
-        (koan_root / "projects.yaml").write_text("""
-projects:
-  koan:
-    path: /path/to/koan
-    max_pending_branches: 5
-""")
-
-        usage_md = instance_dir / "usage.md"
-        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
-
-        result = plan_iteration(
-            instance_dir=str(instance_dir),
-            koan_root=str(koan_root),
-            run_num=2,
-            count=1,
-            projects=PROJECTS_LIST,
-            last_project="koan",
-            usage_state_path=str(usage_state),
-        )
-
-        assert result["action"] == "branch_saturated_wait"
-        assert result["project_name"] == "koan"
-
     @patch("app.branch_limiter.count_pending_branches", return_value=3)
     @patch("app.pick_mission.pick_mission", return_value="koan:fix a bug")
     @patch("app.usage_estimator.cmd_refresh")
@@ -2434,6 +2403,48 @@ projects:
 
         assert result["action"] == "mission"
         assert result["project_name"] == "koan"
+
+    @patch("app.branch_limiter.count_pending_branches", return_value=50)
+    @patch("app.pick_mission.pick_mission", return_value="koan:fix a bug")
+    @patch("app.usage_estimator.cmd_refresh")
+    def test_manual_mission_runs_despite_branch_saturation(
+        self, mock_refresh, mock_pick, mock_count,
+        instance_dir, koan_root, usage_state,
+    ):
+        """max_pending_branches is a self-throttle for autonomous exploration
+        only — explicit missions in missions.md must run regardless of how
+        many open PRs/unmerged branches the project has.
+
+        Regression: previously the picker post-check (commit 5fd621c) and
+        the saturated-projects loop (2b753ec) both returned
+        branch_saturated_wait for a mission whose project was over the limit.
+        A human queuing work should never be blocked by the agent's own
+        throttle.
+        """
+        (koan_root / "projects.yaml").write_text("""
+projects:
+  koan:
+    path: /path/to/koan
+    max_pending_branches: 5
+""")
+
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        # 50 >> 5 limit — but mission is manual, so it proceeds.
+        assert result["action"] == "mission"
+        assert result["project_name"] == "koan"
+        assert result["mission_title"] == "fix a bug"
 
 
 # === Tests: CLI interface ===

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -479,6 +479,33 @@ class TestInterruptibleSleep:
         )
         assert result == "mission"
 
+    def test_wake_on_mission_false_ignores_pending(self, tmp_path):
+        """With wake_on_mission=False, pending missions must NOT wake the sleep.
+
+        Used by branch_saturated_wait: the pending missions are the blocker, so
+        waking on them would tight-loop back into the same blocked state.
+        """
+        from app.loop_manager import interruptible_sleep
+
+        koan_root = str(tmp_path / "root")
+        instance = str(tmp_path / "instance")
+        os.makedirs(koan_root, exist_ok=True)
+        os.makedirs(instance, exist_ok=True)
+
+        missions_md = Path(instance) / "missions.md"
+        missions_md.write_text("## Pending\n\n- Blocked mission\n\n## Done\n")
+
+        # Very short interval so the test completes quickly but still goes
+        # through the full sleep cycle without returning "mission".
+        result = interruptible_sleep(
+            interval=1,
+            koan_root=koan_root,
+            instance_dir=instance,
+            check_interval=1,
+            wake_on_mission=False,
+        )
+        assert result == "timeout"
+
     def test_priority_stop_over_pause(self, tmp_path):
         from app.loop_manager import interruptible_sleep
 

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -2774,13 +2774,15 @@ class TestRunIterationFirstIterationNotifications:
         }
 
     @patch("app.run.plan_iteration")
-    @patch("app.run._notify")
+    @patch("app.run._notify_raw")
     @patch("app.loop_manager.process_jira_notifications", return_value=0)
     @patch("app.loop_manager.process_github_notifications", return_value=0)
     def test_first_iteration_emits_phase_notifications(
-        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
     ):
-        """count=0: scanning-GH, scanning-Jira, picking-mission Telegrams all fire."""
+        """count=0: scanning-GH, scanning-Jira, picking-mission Telegrams all
+        fire via _notify_raw (verbatim, no Claude-CLI rewrite).
+        """
         from app.run import _run_iteration
         mock_plan.return_value = self._stop_plan(koan_root)
         instance = str(koan_root / "instance")
@@ -2792,18 +2794,18 @@ class TestRunIterationFirstIterationNotifications:
                 count=0, max_runs=5, interval=10, git_sync_interval=5,
             )
 
-        messages = [c.args[1] for c in mock_notify.call_args_list]
+        messages = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(messages)
         assert "Scanning GitHub notifications" in joined
         assert "Scanning Jira" in joined
         assert "Picking first mission" in joined
 
     @patch("app.run.plan_iteration")
-    @patch("app.run._notify")
+    @patch("app.run._notify_raw")
     @patch("app.loop_manager.process_jira_notifications", return_value=0)
     @patch("app.loop_manager.process_github_notifications", return_value=0)
     def test_subsequent_iteration_stays_quiet(
-        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
     ):
         """count>=1: no startup Telegrams. Steady-state must not spam."""
         from app.run import _run_iteration
@@ -2817,18 +2819,18 @@ class TestRunIterationFirstIterationNotifications:
                 count=1, max_runs=5, interval=10, git_sync_interval=5,
             )
 
-        messages = [c.args[1] for c in mock_notify.call_args_list]
+        messages = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(messages)
         assert "Scanning GitHub" not in joined
         assert "Scanning Jira" not in joined
         assert "Picking first mission" not in joined
 
     @patch("app.run.plan_iteration")
-    @patch("app.run._notify")
+    @patch("app.run._notify_raw")
     @patch("app.loop_manager.process_jira_notifications", return_value=2)
     @patch("app.loop_manager.process_github_notifications", return_value=3)
     def test_first_iteration_reports_mission_counts(
-        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
     ):
         """When notifications create missions, the count surfaces in the
         startup messages so the human knows new work was queued.
@@ -2844,10 +2846,67 @@ class TestRunIterationFirstIterationNotifications:
                 count=0, max_runs=5, interval=10, git_sync_interval=5,
             )
 
-        messages = [c.args[1] for c in mock_notify.call_args_list]
+        messages = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(messages)
         assert "GitHub: 3 new mission" in joined
         assert "Jira: 2 new mission" in joined
+
+    @patch("app.run.plan_iteration")
+    @patch("app.notify.send_telegram")
+    @patch("app.run._notify")
+    @patch("app.loop_manager.process_jira_notifications", return_value=0)
+    @patch("app.loop_manager.process_github_notifications", return_value=0)
+    def test_first_iteration_status_messages_bypass_formatter(
+        self, mock_gh, mock_jira, mock_notify, mock_send, mock_plan, koan_root,
+    ):
+        """Startup-status notifications must NOT route through _notify (and
+        therefore NOT trigger the Claude-CLI formatter). They must reach
+        send_telegram directly via _notify_raw, with verbatim text + emoji.
+        """
+        from app.run import _run_iteration
+        mock_plan.return_value = self._stop_plan(koan_root)
+        instance = str(koan_root / "instance")
+
+        with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
+            )
+
+        # _notify (formatter path) must not have received the status pings.
+        notify_msgs = " | ".join(c.args[1] for c in mock_notify.call_args_list)
+        assert "Scanning GitHub notifications" not in notify_msgs
+        assert "Scanning Jira" not in notify_msgs
+        assert "Picking first mission" not in notify_msgs
+
+        # send_telegram (raw path) received them verbatim, including emojis.
+        send_msgs = " | ".join(c.args[0] for c in mock_send.call_args_list)
+        assert "🔍 Scanning GitHub notifications" in send_msgs
+        assert "📋 GitHub: scanned, no new missions. Scanning Jira..." in send_msgs
+        assert "🎯 Notifications clear" in send_msgs
+
+
+class TestNotifyRaw:
+    """_notify_raw bypasses the Claude-CLI formatter and sends straight to
+    Telegram. Used for terse status pings where verbatim text matters.
+    """
+
+    @patch("app.notify.send_telegram")
+    def test_calls_send_telegram_directly(self, mock_send):
+        from app.run import _notify_raw
+        _notify_raw("/tmp/instance", "🔍 verbatim test")
+        mock_send.assert_called_once_with("🔍 verbatim test")
+
+    @patch("app.run.log")
+    @patch("app.notify.send_telegram", side_effect=RuntimeError("boom"))
+    def test_swallows_send_errors(self, mock_send, mock_log):
+        """Telegram failures must not crash the run loop; same contract as _notify."""
+        from app.run import _notify_raw
+        _notify_raw("/tmp/instance", "test")
+        # Error logged, no exception propagated.
+        assert any("Raw notification failed" in str(c)
+                   for c in mock_log.call_args_list)
 
 
 class TestRunIterationProjectRefresh:

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -1816,8 +1816,11 @@ class TestIdleWaitConfig:
             count=0, max_runs=10, interval=60, git_sync_interval=5,
         )
 
-        # Verify sleep was called with the interval
-        mock_sleep.assert_called_once_with(60, str(tmp_path), instance)
+        # Verify sleep was called with the interval and wakes on missions
+        # (default behaviour for non-branch-saturated waits).
+        mock_sleep.assert_called_once_with(
+            60, str(tmp_path), instance, wake_on_mission=True,
+        )
         # Verify status was set with focus info
         status_calls = [c for c in mock_status.call_args_list if "Focus mode" in str(c)]
         assert len(status_calls) >= 1
@@ -1890,6 +1893,56 @@ class TestIdleWaitConfig:
         mock_sleep.assert_called_once()
         status_calls = [c for c in mock_status.call_args_list if "PR limit" in str(c)]
         assert len(status_calls) >= 1
+
+    @patch("app.run.run_claude_task")
+    @patch("app.run.interruptible_sleep", return_value=None)
+    @patch("app.run.set_status")
+    @patch("app.run.log")
+    @patch("app.run.plan_iteration")
+    def test_branch_saturated_wait_action(
+        self, mock_plan, mock_log, mock_status, mock_sleep, mock_cli, tmp_path,
+    ):
+        """branch_saturated_wait must sleep without waking on pending missions,
+        not launch the CLI, and return non-idle so auto-pause is not tripped.
+
+        Regressions covered:
+          - Action fell through _IDLE_WAIT_CONFIG → autonomous CLI ran anyway.
+          - interruptible_sleep woke immediately on pending missions (the very
+            missions that caused the saturation), producing a 1-iter/sec tight
+            loop that burned through MAX_CONSECUTIVE_IDLE in seconds and
+            triggered bogus "Idle for 150 min — auto-pausing".
+        """
+        from app.run import _run_iteration
+        mock_plan.return_value = self._make_plan(
+            "branch_saturated_wait",
+            decision_reason="Project 'koan' at branch limit (36/10) — mission stays Pending",
+        )
+        instance = str(tmp_path / "instance")
+        os.makedirs(instance, exist_ok=True)
+        (tmp_path / ".koan-project").write_text("koan")
+
+        result = _run_iteration(
+            koan_root=str(tmp_path),
+            instance=instance,
+            projects=[("koan", "/tmp/koan")],
+            count=0, max_runs=10, interval=60, git_sync_interval=5,
+        )
+
+        # Slept once with wake_on_mission=False so the pending (blocked)
+        # missions don't short-circuit the wait into a tight loop.
+        mock_sleep.assert_called_once_with(
+            60, str(tmp_path), instance, wake_on_mission=False,
+        )
+        # Status contains "Branch-saturated", not "DEEP"
+        status_calls = [c for c in mock_status.call_args_list if "Branch-saturated" in str(c)]
+        assert len(status_calls) >= 1
+        assert not any("DEEP" in str(c) for c in mock_status.call_args_list)
+        # CLI must NOT be launched
+        mock_cli.assert_not_called()
+        # Must not count as "idle" — branch saturation is blocked-on-human,
+        # not truly idle. Returning "idle" would accumulate consecutive_idle
+        # and trigger the 150-min auto-pause path.
+        assert result != "idle"
 
     @patch("app.run.interruptible_sleep", return_value="mission")
     @patch("app.run.set_status")

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -2606,9 +2606,13 @@ class TestRunIterationErrorAction:
 
         # Mission moved to Failed
         mock_update.assert_called_once_with(instance, "do stuff", failed=True)
-        # User notified
-        mock_notify.assert_called_once()
-        assert "Unknown project: foo" in mock_notify.call_args[0][1]
+        # User notified about the error (filter out first-iteration startup
+        # notifications which can also fire when count=0).
+        error_msgs = [
+            c for c in mock_notify.call_args_list
+            if "Unknown project: foo" in c.args[1]
+        ]
+        assert len(error_msgs) == 1
         # Instance committed
         mock_commit.assert_called_once_with(instance)
 
@@ -2652,9 +2656,13 @@ class TestRunIterationErrorAction:
         mock_update.assert_not_called()
         # No instance commit
         mock_commit.assert_not_called()
-        # Notification sent
-        mock_notify.assert_called_once()
-        assert "Iteration error" in mock_notify.call_args[0][1]
+        # Iteration-error notification sent (filter out first-iteration
+        # startup notifications which can also fire when count=0).
+        error_msgs = [
+            c for c in mock_notify.call_args_list
+            if "Iteration error" in c.args[1]
+        ]
+        assert len(error_msgs) == 1
 
 
 # ---------------------------------------------------------------------------
@@ -2741,6 +2749,105 @@ class TestRunIterationGitHubPreCheck:
                 interval=10,
                 git_sync_interval=5,
             )
+
+
+class TestRunIterationFirstIterationNotifications:
+    """Per-phase Telegram visibility for the first iteration after startup
+    or /resume. count==0 fires GH/Jira/picking notifications; count>=1 stays
+    quiet to avoid steady-state spam.
+    """
+
+    @staticmethod
+    def _stop_plan(koan_root):
+        return {
+            "action": "error",
+            "error": "test-stop",
+            "project_name": "test",
+            "project_path": str(koan_root),
+            "mission_title": "",
+            "autonomous_mode": "implement",
+            "focus_area": "",
+            "available_pct": 50,
+            "decision_reason": "Default",
+            "display_lines": [],
+            "recurring_injected": [],
+        }
+
+    @patch("app.run.plan_iteration")
+    @patch("app.run._notify")
+    @patch("app.loop_manager.process_jira_notifications", return_value=0)
+    @patch("app.loop_manager.process_github_notifications", return_value=0)
+    def test_first_iteration_emits_phase_notifications(
+        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+    ):
+        """count=0: scanning-GH, scanning-Jira, picking-mission Telegrams all fire."""
+        from app.run import _run_iteration
+        mock_plan.return_value = self._stop_plan(koan_root)
+        instance = str(koan_root / "instance")
+
+        with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
+            )
+
+        messages = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(messages)
+        assert "Scanning GitHub notifications" in joined
+        assert "Scanning Jira" in joined
+        assert "Picking first mission" in joined
+
+    @patch("app.run.plan_iteration")
+    @patch("app.run._notify")
+    @patch("app.loop_manager.process_jira_notifications", return_value=0)
+    @patch("app.loop_manager.process_github_notifications", return_value=0)
+    def test_subsequent_iteration_stays_quiet(
+        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+    ):
+        """count>=1: no startup Telegrams. Steady-state must not spam."""
+        from app.run import _run_iteration
+        mock_plan.return_value = self._stop_plan(koan_root)
+        instance = str(koan_root / "instance")
+
+        with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=1, max_runs=5, interval=10, git_sync_interval=5,
+            )
+
+        messages = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(messages)
+        assert "Scanning GitHub" not in joined
+        assert "Scanning Jira" not in joined
+        assert "Picking first mission" not in joined
+
+    @patch("app.run.plan_iteration")
+    @patch("app.run._notify")
+    @patch("app.loop_manager.process_jira_notifications", return_value=2)
+    @patch("app.loop_manager.process_github_notifications", return_value=3)
+    def test_first_iteration_reports_mission_counts(
+        self, mock_gh, mock_jira, mock_notify, mock_plan, koan_root,
+    ):
+        """When notifications create missions, the count surfaces in the
+        startup messages so the human knows new work was queued.
+        """
+        from app.run import _run_iteration
+        mock_plan.return_value = self._stop_plan(koan_root)
+        instance = str(koan_root / "instance")
+
+        with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
+            )
+
+        messages = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(messages)
+        assert "GitHub: 3 new mission" in joined
+        assert "Jira: 2 new mission" in joined
 
 
 class TestRunIterationProjectRefresh:
@@ -5507,7 +5614,9 @@ class TestRunIterationPaths:
                 return_value=PrepResult(success=False, error="checkout failed")
             ),
         ) as mocks:
-            result = self._call(tmp_path)
+            # count>=1 — testing operational failure, not first-iteration
+            # behavior; avoids the startup-only Telegram notifications.
+            result = self._call(tmp_path, count=1)
             assert result is False
             mock_update.assert_called_once_with(
                 str(Path(tmp_path) / "instance"), title, failed=True
@@ -5525,7 +5634,7 @@ class TestRunIterationPaths:
             tmp_path, plan,
             prepare_project_branch=MagicMock(side_effect=RuntimeError("git broke")),
         ) as mocks:
-            result = self._call(tmp_path)
+            result = self._call(tmp_path, count=1)
             assert result is False
             mock_update.assert_called_once_with(
                 str(Path(tmp_path) / "instance"), title, failed=True

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -888,6 +888,7 @@ class TestRunStartupNotifications:
     @patch("app.startup_manager.run_morning_ritual", return_value=True)
     @patch("app.startup_manager.run_daily_report")
     @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify_raw")
     @patch("app.run._notify")
     @patch("app.run._build_startup_status", return_value="Active")
     @patch("app.run.set_status")
@@ -915,15 +916,15 @@ class TestRunStartupNotifications:
         mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
         mock_sanity, mock_memory, mock_history, mock_health,
         mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
-        mock_set_status, mock_build_status, mock_notify,
+        mock_set_status, mock_build_status, mock_notify, mock_notify_raw,
         mock_git_sync, mock_daily, mock_ritual,
     ):
         """When the morning ritual succeeds, both the start and complete
-        Telegram messages fire."""
+        Telegram messages fire via _notify_raw (verbatim, no formatter)."""
         from app.startup_manager import run_startup
         run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
 
-        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        msgs = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(msgs)
         assert "Running morning ritual" in joined
         assert "Morning ritual complete" in joined
@@ -932,6 +933,7 @@ class TestRunStartupNotifications:
     @patch("app.startup_manager.run_morning_ritual", return_value=False)
     @patch("app.startup_manager.run_daily_report")
     @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify_raw")
     @patch("app.run._notify")
     @patch("app.run._build_startup_status", return_value="Active")
     @patch("app.run.set_status")
@@ -959,7 +961,7 @@ class TestRunStartupNotifications:
         mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
         mock_sanity, mock_memory, mock_history, mock_health,
         mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
-        mock_set_status, mock_build_status, mock_notify,
+        mock_set_status, mock_build_status, mock_notify, mock_notify_raw,
         mock_git_sync, mock_daily, mock_ritual,
     ):
         """When the morning ritual returns False (failed/skipped), the user
@@ -967,7 +969,7 @@ class TestRunStartupNotifications:
         from app.startup_manager import run_startup
         run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
 
-        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        msgs = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(msgs)
         assert "skipped/failed" in joined
         assert "Morning ritual complete" not in joined
@@ -976,6 +978,7 @@ class TestRunStartupNotifications:
     @patch("app.startup_manager.run_morning_ritual", return_value=True)
     @patch("app.startup_manager.run_daily_report")
     @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify_raw")
     @patch("app.run._notify")
     @patch("app.run._build_startup_status", return_value="Active")
     @patch("app.run.set_status")
@@ -1003,11 +1006,11 @@ class TestRunStartupNotifications:
         mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
         mock_sanity, mock_memory, mock_history, mock_health,
         mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
-        mock_set_status, mock_build_status, mock_notify,
+        mock_set_status, mock_build_status, mock_notify, mock_notify_raw,
         mock_git_sync, mock_daily, mock_ritual, mock_auto_update,
     ):
         """When auto-update pulls new commits, the user is told the agent is
-        restarting under updated code before sys.exit fires.
+        restarting under updated code before sys.exit fires (via _notify_raw).
         """
         from app.startup_manager import run_startup
         from app.restart_manager import RESTART_EXIT_CODE
@@ -1016,6 +1019,6 @@ class TestRunStartupNotifications:
             run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
 
         assert exc.value.code == RESTART_EXIT_CODE
-        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        msgs = [c.args[1] for c in mock_notify_raw.call_args_list]
         joined = " | ".join(msgs)
         assert "Auto-update pulled new commits" in joined

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -589,6 +589,19 @@ class TestRunMorningRitual:
         out = capsys.readouterr().out
         assert "Running morning ritual" in out
 
+    @patch("app.rituals.run_ritual", return_value=True)
+    def test_returns_true_on_success(self, mock_ritual):
+        """run_morning_ritual passes through run_ritual's bool return so the
+        caller can choose between 'complete' and 'skipped/failed' messaging.
+        """
+        from app.startup_manager import run_morning_ritual
+        assert run_morning_ritual("/tmp/instance") is True
+
+    @patch("app.rituals.run_ritual", return_value=False)
+    def test_returns_false_on_failure(self, mock_ritual):
+        from app.startup_manager import run_morning_ritual
+        assert run_morning_ritual("/tmp/instance") is False
+
 
 # ---------------------------------------------------------------------------
 # Test: _safe_run
@@ -795,9 +808,16 @@ class TestRunStartup:
         # Should not raise IndexError
         result = run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
         assert result == (10, 60, "koan/")
-        # Verify notification was sent with "none" as current project
-        call_args = mock_notify.call_args[0]
-        assert "Current: none" in call_args[1]
+        # Verify the "starting" notification was sent with "none" as current
+        # project. Other notifications (morning ritual progress) also fire,
+        # so search across all calls rather than relying on call_args (most
+        # recent only).
+        starting_msgs = [
+            c.args[1] for c in mock_notify.call_args_list
+            if "Kōan starting" in c.args[1]
+        ]
+        assert len(starting_msgs) == 1
+        assert "Current: none" in starting_msgs[0]
 
     @patch("app.startup_manager.run_morning_ritual")
     @patch("app.startup_manager.run_daily_report")
@@ -845,4 +865,157 @@ class TestRunStartup:
         assert "GitHub auth failed" in out
         # Later steps still ran
         mock_git_sync.assert_called_once()
-        mock_notify.assert_called_once()
+        # Startup banner went out (plus per-phase morning-ritual notifications).
+        starting_msgs = [
+            c for c in mock_notify.call_args_list
+            if "Kōan starting" in c.args[1]
+        ]
+        assert len(starting_msgs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test: startup-only Telegram visibility (morning ritual + auto-update)
+# ---------------------------------------------------------------------------
+
+
+class TestRunStartupNotifications:
+    """Per-phase Telegram messages during the ~1-2 min startup window so the
+    user can see what's happening before the first mission picks up.
+    Steady-state notifications are unaffected (this is run_startup, which
+    only fires once per process).
+    """
+
+    @patch("app.startup_manager.run_morning_ritual", return_value=True)
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks")
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_morning_ritual_success_emits_start_and_complete(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual,
+    ):
+        """When the morning ritual succeeds, both the start and complete
+        Telegram messages fire."""
+        from app.startup_manager import run_startup
+        run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+
+        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(msgs)
+        assert "Running morning ritual" in joined
+        assert "Morning ritual complete" in joined
+        assert "skipped/failed" not in joined
+
+    @patch("app.startup_manager.run_morning_ritual", return_value=False)
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks")
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_morning_ritual_failure_emits_skipped_message(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual,
+    ):
+        """When the morning ritual returns False (failed/skipped), the user
+        gets an honest message rather than a misleading "complete"."""
+        from app.startup_manager import run_startup
+        run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+
+        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(msgs)
+        assert "skipped/failed" in joined
+        assert "Morning ritual complete" not in joined
+
+    @patch("app.startup_manager.check_auto_update", return_value=True)
+    @patch("app.startup_manager.run_morning_ritual", return_value=True)
+    @patch("app.startup_manager.run_daily_report")
+    @patch("app.startup_manager.run_git_sync")
+    @patch("app.run._notify")
+    @patch("app.run._build_startup_status", return_value="Active")
+    @patch("app.run.set_status")
+    @patch("app.startup_manager.setup_github_auth")
+    @patch("app.startup_manager.setup_git_identity")
+    @patch("app.startup_manager.handle_start_on_pause")
+    @patch("app.startup_manager.check_self_reflection")
+    @patch("app.startup_manager.check_health")
+    @patch("app.startup_manager.cleanup_mission_history")
+    @patch("app.startup_manager.cleanup_memory")
+    @patch("app.startup_manager.run_sanity_checks")
+    @patch("app.startup_manager.discover_workspace", return_value=[("proj1", "/p1")])
+    @patch("app.startup_manager.populate_github_urls")
+    @patch("app.startup_manager.run_migrations")
+    @patch("app.startup_manager.recover_crashed_missions")
+    @patch("app.banners.print_agent_banner")
+    @patch("app.utils.get_branch_prefix", return_value="koan/")
+    @patch("app.utils.get_cli_binary_for_shell", return_value="claude")
+    @patch("app.utils.get_interval_seconds", return_value=60)
+    @patch("app.utils.get_max_runs", return_value=10)
+    def test_auto_update_emits_restart_notification(
+        self,
+        mock_max_runs, mock_interval, mock_cli, mock_prefix,
+        mock_banner,
+        mock_recover, mock_migrate, mock_gh_urls, mock_workspace,
+        mock_sanity, mock_memory, mock_history, mock_health,
+        mock_reflection, mock_pause, mock_git_id, mock_gh_auth,
+        mock_set_status, mock_build_status, mock_notify,
+        mock_git_sync, mock_daily, mock_ritual, mock_auto_update,
+    ):
+        """When auto-update pulls new commits, the user is told the agent is
+        restarting under updated code before sys.exit fires.
+        """
+        from app.startup_manager import run_startup
+        from app.restart_manager import RESTART_EXIT_CODE
+
+        with pytest.raises(SystemExit) as exc:
+            run_startup("/tmp/koan", "/tmp/koan/instance", [("proj1", "/p1")])
+
+        assert exc.value.code == RESTART_EXIT_CODE
+        msgs = [c.args[1] for c in mock_notify.call_args_list]
+        joined = " | ".join(msgs)
+        assert "Auto-update pulled new commits" in joined

--- a/projects.example.yaml
+++ b/projects.example.yaml
@@ -88,13 +88,16 @@ defaults:
   # Default: 0 (unlimited)
   max_open_prs: 10
 
-  # Max pending branches — limit total unreviewed work per project.
-  # Counts the union of local unmerged koan/* branches and open PRs
-  # (deduplicated by branch name). When the limit is reached, both
-  # mission pickup AND exploration are blocked for this project until
-  # existing branches are reviewed/merged.
-  # More comprehensive than max_open_prs (which only gates exploration
-  # and only counts GitHub PRs).
+  # Max pending branches — limit total unreviewed work the agent will
+  # create via autonomous exploration. Counts the union of local unmerged
+  # <branch_prefix>/* branches and open PRs (deduplicated by branch
+  # name). When the limit is reached, autonomous exploration is paused
+  # for this project until existing branches are reviewed/merged.
+  # Explicit missions (queued in missions.md or via Jira/GitHub
+  # notifications) are never affected by this limit — it is a
+  # self-throttle for the agent, not a gate on human instructions.
+  # More comprehensive than max_open_prs because it also counts local
+  # unmerged branches, not just GitHub PRs.
   # Set to 0 for unlimited.
   # Default: 10
   max_pending_branches: 10


### PR DESCRIPTION
_IDLE_WAIT_CONFIG in run.py listed passive_wait, focus_wait, schedule_wait, exploration_wait, and pr_limit_wait — but not branch_saturated_wait. When iteration_manager returned that action (project at max_pending_branches limit), the dispatcher missed and the code fell through to launch Claude CLI in autonomous DEEP mode with an empty mission title.

Symptoms: .koan-status stuck at "Run N/80 — DEEP on <project>" while missions sat untouched in Pending, loop iterating every ~15s and burning budget on autonomous runs that failed fast against API 500s (check_pending_missions → skipping sleep amplified the tight loop).

Fix: add a branch_saturated_wait entry that surfaces the plan's decision_reason in logs and sets status to "Branch-saturated — waiting (HH:MM)". The action now sleeps via interruptible_sleep like its siblings, wakes on new missions, and does not invoke the CLI.

Add regression test test_branch_saturated_wait_action asserting the sleep path is taken, status does not contain "DEEP", and run_claude_task is never called.