### PR TITLE
feat(brainstorm): enforce template + log prompt provenance

### DIFF
--- a/koan/skills/core/brainstorm/brainstorm_runner.py
+++ b/koan/skills/core/brainstorm/brainstorm_runner.py
@@ -12,6 +12,7 @@ CLI:
         --project-path <path> --topic "Improve caching" --tag prompt-caching
 """
 
+import hashlib
 import json
 import re
 import sys
@@ -20,6 +21,17 @@ from typing import Optional, Tuple
 
 from app.github import run_gh, issue_create, issue_edit
 from app.prompts import load_prompt_or_skill
+
+
+REQUIRED_ISSUE_SECTIONS = (
+    "## Why This Matters",
+    "## Approach",
+    "## Acceptance Criteria",
+    "## Risks & Caveats",
+    "## Scores",
+    "## Priority",
+    "## Dependencies",
+)
 
 
 def run_brainstorm(
@@ -57,26 +69,71 @@ def run_brainstorm(
     if not owner or not repo:
         return False, "No GitHub repository found at project path."
 
-    # Decompose via Claude
+    # Decompose via Claude, with one structural-validation retry.
     try:
-        decomposition = _decompose_topic(project_path, topic, skill_dir)
+        prompt = _build_decompose_prompt(topic, skill_dir)
     except Exception as e:
         return False, f"Decomposition failed: {str(e)[:300]}"
 
-    if not decomposition:
-        return False, "Claude returned empty decomposition."
+    data = None
+    diagnostics = []
+    for attempt in (1, 2):
+        try:
+            decomposition = _call_claude_with_prompt(prompt, project_path)
+        except Exception as e:
+            return False, f"Decomposition failed: {str(e)[:300]}"
 
-    # Parse the JSON output
-    try:
-        data = _parse_decomposition(decomposition)
-    except ValueError as e:
-        return False, f"Failed to parse decomposition: {e}"
+        if not decomposition:
+            return False, "Claude returned empty decomposition."
+
+        try:
+            data = _parse_decomposition(decomposition)
+        except ValueError as e:
+            return False, f"Failed to parse decomposition: {e}"
+
+        diagnostics = _validate_issue_bodies(data["issues"])
+        if not diagnostics:
+            break
+
+        if attempt == 1:
+            print(
+                f"[brainstorm_runner] template enforcement triggered retry "
+                f"({len(diagnostics)} missing-section diagnostics)",
+                file=sys.stderr,
+                flush=True,
+            )
+            notify_fn(
+                "⚠ Template incomplete — retrying once with reminder."
+            )
+            prompt = prompt + _RETRY_REMINDER
+
+    if diagnostics:
+        head = "; ".join(diagnostics[:3])
+        suffix = (
+            f" (+{len(diagnostics) - 3} more)" if len(diagnostics) > 3 else ""
+        )
+        return (
+            False,
+            f"Template enforcement failed after retry: {head}{suffix}",
+        )
 
     master_summary = data["master_summary"]
     issues = data["issues"]
     top_ranked = data.get("top_ranked")
     fast_wins = data.get("fast_wins")
     overall_assessment = data.get("overall_assessment")
+
+    if (
+        top_ranked is None
+        and fast_wins is None
+        and overall_assessment is None
+    ):
+        print(
+            "[brainstorm_runner] master synthesis absent — model returned "
+            "old shape (no top_ranked / fast_wins / overall_assessment)",
+            file=sys.stderr,
+            flush=True,
+        )
 
     # Ensure label exists
     _ensure_label(tag, project_path)
@@ -202,18 +259,113 @@ def _generate_tag(topic: str) -> str:
     return "-".join(keywords)
 
 
-def _decompose_topic(project_path, topic, skill_dir=None):
-    """Run Claude to decompose the topic into sub-issues."""
-    prompt = load_prompt_or_skill(skill_dir, "decompose", TOPIC=topic)
+def _build_decompose_prompt(topic, skill_dir=None):
+    """Load the decompose prompt template and substitute the topic.
 
