### PR TITLE
feat(brainstorm): add ideation framing and master synthesis

### DIFF
--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -329,7 +329,42 @@ These features turn Kōan from a task runner into a full development workflow pa
 
 ### Code Operations
 
-**`/brainstorm`** — Decompose a broad topic into multiple linked GitHub issues grouped under a master tracking issue.
+**`/brainstorm`** — Decompose a broad topic into 3-8 high-leverage GitHub sub-issues grouped under a master tracking issue.
+
+The decomposer runs as a senior-engineer-style ideation pass: it explores the codebase (if provided) or external source, hunts for compounding improvements, and refuses to pad with generic refactors. Every sub-issue body follows this template:
+
+```markdown
+## Why This Matters
+<leverage rationale — why this is unusual or high-leverage>
+
+## Approach
+<concrete implementation strategy, grounded in real files and patterns>
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Risks & Caveats
+<hidden complexity, operational risk, maintenance burden>
+
+## Scores
+- Impact:          ████████░░ 8/10
+- Difficulty:      ██████░░░░ 6/10
+- Short-Term ROI:  ███████░░░ 7/10
+- Long-Term Value: █████████░ 9/10
+
+## Priority
+Immediate | Prototype First | Research Further | Skip
+
+## Dependencies
+<SUB-N references to other sub-issues, or "None">
+```
+
+The master tracking issue then synthesizes the set with three optional sections:
+
+- **Top Ranked** — sub-issues ordered by ROI / feasibility / strategic value, each with a one-line rationale.
+- **Fast Wins** — bucketed by horizon: `< 1 day`, `< 1 week`, `< 1 month`.
+- **Overall Assessment** — short critical verdict on whether the initiative is worth pursuing and what to prioritize.
 
 - **Usage:** `/brainstorm <topic>`, `/brainstorm <project> <topic>`, `/brainstorm <topic> --tag <label>`
 - **GitHub @mention:** `@koan-bot /brainstorm <topic>` on an issue

