### PR TITLE
fix: load .env early in run.py so env vars reach Claude subprocesses

### DIFF
--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -698,6 +698,11 @@ def main_loop():
         log("error", "No instance/ directory found. Run: cp -r instance.example instance")
         sys.exit(1)
 
+    # Load .env so custom env vars (NOTION_API_KEY, SENTRY_ACCESS_TOKEN, etc.)
+    # are available to Claude subprocesses that inherit os.environ.
+    from app.utils import load_dotenv
+    load_dotenv()
+
     # Run pending data migrations (e.g. French→English header conversion)
     from app.migration_runner import run_pending_migrations
     applied = run_pending_migrations()


### PR DESCRIPTION
Custom env vars like NOTION_API_KEY and SENTRY_ACCESS_TOKEN were not
available to Claude CLI subprocesses because load_dotenv() was called
too late. Move it to main_loop() startup before any subprocess is spawned.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
