### PR TITLE
feat: add pause/resume, day-of-week filter, and status display to recurring missions

### DIFF
--- a/koan/app/recurring.py
+++ b/koan/app/recurring.py
@@ -25,6 +25,12 @@ The optional "at" field (e.g. "20:00") restricts when the mission fires:
   - daily: fires once per day, but only at or after the specified time
   - weekly: fires once per week, but only at or after the specified time
   - hourly: "at" is ignored (hourly already fires every hour)
+
+The optional "days" field restricts which days the mission fires:
+  - "weekdays" — Monday through Friday
+  - "weekends" — Saturday and Sunday
+  - "mon,wed,fri" — specific days (3-letter abbreviations, comma-separated)
+  - null/absent — fires every day (default)
 """
 
 import fcntl
@@ -47,6 +53,148 @@ import re
 _AT_TIME_RE = re.compile(r"^(\d{1,2}):(\d{2})\s+")
 # Regex for parsing interval strings like "5m", "2h", "1h30m", "90s"
 _INTERVAL_RE = re.compile(r"^(?:(\d+)h)?(?:(\d+)m)?(?:(\d+)s)?$")
+
+# Day-of-week abbreviations (Python weekday: 0=Monday)
+_DAY_ABBREVS = ("mon", "tue", "wed", "thu", "fri", "sat", "sun")
+_WEEKDAYS = {"mon", "tue", "wed", "thu", "fri"}
+_WEEKENDS = {"sat", "sun"}
+
+
+_FREQ_ORDER = {"every": 0, "hourly": 1, "daily": 2, "weekly": 3}
+
+
+def _sorted_missions(missions: List[Dict]) -> List[Dict]:
+    """Return missions sorted by frequency, matching the display order in /recurring."""
+    return sorted(missions, key=lambda m: _FREQ_ORDER.get(m["frequency"], 99))
+
+
+def _resolve_target(missions: List[Dict], identifier: str) -> Dict:
+    """Resolve a mission by number (1-indexed, display order) or keyword.
+
+    Numbers match the sorted display order shown by /recurring.
+    Keywords match against mission text (case-insensitive substring).
+
+    Raises:
+        ValueError: If identifier doesn't match any mission.
+    """
+    if not missions:
+        raise ValueError("No recurring missions configured.")
+
+    if identifier.isdigit():
+        sorted_list = _sorted_missions(missions)
+        idx = int(identifier) - 1
+        if idx < 0 or idx >= len(sorted_list):
+            raise ValueError(
+                f"Invalid number: {identifier}. "
+                f"Valid range: 1-{len(sorted_list)}"
+            )
+        return sorted_list[idx]
+
+    matches = [
+        m for m in missions
+        if identifier.lower() in m["text"].lower()
+    ]
+    if not matches:
+        raise ValueError(f"No recurring mission matching '{identifier}'.")
+    if len(matches) > 1:
+        raise ValueError(
+            f"Multiple matches for '{identifier}'. Be more specific or use a number."
+        )
+    return matches[0]
+
+
+def parse_days(text: str) -> str:
+    """Parse and validate a days-of-week specification.
+
+    Accepts:
+        "weekdays" — Monday through Friday
+        "weekends" — Saturday and Sunday
+        "mon,wed,fri" — specific day abbreviations (comma-separated)
+
+    Returns:
+        Normalized string (e.g. "weekdays", "weekends", "mon,wed,fri").
+
+    Raises:
+        ValueError: If any day abbreviation is invalid.
+    """
+    text = text.strip().lower()
+    if text in ("weekdays", "weekends"):
+        return text
+    days = [d.strip() for d in text.split(",") if d.strip()]
+    for d in days:
+        if d not in _DAY_ABBREVS:
+            raise ValueError(
+                f"Invalid day: '{d}'. Use 3-letter abbreviations: "
+                f"{', '.join(_DAY_ABBREVS)}, or 'weekdays'/'weekends'."
+            )
+    return ",".join(days)
+
+
+def _matches_day(days: Optional[str], now: datetime) -> bool:
+    """Check if the current day matches the days-of-week filter.
+
+    Returns True if no filter is set (always eligible).
+    """
+    if not days:
+        return True
+    today = _DAY_ABBREVS[now.weekday()]
+    if days == "weekdays":
+        return today in _WEEKDAYS
+    if days == "weekends":
+        return today in _WEEKENDS
+    allowed = {d.strip() for d in days.split(",")}
+    return today in allowed
+
+
+def toggle_recurring(recurring_path: Path, identifier: str, enabled: bool) -> str:
+    """Enable or disable a recurring mission by number or keyword.
+
+    Numbers match the sorted display order shown by /recurring.
+
+    Args:
+        recurring_path: Path to recurring.json
+        identifier: Number (1-indexed, display order) or keyword substring
+        enabled: True to enable, False to disable
+
+    Returns:
+        Description of the toggled mission
+
+    Raises:
+        ValueError: If identifier doesn't match any mission
+    """
+    def _toggle(missions: List[Dict]) -> str:
+        target = _resolve_target(missions, identifier)
+        target["enabled"] = enabled
+        return f"[{target['frequency']}] {target['text']}"
+
+    return _locked_modify(recurring_path, _toggle)
+
+
+def set_days(recurring_path: Path, identifier: str, days: Optional[str]) -> str:
+    """Set or clear the days-of-week filter on a recurring mission.
+
+    Numbers match the sorted display order shown by /recurring.
+
+    Args:
+        recurring_path: Path to recurring.json
+        identifier: Number (1-indexed, display order) or keyword substring
+        days: Days spec (e.g. "weekdays", "mon,wed,fri") or None to clear
+
+    Returns:
+        Description of the updated mission
+
+    Raises:
+        ValueError: If identifier doesn't match or days are invalid
+    """
+    if days:
+        days = parse_days(days)
+
+    def _set(missions: List[Dict]) -> str:
+        target = _resolve_target(missions, identifier)
+        target["days"] = days
+        return f"[{target['frequency']}] {target['text']}"
+
+    return _locked_modify(recurring_path, _set)
 
 
 def load_recurring(recurring_path: Path) -> List[Dict]:
@@ -236,11 +384,13 @@ def add_recurring(
 
 
 def remove_recurring(recurring_path: Path, identifier: str) -> str:
-    """Remove a recurring mission by number (1-indexed) or keyword.
+    """Remove a recurring mission by number (1-indexed, display order) or keyword.
+
+    Numbers match the sorted display order shown by /recurring.
 
     Args:
         recurring_path: Path to recurring.json
-        identifier: Number (1-indexed) or keyword substring
+        identifier: Number (1-indexed, display order) or keyword substring
 
     Returns:
         Description of the removed mission
@@ -249,51 +399,26 @@ def remove_recurring(recurring_path: Path, identifier: str) -> str:
         ValueError: If identifier doesn't match any mission
     """
     def _remove(missions: List[Dict]) -> str:
-        if not missions:
-            raise ValueError("No recurring missions configured.")
-
-        enabled = [m for m in missions if m.get("enabled", True)]
-        if not enabled:
-            raise ValueError("No active recurring missions.")
-
-        if identifier.isdigit():
-            idx = int(identifier) - 1
-            if idx < 0 or idx >= len(enabled):
-                raise ValueError(
-                    f"Invalid number: {identifier}. "
-                    f"Valid range: 1-{len(enabled)}"
-                )
-            target = enabled[idx]
-        else:
-            # Keyword match (case-insensitive substring)
-            matches = [
-                m for m in enabled
-                if identifier.lower() in m["text"].lower()
-            ]
-            if not matches:
-                raise ValueError(f"No recurring mission matching '{identifier}'.")
-            if len(matches) > 1:
-                raise ValueError(
-                    f"Multiple matches for '{identifier}'. Be more specific or use a number."
-                )
-            target = matches[0]
-
-        # Remove from list (mutate in place so _locked_modify saves correctly)
+        target = _resolve_target(missions, identifier)
         missions[:] = [m for m in missions if m["id"] != target["id"]]
         return f"[{target['frequency']}] {target['text']}"
 
     return _locked_modify(recurring_path, _remove)
 
 
-def list_recurring(recurring_path: Path) -> List[Dict]:
-    """List all enabled recurring missions.
+def list_recurring(recurring_path: Path, include_disabled: bool = True) -> List[Dict]:
+    """List recurring missions.
+
+    Args:
+        recurring_path: Path to recurring.json
+        include_disabled: If True, include disabled missions in the list.
 
     Returns list of mission dicts, sorted by frequency (hourly, daily, weekly).
     """
     missions = load_recurring(recurring_path)
-    enabled = [m for m in missions if m.get("enabled", True)]
-    freq_order = {"every": 0, "hourly": 1, "daily": 2, "weekly": 3}
-    return sorted(enabled, key=lambda m: freq_order.get(m["frequency"], 99))
+    if not include_disabled:
+        missions = [m for m in missions if m.get("enabled", True)]
+    return _sorted_missions(missions)
 
 
 def format_recurring_list(missions: List[Dict]) -> str:
@@ -310,19 +435,25 @@ def format_recurring_list(missions: List[Dict]) -> str:
         text = m["text"]
         project = m.get("project")
         last_run = m.get("last_run")
+        enabled = m.get("enabled", True)
+        days = m.get("days")
+
+        # Status indicator
+        status = "✅" if enabled else "⏸️"
 
         at = m.get("at")
         if freq == "every":
             interval_display = m.get("interval_display") or format_interval(m.get("interval_seconds", 0))
-            entry = f"  {i}. [every {interval_display}] {text}"
+            entry = f"  {i}. {status} [every {interval_display}] {text}"
         elif at:
-            entry = f"  {i}. [{freq} at {at}] {text}"
+            entry = f"  {i}. {status} [{freq} at {at}] {text}"
         else:
-            entry = f"  {i}. [{freq}] {text}"
+            entry = f"  {i}. {status} [{freq}] {text}"
+        if days:
+            entry += f" 📅{days}"
         if project:
             entry += f" (project: {project})"
         if last_run:
-            # Show relative time
             try:
                 last_dt = datetime.fromisoformat(last_run)
                 delta = datetime.now() - last_dt
@@ -374,6 +505,11 @@ def is_due(mission: Dict, now: Optional[datetime] = None) -> bool:
         return False
 
     now = now or datetime.now()
+
+    # Day-of-week filter — skip if today doesn't match
+    if not _matches_day(mission.get("days"), now):
+        return False
+
     last_run = mission.get("last_run")
     at = mission.get("at")
 

--- a/koan/skills/core/recurring/SKILL.md
+++ b/koan/skills/core/recurring/SKILL.md
@@ -4,7 +4,7 @@ scope: core
 group: missions
 emoji: 🔁
 description: Manage recurring missions (hourly, daily, weekly, custom interval)
-version: 1.2.0
+version: 1.3.0
 audience: bridge
 commands:
   - name: daily
@@ -20,10 +20,19 @@ commands:
     description: Add a custom-interval recurring mission
     usage: /every <interval> <text> [project:<name>]
   - name: recurring
-    description: List all recurring missions
+    description: List all recurring missions (shows enabled/disabled status)
     usage: /recurring
   - name: cancel_recurring
     description: Cancel a recurring mission
     usage: /cancel_recurring <n>, /cancel_recurring <keyword>
+  - name: pause_recurring
+    description: Disable a recurring mission without deleting it
+    usage: /pause_recurring <n>, /pause_recurring <keyword>
+  - name: resume_recurring
+    description: Re-enable a disabled recurring mission
+    usage: /resume_recurring <n>, /resume_recurring <keyword>
+  - name: days_recurring
+    description: Set day-of-week filter (weekdays/weekends/specific days)
+    usage: /days_recurring <n> weekdays, /days_recurring <n> mon,wed,fri, /days_recurring <n> all
 handler: handler.py
 ---

--- a/koan/skills/core/recurring/handler.py
+++ b/koan/skills/core/recurring/handler.py
@@ -2,14 +2,17 @@
 
 
 def handle(ctx):
-    """Handle /daily, /hourly, /weekly, /every, /recurring, /cancel_recurring commands.
+    """Handle recurring mission commands.
 
-    /daily <text>           — add a daily recurring mission
-    /hourly <text>          — add an hourly recurring mission
-    /weekly <text>          — add a weekly recurring mission
-    /every <interval> <text> — add a custom-interval recurring mission
-    /recurring              — list all recurring missions
-    /cancel_recurring [n]   — cancel a recurring mission by number or keyword
+    /daily <text>              — add a daily recurring mission
+    /hourly <text>             — add an hourly recurring mission
+    /weekly <text>             — add a weekly recurring mission
+    /every <interval> <text>   — add a custom-interval recurring mission
+    /recurring                 — list all recurring missions
+    /cancel_recurring [n]      — cancel a recurring mission by number or keyword
+    /pause_recurring [n]       — disable a recurring mission
+    /resume_recurring [n]      — re-enable a recurring mission
+    /days_recurring <n> <days> — set day-of-week filter (weekdays/weekends/mon,wed,fri)
     """
     command = ctx.command_name
 