--- a/koan/skills/core/brainstorm/brainstorm_runner.py
+++ b/koan/skills/core/brainstorm/brainstorm_runner.py
@@ -74,6 +74,9 @@ def run_brainstorm(
 
     master_summary = data["master_summary"]
     issues = data["issues"]
+    top_ranked = data.get("top_ranked")
+    fast_wins = data.get("fast_wins")
+    overall_assessment = data.get("overall_assessment")
 
     # Ensure label exists
     _ensure_label(tag, project_path)
@@ -113,7 +116,10 @@ def run_brainstorm(
     # Build master issue
     master_title = f"[{tag}] {_extract_master_title(topic)}"
     master_body = _build_master_body(
-        topic, master_summary, created_issues, owner, repo
+        topic, master_summary, created_issues, owner, repo,
+        top_ranked=top_ranked,
+        fast_wins=fast_wins,
+        overall_assessment=overall_assessment,
     )
 
     try:
@@ -251,7 +257,69 @@ def _parse_decomposition(raw_output: str) -> dict:
     if "master_summary" not in data:
         data["master_summary"] = ""
 
+    # Normalize optional synthesis keys — drop them silently if malformed so a
+    # bad synthesis blob never blocks issue creation.
+    data["top_ranked"] = _coerce_top_ranked(
+        data.get("top_ranked"), num_issues=len(data["issues"]),
+    )
+    data["fast_wins"] = _coerce_fast_wins(data.get("fast_wins"))
+    data["overall_assessment"] = _coerce_overall_assessment(
+        data.get("overall_assessment"),
+    )
+
     return data
+
+
+def _coerce_top_ranked(value, num_issues):
+    """Return a list of ``{position, rationale}`` dicts or ``None``.
+
+    Drops entries whose position is out of range or non-int. Returns ``None``
+    if the input is missing, wrong-typed, or yields no usable entries.
+    """
+    if not isinstance(value, list):
+        return None
+    cleaned = []
+    for entry in value:
+        if not isinstance(entry, dict):
+            continue
+        position = entry.get("position")
+        if not isinstance(position, int):
+            continue
+        if position < 1 or position > num_issues:
+            continue
+        rationale = entry.get("rationale")
+        cleaned.append({
+            "position": position,
+            "rationale": rationale if isinstance(rationale, str) else "",
+        })
+    return cleaned or None
+
+
+def _coerce_fast_wins(value):
+    """Return a dict of bucket → list[str], or ``None``.
+
+    Recognized buckets: ``under_1_day``, ``under_1_week``, ``under_1_month``.
+    Any other key is dropped.
+    """
+    if not isinstance(value, dict):
+        return None
+    allowed = ("under_1_day", "under_1_week", "under_1_month")
+    cleaned = {}
+    for key in allowed:
+        items = value.get(key)
+        if not isinstance(items, list):
+            continue
+        bucket = [s for s in items if isinstance(s, str) and s.strip()]
+        if bucket:
+            cleaned[key] = bucket
+    return cleaned or None
+
+
+def _coerce_overall_assessment(value):
+    """Return a non-empty string or ``None``."""
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
 
 
 def _ensure_label(tag, project_path):
@@ -277,8 +345,25 @@ def _extract_master_title(topic: str) -> str:
     return first_sentence or "Brainstorm"
 
 
-def _build_master_body(topic, master_summary, created_issues, owner, repo):
-    """Build the master tracking issue body."""
+def _build_master_body(
+    topic, master_summary, created_issues, owner, repo,
+    top_ranked=None, fast_wins=None, overall_assessment=None,
+):
+    """Build the master tracking issue body.
+
+    The Top Ranked / Fast Wins / Overall Assessment sections are rendered
+    only when their corresponding keys are present and non-empty, so older
+    decompositions without synthesis data still produce a clean master.
+    """
+    ordinal_to_number = {
+        idx: number
+        for idx, (number, _title, _url) in enumerate(created_issues, 1)
+    }
+    ordinal_to_title = {
+        idx: title
+        for idx, (_number, title, _url) in enumerate(created_issues, 1)
+    }
+
     parts = []
 
     # Original topic
@@ -290,6 +375,56 @@ def _build_master_body(topic, master_summary, created_issues, owner, repo):
     if master_summary:
         parts.append("## Summary\n")
         parts.append(master_summary)
+        parts.append("")
+
+    # Top Ranked
+    if top_ranked:
+        parts.append("## Top Ranked\n")
+        for rank, entry in enumerate(top_ranked, 1):
+            position = entry["position"]
+            number = ordinal_to_number.get(position)
+            title = ordinal_to_title.get(position, "")
+            if number is None:
+                continue
+            rationale = _apply_sub_replacements(
+                entry.get("rationale", ""), ordinal_to_number,
+            ).strip()
+            line = f"{rank}. #{number} — {title}"
+            if rationale:
+                line += f": {rationale}"
+            parts.append(line)
+        parts.append("")
+
+    # Fast Wins
+    if fast_wins:
+        bucket_labels = [
+            ("under_1_day", "### < 1 day"),
+            ("under_1_week", "### < 1 week"),
+            ("under_1_month", "### < 1 month"),
+        ]
+        rendered_buckets = []
+        for key, header in bucket_labels:
+            items = fast_wins.get(key)
+            if not items:
+                continue
+            bucket_lines = [header, ""]
+            for item in items:
+                resolved = _resolve_sub_reference(
+                    item, ordinal_to_number, ordinal_to_title,
+                )
+                bucket_lines.append(f"- {resolved}")
+            rendered_buckets.append("\n".join(bucket_lines))
+        if rendered_buckets:
+            parts.append("## Fast Wins\n")
+            parts.append("\n\n".join(rendered_buckets))
+            parts.append("")
+
+    # Overall Assessment
+    if overall_assessment:
+        parts.append("## Overall Assessment\n")
+        parts.append(
+            _apply_sub_replacements(overall_assessment, ordinal_to_number)
+        )
         parts.append("")
 
     # Task list with links to sub-issues
@@ -306,6 +441,26 @@ def _build_master_body(topic, master_summary, created_issues, owner, repo):
     )
 
     return "\n".join(parts)
+
+
+def _resolve_sub_reference(value, ordinal_to_number, ordinal_to_title):
+    """Resolve a ``SUB-N`` token (or freeform string) to ``#N — Title``.
+
+    If ``value`` is exactly ``SUB-N`` and N maps to a known issue, return
+    ``#<number> — <title>``. Otherwise rewrite any embedded SUB-N tokens via
+    :func:`_apply_sub_replacements` and return the result as-is.
+    """
+    if not isinstance(value, str):
+        return ""
+    stripped = value.strip()
+    match = re.fullmatch(r'SUB-(\d+)', stripped)
+    if match:
+        idx = int(match.group(1))
+        number = ordinal_to_number.get(idx)
+        title = ordinal_to_title.get(idx, "")
+        if number is not None:
+            return f"#{number} — {title}" if title else f"#{number}"
+    return _apply_sub_replacements(stripped, ordinal_to_number)
 
 
 def _get_repo_info(project_path):

--- a/koan/skills/core/brainstorm/prompts/decompose.md
+++ b/koan/skills/core/brainstorm/prompts/decompose.md
@@ -1,44 +1,127 @@
-You are a technical decomposition assistant. Your job is to break down a broad problem statement into 3-8 focused, actionable GitHub issues that can be planned and executed sequentially.
+You are a senior engineer hunting for high-leverage, compounding improvements in the codebase you are about to investigate. Your goal is NOT to summarize the repo and NOT to propose generic refactors — it is to extract focused, codebase-grounded sub-issues that materially improve the project along the dimension of the topic below.
 
 ## The Topic
 
 {TOPIC}
 
-## Instructions
+## Mission
 
-1. **Understand the topic**: Restate the core problem. What is the user really trying to solve?
+Decompose this topic into 3-8 focused, actionable GitHub sub-issues. Each must be a real lever — something whose absence is costing the project, or whose presence would compound future value. Throwaway ideas, generic refactors, and boilerplate scaffolding do not belong here.
 
-2. **Explore the codebase**: Use Read, Glob, and Grep to understand the relevant code, architecture, and existing patterns. Ground your decomposition in reality, not abstraction.
+## Investigation Rules
 
-3. **Decompose into sub-issues**: Break the topic into 3-8 focused sub-issues. Each should be:
-   - **Self-contained**: understandable without reading the others
-   - **Actionable**: clear enough to plan and implement
-   - **Sequenced**: ordered from foundational to advanced (earlier issues unblock later ones)
-   - **Right-sized**: each is a single PR worth of work (not too big, not trivial)
+- Focus on changes with strategic leverage; ignore boilerplate.
+- Prioritize ideas that compound — each one should unlock further value over time.
+- Look for hidden gems buried in implementation details, not just the obvious surface.
+- Identify reusable patterns that transfer to other parts of the codebase.
+- Compare against modern best practices for the language and stack actually in use.
+- Detect performance bottlenecks, observability gaps, and automation opportunities.
+- Ground every idea in actual files, functions, or call sites you have read — never speculate.
+- Return fewer issues if the topic doesn't warrant 8 — three excellent issues beat eight mediocre ones.
 
-4. **Write each sub-issue** with enough context that someone encountering it for the first time can understand the problem, the approach, and the acceptance criteria.
+## Special Attention Areas
+
+While exploring, look hardest at:
+
+- concurrency and async correctness
+- error handling and recovery paths
+- observability (logs, metrics, tracing)
+- caching and performance hot paths
+- testing leverage and coverage gaps
+- plugin / extensibility surfaces
+- automation and agentic workflow opportunities
+- data flow efficiency
+- idempotency and crash safety
+- security boundaries and trust assumptions
+
+## Anti-Goals — explicit do-NOTs
+
+- Do NOT propose generic refactors or trivial sub-issues.
+- Do NOT pad to 8 — return 3 if 3 is the right answer.
+- Do NOT summarize the codebase.
+- Do NOT propose ideas you cannot ground in actual files / patterns / call sites.
+- Do NOT use research-style titles ("Investigate X", "Look into Y") unless research IS the deliverable.
+
+## Process
+
+1. **Restate the core problem** in your head — what is the user really trying to solve?
+2. **Explore the codebase** with Read, Glob, Grep, WebFetch. Read enough to ground every idea you propose.
+3. **Decompose** into 3-8 sub-issues. Each must be:
+   - **Self-contained** — understandable without reading the others.
+   - **Actionable** — clear enough to plan and implement.
+   - **Right-sized** — a single PR worth of work, not too big, not trivial.
+   - **Sequenced** — ordered foundational → advanced; earlier issues unblock later ones.
+4. **Score and prioritize** each issue honestly. Surface risks, not just upside.
+5. **Synthesize**: rank the top ideas, bucket fast wins by horizon, and write a critical overall assessment.
 
 ## Output Format
 
 You MUST output valid JSON and nothing else. No markdown fences, no commentary, no preamble.
 
-The JSON must have this exact structure:
+The JSON must have this exact top-level shape:
 
+```jsonc
 {
   "master_summary": "One paragraph summarizing the overall initiative and why it matters.",
-  "issues": [
-    {
-      "title": "Short, specific issue title (under 80 chars)",
-      "body": "Full issue body in markdown. Include:\n\n## Context\nWhy this matters and how it fits the bigger picture.\n\n## Approach\nRecommended implementation strategy.\n\n## Acceptance Criteria\n- [ ] Criterion 1\n- [ ] Criterion 2\n\n## Dependencies\nWhich other sub-issues (if any) should be done first."
-    }
-  ]
-}
+  "issues": [ { "title": "...", "body": "..." } ],
 
-Rules:
-- Return between 3 and 8 issues, no more, no less.
+  // All three of the keys below are OPTIONAL but strongly encouraged.
+  "top_ranked": [
+    { "position": 3, "rationale": "Highest ROI; unblocks SUB-5 and SUB-7." },
+    { "position": 1, "rationale": "Foundational; everything else assumes it." }
+  ],
+  "fast_wins": {
+    "under_1_day":  ["SUB-2"],
+    "under_1_week": ["SUB-1", "SUB-4"],
+    "under_1_month":["SUB-6"]
+  },
+  "overall_assessment": "Two-to-four sentence critical verdict: is this initiative strategically valuable, what to prioritize, what to skip."
+}
+```
+
+### Per-issue body template
+
+Each `issues[].body` MUST be a markdown string built from these exact section headers, in this order:
+
+```
+## Why This Matters
+<one short paragraph — leverage rationale, why this is unusual or high-leverage. No platitudes.>
+
+## Approach
+<concrete recommended implementation strategy, grounded in real files and patterns>
+
+## Acceptance Criteria
+- [ ] Criterion 1
+- [ ] Criterion 2
+
+## Risks & Caveats
+<hidden complexity, operational risk, maintenance burden — surface downsides honestly>
+
+## Scores
+- Impact: ████████░░ 8/10
+- Difficulty: ██████░░░░ 6/10
+- Short-Term ROI: ███████░░░ 7/10
+- Long-Term Value: █████████░ 9/10
+
+## Priority
+Immediate | Prototype First | Research Further | Skip
+
+## Dependencies
+<SUB-N references, or "None">
+```
+
+Score-bar rules: ten cells total, filled with `█` for the rating value and `░` for the rest, followed by `N/10`. Choose ratings deliberately — never give every issue 8/10.
+
+### Top-level rules
+
+- Return between 3 and 8 issues. No fewer than 3, no more than 8.
 - Order issues from foundational to advanced — issue 1 should be doable first.
+- Each issue title must be specific and actionable, under 80 chars.
+- Do NOT include the tag or label in titles — that's handled externally.
 - Each issue body must reference the master initiative context so it stands alone.
-- Each title must be specific and actionable (not "Research X" unless research IS the deliverable).
-- Do NOT include the tag or label in the titles — that's handled externally.
-- Keep issue bodies focused: 10-30 lines each. Enough context to act on, not a novel.
-- When referencing other sub-issues in Dependencies or elsewhere, use the placeholder format `SUB-1`, `SUB-2`, etc. (matching their 1-based position in the issues array). Do NOT use `#1`, `#2` or any `#N` syntax — those will conflict with real GitHub issue numbers. The placeholders will be replaced with correct GitHub issue links after creation.
+- Keep each issue body focused: 25-60 lines. Enough context to act on, not a novel.
+- When referencing other sub-issues (in Dependencies, top_ranked rationales, fast_wins buckets, overall_assessment), use the placeholder format `SUB-1`, `SUB-2`, etc. (1-based position in the issues array). Do NOT use `#1` or `#N` — those will conflict with real GitHub issue numbers. Placeholders are rewritten to real issue links after creation.
+- `top_ranked[].position` is the 1-based index into the `issues` array.
+- `fast_wins` bucket entries should be `SUB-N` strings; the renderer resolves them to real titles.
+
+Be highly critical, technical, and practical. Think like an engineer searching for the few changes that materially move the project forward.

--- a/koan/tests/test_brainstorm_skill.py
+++ b/koan/tests/test_brainstorm_skill.py
@@ -243,6 +243,10 @@ from skills.core.brainstorm.brainstorm_runner import (
     _extract_master_title,
     _apply_sub_replacements,
     _replace_sub_placeholders,
+    _resolve_sub_reference,
+    _coerce_top_ranked,
+    _coerce_fast_wins,
+    _coerce_overall_assessment,
 )
 
 
@@ -329,6 +333,58 @@ class TestParseDecomposition:
         }))
         assert data["master_summary"] == ""
 