+    Logs prompt provenance (path / size / sha256 prefix / version
+    marker) to stderr so post-mortem debugging of "wrong template"
+    runs is one journal grep away.
+    """
+    prompt = load_prompt_or_skill(skill_dir, "decompose", TOPIC=topic)
+    prompt_path = (
+        skill_dir / "prompts" / "decompose.md" if skill_dir else None
+    )
+    _log_prompt_provenance(prompt_path, prompt)
+    return prompt
+
+
+def _call_claude_with_prompt(prompt, project_path):
+    """Run Claude with the given prompt against ``project_path``.
+
+    Thin wrapper around :func:`run_command_streaming` so the retry
+    loop in :func:`run_brainstorm` can mock at this seam.
+    """
     from app.cli_provider import run_command_streaming
     from app.config import get_analysis_max_turns, get_skill_timeout
-    output = run_command_streaming(
+    return run_command_streaming(
         prompt, project_path,
         allowed_tools=["Read", "Glob", "Grep", "WebFetch"],
         max_turns=get_analysis_max_turns(), timeout=get_skill_timeout(),
     )
-    return output
+
+
+def _decompose_topic(project_path, topic, skill_dir=None):
+    """Run Claude to decompose the topic into sub-issues.
+
+    Kept as a single-shot helper for the CLI smoke path; the
+    retry-aware pipeline in :func:`run_brainstorm` calls
+    :func:`_build_decompose_prompt` and :func:`_call_claude_with_prompt`
+    directly.
+    """
+    prompt = _build_decompose_prompt(topic, skill_dir)
+    return _call_claude_with_prompt(prompt, project_path)
+
+
+def _log_prompt_provenance(prompt_path, prompt_text):
+    """Emit one stderr line describing which prompt was loaded.
+
+    Format::
+
+        [brainstorm_runner] prompt_provenance path=<abs> size=<bytes>
+            head_sha256=<12hex> version=<new|old>
+
+    ``version`` is ``new`` when the loaded template contains the
+    sentinel ``## Why This Matters`` and ``old`` otherwise. The
+    sha256 is truncated to 12 hex chars of the first 256 chars.
+    """
+    head = (prompt_text or "")[:256].encode("utf-8", errors="replace")
+    head_sha = hashlib.sha256(head).hexdigest()[:12]
+    version = "new" if "## Why This Matters" in (prompt_text or "") else "old"
+    size = len(prompt_text or "")
+    path_repr = str(prompt_path) if prompt_path else "<system-prompt>"
+    print(
+        f"[brainstorm_runner] prompt_provenance "
+        f"path={path_repr} size={size} head_sha256={head_sha} "
+        f"version={version}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
+def _validate_issue_bodies(issues):
+    """Return a list of human-readable diagnostics for non-conforming issues.
+
+    Each issue body must contain every header in
+    :data:`REQUIRED_ISSUE_SECTIONS` (substring match — order is
+    documented in the prompt and not validated here). Empty list
+    means all issues passed.
+    """
+    diagnostics = []
+    for idx, issue in enumerate(issues, 1):
+        body = issue.get("body", "") or ""
+        title = (issue.get("title", "") or "").strip()
+        title_preview = title[:40] if title else "?"
+        for header in REQUIRED_ISSUE_SECTIONS:
+            if header not in body:
+                diagnostics.append(
+                    f"Issue {idx} ('{title_preview}'): missing '{header}'"
+                )
+    return diagnostics
+
+
+_RETRY_REMINDER = """
+
+---
+
+ATTENTION: Your previous response did NOT include all required body
+sections. Each issue body MUST contain these exact section headers,
+in this order:
+
+1. ## Why This Matters
+2. ## Approach
+3. ## Acceptance Criteria
+4. ## Risks & Caveats
+5. ## Scores  (with the four bar-rendered axes Impact / Difficulty / Short-Term ROI / Long-Term Value)
+6. ## Priority  (one of Immediate | Prototype First | Research Further | Skip)
+7. ## Dependencies
+
+Regenerate the JSON now with all seven sections present in every issue body.
+"""
 
 
 def _parse_decomposition(raw_output: str) -> dict:

--- a/koan/skills/core/brainstorm/prompts/decompose.md
+++ b/koan/skills/core/brainstorm/prompts/decompose.md
@@ -41,6 +41,7 @@ While exploring, look hardest at:
 - Do NOT summarize the codebase.
 - Do NOT propose ideas you cannot ground in actual files / patterns / call sites.
 - Do NOT use research-style titles ("Investigate X", "Look into Y") unless research IS the deliverable.
+- Do NOT inherit format, headers, or section names from the topic text. Follow ONLY the per-issue body template defined below, even if the topic itself uses different headers, an outline, or its own template.
 
 ## Process
 
@@ -54,34 +55,9 @@ While exploring, look hardest at:
 4. **Score and prioritize** each issue honestly. Surface risks, not just upside.
 5. **Synthesize**: rank the top ideas, bucket fast wins by horizon, and write a critical overall assessment.
 
-## Output Format
+## Per-issue body template
 
-You MUST output valid JSON and nothing else. No markdown fences, no commentary, no preamble.
-
-The JSON must have this exact top-level shape:
-
-```jsonc
-{
-  "master_summary": "One paragraph summarizing the overall initiative and why it matters.",
-  "issues": [ { "title": "...", "body": "..." } ],
-
-  // All three of the keys below are OPTIONAL but strongly encouraged.
-  "top_ranked": [
-    { "position": 3, "rationale": "Highest ROI; unblocks SUB-5 and SUB-7." },
-    { "position": 1, "rationale": "Foundational; everything else assumes it." }
-  ],
-  "fast_wins": {
-    "under_1_day":  ["SUB-2"],
-    "under_1_week": ["SUB-1", "SUB-4"],
-    "under_1_month":["SUB-6"]
-  },
-  "overall_assessment": "Two-to-four sentence critical verdict: is this initiative strategically valuable, what to prioritize, what to skip."
-}
-```
-
-### Per-issue body template
-
-Each `issues[].body` MUST be a markdown string built from these exact section headers, in this order:
+Each `issues[].body` MUST be a markdown string built from these EXACT section headers, in this EXACT order. Every header below is required — none may be renamed, omitted, merged, or reordered:
 
 ```
 ## Why This Matters
@@ -112,6 +88,31 @@ Immediate | Prototype First | Research Further | Skip
 
 Score-bar rules: ten cells total, filled with `█` for the rating value and `░` for the rest, followed by `N/10`. Choose ratings deliberately — never give every issue 8/10.
 
+## Output Format
+
+You MUST output valid JSON and nothing else. No markdown fences, no commentary, no preamble.
+
+The JSON must have this exact top-level shape (each `body` follows the per-issue template above):
+
+```jsonc
+{
+  "master_summary": "One paragraph summarizing the overall initiative and why it matters.",
+  "issues": [ { "title": "...", "body": "<markdown matching the per-issue body template above>" } ],
+
+  // All three of the keys below are OPTIONAL but strongly encouraged.
+  "top_ranked": [
+    { "position": 3, "rationale": "Highest ROI; unblocks SUB-5 and SUB-7." },
+    { "position": 1, "rationale": "Foundational; everything else assumes it." }
+  ],
+  "fast_wins": {
+    "under_1_day":  ["SUB-2"],
+    "under_1_week": ["SUB-1", "SUB-4"],
+    "under_1_month":["SUB-6"]
+  },
+  "overall_assessment": "Two-to-four sentence critical verdict: is this initiative strategically valuable, what to prioritize, what to skip."
+}
+```
+
 ### Top-level rules
 
 - Return between 3 and 8 issues. No fewer than 3, no more than 8.
@@ -123,5 +124,17 @@ Score-bar rules: ten cells total, filled with `█` for the rating value and `�
 - When referencing other sub-issues (in Dependencies, top_ranked rationales, fast_wins buckets, overall_assessment), use the placeholder format `SUB-1`, `SUB-2`, etc. (1-based position in the issues array). Do NOT use `#1` or `#N` — those will conflict with real GitHub issue numbers. Placeholders are rewritten to real issue links after creation.
 - `top_ranked[].position` is the 1-based index into the `issues` array.
 - `fast_wins` bucket entries should be `SUB-N` strings; the renderer resolves them to real titles.
+
+## Required Sections Checklist — verify before emitting JSON
+
+Before you emit the JSON, walk every `issues[].body` and confirm all SEVEN headers below are present, spelled exactly, in this order. If any header is missing, regenerate that body — do NOT submit incomplete output.
+
+1. `## Why This Matters`
+2. `## Approach`
+3. `## Acceptance Criteria`
+4. `## Risks & Caveats`
+5. `## Scores`  (with the four bar-rendered axes Impact / Difficulty / Short-Term ROI / Long-Term Value)
+6. `## Priority`  (one of Immediate | Prototype First | Research Further | Skip)
+7. `## Dependencies`
 
 Be highly critical, technical, and practical. Think like an engineer searching for the few changes that materially move the project forward.

--- a/koan/tests/test_brainstorm_skill.py
+++ b/koan/tests/test_brainstorm_skill.py
@@ -1,6 +1,7 @@
 """Tests for the /brainstorm core skill — handler + runner."""
 
 import json
+import re
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
@@ -247,7 +248,11 @@ from skills.core.brainstorm.brainstorm_runner import (
     _coerce_top_ranked,
     _coerce_fast_wins,
     _coerce_overall_assessment,
+    _validate_issue_bodies,
+    _log_prompt_provenance,
+    REQUIRED_ISSUE_SECTIONS,
 )
+import skills.core.brainstorm.brainstorm_runner as brainstorm_runner
 
 
 class TestGenerateTag:
@@ -764,3 +769,244 @@ class TestDecomposeMaxTurns:
             result = runner._decompose_topic("/tmp/proj", "topic")
 
         assert mock_run.call_args[1]["max_turns"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Structural validation
+# ---------------------------------------------------------------------------
+
+
+def _full_body():
+    """Return a body string containing every required section header."""
+    return "\n\n".join(f"{h}\nplaceholder" for h in REQUIRED_ISSUE_SECTIONS)
+
+
+class TestValidateIssueBodies:
+    def test_required_sections_constant_has_seven_headers(self):
+        assert len(REQUIRED_ISSUE_SECTIONS) == 7
+        # Spot-check the canonical names — these are also referenced in
+        # the prompt's required-sections checklist, so they must match.
+        assert "## Why This Matters" in REQUIRED_ISSUE_SECTIONS
+        assert "## Risks & Caveats" in REQUIRED_ISSUE_SECTIONS
+        assert "## Scores" in REQUIRED_ISSUE_SECTIONS
+        assert "## Priority" in REQUIRED_ISSUE_SECTIONS
+
+    def test_all_sections_present_returns_no_diagnostics(self):
+        issues = [
+            {"title": "Alpha", "body": _full_body()},
+            {"title": "Beta",  "body": _full_body()},
+        ]
+        assert _validate_issue_bodies(issues) == []
+
+    def test_one_missing_section_yields_one_diagnostic(self):
+        body = _full_body().replace("## Risks & Caveats\n", "")
+        diagnostics = _validate_issue_bodies(
+            [{"title": "Alpha", "body": body}]
+        )
+        assert len(diagnostics) == 1
+        assert "Issue 1" in diagnostics[0]
+        assert "Alpha" in diagnostics[0]
+        assert "## Risks & Caveats" in diagnostics[0]
+
+    def test_old_template_is_fully_rejected(self):
+        """The exact old-template body from the cryptoan run must
+        trigger diagnostics for all four newly-required headers."""
+        old_body = (
+            "## Context\nFoundational thing.\n\n"
+            "## Approach\nDo this.\n\n"
+            "## Acceptance Criteria\n- [ ] Done\n\n"
+            "## Dependencies\nNone."
+        )
+        diagnostics = _validate_issue_bodies(
+            [{"title": "Implement signal ensemble", "body": old_body}]
+        )
+        missing_headers = {d.split("missing '")[1].rstrip("'") for d in diagnostics}
+        assert "## Why This Matters" in missing_headers
+        assert "## Risks & Caveats" in missing_headers
+        assert "## Scores" in missing_headers
+        assert "## Priority" in missing_headers
+        # Old template did include these — should NOT be flagged
+        assert "## Approach" not in missing_headers
+        assert "## Acceptance Criteria" not in missing_headers
+        assert "## Dependencies" not in missing_headers
+
+    def test_empty_body_flags_all_seven_sections(self):
+        diagnostics = _validate_issue_bodies(
+            [{"title": "Empty", "body": ""}]
+        )
+        assert len(diagnostics) == len(REQUIRED_ISSUE_SECTIONS)
+
+    def test_missing_body_key_treated_as_empty(self):
+        diagnostics = _validate_issue_bodies([{"title": "No body"}])
+        assert len(diagnostics) == len(REQUIRED_ISSUE_SECTIONS)
+
+    def test_diagnostic_includes_issue_number_and_title_preview(self):
+        issues = [
+            {"title": "Alpha", "body": _full_body()},
+            {"title": "B" * 80, "body": ""},
+        ]
+        diagnostics = _validate_issue_bodies(issues)
+        assert all("Issue 2" in d for d in diagnostics)
+        # Title preview is truncated to 40 chars
+        assert all(("'" + "B" * 40 + "'") in d for d in diagnostics)
+
+
+# ---------------------------------------------------------------------------
+# Prompt provenance log
+# ---------------------------------------------------------------------------
+
+
+class TestPromptProvenance:
+    def test_logs_version_new_when_marker_present(self, capsys):
+        prompt = "Some prefix.\n\n## Why This Matters\n...rest of prompt."
+        _log_prompt_provenance(Path("/some/path/decompose.md"), prompt)
+        err = capsys.readouterr().err
+        assert "prompt_provenance" in err
+        assert "version=new" in err
+        assert "path=/some/path/decompose.md" in err
+        assert f"size={len(prompt)}" in err
+
+    def test_logs_version_old_when_marker_absent(self, capsys):
+        prompt = "You are a technical decomposition assistant.\n## Context\n..."
+        _log_prompt_provenance(Path("/old/decompose.md"), prompt)
+        err = capsys.readouterr().err
+        assert "version=old" in err
+
+    def test_includes_truncated_sha256(self, capsys):
+        prompt = "## Why This Matters\nbody"
+        _log_prompt_provenance(Path("/p.md"), prompt)
+        err = capsys.readouterr().err
+        match = re.search(r"head_sha256=([0-9a-f]+)", err)
+        assert match is not None
+        assert len(match.group(1)) == 12
+
+    def test_handles_none_path_gracefully(self, capsys):
+        _log_prompt_provenance(None, "## Why This Matters\nbody")
+        err = capsys.readouterr().err
+        assert "path=<system-prompt>" in err
+
+    def test_handles_empty_prompt(self, capsys):
+        _log_prompt_provenance(Path("/missing.md"), "")
+        err = capsys.readouterr().err
+        assert "size=0" in err
+        assert "version=old" in err  # marker absent → old
+
+
+# ---------------------------------------------------------------------------
+# run_brainstorm — retry-once on validation failure
+# ---------------------------------------------------------------------------
+
+
+def _decomposition_json(issues_bodies, master_summary="Initiative summary."):
+    """Build a JSON decomposition string from issue bodies."""
+    return json.dumps({
+        "master_summary": master_summary,
+        "issues": [
+            {"title": f"Issue {i+1}", "body": body}
+            for i, body in enumerate(issues_bodies)
+        ],
+    })
+
+
+_OLD_BODY = (
+    "## Context\nx\n\n## Approach\nx\n\n"
+    "## Acceptance Criteria\n- [ ] x\n\n## Dependencies\nNone"
+)
+
+
+class TestRunBrainstormRetry:
+    def _run(self, claude_outputs, issue_create_returns=None):
+        """Execute run_brainstorm with stubbed Claude + GitHub calls."""
+        if issue_create_returns is None:
+            issue_create_returns = [
+                f"https://github.com/o/r/issues/{100 + i}"
+                for i in range(len(claude_outputs[-1]) if claude_outputs else 3)
+            ]
+        notify = MagicMock()
+        # _build_decompose_prompt avoids touching disk
+        with patch.object(brainstorm_runner, "_build_decompose_prompt",
+                          return_value="<prompt>"), \
+             patch.object(brainstorm_runner, "_call_claude_with_prompt",
+                          side_effect=claude_outputs) as mock_claude, \
+             patch.object(brainstorm_runner, "_get_repo_info",
+                          return_value=("owner", "repo")), \
+             patch.object(brainstorm_runner, "_ensure_label"), \
+             patch.object(brainstorm_runner, "issue_create",
+                          side_effect=issue_create_returns) as mock_create, \
+             patch.object(brainstorm_runner, "_replace_sub_placeholders"):
+            success, summary = brainstorm_runner.run_brainstorm(
+                project_path="/proj",
+                topic="A topic",
+                tag="my-tag",
+                notify_fn=notify,
+            )
+        return success, summary, mock_claude, mock_create, notify
+
+    def test_no_retry_when_first_response_is_compliant(self):
+        good = _decomposition_json([_full_body()] * 3)
+        success, summary, mock_claude, mock_create, _notify = self._run(
+            [good],
+        )
+        assert success is True
+        assert mock_claude.call_count == 1
+        assert mock_create.call_count >= 3
+
+    def test_retries_once_when_first_response_is_old_shape(self):
+        bad = _decomposition_json([_OLD_BODY] * 3)
+        good = _decomposition_json([_full_body()] * 3)
+        success, summary, mock_claude, mock_create, notify = self._run(
+            [bad, good],
+        )
+        assert success is True
+        assert mock_claude.call_count == 2
+        # Second call must include the retry reminder appended to prompt
+        second_prompt = mock_claude.call_args_list[1].args[0]
+        assert "ATTENTION" in second_prompt
+        assert "## Why This Matters" in second_prompt
+        # User got a notification about the retry
+        assert any(
+            "retrying" in str(c).lower() or "template" in str(c).lower()
+            for c in notify.call_args_list
+        )
+        # Issues created from the retry response, not the bad first one
+        assert mock_create.call_count >= 3
+
+    def test_aborts_when_both_attempts_fail_validation(self):
+        bad = _decomposition_json([_OLD_BODY] * 3)
+        success, summary, mock_claude, mock_create, _notify = self._run(
+            [bad, bad],
+        )
+        assert success is False
+        assert mock_claude.call_count == 2
+        # No GitHub issues are created when validation fails twice
+        assert mock_create.call_count == 0
+        assert "Template enforcement failed" in summary
+
+    def test_summary_truncates_long_diagnostic_list(self):
+        # Three issues × 4 missing sections = 12 diagnostics
+        bad = _decomposition_json([_OLD_BODY] * 3)
+        success, summary, _claude, _create, _notify = self._run([bad, bad])
+        assert success is False
+        # Only the first three diagnostics in the summary, plus a count
+        assert "+9 more" in summary
+
+    def test_master_synthesis_warning_when_all_keys_absent(self, capsys):
+        good = _decomposition_json([_full_body()] * 3)
+        with patch.object(brainstorm_runner, "_build_decompose_prompt",
+                          return_value="<prompt>"), \
+             patch.object(brainstorm_runner, "_call_claude_with_prompt",
+                          return_value=good), \
+             patch.object(brainstorm_runner, "_get_repo_info",
+                          return_value=("o", "r")), \
+             patch.object(brainstorm_runner, "_ensure_label"), \
+             patch.object(brainstorm_runner, "issue_create",
+                          side_effect=[f"https://x/{i}" for i in range(10)]), \
+             patch.object(brainstorm_runner, "_replace_sub_placeholders"):
+            brainstorm_runner.run_brainstorm(
+                project_path="/proj",
+                topic="t",
+                tag="t",
+                notify_fn=MagicMock(),
+            )
+        err = capsys.readouterr().err
+        assert "master synthesis absent" in err


### PR DESCRIPTION
Add three layers of defense against the failure mode observed on a
recent /brainstorm cryptoan run, where the master + sub-issues
shipped with the OLD pre-upgrade template (## Context / ## Approach
/ ## Acceptance Criteria / ## Dependencies) and no synthesis
sections. Root cause was a stale koan checkout serving the old
prompt; the runner had no way to detect or reject the bad output.

1. Provenance log. _build_decompose_prompt now emits one stderr
line per run -- "[brainstorm_runner] prompt_provenance path=<abs>
size=<bytes> head_sha256=<12hex> version=<new|old>" -- with version
flipping on the presence of the literal sentinel "## Why This
Matters" in the loaded template. Future "wrong template" debug is
one journal grep instead of a manual checkout audit.

2. Structural validation + retry-once. New constant
REQUIRED_ISSUE_SECTIONS lists the seven mandatory headers; new
helper _validate_issue_bodies returns human-readable diagnostics
for each missing section. run_brainstorm now extracts
_call_claude_with_prompt as a mockable seam, runs the parse +
validate cycle, and on first failure re-sends the same prompt with
an "ATTENTION" reminder block appended. Telegram gets a "Template
incomplete -- retrying once" notice. If the second attempt also
fails, run_brainstorm returns (False, "Template enforcement failed
after retry: ...") -- zero GitHub issues are created, so old-shape
output can never silently ship again. A soft stderr warning fires
when all three optional master synthesis keys (top_ranked,
fast_wins, overall_assessment) are absent.

3. Prompt reorder. Per-issue body template now precedes the JSON
shape (primacy effect), and a final "Required Sections Checklist"
sits immediately before the closing critical-engineer line (recency
effect). A new anti-goal forbids inheriting format from the topic
text -- defense against ideation-style topics that bring their own
implicit template and bait the model into following it instead of
the strict per-issue body template.

Tests add 17 cases across TestValidateIssueBodies (including an
explicit replay of the cryptoan #744-style old-shape body that
confirms the four newly-required headers are flagged),
TestPromptProvenance (new/old marker, sha256 truncation, None path,
empty prompt), and TestRunBrainstormRetry (no-retry happy path,
old->new retry success, old->old abort with diagnostic-truncated
summary, master-synthesis-absent warning emit). Full brainstorm
suite now 104/104 passing; no production code path was added that
isn't covered.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
