### PR TITLE
fix: stop cold-start Telegram flood on non-productive wake-ups (#1193)

### DIFF
--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -789,6 +789,8 @@ def main_loop():
                     count = 0
                     consecutive_errors = 0
                     consecutive_idle = 0
+                    global _startup_notified
+                    _startup_notified = False
                 continue
 
             # --- Iteration body (exception-protected) ---
@@ -1238,6 +1240,13 @@ _MISSION_RETRY_DELAY = 10  # seconds
 _last_mission_timed_out = False
 _last_mission_aborted = False
 
+# Tracks whether the cold-start Telegram burst (GH scan / Jira scan / first
+# mission pick) has already fired since process start or /resume. Decoupled
+# from the productive-run `count` because idle/passive/quota/sleep-wake paths
+# leave `count` at 0, which previously caused the startup trio to re-fire on
+# every non-productive wake-up (issue #1193).
+_startup_notified = False
+
 
 def _get_git_head(project_path: str) -> str:
     """Get current git HEAD SHA for retry safety check."""
@@ -1399,7 +1408,9 @@ def _run_iteration(
     # together take ~30-90s before any mission notification fires. Surface
     # progress to Telegram so the human knows what's happening. count>=1
     # iterations stay quiet to avoid steady-state spam.
-    is_first_iteration = (count == 0)
+    global _startup_notified
+    is_first_iteration = not _startup_notified
+    _startup_notified = True
 
     # Check GitHub notifications before planning (converts @mentions to missions
     # so plan_iteration() sees them immediately instead of waiting for sleep)

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -2774,6 +2774,13 @@ class TestRunIterationFirstIterationNotifications:
             "recurring_injected": [],
         }
 
+    @pytest.fixture(autouse=True)
+    def _reset_startup_flag(self):
+        import app.run as run_mod
+        run_mod._startup_notified = False
+        yield
+        run_mod._startup_notified = False
+
     @patch("app.jira_config.get_jira_enabled", return_value=True)
     @patch("app.run.plan_iteration")
     @patch("app.run._notify_raw")
@@ -2809,7 +2816,10 @@ class TestRunIterationFirstIterationNotifications:
     def test_subsequent_iteration_stays_quiet(
         self, mock_gh, mock_jira, mock_notify_raw, mock_plan, koan_root,
     ):
-        """count>=1: no startup Telegrams. Steady-state must not spam."""
+        """After the first iteration, the startup trio must not re-fire —
+        even when count stays 0 (non-productive idle/passive wake loop,
+        regression test for #1193).
+        """
         from app.run import _run_iteration
         mock_plan.return_value = self._stop_plan(koan_root)
         instance = str(koan_root / "instance")
@@ -2818,7 +2828,15 @@ class TestRunIterationFirstIterationNotifications:
             _run_iteration(
                 koan_root=str(koan_root), instance=instance,
                 projects=[("test", str(koan_root))],
-                count=1, max_runs=5, interval=10, git_sync_interval=5,
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
+            )
+            mock_notify_raw.reset_mock()
+            # Simulate a non-productive wake-up: count still 0 because the
+            # previous iteration was idle/passive, not a productive mission.
+            _run_iteration(
+                koan_root=str(koan_root), instance=instance,
+                projects=[("test", str(koan_root))],
+                count=0, max_runs=5, interval=10, git_sync_interval=5,
             )
 
         messages = [c.args[1] for c in mock_notify_raw.call_args_list]


### PR DESCRIPTION
Closes #1193.

`is_first_iteration` in `_run_iteration` was derived from `count == 0`, but `count` only increments on **productive** runs. Idle, passive, quota-wait and sleep-wake paths all leave `count` at 0, so the GH/Jira/pick-mission startup trio re-fired on every wake-up — flooding Telegram.

## Fix

- Decouple startup-burst-already-fired from productive-run `count` via a module-level `_startup_notified` flag in `koan/app/run.py`.
- Flip to `True` after the first `_run_iteration` call, regardless of outcome.
- Reset to `False` only on genuine cold starts: process start (natural, module import) and `/resume` from pause (alongside the existing `count = 0` reset).

## Test plan

- Existing TestRunIterationFirstIterationNotifications suite still passes (5/5).
- New regression path in `test_subsequent_iteration_stays_quiet`: two back-to-back `_run_iteration` calls with `count=0` — asserts the second emits no startup messages (the exact #1193 scenario).
- Full `koan/tests/test_run.py` passes (315/315).