+    def test_synthesis_keys_default_to_none_when_absent(self):
+        """Old-shape payloads (no synthesis fields) still parse cleanly."""
+        data = _parse_decomposition(json.dumps({
+            "master_summary": "S",
+            "issues": [{"title": "T", "body": "B"}],
+        }))
+        assert data["top_ranked"] is None
+        assert data["fast_wins"] is None
+        assert data["overall_assessment"] is None
+
+    def test_synthesis_keys_passed_through_when_well_formed(self):
+        data = _parse_decomposition(json.dumps({
+            "master_summary": "S",
+            "issues": [
+                {"title": "A", "body": "B"},
+                {"title": "C", "body": "D"},
+                {"title": "E", "body": "F"},
+            ],
+            "top_ranked": [
+                {"position": 2, "rationale": "Highest leverage."},
+                {"position": 1, "rationale": "Foundational."},
+            ],
+            "fast_wins": {
+                "under_1_day": ["SUB-1"],
+                "under_1_week": ["SUB-2", "SUB-3"],
+            },
+            "overall_assessment": "Worth pursuing.",
+        }))
+        assert data["top_ranked"] == [
+            {"position": 2, "rationale": "Highest leverage."},
+            {"position": 1, "rationale": "Foundational."},
+        ]
+        assert data["fast_wins"] == {
+            "under_1_day": ["SUB-1"],
+            "under_1_week": ["SUB-2", "SUB-3"],
+        }
+        assert data["overall_assessment"] == "Worth pursuing."
+
+    def test_malformed_synthesis_dropped_silently(self):
+        """Wrong-typed synthesis values are dropped, not raised — issue
+        creation must never be blocked by a bad synthesis blob."""
+        data = _parse_decomposition(json.dumps({
+            "master_summary": "S",
+            "issues": [{"title": "T", "body": "B"}],
+            "top_ranked": "not a list",
+            "fast_wins": ["not a dict"],
+            "overall_assessment": "",
+        }))
+        assert data["top_ranked"] is None
+        assert data["fast_wins"] is None
+        assert data["overall_assessment"] is None
+
 
 class TestBuildMasterBody:
     def test_contains_task_list(self):
