### PR TITLE
fix: skip Jira startup notifications when not configured

### DIFF
--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1419,26 +1419,32 @@ def _run_iteration(
 
     # Check Jira notifications before planning (converts @mentions to missions
     # so plan_iteration() sees them immediately instead of waiting for sleep)
-    log("koan", "Checking Jira notifications...")
-    if is_first_iteration:
-        if gh_missions > 0:
-            _notify_raw(instance, f"📋 GitHub: {gh_missions} new mission(s) queued. Scanning Jira...")
-        else:
-            _notify_raw(instance, "📋 GitHub: scanned, no new missions. Scanning Jira...")
-    from app.loop_manager import process_jira_notifications
+    from app.jira_config import get_jira_enabled
+    from app.utils import load_config
+    jira_enabled = get_jira_enabled(load_config())
     jira_missions = 0
-    try:
-        jira_missions = process_jira_notifications(koan_root, instance)
-        if jira_missions > 0:
-            log("jira", f"Pre-iteration: {jira_missions} mission(s) created from Jira notifications")
-        else:
-            log("koan", "No new Jira notifications")
-    except Exception as e:
-        log("error", f"Pre-iteration Jira notification check failed: {e}")
+    if jira_enabled:
+        log("koan", "Checking Jira notifications...")
+        if is_first_iteration:
+            if gh_missions > 0:
+                _notify_raw(instance, f"📋 GitHub: {gh_missions} new mission(s) queued. Scanning Jira...")
+            else:
+                _notify_raw(instance, "📋 GitHub: scanned, no new missions. Scanning Jira...")
+        from app.loop_manager import process_jira_notifications
+        try:
+            jira_missions = process_jira_notifications(koan_root, instance)
+            if jira_missions > 0:
+                log("jira", f"Pre-iteration: {jira_missions} mission(s) created from Jira notifications")
+            else:
+                log("koan", "No new Jira notifications")
+        except Exception as e:
+            log("error", f"Pre-iteration Jira notification check failed: {e}")
 
     if is_first_iteration:
-        if jira_missions > 0:
+        if jira_enabled and jira_missions > 0:
             _notify_raw(instance, f"🎯 Jira: {jira_missions} new mission(s) queued. Picking first mission from queue...")
+        elif gh_missions > 0:
+            _notify_raw(instance, f"🎯 GitHub: {gh_missions} new mission(s) queued. Picking first mission from queue...")
         else:
             _notify_raw(instance, "🎯 Notifications clear. Picking first mission from queue...")
 

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -2774,12 +2774,13 @@ class TestRunIterationFirstIterationNotifications:
             "recurring_injected": [],
         }
 
+    @patch("app.jira_config.get_jira_enabled", return_value=True)
     @patch("app.run.plan_iteration")
     @patch("app.run._notify_raw")
     @patch("app.loop_manager.process_jira_notifications", return_value=0)
     @patch("app.loop_manager.process_github_notifications", return_value=0)
     def test_first_iteration_emits_phase_notifications(
-        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, mock_jira_enabled, koan_root,
     ):
         """count=0: scanning-GH, scanning-Jira, picking-mission Telegrams all
         fire via _notify_raw (verbatim, no Claude-CLI rewrite).
@@ -2826,12 +2827,38 @@ class TestRunIterationFirstIterationNotifications:
         assert "Scanning Jira" not in joined
         assert "Picking first mission" not in joined
 
+    @patch("app.jira_config.get_jira_enabled", return_value=False)
+    @patch("app.run.plan_iteration")
+    @patch("app.run._notify_raw")
+    @patch("app.loop_manager.process_github_notifications", return_value=0)
+    def test_first_iteration_skips_jira_when_disabled(
+        self, mock_gh, mock_notify_raw, mock_plan, mock_jira_enabled, koan_root,
+    ):
+        """When Jira is not configured, no Jira-related messages appear."""
+        from app.run import _run_iteration
+        mock_plan.return_value = self._stop_plan(koan_root)
+        instance = str(koan_root / "instance")
+
+        with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
+            )
+
+        messages = [c.args[1] for c in mock_notify_raw.call_args_list]
+        joined = " | ".join(messages)
+        assert "Jira" not in joined
+        assert "Scanning GitHub notifications" in joined
+        assert "Notifications clear" in joined
+
+    @patch("app.jira_config.get_jira_enabled", return_value=True)
     @patch("app.run.plan_iteration")
     @patch("app.run._notify_raw")
     @patch("app.loop_manager.process_jira_notifications", return_value=2)
     @patch("app.loop_manager.process_github_notifications", return_value=3)
     def test_first_iteration_reports_mission_counts(
-        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify_raw, mock_plan, mock_jira_enabled, koan_root,
     ):
         """When notifications create missions, the count surfaces in the
         startup messages so the human knows new work was queued.
@@ -2852,13 +2879,14 @@ class TestRunIterationFirstIterationNotifications:
         assert "GitHub: 3 new mission" in joined
         assert "Jira: 2 new mission" in joined
 
+    @patch("app.jira_config.get_jira_enabled", return_value=True)
     @patch("app.run.plan_iteration")
     @patch("app.notify.send_telegram")
     @patch("app.run._notify")
     @patch("app.loop_manager.process_jira_notifications", return_value=0)
     @patch("app.loop_manager.process_github_notifications", return_value=0)
     def test_first_iteration_status_messages_bypass_formatter(
-        self, mock_gh, mock_jira, mock_notify, mock_send, mock_plan, koan_root,
+        self, mock_gh, mock_jira, mock_notify, mock_send, mock_plan, mock_jira_enabled, koan_root,
     ):
         """Startup-status notifications must NOT route through _notify (and
         therefore NOT trigger the Claude-CLI formatter). They must reach


### PR DESCRIPTION
## Summary

Gate Jira-phase startup notifications behind `get_jira_enabled()` so cold starts don't announce "Scanning Jira..." when Jira is not configured. Reduces startup Telegram noise from 3 messages to 2 when Jira is disabled.

Closes https://github.com/Anantys-oss/koan/issues/1187

## Changes

- Gate Jira log line and `_notify_raw` calls in `run.py` behind `get_jira_enabled()`
- When Jira is disabled, GitHub summary flows directly into the final 🎯 message
- Add `test_first_iteration_skips_jira_when_disabled` test
- Update existing tests to mock `get_jira_enabled` for Jira-enabled scenarios

## Test plan

- Full test suite passes (11717 tests)
- New test verifies no Jira-related messages when Jira is disabled
- Existing tests verify Jira messages still appear when Jira is enabled

---
*Generated by Kōan /implement*