@@ -21,6 +24,12 @@ def handle(ctx):
         return _handle_list(ctx)
     elif command == "cancel_recurring":
         return _handle_cancel(ctx)
+    elif command == "pause_recurring":
+        return _handle_toggle(ctx, enabled=False)
+    elif command == "resume_recurring":
+        return _handle_toggle(ctx, enabled=True)
+    elif command == "days_recurring":
+        return _handle_days(ctx)
 
     return None
 
@@ -132,5 +141,72 @@ def _handle_cancel(ctx):
     try:
         removed = remove_recurring(recurring_path, identifier)
         return f"Recurring mission removed: {removed}"
+    except ValueError as e:
+        return str(e)
+
+
+def _handle_toggle(ctx, enabled):
+    """Enable or disable a recurring mission."""
+    from app.recurring import list_recurring, format_recurring_list, toggle_recurring
+
+    recurring_path = ctx.instance_dir / "recurring.json"
+    identifier = ctx.args.strip()
+    action = "resume" if enabled else "pause"
+
+    if not identifier:
+        missions = list_recurring(recurring_path)
+        if missions:
+            msg = format_recurring_list(missions)
+            msg += f"\n\nUsage: /{action}_recurring <number or keyword>"
+            return msg
+        return "No recurring missions configured."
+
+    try:
+        toggled = toggle_recurring(recurring_path, identifier, enabled)
+        status = "enabled ✅" if enabled else "disabled ⏸️"
+        return f"Recurring mission {status}: {toggled}"
+    except ValueError as e:
+        return str(e)
+
+
+def _handle_days(ctx):
+    """Set or clear the days-of-week filter on a recurring mission."""
+    from app.recurring import list_recurring, format_recurring_list, set_days
+
+    recurring_path = ctx.instance_dir / "recurring.json"
+    args = ctx.args.strip()
+
+    if not args:
+        missions = list_recurring(recurring_path)
+        if missions:
+            msg = format_recurring_list(missions)
+            msg += (
+                "\n\nUsage: /days_recurring <number> <days>\n"
+                "Days: weekdays, weekends, or mon,tue,wed,thu,fri,sat,sun\n"
+                "Clear: /days_recurring <number> all"
+            )
+            return msg
+        return "No recurring missions configured."
+
+    parts = args.split(None, 1)
+    identifier = parts[0]
+    days_spec = parts[1].strip() if len(parts) > 1 else None
+
+    if not days_spec:
+        return (
+            "Usage: /days_recurring <number> <days>\n"
+            "Days: weekdays, weekends, or mon,tue,wed,thu,fri,sat,sun\n"
+            "Clear: /days_recurring <number> all"
+        )
+
+    # "all" clears the filter
+    if days_spec.lower() == "all":
+        days_spec = None
+
+    try:
+        updated = set_days(recurring_path, identifier, days_spec)
+        if days_spec:
+            return f"Days filter set to '{days_spec}': {updated}"
+        return f"Days filter cleared (runs every day): {updated}"
     except ValueError as e:
         return str(e)