@@ -350,6 +406,91 @@ class TestBuildMasterBody:
     def test_footer(self):
         body = _build_master_body("T", "", [("1", "T", "u")], "o", "r")
         assert "Koan /brainstorm" in body
+
+    def test_no_synthesis_sections_when_keys_absent(self):
+        body = _build_master_body(
+            "T", "S", [("1", "Alpha", "u"), ("2", "Beta", "u")], "o", "r",
+        )
+        assert "## Top Ranked" not in body
+        assert "## Fast Wins" not in body
+        assert "## Overall Assessment" not in body
+
+    def test_renders_top_ranked_with_resolved_numbers_and_titles(self):
+        issues = [("42", "Alpha", "u1"), ("43", "Beta", "u2")]
+        top_ranked = [
+            {"position": 2, "rationale": "Best ROI; unblocks SUB-1."},
+            {"position": 1, "rationale": "Foundational."},
+        ]
+        body = _build_master_body(
+            "T", "", issues, "o", "r", top_ranked=top_ranked,
+        )
+        assert "## Top Ranked" in body
+        assert "1. #43 — Beta" in body
+        assert "2. #42 — Alpha" in body
+        # SUB-1 inside rationale rewritten to #42
+        assert "unblocks #42" in body
+
+    def test_top_ranked_drops_out_of_range_positions(self):
+        issues = [("42", "Alpha", "u")]
+        top_ranked = [
+            {"position": 1, "rationale": "Yes."},
+            {"position": 99, "rationale": "Should not appear."},
+        ]
+        body = _build_master_body(
+            "T", "", issues, "o", "r", top_ranked=top_ranked,
+        )
+        assert "1. #42 — Alpha" in body
+        assert "Should not appear" not in body
+
+    def test_renders_fast_wins_with_horizon_headers(self):
+        issues = [
+            ("10", "Alpha", "u"),
+            ("11", "Beta", "u"),
+            ("12", "Gamma", "u"),
+        ]
+        fast_wins = {
+            "under_1_day": ["SUB-2"],
+            "under_1_week": ["SUB-1", "SUB-3"],
+        }
+        body = _build_master_body(
+            "T", "", issues, "o", "r", fast_wins=fast_wins,
+        )
+        assert "## Fast Wins" in body
+        assert "### < 1 day" in body
+        assert "### < 1 week" in body
+        # under_1_month not provided, header should be absent
+        assert "### < 1 month" not in body
+        assert "- #11 — Beta" in body
+        assert "- #10 — Alpha" in body
+        assert "- #12 — Gamma" in body
+
+    def test_fast_wins_skipped_entirely_when_all_buckets_empty(self):
+        issues = [("10", "Alpha", "u")]
+        body = _build_master_body(
+            "T", "", issues, "o", "r",
+            fast_wins={"under_1_day": [], "under_1_week": []},
+        )
+        # _coerce_fast_wins would have returned None upstream, but
+        # _build_master_body should also skip cleanly if it ever receives
+        # an all-empty dict directly.
+        assert "## Fast Wins" not in body
+
+    def test_renders_overall_assessment_with_sub_replacement(self):
+        issues = [("42", "Alpha", "u"), ("43", "Beta", "u")]
+        body = _build_master_body(
+            "T", "", issues, "o", "r",
+            overall_assessment="Worth doing. Start with SUB-1, then SUB-2.",
+        )
+        assert "## Overall Assessment" in body
+        assert "Start with #42, then #43." in body
+
+    def test_synthesis_sections_appear_before_subissues_list(self):
+        issues = [("42", "Alpha", "u")]
+        body = _build_master_body(
+            "T", "Summary", issues, "o", "r",
+            overall_assessment="Verdict.",
+        )
+        assert body.index("## Overall Assessment") < body.index("## Sub-Issues")
 
 
 class TestApplySubReplacements:
@@ -434,6 +575,111 @@ class TestExtractMasterTitle:
 
     def test_empty_topic(self):
         assert _extract_master_title("") == "Brainstorm"
+
+
+class TestCoerceTopRanked:
+    def test_drops_non_list(self):
+        assert _coerce_top_ranked("oops", num_issues=3) is None
+        assert _coerce_top_ranked(None, num_issues=3) is None
+
+    def test_drops_out_of_range_positions(self):
+        result = _coerce_top_ranked(
+            [{"position": 1, "rationale": "ok"},
+             {"position": 99, "rationale": "out of range"},
+             {"position": 0, "rationale": "below"}],
+            num_issues=2,
+        )
+        assert result == [{"position": 1, "rationale": "ok"}]
+
+    def test_drops_non_int_positions(self):
+        result = _coerce_top_ranked(
+            [{"position": "1", "rationale": "string"}],
+            num_issues=2,
+        )
+        assert result is None
+
+    def test_empty_rationale_replaced_with_blank_string(self):
+        result = _coerce_top_ranked(
+            [{"position": 1}],
+            num_issues=2,
+        )
+        assert result == [{"position": 1, "rationale": ""}]
+
+    def test_returns_none_when_all_entries_invalid(self):
+        result = _coerce_top_ranked(
+            [{"position": 0}, "garbage"], num_issues=2,
+        )
+        assert result is None
+
+
+class TestCoerceFastWins:
+    def test_drops_non_dict(self):
+        assert _coerce_fast_wins("oops") is None
+        assert _coerce_fast_wins(["a", "b"]) is None
+        assert _coerce_fast_wins(None) is None
+
+    def test_keeps_only_recognized_buckets(self):
+        result = _coerce_fast_wins({
+            "under_1_day": ["SUB-1"],
+            "under_1_year": ["SUB-2"],  # not a recognized bucket
+            "random_key": ["junk"],
+        })
+        assert result == {"under_1_day": ["SUB-1"]}
+
+    def test_filters_non_string_items(self):
+        result = _coerce_fast_wins({
+            "under_1_week": ["SUB-1", 42, None, "SUB-3", ""],
+        })
+        assert result == {"under_1_week": ["SUB-1", "SUB-3"]}
+
+    def test_returns_none_when_all_buckets_empty(self):
+        result = _coerce_fast_wins({
+            "under_1_day": [],
+            "under_1_week": [None, ""],
+        })
+        assert result is None
+
+
+class TestCoerceOverallAssessment:
+    def test_strips_and_returns_string(self):
+        assert _coerce_overall_assessment("  worth doing  ") == "worth doing"
+
+    def test_drops_non_string(self):
+        assert _coerce_overall_assessment(42) is None
+        assert _coerce_overall_assessment(None) is None
+        assert _coerce_overall_assessment(["list"]) is None
+
+    def test_drops_empty_or_whitespace(self):
+        assert _coerce_overall_assessment("") is None
+        assert _coerce_overall_assessment("   \n  ") is None
+
+
+class TestResolveSubReference:
+    def test_resolves_exact_sub_token_to_number_and_title(self):
+        result = _resolve_sub_reference(
+            "SUB-1", {1: "42"}, {1: "Alpha"},
+        )
+        assert result == "#42 — Alpha"
+
+    def test_falls_back_to_number_only_when_title_missing(self):
+        result = _resolve_sub_reference("SUB-1", {1: "42"}, {})
+        assert result == "#42"
+
+    def test_unknown_sub_token_left_unresolved(self):
+        result = _resolve_sub_reference("SUB-9", {1: "42"}, {1: "Alpha"})
+        # Unknown SUB-N is left as-is by _apply_sub_replacements.
+        assert "SUB-9" in result
+
+    def test_freeform_string_has_embedded_subs_rewritten(self):
+        result = _resolve_sub_reference(
+            "After SUB-1 lands", {1: "42"}, {1: "Alpha"},
+        )
+        # Not an exact SUB-N match → falls through to the rewrite path.
+        assert result == "After #42 lands"
+
+    def test_non_string_returns_empty(self):
+        assert _resolve_sub_reference(None, {}, {}) == ""
+        assert _resolve_sub_reference(42, {}, {}) == ""
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Reframe /brainstorm from a flat decomposition tool into a
senior-engineer-style ideation pass that hunts for high-leverage,
codebase-grounded sub-issues, then synthesizes the result for fast
human triage.