--- a/koan/tests/test_recurring.py
+++ b/koan/tests/test_recurring.py
@@ -18,6 +18,10 @@ from app.recurring import (
     parse_at_time,
     parse_interval,
     format_interval,
+    parse_days,
+    toggle_recurring,
+    set_days,
+    _matches_day,
     FREQUENCIES,
 )
 
@@ -108,8 +112,9 @@ class TestRemoveRecurring:
 
     def test_remove_by_number(self, tmp_path):
         f = self._setup(tmp_path)
+        # Sorted display order: 1=hourly(check PRs), 2=daily(check emails), 3=weekly(security audit)
         removed = remove_recurring(f, "1")
-        assert "check emails" in removed
+        assert "check PRs" in removed
         assert len(load_recurring(f)) == 2
 
     def test_remove_by_keyword(self, tmp_path):
@@ -158,7 +163,7 @@ class TestListRecurring:
         result = list_recurring(f)
         assert [m["frequency"] for m in result] == ["hourly", "daily", "weekly"]
 
-    def test_excludes_disabled(self, tmp_path):
+    def test_includes_disabled_by_default(self, tmp_path):
         f = tmp_path / "recurring.json"
         missions = [
             {"id": "1", "frequency": "daily", "text": "active", "enabled": True},
@@ -166,6 +171,16 @@ class TestListRecurring:
         ]
         save_recurring(f, missions)
         result = list_recurring(f)
+        assert len(result) == 2
+
+    def test_excludes_disabled_when_requested(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        missions = [
+            {"id": "1", "frequency": "daily", "text": "active", "enabled": True},
+            {"id": "2", "frequency": "daily", "text": "disabled", "enabled": False},
+        ]
+        save_recurring(f, missions)
+        result = list_recurring(f, include_disabled=False)
         assert len(result) == 1
         assert result[0]["text"] == "active"
 
@@ -722,3 +737,153 @@ class TestRecurringSchedulerCLI:
             cwd=str(Path(__file__).parent.parent),
         )
         assert result.returncode == 0
+
+
+# --- parse_days ---
+
+class TestParseDays:
+    def test_weekdays(self):
+        assert parse_days("weekdays") == "weekdays"
+
+    def test_weekends(self):
+        assert parse_days("weekends") == "weekends"
+
+    def test_specific_days(self):
+        assert parse_days("mon,wed,fri") == "mon,wed,fri"
+
+    def test_case_insensitive(self):
+        assert parse_days("MON,FRI") == "mon,fri"
+
+    def test_with_spaces(self):
+        assert parse_days("  mon , wed , fri  ") == "mon,wed,fri"
+
+    def test_invalid_day(self):
+        with pytest.raises(ValueError, match="Invalid day"):
+            parse_days("monday")
+
+    def test_mixed_valid_invalid(self):
+        with pytest.raises(ValueError, match="Invalid day"):
+            parse_days("mon,xyz")
+
+
+# --- _matches_day ---
+
+class TestMatchesDay:
+    def test_no_filter(self):
+        assert _matches_day(None, datetime(2026, 4, 14)) is True  # Monday
+
+    def test_weekdays_on_monday(self):
+        assert _matches_day("weekdays", datetime(2026, 4, 13)) is True  # Monday
+
+    def test_weekdays_on_saturday(self):
+        assert _matches_day("weekdays", datetime(2026, 4, 11)) is False  # Saturday
+
+    def test_weekends_on_saturday(self):
+        assert _matches_day("weekends", datetime(2026, 4, 11)) is True  # Saturday
+
+    def test_weekends_on_monday(self):
+        assert _matches_day("weekends", datetime(2026, 4, 13)) is False  # Monday
+
+    def test_specific_days_match(self):
+        assert _matches_day("mon,wed,fri", datetime(2026, 4, 13)) is True  # Monday
+
+    def test_specific_days_no_match(self):
+        assert _matches_day("tue,thu", datetime(2026, 4, 13)) is False  # Monday
+
+
+# --- toggle_recurring ---
+
+class TestToggleRecurring:
+    def test_disable_by_number(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "task one")
+        toggle_recurring(f, "1", enabled=False)
+        missions = load_recurring(f)
+        assert missions[0]["enabled"] is False
+
+    def test_enable_by_number(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        save_recurring(f, [{"id": "1", "frequency": "daily", "text": "paused", "enabled": False}])
+        toggle_recurring(f, "1", enabled=True)
+        missions = load_recurring(f)
+        assert missions[0]["enabled"] is True
+
+    def test_toggle_by_keyword(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "check emails")
+        add_recurring(f, "hourly", "health check")
+        toggle_recurring(f, "emails", enabled=False)
+        missions = load_recurring(f)
+        disabled = [m for m in missions if not m["enabled"]]
+        assert len(disabled) == 1
+        assert "emails" in disabled[0]["text"]
+
+    def test_toggle_invalid_number(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "task")
+        with pytest.raises(ValueError, match="Invalid number"):
+            toggle_recurring(f, "99", enabled=False)
+
+    def test_toggle_no_match(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "task")
+        with pytest.raises(ValueError, match="No recurring mission matching"):
+            toggle_recurring(f, "nonexistent", enabled=False)
+
+
+# --- set_days ---
+
+class TestSetDays:
+    def test_set_weekdays(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "work task")
+        set_days(f, "1", "weekdays")
+        missions = load_recurring(f)
+        assert missions[0]["days"] == "weekdays"
+
+    def test_set_specific_days(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "work task")
+        set_days(f, "1", "mon,wed,fri")
+        missions = load_recurring(f)
+        assert missions[0]["days"] == "mon,wed,fri"
+
+    def test_clear_days(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        save_recurring(f, [{"id": "1", "frequency": "daily", "text": "task", "days": "weekdays"}])
+        set_days(f, "1", None)
+        missions = load_recurring(f)
+        assert missions[0]["days"] is None
+
+    def test_set_by_keyword(self, tmp_path):
+        f = tmp_path / "recurring.json"
+        add_recurring(f, "daily", "check emails")
+        set_days(f, "emails", "weekdays")
+        missions = load_recurring(f)
+        assert missions[0]["days"] == "weekdays"
+
+
+# --- is_due with days filter ---
+
+class TestIsDueWithDays:
+    def test_skips_on_wrong_day(self):
+        mission = {"frequency": "daily", "enabled": True, "last_run": None, "days": "weekdays"}
+        saturday = datetime(2026, 4, 11, 10, 0)  # Saturday
+        assert is_due(mission, saturday) is False
+
+    def test_fires_on_matching_day(self):
+        mission = {"frequency": "daily", "enabled": True, "last_run": None, "days": "weekdays"}
+        monday = datetime(2026, 4, 13, 10, 0)  # Monday
+        assert is_due(mission, monday) is True
+
+    def test_every_with_days_filter(self):
+        last = datetime(2026, 4, 11, 9, 0)  # Saturday 9:00
+        mission = {
+            "frequency": "every", "enabled": True,
+            "interval_seconds": 300, "days": "weekdays",
+            "last_run": last.isoformat(),
+        }
+        saturday_later = datetime(2026, 4, 11, 10, 0)  # Saturday 10:00
+        assert is_due(mission, saturday_later) is False
+        monday = datetime(2026, 4, 13, 10, 0)  # Monday
+        assert is_due(mission, monday) is True


### PR DESCRIPTION
- /pause_recurring and /resume_recurring to toggle tasks without deleting them
- /days_recurring to restrict tasks to weekdays, weekends, or specific days
- /recurring list now shows enabled/disabled status and day filters
- Fix index mismatch: numbers now match the sorted display order
- All changes picked up on next loop iteration without restart

New Telegram commands:
- /pause_recurring <n or keyword> — disable a task without deleting it
- /resume_recurring <n or keyword> — re-enable a disabled task
- /days_recurring <n> weekdays — only run Mon-Fri
- /days_recurring <n> weekends — only run Sat-Sun
- /days_recurring <n> mon,wed,fri — specific days
- /days_recurring <n> all — clear the filter (run every day)

/recurring list now shows:
- ✅ / ⏸️ status indicator per task
- 📅 day filter when set
- Disabled tasks are visible (not hidden)


Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