Prompt (decompose.md) now opens with a persona, lists explicit
investigation rules and special-attention areas (concurrency,
observability, error paths, plugin surfaces, idempotency, security,
...), and forbids padding to 8 issues or proposing ungrounded
generic refactors. Each sub-issue body must follow a structured
template with Why-This-Matters / Approach / Acceptance Criteria /
Risks & Caveats / Scores (Impact, Difficulty, Short-Term ROI,
Long-Term Value rendered as filled bars) / Priority (Immediate /
Prototype First / Research Further / Skip) / Dependencies.

Three new optional top-level JSON keys -- top_ranked, fast_wins
(under_1_day / under_1_week / under_1_month), overall_assessment --
let the model surface a critical synthesis. brainstorm_runner
defensively coerces these via _coerce_top_ranked, _coerce_fast_wins,
and _coerce_overall_assessment so a malformed synthesis blob never
blocks issue creation. _build_master_body renders Top Ranked, Fast
Wins, and Overall Assessment sections between the existing Summary
and Sub-Issues list, reusing _apply_sub_replacements (and a new
_resolve_sub_reference helper) to rewrite SUB-N tokens in
rationales, fast-win buckets, and assessment prose to real GitHub
issue numbers and titles. Old-shape payloads continue to render
exactly as before.

User manual is refreshed to describe the enriched per-issue and
master sections. Test suite gains 22 new tests covering parser
tolerance for present/absent/malformed synthesis keys, the three
coerce helpers, _resolve_sub_reference, and master body rendering
with synthesis sections; full brainstorm suite passes 87/87.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
