### PR TITLE
feat(rtk): integrate optional rtk-ai/rtk for compressed tool output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,3 @@ projects.docker.yaml
 docker-compose.override.yml
 .env.docker
 claude-auth/
-
-# Local implementation tracking (ant-implement / Claude Code plan files)
-.spec/

--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ projects.docker.yaml
 docker-compose.override.yml
 .env.docker
 claude-auth/
+
+# Local implementation tracking (ant-implement / Claude Code plan files)
+.spec/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,7 +118,7 @@ Communication between processes happens through shared files in `instance/` with
 Extensible command plugin system. Each skill lives in `skills/<scope>/<skill-name>/` with a `SKILL.md` (YAML frontmatter defining commands, aliases, metadata) and an optional `handler.py`.
 
 - **`skills.py`** — Registry that discovers SKILL.md files, parses frontmatter (custom lite YAML parser, no PyYAML), maps commands/aliases to skills, and dispatches execution.
-- **Core skills** live in `koan/skills/core/` (audit, cancel, chat, check, check_notifications, claudemd, config_check, delete_project, focus, idea, implement, journal, language, list, live, magic, mission, passive, plan, pr, priority, projects, quota, rebase, recreate, recurring, refactor, reflect, review, security_audit, shutdown, sparring, start, status, update, verbose)
+- **Core skills** live in `koan/skills/core/` (audit, cancel, chat, check, check_notifications, claudemd, config_check, delete_project, focus, idea, implement, journal, language, list, live, magic, mission, passive, plan, pr, priority, projects, quota, rebase, recreate, recurring, refactor, reflect, review, rtk, security_audit, shutdown, sparring, start, status, update, verbose)
 - **Custom skills** loaded from `instance/skills/<scope>/` — each scope directory can be a cloned Git repo for team sharing.
 - **Handler pattern**: `def handle(ctx: SkillContext) -> Optional[str]` — return string for Telegram reply, empty string for "already handled", None for no message.
 - **`worker: true`** flag in SKILL.md marks blocking skills (Claude calls, API requests) that run in a background thread.

--- a/docs/rtk.md
+++ b/docs/rtk.md
@@ -1,0 +1,116 @@
+# RTK integration
+
+Kōan can optionally lean on [`rtk`](https://github.com/rtk-ai/rtk) — a Rust CLI proxy that compresses common dev-command output (`git`, `ls`, `cat`, `grep`, `pytest`, `cargo`, `gh`, `docker`, …) by 60–90 % before it reaches Claude. Strictly complementary to the [caveman optimisation](../instance.example/config.yaml): caveman trims what Claude **writes**; rtk trims what Claude **reads**.
+
+`rtk` is **never** a Kōan dependency. If it isn't installed, nothing changes.
+
+## How it plugs in
+
+Three layers, each independently useful:
+
+| Layer | What it does | Activation |
+|---|---|---|
+| **L1 — Detection** | At boot, log whether `rtk` and `jq` are present and whether the `~/.claude/settings.json` PreToolUse hook is wired up. | Always on (read-only probe). |
+| **L2 — Awareness** | Inject `koan/system-prompts/rtk-awareness.md` into Claude's system prompt so Claude prefers `rtk git status` over `git status`. | Default `auto` — on iff the binary is detected. |
+| **L3 — Hook setup** | The `/rtk setup` Telegram skill runs `rtk init -g --auto-patch` to install the official PreToolUse hook (transparent rewrite of every Bash command). | Manual — never automatic. |
+
+## Quick start
+
+```bash
+# 1. Install rtk on the host (one-time)
+brew install rtk
+# or: curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh
+
+# 2. Restart Kōan — boot log should show:
+#    [init] rtk 0.28.2 detected, hook: inactive
+
+# 3. (optional) From Telegram, install the auto-rewrite hook:
+/rtk setup           # preview
+/rtk setup confirm   # actually run rtk init -g --auto-patch
+```
+
+After step 3, every Bash command Claude runs inside a Kōan mission gets transparently rewritten to its `rtk` equivalent. Nothing changes in Kōan's argv or prompt assembly — the hook fires inside Claude Code itself.
+
+## The `/rtk` skill
+
+| Command | Effect |
+|---|---|
+| `/rtk` | Show detection status (binary, version, hook, jq, project gate) |
+| `/rtk setup` | Preview what `rtk init -g --auto-patch` would change |
+| `/rtk setup confirm` | Actually install the PreToolUse hook |
+| `/rtk uninstall` | Run `rtk init -g --uninstall` |
+| `/rtk gain [args]` | Forward to `rtk gain` (analytics — token savings, history, daily) |
+| `/rtk discover [args]` | Forward to `rtk discover` (find missed savings opportunities) |
+| `/rtk on` / `/rtk off` | Runtime override — toggles awareness without editing `config.yaml`. Writes `instance/.koan-rtk-override`. |
+
+## Configuration
+
+```yaml
+# instance/config.yaml
+optimizations:
+  rtk:
+    enabled: auto         # auto | true | false
+                          #   auto = on iff `rtk` is on PATH (default)
+    awareness: true       # inject the awareness section into system prompts
+    require_jq: true      # warn at boot if jq is missing
+```
+
+```yaml
+# projects.yaml — per-project opt-out
+projects:
+  myproject:
+    rtk: false            # never inject awareness for this project
+```
+
+Resolution order for `is_rtk_mode()`:
+
+1. `instance/.koan-rtk-override` (`/rtk on` / `/rtk off`) — highest priority.
+2. `optimizations.rtk.enabled` in `config.yaml`.
+3. `auto` → fall through to `app.rtk_detector.detect_rtk()`.
+
+Per-project resolution (`get_project_rtk_enabled`):
+- `projects.<name>.rtk: true` or `false` → hard override for that project.
+- Anything else (or omitted) → defer to global `is_rtk_mode()`.
+
+## What rtk filters and what it doesn't
+
+The hook only intercepts the **Bash tool** — Claude Code's native `Read` / `Glob` / `Grep` bypass it. The awareness section nudges Claude to prefer `rtk read <file>` and `rtk grep <pat>` for large files, but agents may still default to native tools, capping practical savings below the headline 80 %.
+
+Filters exist for:
+
+- Git: `git status`, `git log`, `git diff`, `git add`, `git commit`, `git push`, `git pull`
+- Files: `ls`, `cat`/`read`, `find`, `grep`, `diff`
+- GitHub: `gh pr list/view`, `gh issue list`, `gh run list`
+- Tests: `pytest`, `jest`, `vitest`, `cargo test`, `go test`, `rspec`, `playwright test`, generic `rtk test <cmd>`
+- Build/lint: `tsc`, `ruff check`, `cargo build/clippy`, `golangci-lint`, `eslint/biome`, `rubocop`
+- Containers: `docker ps`, `docker logs`, `kubectl pods/logs`
+- Cloud: `aws sts/ec2/lambda/logs/cloudformation/dynamodb/iam/s3`
+- Misc: `log`, `json`, `curl`, `env`
+
+Unknown commands pass through unchanged — rtk is never destructive.
+
+## Caveats
+
+- **Never auto-patches `~/.claude/settings.json`.** Hook installation only happens via explicit `/rtk setup confirm`.
+- **`jq` is required for the hook script.** The detector probes for it independently of `rtk`. If missing, `/rtk` warns but the awareness section still works (Claude calls `rtk` directly via Bash).
+- **Telemetry is opt-in.** rtk has its own anonymous usage telemetry, off by default. Kōan never enables it on the user's behalf.
+- **Copilot provider is out of scope (v1).** rtk's Copilot support is `deny-with-suggestion` rather than transparent rewrite — friction outweighs savings. Skip the Copilot path for now.
+- **Windows native is degraded.** rtk's hook is Unix-only; the awareness section still works.
+
+## Verifying
+
+```bash
+# Without rtk on PATH:
+python -c "from app.rtk_detector import detect_rtk; print(detect_rtk())"
+# RtkStatus(installed=False, ...)
+
+# With rtk installed:
+rtk --version           # rtk 0.28.2
+KOAN_ROOT=/path .venv/bin/pytest koan/tests/test_rtk_detector.py koan/tests/test_rtk_skill.py -v
+```
+
+## Related
+
+- Issue [#1295](https://github.com/Anantys-oss/koan/issues/1295) — the integration plan.
+- Issue [#1279](https://github.com/Anantys-oss/koan/issues/1279) — caveman mode (composes orthogonally).
+- Modules: `koan/app/rtk_detector.py`, `koan/app/prompt_builder.py` (`_get_rtk_section`), `koan/skills/core/rtk/`.

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -1563,9 +1563,10 @@ All commands at a glance. **Tier:** B = Beginner, I = Intermediate, P = Power Us
 | `/dead_code [project]` | `/dc` | P | Scan for unused code |
 | `/incident <error>` | — | P | Triage a production error |
 | `/scaffold_skill <scope> <name> <desc>` | `/scaffold`, `/new_skill` | P | Generate SKILL.md + handler.py for a new custom skill |
+| `/rtk [setup\|uninstall\|gain\|on\|off]` | — | P | Manage optional [rtk](https://github.com/rtk-ai/rtk) integration for compressed tool output (60-90 % token savings on Bash commands). See [docs/rtk.md](rtk.md). |
 
 Skills marked with GitHub @mention support: `/audit`, `/security_audit`, `/brainstorm`, `/plan`, `/implement`, `/fix`, `/review`, `/rebase`, `/recreate`, `/refactor`, `/profile`, `/gh_request`. See [GitHub Commands](github-commands.md) for details.
 
 ---
 
-*This manual covers all 42 core skills. For the full command reference with tabular format, see [docs/skills.md](skills.md). For skill authoring, see [koan/skills/README.md](../koan/skills/README.md).*
+*This manual covers all 43 core skills. For the full command reference with tabular format, see [docs/skills.md](skills.md). For skill authoring, see [koan/skills/README.md](../koan/skills/README.md).*

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -513,3 +513,39 @@ usage:
 #   caveman:
 #     enabled: true
 #     include: [my_custom_skill]   # canonical names; aliases auto-resolved
+
+# RTK (Rust Token Killer — https://github.com/rtk-ai/rtk)
+#
+# Optional CLI proxy that compresses common dev-command output (git, ls,
+# cat/read, grep/find, pytest, jest, cargo, gh, docker, kubectl, aws, …) by
+# 60-90 % before it reaches Claude.  Strictly complementary to caveman:
+#   - caveman trims what Claude WRITES.
+#   - rtk     trims what Claude READS.
+#
+# rtk is **not** a Kōan dependency.  Kōan only:
+#   1. Detects the binary at boot (logged once).
+#   2. Optionally injects an awareness section into Claude's system prompt
+#      so Claude prefers ``rtk <cmd>`` over the raw command.
+#   3. Exposes a ``/rtk`` skill for status/setup/uninstall/gain.
+#
+# Hook installation (``rtk init -g``) only ever happens via explicit
+# ``/rtk setup`` from Telegram — Kōan never silently mutates
+# ``~/.claude/settings.json``.
+#
+# optimizations:
+#   rtk:
+#     enabled: auto         # auto | true | false
+#                           #   auto = on iff `rtk` is on PATH (default)
+#                           #   true = on regardless of detection
+#                           #   false = off everywhere
+#     awareness: true       # inject RTK awareness into the system prompt
+#     require_jq: true      # warn at boot if `jq` is missing (rtk's
+#                           # auto-rewrite hook requires jq)
+#
+# Per-project opt-out lives in ``projects.yaml``:
+#
+#   projects:
+#     myproject:
+#       rtk: false          # never inject awareness for this project
+#                           # (e.g. its test runner emits JSON that rtk's
+#                           #  filter would clobber)

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -14,6 +14,7 @@ Functions here call it via import to ensure mocks propagate correctly.
 
 import os
 import sys
+from pathlib import Path
 from typing import List, Optional
 
 
@@ -1073,3 +1074,127 @@ def get_caveman_include_list() -> set:
             continue
         result.add(_resolve_canonical(name))
     return result
+
+
+def _get_rtk_dict() -> dict:
+    """Return the ``optimizations.rtk`` mapping (or an empty dict).
+
+    Mirrors :func:`_get_caveman_dict` — normalises away missing parents,
+    non-dict optimizations blocks, and scalar rtk values so callers can treat
+    the result as a plain dict.
+    """
+    config = _load_config()
+    optimizations = config.get("optimizations", {})
+    if not isinstance(optimizations, dict):
+        return {}
+    rtk = optimizations.get("rtk", {})
+    return rtk if isinstance(rtk, dict) else {}
+
+
+# Canonical accepted values for ``optimizations.rtk.enabled`` and the
+# per-project ``rtk:`` knob.  Single source of truth — :mod:`app.config_validator`
+# imports these so the doc-time validation and runtime parsing never drift.
+RTK_ENABLED_TRUE = frozenset({"true", "yes", "1", "on"})
+RTK_ENABLED_FALSE = frozenset({"false", "no", "0", "off"})
+RTK_ENABLED_AUTO = frozenset({"auto", ""})
+RTK_ENABLED_VALID = RTK_ENABLED_TRUE | RTK_ENABLED_FALSE | RTK_ENABLED_AUTO
+
+
+def coerce_rtk_enabled(raw: object) -> Optional[bool]:
+    """Coerce a config value into ``True`` / ``False`` / ``None`` (= auto).
+
+    Used by both :func:`is_rtk_mode` and
+    :func:`app.projects_config.get_project_rtk_enabled` so the global and
+    per-project knobs accept exactly the same shapes.
+
+    Returns:
+        ``True`` / ``False`` for explicit values, ``None`` to defer to the
+        next layer (binary detection for the global knob, global resolution
+        for the per-project knob).
+    """
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        value = raw.strip().lower()
+        if value in RTK_ENABLED_TRUE:
+            return True
+        if value in RTK_ENABLED_FALSE:
+            return False
+    return None
+
+
+def _rtk_runtime_override() -> Optional[bool]:
+    """Read the runtime override written by ``/rtk on`` / ``/rtk off``.
+
+    Returns ``True`` for any truthy value, ``False`` for any falsy value, or
+    ``None`` when no override file is present or its content is unrecognised
+    (i.e. defer to ``config.yaml``).  The override lives at
+    ``instance/.koan-rtk-override`` so users can flip rtk awareness on the
+    fly without editing config files.
+
+    Accepts the same vocabulary as ``optimizations.rtk.enabled`` —
+    :func:`coerce_rtk_enabled` is the single source of truth.  ``/rtk on``
+    and ``/rtk off`` write ``"on"`` / ``"off"``, but a user who hand-writes
+    ``true`` / ``false`` / ``yes`` / ``no`` gets the same behaviour.
+    """
+    koan_root = os.environ.get("KOAN_ROOT")
+    if not koan_root:
+        return None
+    path = Path(koan_root) / "instance" / ".koan-rtk-override"
+    try:
+        value = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return coerce_rtk_enabled(value)
+
+
+def is_rtk_mode() -> bool:
+    """Check whether the rtk awareness section should be injected.
+
+    Resolution order (highest priority first):
+
+    1.  ``instance/.koan-rtk-override`` (written by ``/rtk on`` / ``/rtk off``).
+    2.  ``optimizations.rtk.enabled`` in ``config.yaml``::
+
+            optimizations:
+              rtk:
+                enabled: auto    # auto | true | false
+
+        - ``auto`` (default): on iff the rtk binary is detected on the host.
+          When the tool is installed the user almost certainly wants Claude
+          to prefer it; when it's missing, the awareness blurb would just
+          be dead context.
+        - ``true``: always on (forces injection even if the binary is
+          missing — useful when the user installs rtk after Kōan boots).
+        - ``false``: always off.
+
+    The detection probe is cached per-process by :mod:`app.rtk_detector`, so
+    this function is safe to call from per-prompt code paths.
+    """
+    override = _rtk_runtime_override()
+    if override is not None:
+        return override
+    explicit = coerce_rtk_enabled(_get_rtk_dict().get("enabled", "auto"))
+    if explicit is not None:
+        return explicit
+    # "auto" (and any unrecognised value) → defer to binary detection.
+    try:
+        from app.rtk_detector import detect_rtk
+        return detect_rtk().installed
+    except Exception as e:
+        print(f"[config] rtk detection failed: {e}", file=sys.stderr)
+        return False
+
+
+def is_rtk_awareness_enabled() -> bool:
+    """Return ``True`` when the awareness section should ship in prompts.
+
+    Two-stage gate: ``optimizations.rtk.enabled`` controls overall rtk
+    integration; ``optimizations.rtk.awareness`` toggles the prompt-injection
+    layer specifically.  Default: ``True`` — if rtk mode is on at all,
+    awareness is part of it unless explicitly disabled.
+    """
+    if not is_rtk_mode():
+        return False
+    raw = _get_rtk_dict().get("awareness", True)
+    return bool(raw) if isinstance(raw, bool) else True

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -222,6 +222,12 @@ SECTION_SCHEMAS: Dict[str, Dict[str, str]] = {
         # validation of that mapping lives in
         # :func:`_validate_caveman_nested` below.
         "caveman": "dict",
+        # RTK (https://github.com/rtk-ai/rtk) — optional CLI proxy that
+        # compresses common dev-command output before Claude reads it.
+        # Configured via ``rtk: {enabled: auto|true|false, awareness: bool,
+        # require_jq: bool}``.  Validation lives in
+        # :func:`_validate_rtk_nested` below.
+        "rtk": "dict",
     },
 }
 
@@ -347,6 +353,9 @@ def validate_config(config: dict) -> List[Tuple[str, str]]:
         caveman = optimizations.get("caveman")
         if isinstance(caveman, dict):
             warnings.extend(_validate_caveman_nested(caveman))
+        rtk = optimizations.get("rtk")
+        if isinstance(rtk, dict):
+            warnings.extend(_validate_rtk_nested(rtk))
 
     # Semantic check: warn on overlapping deep_hours and work_hours
     schedule = config.get("schedule")
@@ -370,6 +379,58 @@ _CAVEMAN_NESTED_SCHEMA: Dict[str, Any] = {
     "enabled": "bool",
     "include": "list",
 }
+
+
+# RTK accepts ``enabled: auto`` (string) in addition to bool, so the schema
+# uses a tuple of accepted types.  ``_check_type`` already handles tuples.
+_RTK_NESTED_SCHEMA: Dict[str, Any] = {
+    "enabled": ("bool", "str"),
+    "awareness": "bool",
+    "require_jq": "bool",
+}
+
+
+def _validate_rtk_nested(rtk: dict) -> List[Tuple[str, str]]:
+    """Validate the nested ``optimizations.rtk`` dict.
+
+    Mirrors :func:`_validate_caveman_nested` with one extra check: when
+    ``enabled`` is a string we constrain it to the documented set
+    (``auto``, ``true``, ``false``, …) — same set
+    :func:`app.config.coerce_rtk_enabled` accepts at runtime, so a typo
+    like ``enabld: yse`` surfaces clearly here instead of silently
+    falling through to ``auto``.
+    """
+    from app.config import RTK_ENABLED_VALID
+
+    warnings: List[Tuple[str, str]] = []
+    known = list(_RTK_NESTED_SCHEMA.keys())
+    for key, value in rtk.items():
+        path = f"optimizations.rtk.{key}"
+        if key not in _RTK_NESTED_SCHEMA:
+            suggestion = _suggest_typo(key, known)
+            msg = f"unrecognized key '{path}'"
+            if suggestion:
+                msg += f" (did you mean 'optimizations.rtk.{suggestion}'?)"
+            warnings.append((path, msg))
+            continue
+        if value is None:
+            continue
+        expected = _RTK_NESTED_SCHEMA[key]
+        if not _check_type(value, expected):
+            exp_label = expected if isinstance(expected, str) else "/".join(expected)
+            warnings.append((
+                path,
+                f"'{path}' should be {exp_label}, got {type(value).__name__}",
+            ))
+            continue
+        if key == "enabled" and isinstance(value, str):
+            if value.strip().lower() not in RTK_ENABLED_VALID:
+                warnings.append((
+                    path,
+                    f"'{path}' should be one of "
+                    f"{sorted(RTK_ENABLED_VALID - {''})}, got {value!r}",
+                ))
+    return warnings
 
 
 def _validate_caveman_nested(caveman: dict) -> List[Tuple[str, str]]:

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -294,6 +294,38 @@ def get_project_tools(config: dict, project_name: str) -> dict:
     return tools
 
 
+def get_project_rtk_enabled(config: dict, project_name: str) -> bool:
+    """Return whether the rtk awareness section should fire for a project.
+
+    Reads ``rtk`` from the per-project config (with defaults merged in).
+    Accepts the same shapes as the global ``optimizations.rtk.enabled``
+    knob — bool, ``"auto"``, ``"true"``, ``"false"``, etc.
+
+    Resolution:
+      1. If the project sets ``rtk: false`` (or any false-y value) →
+         hard opt-out, returns ``False`` regardless of global state.
+      2. If the project sets ``rtk: true`` → opts in even when the global
+         knob would say no.
+      3. If the project sets ``rtk: auto`` (or omits it entirely, or sets
+         it to anything else) → defer to the global resolution in
+         :func:`app.config.is_rtk_mode`.
+
+    The intent: the global config tracks "do I want rtk on this Kōan
+    instance"; the per-project field tracks "does this project's tooling
+    play nicely with rtk's filters".  A project can opt out (e.g. its test
+    runner emits unusual JSON that rtk's filter would clobber) without
+    affecting the rest of the instance.
+    """
+    project_cfg = get_project_config(config, project_name)
+    from app.config import coerce_rtk_enabled, is_rtk_mode
+    if "rtk" in project_cfg:
+        explicit = coerce_rtk_enabled(project_cfg["rtk"])
+        if explicit is not None:
+            return explicit
+        # "auto" or unrecognised → fall through to global.
+    return is_rtk_mode()
+
+
 def get_project_mcp(config: dict, project_name: str) -> list:
     """Get MCP config file paths for a project from projects.yaml.
 

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -78,6 +78,42 @@ def _get_language_section() -> str:
     return ""
 
 
+def _get_rtk_section(project_name: str = "") -> str:
+    """Return the RTK awareness section when rtk is enabled for this context.
+
+    Mirrors :func:`_get_caveman_section` but with one extra gate: a project
+    can opt out via ``projects.yaml`` even when the global config has rtk
+    enabled (``get_project_rtk_enabled``).  The dual gate keeps two
+    legitimate concerns separate — "do I want rtk on this Kōan instance"
+    and "does this project's tooling tolerate rtk's filters".
+
+    Failures are non-fatal — like caveman, rtk is an optimization, not a
+    correctness feature — but are logged so silent regressions stay
+    visible.
+    """
+    try:
+        from app.config import is_rtk_awareness_enabled
+        if not is_rtk_awareness_enabled():
+            return ""
+        if project_name:
+            from app.projects_config import get_project_rtk_enabled
+            from app.utils import load_config
+            try:
+                if not get_project_rtk_enabled(load_config(), project_name):
+                    return ""
+            except (OSError, ValueError, KeyError):
+                # Project resolution failed — fall through to global decision
+                # rather than silently dropping the section.
+                pass
+        from app.prompts import load_prompt
+        return "\n\n" + load_prompt("rtk-awareness")
+    except (OSError, FileNotFoundError):
+        return ""
+    except Exception as e:
+        logger.warning("rtk awareness section unavailable: %s", e)
+        return ""
+
+
 def _load_config_safe() -> dict:
     """Load config.yaml, returning empty dict on failure."""
     try:
@@ -541,8 +577,11 @@ def build_agent_prompt(
     # Append verbose mode section if active
     prompt += _get_verbose_section(instance)
 
-    # Append caveman output optimization (token reduction)
+    # Append caveman output optimization (token reduction in Claude's output)
     prompt += _get_caveman_section()
+
+    # Append RTK awareness (token reduction in Claude's tool input)
+    prompt += _get_rtk_section(project_name)
 
     # Append language preference (overrides soul.md default)
     prompt += _get_language_section()
@@ -631,6 +670,10 @@ def build_agent_prompt_parts(
     caveman = _get_caveman_section()
     if caveman:
         sys_parts.append(caveman)
+
+    rtk = _get_rtk_section(project_name)
+    if rtk:
+        sys_parts.append(rtk)
 
     security = _get_security_flagging_section(mission_title, autonomous_mode)
     if security:

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -96,10 +96,11 @@ def _get_rtk_section(project_name: str = "") -> str:
         if not is_rtk_awareness_enabled():
             return ""
         if project_name:
-            from app.projects_config import get_project_rtk_enabled
-            from app.utils import load_config
+            from app.projects_config import get_project_rtk_enabled, load_projects_config
             try:
-                if not get_project_rtk_enabled(load_config(), project_name):
+                koan_root = os.environ.get("KOAN_ROOT", "")
+                projects_cfg = load_projects_config(koan_root) if koan_root else None
+                if projects_cfg and not get_project_rtk_enabled(projects_cfg, project_name):
                     return ""
             except (OSError, ValueError, KeyError):
                 # Project resolution failed — fall through to global decision

--- a/koan/app/rtk_detector.py
+++ b/koan/app/rtk_detector.py
@@ -1,0 +1,252 @@
+"""Kōan — Detect optional `rtk` binary (https://github.com/rtk-ai/rtk).
+
+`rtk` (Rust Token Killer) is a CLI proxy that filters and compresses common
+dev-command output (git, ls, cat/read, grep/find, pytest, jest, cargo, gh,
+docker, kubectl, aws, …) by 60-90 % before it reaches the LLM.  When `rtk` is
+on the user's PATH, Kōan optionally:
+
+1.  Logs detection at boot (this module).
+2.  Injects an RTK awareness section into Claude's system prompt
+    (:func:`app.prompt_builder._get_rtk_section`) so Claude prefers
+    ``rtk <cmd>`` over the raw command.
+3.  Exposes a ``/rtk`` skill (status / setup / uninstall / gain / on / off)
+    that can install rtk's official ``PreToolUse`` hook into the user's
+    ``~/.claude/settings.json``.
+
+This module is **read-only** by design.  We never mutate the user's machine
+state from detection — the ``/rtk setup`` skill is the only path that touches
+``~/.claude/settings.json`` and it does so only after explicit Telegram
+confirmation.
+
+Resolution is cached per-process: the binary doesn't appear or disappear
+mid-loop, and re-probing on every prompt build would add unnecessary
+subprocess churn.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import platform
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# --- Constants --------------------------------------------------------------
+
+# Marker substrings we look for inside ~/.claude/settings.json to decide whether
+# rtk's PreToolUse hook is already installed.  We accept either:
+#   - "rtk-rewrite.sh" — the hook script shipped by rtk init -g
+#   - "rtk rewrite"    — the inline command form some rtk versions use
+# Either match is sufficient; this is a hint for diagnostics, not a security
+# check.
+_HOOK_MARKERS = ("rtk-rewrite.sh", "rtk rewrite")
+
+# Bound the version probe so a hung binary can't stall startup.
+_VERSION_PROBE_TIMEOUT = 2.0  # seconds
+
+
+# --- Data class -------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RtkStatus:
+    """Snapshot of rtk availability on the host.
+
+    Attributes:
+        installed: ``True`` when ``rtk`` is on PATH.
+        version: ``rtk --version`` output (e.g. ``"0.28.2"``) or ``None``.
+        hook_active: ``True`` when ``~/.claude/settings.json`` contains the
+            rtk PreToolUse hook marker.  ``False`` when the file exists but
+            no marker is present.  ``None`` when the file is missing or
+            unreadable.
+        jq_available: ``True`` when ``jq`` (required by rtk's hook script)
+            is on PATH.  ``False`` otherwise.  Independent of ``installed``
+            so the diagnostic skill can warn about it.
+        config_path: Path to the user's rtk config file when present, else
+            ``None``.  Looks for ``~/.config/rtk/config.toml`` (Linux/macOS
+            XDG) and the macOS Application Support path.
+        binary_path: Resolved path to the rtk binary, or ``None``.
+    """
+
+    installed: bool = False
+    version: Optional[str] = None
+    hook_active: Optional[bool] = None
+    jq_available: bool = False
+    config_path: Optional[Path] = None
+    binary_path: Optional[Path] = None
+
+    def summary_line(self) -> str:
+        """One-line human summary for boot logs and ``/rtk`` status output."""
+        if not self.installed:
+            return "rtk: not installed"
+        version = self.version or "unknown"
+        if self.hook_active is True:
+            hook = "hook: active"
+        elif self.hook_active is False:
+            hook = "hook: inactive"
+        else:
+            hook = "hook: unknown"
+        jq = "" if self.jq_available else " (jq missing)"
+        return f"rtk {version} detected, {hook}{jq}"
+
+
+# --- Probes -----------------------------------------------------------------
+
+
+def _probe_binary() -> Optional[Path]:
+    """Return the resolved path to ``rtk`` on PATH, or None."""
+    found = shutil.which("rtk")
+    return Path(found) if found else None
+
+
+def _probe_version(binary: Path) -> Optional[str]:
+    """Run ``rtk --version`` once and return the version token.
+
+    rtk emits ``rtk X.Y.Z`` on stdout.  Returns the version token (e.g.
+    ``"0.28.2"``) on a match, or ``None`` for any other shape — failures
+    (timeout, non-zero exit, unrecognised format) all map to ``None`` so
+    callers see "unknown" instead of leaking raw subprocess output.
+    """
+    try:
+        result = subprocess.run(
+            [str(binary), "--version"],
+            capture_output=True,
+            text=True,
+            timeout=_VERSION_PROBE_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired) as e:
+        logger.debug("rtk --version probe failed: %s", e)
+        return None
+    parts = (result.stdout or result.stderr or "").split()
+    if len(parts) >= 2 and parts[0].lower() == "rtk":
+        return parts[1]
+    return None
+
+
+def _claude_settings_path() -> Path:
+    """Return the path to the user's global Claude Code settings.json.
+
+    Claude Code reads ``~/.claude/settings.json`` regardless of platform, so
+    we don't branch on macOS/Linux/Windows here.
+    """
+    return Path.home() / ".claude" / "settings.json"
+
+
+def _probe_hook(settings_path: Optional[Path] = None) -> Optional[bool]:
+    """Return whether rtk's PreToolUse hook is wired into Claude Code.
+
+    Strategy: validate the JSON once, then substring-scan the raw text for
+    rtk's hook markers.  The shape of ``hooks`` in ``settings.json`` has
+    shifted between Claude Code versions, so a substring match is more
+    robust than walking a specific schema.
+
+    Returns:
+        ``True`` if any marker is found, ``False`` if the file is valid
+        JSON but contains no marker, ``None`` if the file is missing,
+        unreadable, or not valid JSON.
+    """
+    path = settings_path or _claude_settings_path()
+    if not path.is_file():
+        return None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as e:
+        # OSError covers I/O failures; UnicodeDecodeError covers a
+        # settings.json edited with the wrong encoding.  Either way we
+        # can't confirm the hook state, but the *binary* probe must keep
+        # its result — so we return None (unknown), not propagate.  Note:
+        # UnicodeDecodeError is a ValueError subclass, not OSError, so it
+        # has to be listed explicitly.
+        logger.debug("could not read %s: %s", path, e)
+        return None
+    try:
+        json.loads(text)
+    except ValueError:
+        # Broken JSON — treat as unknown rather than claiming the hook is
+        # active or inactive based on a half-written config.
+        return None
+    return any(marker in text for marker in _HOOK_MARKERS)
+
+
+def _probe_config_path() -> Optional[Path]:
+    """Return the path to rtk's own config.toml, when present.
+
+    rtk's documented locations:
+      - Linux:   ``~/.config/rtk/config.toml`` (or ``$XDG_CONFIG_HOME``)
+      - macOS:   ``~/Library/Application Support/rtk/config.toml``
+
+    We never create or modify this file — only report whether it exists so
+    ``/rtk`` can show the user where their settings live.
+    """
+    candidates = []
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        candidates.append(Path(xdg) / "rtk" / "config.toml")
+    candidates.append(Path.home() / ".config" / "rtk" / "config.toml")
+    if platform.system() == "Darwin":
+        candidates.append(
+            Path.home() / "Library" / "Application Support" / "rtk" / "config.toml"
+        )
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+    return None
+
+
+# --- Public API -------------------------------------------------------------
+
+
+_cached_status: Optional[RtkStatus] = None
+
+
+def detect_rtk(force: bool = False) -> RtkStatus:
+    """Return a cached :class:`RtkStatus` for this process.
+
+    Args:
+        force: When ``True``, re-runs the probes and overwrites the cache.
+            Intended for tests and the ``/rtk`` skill (so users can verify
+            after running ``/rtk setup``).
+
+    The first call probes the host; subsequent calls reuse the result.  All
+    probes swallow their own errors and degrade gracefully — if anything goes
+    wrong we return ``RtkStatus(installed=False)`` rather than raising.
+    """
+    global _cached_status
+    if _cached_status is not None and not force:
+        return _cached_status
+
+    try:
+        binary = _probe_binary()
+        if binary is None:
+            status = RtkStatus(installed=False, jq_available=bool(shutil.which("jq")))
+        else:
+            status = RtkStatus(
+                installed=True,
+                version=_probe_version(binary),
+                hook_active=_probe_hook(),
+                jq_available=bool(shutil.which("jq")),
+                config_path=_probe_config_path(),
+                binary_path=binary,
+            )
+    except Exception as e:  # pragma: no cover — defensive; probes already swallow
+        logger.warning("rtk detection failed: %s", e)
+        status = RtkStatus(installed=False)
+
+    _cached_status = status
+    return status
+
+
+def reset_cache() -> None:
+    """Clear the cached :class:`RtkStatus`.
+
+    Intended for tests.  Production code should rely on :func:`detect_rtk` to
+    cache automatically.
+    """
+    global _cached_status
+    _cached_status = None

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -800,6 +800,16 @@ def main_loop():
         # Startup sequence
         max_runs, interval, branch_prefix = run_startup(koan_root, instance, projects)
 
+        # Probe for optional rtk binary (https://github.com/rtk-ai/rtk).
+        # When present, the prompt builder injects an awareness section so
+        # Claude prefers ``rtk <cmd>`` over the raw command for 60-90 % less
+        # tool output.  Detection is cheap, cached, and never mutates state.
+        try:
+            from app.rtk_detector import detect_rtk
+            log("init", detect_rtk().summary_line())
+        except Exception as e:
+            log("error", f"rtk detection failed: {e}")
+
         git_sync_interval = int(os.environ.get("KOAN_GIT_SYNC_INTERVAL", "5"))
 
         # --- Startup delay (#1039) ---

--- a/koan/skills/core/rtk/SKILL.md
+++ b/koan/skills/core/rtk/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: rtk
+scope: core
+group: system
+emoji: 🪓
+description: Manage optional rtk integration (https://github.com/rtk-ai/rtk) for compressed tool output
+version: 1.0.0
+audience: bridge
+worker: true
+commands:
+  - name: rtk
+    description: Show rtk detection status (binary, version, hook, jq, project setting)
+    usage: /rtk [setup|uninstall|gain|on|off]
+    aliases: []
+handler: handler.py
+---

--- a/koan/skills/core/rtk/handler.py
+++ b/koan/skills/core/rtk/handler.py
@@ -1,0 +1,259 @@
+"""Kōan ``/rtk`` skill — diagnostics and setup for the optional rtk binary.
+
+Subcommands:
+    /rtk                  — show detection status
+    /rtk setup            — preview what ``rtk init -g`` would change
+    /rtk setup confirm    — actually run ``rtk init -g --auto-patch``
+    /rtk uninstall        — run ``rtk init -g --uninstall``
+    /rtk gain [...]       — forward to ``rtk gain``
+    /rtk discover [...]   — forward to ``rtk discover``
+
+The two-step confirmation on ``setup`` is deliberate: the install command
+mutates the user's global ``~/.claude/settings.json``, which is outside
+Kōan's instance/ directory.  Showing the preview first surfaces what's
+about to change so the user can audit before committing.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+from typing import List, Optional
+
+
+_RTK_TIMEOUT = 30  # seconds — covers `rtk init -g` network/disk I/O
+_GAIN_TIMEOUT = 10
+_HELP = (
+    "🪓 RTK — token-efficient CLI proxy.\n"
+    "Usage:\n"
+    "  /rtk                — status\n"
+    "  /rtk setup          — preview hook install\n"
+    "  /rtk setup confirm  — install hook into ~/.claude/settings.json\n"
+    "  /rtk uninstall      — remove hook\n"
+    "  /rtk gain [args]    — token-savings analytics\n"
+    "  /rtk discover [args]— missed-savings opportunities"
+)
+
+
+def _format_status(status, project_setting: Optional[bool] = None) -> str:
+    """Render an :class:`RtkStatus` snapshot for Telegram output."""
+    lines = ["🪓 *RTK status*", ""]
+    if not status.installed:
+        lines.append("• Binary: not installed")
+        lines.append(
+            "• Install: `brew install rtk` or "
+            "`curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh`"
+        )
+        if not status.jq_available:
+            lines.append("• jq: missing (required for the auto-rewrite hook)")
+        return "\n".join(lines)
+
+    lines.append(f"• Binary: `{status.binary_path}` (version {status.version or 'unknown'})")
+    if status.hook_active is True:
+        lines.append("• Hook: ✅ active in `~/.claude/settings.json`")
+    elif status.hook_active is False:
+        lines.append("• Hook: ⚠️  not installed — run `/rtk setup` to enable")
+    else:
+        lines.append("• Hook: ❓ no `~/.claude/settings.json` (Claude Code never run?)")
+    lines.append(f"• jq: {'✅ available' if status.jq_available else '❌ missing (hook needs it)'}")
+    if status.config_path:
+        lines.append(f"• Config: `{status.config_path}`")
+    else:
+        lines.append("• Config: (none — using rtk defaults)")
+
+    # Surface the resolved per-project + global gate so the user knows whether
+    # the awareness section will actually fire on the next mission.
+    try:
+        from app.config import is_rtk_awareness_enabled
+        global_on = is_rtk_awareness_enabled()
+    except Exception:
+        global_on = False
+    if project_setting is None:
+        lines.append(f"• Awareness in prompts: {'on' if global_on else 'off'}")
+    else:
+        effective = global_on and project_setting
+        lines.append(
+            f"• Awareness in prompts: {'on' if effective else 'off'} "
+            f"(global={global_on}, project={project_setting})"
+        )
+    return "\n".join(lines)
+
+
+def _run_rtk(args: List[str], timeout: int = _RTK_TIMEOUT) -> tuple[int, str]:
+    """Invoke rtk and return (exit_code, combined_output).
+
+    All errors are caught so the skill always returns a renderable message
+    rather than crashing the bridge.
+    """
+    if not shutil.which("rtk"):
+        return 127, "rtk binary not found on PATH"
+    try:
+        result = subprocess.run(
+            ["rtk", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return 124, f"rtk {' '.join(args)} timed out after {timeout}s"
+    except OSError as e:
+        return 1, f"rtk failed to launch: {e}"
+    out = (result.stdout or "") + (result.stderr or "")
+    return result.returncode, out.strip() or "(no output)"
+
+
+def _truncate(text: str, limit: int = 1500) -> str:
+    """Trim long rtk output for Telegram while preserving the head + tail."""
+    if len(text) <= limit:
+        return text
+    head = text[: limit // 2]
+    tail = text[-limit // 2 :]
+    return f"{head}\n…\n{tail}"
+
+
+# Subcommands that simply forward to ``rtk <sub> [args]`` and pretty-print
+# the result.  Mapped to (emoji, label) for the response header.
+_PASSTHROUGH = {
+    "gain": ("📊", "rtk gain"),
+    "discover": ("🔎", "rtk discover"),
+}
+
+
+def _passthrough(sub: str, rest: List[str]) -> str:
+    """Forward ``/rtk <sub> [args]`` to the rtk binary and render the result."""
+    code, output = _run_rtk([sub, *rest], timeout=_GAIN_TIMEOUT)
+    if code == 127:
+        return f"❌ {output}"
+    emoji, label = _PASSTHROUGH[sub]
+    return f"{emoji} *{label}*\n\n```\n{_truncate(output)}\n```"
+
+
+def _toggle_override(instance_dir: Path, enable: bool) -> str:
+    """Write the ``instance/.koan-rtk-override`` runtime flag and report.
+
+    The config layer treats this file as the highest-priority source for
+    :func:`app.config.is_rtk_mode`, so the change takes effect on the next
+    mission without editing ``config.yaml``.
+
+    Uses :func:`app.utils.atomic_write` per the project convention for
+    ``instance/`` files — the run loop may be reading the override
+    concurrently and a partial-write window would briefly mask the new
+    value.
+    """
+    from app.utils import atomic_write
+
+    override = instance_dir / ".koan-rtk-override"
+    atomic_write(override, "on\n" if enable else "off\n")
+    state = "ON" if enable else "OFF"
+    inverse = "/rtk off" if enable else "/rtk on"
+    return (
+        f"🪓 RTK awareness {state} (runtime override).\n"
+        f"Takes effect on the next mission. "
+        f"Reverse with `{inverse}`."
+    )
+
+
+def _current_project_name(koan_root: Path) -> str:
+    """Best-effort current project name for project-scoped status."""
+    project_file = koan_root / "instance" / ".koan-project"
+    try:
+        return project_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        return ""
+
+
+def _resolve_project_setting(koan_root: Path) -> Optional[bool]:
+    """Return the per-project rtk setting for the active project, if any."""
+    project = _current_project_name(koan_root)
+    if not project:
+        return None
+    try:
+        from app.projects_config import get_project_rtk_enabled, load_projects_config
+        cfg = load_projects_config(str(koan_root))
+        if not cfg:
+            return None
+        return get_project_rtk_enabled(cfg, project)
+    except Exception:
+        return None
+
+
+def handle(ctx) -> str:
+    from app.rtk_detector import detect_rtk, reset_cache
+
+    args = (ctx.args or "").strip()
+    parts = args.split()
+
+    # /rtk         → status
+    if not parts:
+        status = detect_rtk()
+        project_setting = _resolve_project_setting(Path(ctx.koan_root))
+        return _format_status(status, project_setting=project_setting)
+
+    sub = parts[0].lower()
+    rest = parts[1:]
+
+    if sub in ("help", "--help", "-h"):
+        return _HELP
+
+    if sub == "setup":
+        if not shutil.which("rtk"):
+            return (
+                "❌ rtk is not installed. Install it first:\n"
+                "  `brew install rtk`\n"
+                "  or `curl -fsSL https://raw.githubusercontent.com/rtk-ai/rtk/refs/heads/master/install.sh | sh`"
+            )
+        # Preview / confirm gate.
+        if not rest or rest[0].lower() != "confirm":
+            status = detect_rtk(force=True)
+            if status.hook_active is True:
+                return (
+                    "🪓 Hook already installed in `~/.claude/settings.json`.\n"
+                    "Run `/rtk uninstall` to remove it, or `/rtk setup confirm` to reinstall."
+                )
+            return (
+                "🪓 *Setup preview*\n\n"
+                "Running `rtk init -g --auto-patch` will:\n"
+                "  1. Add a `PreToolUse` Bash hook to `~/.claude/settings.json`.\n"
+                "  2. Drop an `RTK.md` awareness file next to it.\n"
+                "  3. Restart Claude Code (any new sessions pick up the hook).\n\n"
+                f"jq available: {'✅' if status.jq_available else '❌  install jq first or the hook will be a no-op'}\n\n"
+                "Confirm by sending `/rtk setup confirm`."
+            )
+        # Confirmed — actually run the installer.
+        code, output = _run_rtk(["init", "-g", "--auto-patch"])
+        reset_cache()
+        new_status = detect_rtk(force=True)
+        if code == 0 and new_status.hook_active:
+            return (
+                "✅ Hook installed.\n\n"
+                f"```\n{_truncate(output, 800)}\n```\n\n"
+                "Restart any active Claude Code sessions to pick up the hook."
+            )
+        return (
+            f"❌ `rtk init -g --auto-patch` exited {code}.\n\n"
+            f"```\n{_truncate(output)}\n```"
+        )
+
+    if sub == "uninstall":
+        if not shutil.which("rtk"):
+            return "❌ rtk binary not on PATH — nothing to uninstall."
+        code, output = _run_rtk(["init", "-g", "--uninstall"])
+        reset_cache()
+        if code == 0:
+            return (
+                "✅ Hook uninstalled.\n\n"
+                f"```\n{_truncate(output, 800)}\n```"
+            )
+        return (
+            f"❌ Uninstall exited {code}.\n\n"
+            f"```\n{_truncate(output)}\n```"
+        )
+
+    if sub in _PASSTHROUGH:
+        return _passthrough(sub, rest)
+
+    if sub in ("on", "off"):
+        return _toggle_override(Path(ctx.instance_dir), sub == "on")
+
+    return f"Unknown subcommand: `{sub}`\n\n{_HELP}"

--- a/koan/system-prompts/rtk-awareness.md
+++ b/koan/system-prompts/rtk-awareness.md
@@ -1,0 +1,25 @@
+# Tool Output Optimization — RTK
+
+`rtk` is installed on this host. It compresses common dev-command output 60-90% before you read it. Prefer it over the raw command whenever an `rtk` filter exists. The unfiltered output is auto-saved on failure, so nothing is lost.
+
+## Use `rtk <cmd>` for these
+
+- Git: `rtk git status`, `rtk git log`, `rtk git diff`, `rtk git add`, `rtk git commit`, `rtk git push`, `rtk git pull`
+- Files: `rtk ls`, `rtk read <file>`, `rtk find <glob>`, `rtk grep <pattern>`, `rtk diff a b`
+- GitHub: `rtk gh pr list`, `rtk gh pr view`, `rtk gh issue list`, `rtk gh run list`
+- Tests: `rtk pytest`, `rtk jest`, `rtk vitest`, `rtk cargo test`, `rtk go test`, `rtk rspec`, `rtk test <any-test-cmd>`
+- Build/lint: `rtk lint`, `rtk tsc`, `rtk ruff check`, `rtk cargo build`, `rtk cargo clippy`, `rtk golangci-lint run`
+- Containers: `rtk docker ps`, `rtk docker logs`, `rtk kubectl pods`, `rtk kubectl logs`
+- Logs/data: `rtk log <file>`, `rtk json <file>`, `rtk err <cmd>`
+
+If a command has no rtk filter, run it raw — rtk only intercepts known commands.
+
+## Meta commands (always raw, not via filter)
+
+- `rtk gain` — show token-savings analytics
+- `rtk discover` — find missed savings opportunities
+
+## Notes
+
+- `Read` / `Glob` / `Grep` Claude Code tools bypass rtk. For large files or wide searches, prefer `rtk read <file>` or `rtk grep <pattern>` via Bash.
+- Never pipe through `cat -n` or similar — rtk has already filtered.

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -1710,13 +1710,14 @@ class TestGetRtkSection:
             mock_lp.assert_called_once_with("rtk-awareness")
             assert "RTK" in result
 
-    def test_per_project_opt_out(self):
+    def test_per_project_opt_out(self, monkeypatch):
         """When the project sets rtk: false, the section is suppressed."""
         from app.prompt_builder import _get_rtk_section
 
+        monkeypatch.setenv("KOAN_ROOT", "/tmp/test-koan")
         with patch("app.config.is_rtk_awareness_enabled", return_value=True), \
+             patch("app.projects_config.load_projects_config", return_value={"projects": {"myproject": {"rtk": False}}}), \
              patch("app.projects_config.get_project_rtk_enabled", return_value=False), \
-             patch("app.utils.load_config", return_value={}), \
              patch("app.prompts.load_prompt", return_value="# RTK\nUse rtk."):
             assert _get_rtk_section(project_name="myproject") == ""
 

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -268,6 +268,7 @@ class TestBuildAgentPrompt:
         # Merge policy appended
         assert "Git Merge" in result
 
+    @patch("app.prompt_builder._get_rtk_section", return_value="")
     @patch("app.prompt_builder._get_caveman_section", return_value="")
     @patch("app.prompt_builder._get_verbose_section", return_value="")
     @patch("app.prompt_builder._get_security_flagging_section", return_value="")
@@ -278,7 +279,7 @@ class TestBuildAgentPrompt:
     @patch("app.prompts.load_prompt")
     def test_autonomous_mode_instruction(
         self, mock_load, mock_prefix, mock_merge, mock_deep, mock_submit_pr,
-        mock_security, mock_verbose, mock_caveman,
+        mock_security, mock_verbose, mock_caveman, mock_rtk,
         prompt_env,
     ):
         mock_load.return_value = "Template"
@@ -1686,6 +1687,163 @@ class TestIsCavemanMode:
 
         with patch("app.config._load_config", return_value={"optimizations": "invalid"}):
             assert is_caveman_mode() is True
+
+
+# --- Tests for _get_rtk_section ---
+
+
+class TestGetRtkSection:
+    """Tests for the RTK awareness section in agent prompts."""
+
+    def test_disabled_returns_empty(self):
+        from app.prompt_builder import _get_rtk_section
+
+        with patch("app.config.is_rtk_awareness_enabled", return_value=False):
+            assert _get_rtk_section() == ""
+
+    def test_enabled_returns_prompt(self):
+        from app.prompt_builder import _get_rtk_section
+
+        with patch("app.config.is_rtk_awareness_enabled", return_value=True), \
+             patch("app.prompts.load_prompt", return_value="# RTK\nUse rtk.") as mock_lp:
+            result = _get_rtk_section()
+            mock_lp.assert_called_once_with("rtk-awareness")
+            assert "RTK" in result
+
+    def test_per_project_opt_out(self):
+        """When the project sets rtk: false, the section is suppressed."""
+        from app.prompt_builder import _get_rtk_section
+
+        with patch("app.config.is_rtk_awareness_enabled", return_value=True), \
+             patch("app.projects_config.get_project_rtk_enabled", return_value=False), \
+             patch("app.utils.load_config", return_value={}), \
+             patch("app.prompts.load_prompt", return_value="# RTK\nUse rtk."):
+            assert _get_rtk_section(project_name="myproject") == ""
+
+    def test_load_prompt_failure_returns_empty(self):
+        from app.prompt_builder import _get_rtk_section
+
+        with patch("app.config.is_rtk_awareness_enabled", return_value=True), \
+             patch(
+                 "app.prompts.load_prompt",
+                 side_effect=FileNotFoundError("missing"),
+             ):
+            assert _get_rtk_section() == ""
+
+
+# --- Tests for is_rtk_mode ---
+
+
+class TestIsRtkMode:
+    """Tests for config.is_rtk_mode()."""
+
+    def test_default_auto_with_binary_returns_true(self, tmp_path, monkeypatch):
+        from app.config import is_rtk_mode
+        from app.rtk_detector import RtkStatus, reset_cache
+        reset_cache()
+
+        # No KOAN_ROOT override file.
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        with patch("app.config._load_config", return_value={}), \
+             patch("app.rtk_detector.detect_rtk", return_value=RtkStatus(installed=True)):
+            assert is_rtk_mode() is True
+
+    def test_default_auto_without_binary_returns_false(self, tmp_path, monkeypatch):
+        from app.config import is_rtk_mode
+        from app.rtk_detector import RtkStatus, reset_cache
+        reset_cache()
+
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        with patch("app.config._load_config", return_value={}), \
+             patch("app.rtk_detector.detect_rtk", return_value=RtkStatus(installed=False)):
+            assert is_rtk_mode() is False
+
+    def test_explicit_true_overrides_detection(self, tmp_path, monkeypatch):
+        from app.config import is_rtk_mode
+        from app.rtk_detector import RtkStatus, reset_cache
+        reset_cache()
+
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        with patch("app.config._load_config", return_value={
+            "optimizations": {"rtk": {"enabled": True}}
+        }), patch("app.rtk_detector.detect_rtk", return_value=RtkStatus(installed=False)):
+            assert is_rtk_mode() is True
+
+    def test_explicit_false(self, tmp_path, monkeypatch):
+        from app.config import is_rtk_mode
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        with patch("app.config._load_config", return_value={
+            "optimizations": {"rtk": {"enabled": False}}
+        }):
+            assert is_rtk_mode() is False
+
+    def test_runtime_override_off_wins(self, tmp_path, monkeypatch):
+        """``/rtk off`` writes an override that beats config.yaml."""
+        from app.config import is_rtk_mode
+        from app.rtk_detector import RtkStatus, reset_cache
+        reset_cache()
+
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / ".koan-rtk-override").write_text("off")
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+
+        with patch("app.config._load_config", return_value={
+            "optimizations": {"rtk": {"enabled": True}}
+        }), patch("app.rtk_detector.detect_rtk", return_value=RtkStatus(installed=True)):
+            assert is_rtk_mode() is False
+
+    def test_runtime_override_on_wins(self, tmp_path, monkeypatch):
+        from app.config import is_rtk_mode
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / ".koan-rtk-override").write_text("on")
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+
+        with patch("app.config._load_config", return_value={
+            "optimizations": {"rtk": {"enabled": False}}
+        }):
+            assert is_rtk_mode() is True
+
+    @pytest.mark.parametrize("content,expected", [
+        ("true", True), ("True\n", True), ("yes", True), ("1", True), ("on", True),
+        ("false", False), ("FALSE", False), ("no", False), ("0", False), ("off", False),
+    ])
+    def test_runtime_override_accepts_full_vocabulary(
+        self, content, expected, tmp_path, monkeypatch,
+    ):
+        """Override file must accept the same vocabulary as ``optimizations.rtk.enabled``.
+
+        Without parity, a user mirroring config syntax (``echo true > .koan-rtk-override``)
+        gets a silent no-op.
+        """
+        from app.config import is_rtk_mode
+        from app.rtk_detector import RtkStatus, reset_cache
+        reset_cache()
+
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / ".koan-rtk-override").write_text(content)
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+
+        # Set config to the *opposite* state so we know the override won.
+        config_state = {"optimizations": {"rtk": {"enabled": not expected}}}
+        with patch("app.config._load_config", return_value=config_state), \
+             patch("app.rtk_detector.detect_rtk", return_value=RtkStatus(installed=False)):
+            assert is_rtk_mode() is expected
+
+    def test_runtime_override_unrecognised_falls_through(self, tmp_path, monkeypatch):
+        """A garbage override file must not silently force a state — defer to config."""
+        from app.config import is_rtk_mode
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / ".koan-rtk-override").write_text("maybe\n")
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+
+        with patch("app.config._load_config", return_value={
+            "optimizations": {"rtk": {"enabled": False}}
+        }):
+            assert is_rtk_mode() is False
 
 
 # --- Tests for _get_language_section ---

--- a/koan/tests/test_rtk_detector.py
+++ b/koan/tests/test_rtk_detector.py
@@ -1,0 +1,248 @@
+"""Tests for app.rtk_detector — optional rtk binary detection."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    """Each test starts with a clean detector cache."""
+    from app.rtk_detector import reset_cache
+    reset_cache()
+    yield
+    reset_cache()
+
+
+# ---------------------------------------------------------------------------
+# detect_rtk — binary not on PATH
+# ---------------------------------------------------------------------------
+
+
+class TestRtkNotInstalled:
+    def test_returns_not_installed(self):
+        from app.rtk_detector import detect_rtk
+
+        with patch("app.rtk_detector.shutil.which", return_value=None):
+            status = detect_rtk()
+
+        assert status.installed is False
+        assert status.version is None
+        assert status.binary_path is None
+
+    def test_summary_line_when_missing(self):
+        from app.rtk_detector import detect_rtk
+
+        with patch("app.rtk_detector.shutil.which", return_value=None):
+            assert detect_rtk().summary_line() == "rtk: not installed"
+
+    def test_jq_probed_independently(self):
+        """Even with no rtk binary, the jq probe still runs so /rtk can warn."""
+        from app.rtk_detector import detect_rtk
+
+        def fake_which(name):
+            return "/usr/bin/jq" if name == "jq" else None
+
+        with patch("app.rtk_detector.shutil.which", side_effect=fake_which):
+            status = detect_rtk()
+
+        assert status.installed is False
+        assert status.jq_available is True
+
+
+# ---------------------------------------------------------------------------
+# detect_rtk — binary present
+# ---------------------------------------------------------------------------
+
+
+class TestRtkInstalled:
+    def _patch_which(self, mock):
+        """Make shutil.which find both rtk and jq."""
+        def _which(name):
+            if name == "rtk":
+                return "/opt/homebrew/bin/rtk"
+            if name == "jq":
+                return "/opt/homebrew/bin/jq"
+            return None
+        mock.side_effect = _which
+
+    def test_parses_version(self):
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.28.2\n", "stderr": ""})()
+        with patch("app.rtk_detector.shutil.which") as which, \
+             patch("app.rtk_detector.subprocess.run", return_value=completed), \
+             patch("app.rtk_detector._probe_hook", return_value=None), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            self._patch_which(which)
+            status = detect_rtk()
+
+        assert status.installed is True
+        assert status.version == "0.28.2"
+        assert status.jq_available is True
+        assert status.binary_path == Path("/opt/homebrew/bin/rtk")
+
+    def test_summary_line_with_active_hook(self):
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.30.0\n", "stderr": ""})()
+        with patch("app.rtk_detector.shutil.which") as which, \
+             patch("app.rtk_detector.subprocess.run", return_value=completed), \
+             patch("app.rtk_detector._probe_hook", return_value=True), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            self._patch_which(which)
+            assert detect_rtk().summary_line() == "rtk 0.30.0 detected, hook: active"
+
+    def test_summary_line_jq_missing(self):
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.28.2\n", "stderr": ""})()
+
+        def _which(name):
+            return "/opt/homebrew/bin/rtk" if name == "rtk" else None
+
+        with patch("app.rtk_detector.shutil.which", side_effect=_which), \
+             patch("app.rtk_detector.subprocess.run", return_value=completed), \
+             patch("app.rtk_detector._probe_hook", return_value=False), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            line = detect_rtk().summary_line()
+        assert "rtk 0.28.2 detected, hook: inactive (jq missing)" == line
+
+    def test_version_probe_timeout_returns_none(self):
+        """Hung binary → version is None but installed remains True."""
+        from app.rtk_detector import detect_rtk
+        import subprocess as sp
+
+        with patch("app.rtk_detector.shutil.which") as which, \
+             patch(
+                 "app.rtk_detector.subprocess.run",
+                 side_effect=sp.TimeoutExpired(cmd="rtk", timeout=2.0),
+             ), \
+             patch("app.rtk_detector._probe_hook", return_value=None), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            self._patch_which(which)
+            status = detect_rtk()
+        assert status.installed is True
+        assert status.version is None
+
+
+# ---------------------------------------------------------------------------
+# Hook probe
+# ---------------------------------------------------------------------------
+
+
+class TestHookProbe:
+    def test_missing_settings_file_returns_none(self, tmp_path):
+        from app.rtk_detector import _probe_hook
+
+        assert _probe_hook(tmp_path / "settings.json") is None
+
+    def test_no_marker_returns_false(self, tmp_path):
+        from app.rtk_detector import _probe_hook
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({"hooks": {}}))
+        assert _probe_hook(settings) is False
+
+    def test_marker_present_returns_true(self, tmp_path):
+        from app.rtk_detector import _probe_hook
+
+        settings = tmp_path / "settings.json"
+        settings.write_text(json.dumps({
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [
+                        {"type": "command", "command": "~/.claude/hooks/rtk-rewrite.sh"}
+                    ]}
+                ]
+            }
+        }))
+        assert _probe_hook(settings) is True
+
+    def test_invalid_json_returns_none(self, tmp_path):
+        from app.rtk_detector import _probe_hook
+
+        settings = tmp_path / "settings.json"
+        settings.write_text("{not json")
+        assert _probe_hook(settings) is None
+
+    def test_marker_in_invalid_json_returns_none(self, tmp_path):
+        """A JSON-broken settings file with the marker should not falsely report active."""
+        from app.rtk_detector import _probe_hook
+
+        settings = tmp_path / "settings.json"
+        # Marker present, but file is not valid JSON.
+        settings.write_text('{"hooks": "rtk-rewrite.sh"')  # missing closing brace
+        assert _probe_hook(settings) is None
+
+    def test_invalid_utf8_returns_none(self, tmp_path):
+        """Settings.json saved with the wrong encoding must not blow up the probe.
+
+        Regression for #1295: ``UnicodeDecodeError`` is a ``ValueError``, not
+        an ``OSError`` — without an explicit catch it would escape and
+        clobber the binary/version probes in :func:`detect_rtk`.
+        """
+        from app.rtk_detector import _probe_hook
+
+        settings = tmp_path / "settings.json"
+        # 0xff is invalid as a leading byte in UTF-8.
+        settings.write_bytes(b'\xff\xfe{"hooks":{}}')
+        assert _probe_hook(settings) is None
+
+    def test_invalid_utf8_does_not_clobber_install_status(self, tmp_path):
+        """Even with a broken settings.json, ``installed`` must remain True."""
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.28.2\n", "stderr": ""})()
+        settings = tmp_path / "settings.json"
+        settings.write_bytes(b"\xff\xfe{")  # invalid UTF-8
+
+        with patch("app.rtk_detector.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("app.rtk_detector.subprocess.run", return_value=completed), \
+             patch("app.rtk_detector._claude_settings_path", return_value=settings), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            status = detect_rtk()
+
+        assert status.installed is True
+        assert status.version == "0.28.2"
+        assert status.hook_active is None
+
+
+# ---------------------------------------------------------------------------
+# Cache behavior
+# ---------------------------------------------------------------------------
+
+
+class TestCache:
+    def test_second_call_does_not_re_probe(self):
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.28.2\n", "stderr": ""})()
+        with patch("app.rtk_detector.shutil.which", return_value="/usr/bin/rtk") as which, \
+             patch("app.rtk_detector.subprocess.run", return_value=completed) as run, \
+             patch("app.rtk_detector._probe_hook", return_value=None), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            detect_rtk()
+            detect_rtk()  # second call
+            detect_rtk()  # third call
+
+        # which() is called twice on the first probe (rtk + jq) and not again.
+        assert which.call_count == 2
+        assert run.call_count == 1
+
+    def test_force_reprobes(self):
+        from app.rtk_detector import detect_rtk
+
+        completed = type("R", (), {"stdout": "rtk 0.28.2\n", "stderr": ""})()
+        with patch("app.rtk_detector.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("app.rtk_detector.subprocess.run", return_value=completed) as run, \
+             patch("app.rtk_detector._probe_hook", return_value=None), \
+             patch("app.rtk_detector._probe_config_path", return_value=None):
+            detect_rtk()
+            detect_rtk(force=True)
+
+        assert run.call_count == 2

--- a/koan/tests/test_rtk_skill.py
+++ b/koan/tests/test_rtk_skill.py
@@ -1,0 +1,258 @@
+"""Tests for the /rtk skill handler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.skills import SkillContext
+
+
+def _make_ctx(args: str, koan_root: Path):
+    instance = koan_root / "instance"
+    instance.mkdir(parents=True, exist_ok=True)
+    ctx = MagicMock(spec=SkillContext)
+    ctx.command_name = "rtk"
+    ctx.args = args
+    ctx.koan_root = koan_root
+    ctx.instance_dir = instance
+    return ctx
+
+
+@pytest.fixture(autouse=True)
+def _reset_detector():
+    from app.rtk_detector import reset_cache
+    reset_cache()
+    yield
+    reset_cache()
+
+
+def _fake_status(**kwargs):
+    """Build a real RtkStatus so .summary_line()/etc. work."""
+    from app.rtk_detector import RtkStatus
+    defaults = dict(
+        installed=False, version=None, hook_active=None,
+        jq_available=False, config_path=None, binary_path=None,
+    )
+    defaults.update(kwargs)
+    return RtkStatus(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# /rtk (status)
+# ---------------------------------------------------------------------------
+
+
+class TestStatus:
+    def test_status_when_not_installed(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        with patch("app.rtk_detector.detect_rtk", return_value=_fake_status()):
+            result = handle(_make_ctx("", tmp_path))
+
+        assert "not installed" in result
+        assert "brew install rtk" in result
+
+    def test_status_when_installed_with_active_hook(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        status = _fake_status(
+            installed=True, version="0.28.2", hook_active=True,
+            jq_available=True, binary_path=Path("/opt/homebrew/bin/rtk"),
+        )
+        with patch("app.rtk_detector.detect_rtk", return_value=status), \
+             patch("app.config.is_rtk_awareness_enabled", return_value=True):
+            result = handle(_make_ctx("", tmp_path))
+
+        assert "0.28.2" in result
+        assert "active" in result
+        assert "✅" in result
+
+    def test_status_warns_when_hook_inactive(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        status = _fake_status(
+            installed=True, version="0.28.2", hook_active=False, jq_available=True,
+            binary_path=Path("/usr/bin/rtk"),
+        )
+        with patch("app.rtk_detector.detect_rtk", return_value=status), \
+             patch("app.config.is_rtk_awareness_enabled", return_value=True):
+            result = handle(_make_ctx("", tmp_path))
+
+        assert "/rtk setup" in result
+
+
+# ---------------------------------------------------------------------------
+# /rtk help
+# ---------------------------------------------------------------------------
+
+
+class TestHelp:
+    def test_help_lists_subcommands(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        result = handle(_make_ctx("help", tmp_path))
+        for sub in ("setup", "uninstall", "gain", "discover"):
+            assert sub in result
+
+
+# ---------------------------------------------------------------------------
+# /rtk setup
+# ---------------------------------------------------------------------------
+
+
+class TestSetup:
+    def test_setup_blocks_when_rtk_missing(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        with patch("skills.core.rtk.handler.shutil.which", return_value=None):
+            result = handle(_make_ctx("setup", tmp_path))
+
+        assert "not installed" in result
+        assert "brew install rtk" in result
+
+    def test_setup_preview_without_confirm(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        with patch("skills.core.rtk.handler.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("app.rtk_detector.detect_rtk", return_value=_fake_status(
+                 installed=True, version="0.28.2", hook_active=False, jq_available=True,
+             )):
+            result = handle(_make_ctx("setup", tmp_path))
+
+        assert "preview" in result.lower()
+        assert "/rtk setup confirm" in result
+
+    def test_setup_already_installed(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        with patch("skills.core.rtk.handler.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("app.rtk_detector.detect_rtk", return_value=_fake_status(
+                 installed=True, version="0.28.2", hook_active=True, jq_available=True,
+             )):
+            result = handle(_make_ctx("setup", tmp_path))
+
+        assert "already installed" in result.lower()
+
+    def test_setup_confirm_runs_init(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        completed = type("R", (), {"returncode": 0, "stdout": "Hook installed\n", "stderr": ""})()
+        with patch("skills.core.rtk.handler.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("skills.core.rtk.handler.subprocess.run", return_value=completed) as run_mock, \
+             patch("app.rtk_detector.detect_rtk", return_value=_fake_status(
+                 installed=True, version="0.28.2", hook_active=True, jq_available=True,
+             )):
+            result = handle(_make_ctx("setup confirm", tmp_path))
+
+        assert "Hook installed" in result
+        # Verify rtk init -g was actually invoked.
+        called_args = run_mock.call_args[0][0]
+        assert called_args[:3] == ["rtk", "init", "-g"]
+
+
+# ---------------------------------------------------------------------------
+# /rtk on / off — runtime override
+# ---------------------------------------------------------------------------
+
+
+class TestOnOff:
+    def test_on_writes_override(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        result = handle(_make_ctx("on", tmp_path))
+
+        override = tmp_path / "instance" / ".koan-rtk-override"
+        assert override.read_text().strip() == "on"
+        assert "ON" in result
+
+    def test_off_writes_override(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        result = handle(_make_ctx("off", tmp_path))
+
+        override = tmp_path / "instance" / ".koan-rtk-override"
+        assert override.read_text().strip() == "off"
+        assert "OFF" in result
+
+    def test_on_uses_atomic_write(self, tmp_path):
+        """Override must be written via app.utils.atomic_write per koan convention.
+
+        Regression: a direct ``Path.write_text`` truncates+writes in two
+        syscalls and exposes a window where a concurrent reader sees an
+        empty file.
+        """
+        from unittest.mock import patch
+        from skills.core.rtk.handler import handle
+
+        with patch("app.utils.atomic_write") as mock_atomic:
+            handle(_make_ctx("on", tmp_path))
+
+        mock_atomic.assert_called_once()
+        path_arg, content_arg = mock_atomic.call_args[0]
+        assert path_arg.name == ".koan-rtk-override"
+        assert content_arg == "on\n"
+
+
+# ---------------------------------------------------------------------------
+# SKILL.md frontmatter contract
+# ---------------------------------------------------------------------------
+
+
+class TestSkillManifest:
+    def test_worker_true_is_set(self):
+        """The /rtk skill shells out to subprocesses with timeouts up to 30s.
+
+        Without ``worker: true`` the handler runs on the bridge thread and
+        freezes Telegram polling for the duration of the subprocess.
+        """
+        from pathlib import Path
+        from app.skills import parse_skill_md
+
+        skill_md = Path(__file__).resolve().parents[1] / "skills" / "core" / "rtk" / "SKILL.md"
+        skill = parse_skill_md(skill_md)
+        assert skill is not None
+        assert getattr(skill, "worker", False) is True
+
+
+# ---------------------------------------------------------------------------
+# /rtk gain — passthrough
+# ---------------------------------------------------------------------------
+
+
+class TestGain:
+    def test_gain_when_not_installed(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        with patch("skills.core.rtk.handler.shutil.which", return_value=None):
+            result = handle(_make_ctx("gain", tmp_path))
+        assert "not found" in result.lower() or "❌" in result
+
+    def test_gain_forwards_args(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        completed = type("R", (), {
+            "returncode": 0, "stdout": "Total saved: 12345 tokens\n", "stderr": ""
+        })()
+        with patch("skills.core.rtk.handler.shutil.which", return_value="/usr/bin/rtk"), \
+             patch("skills.core.rtk.handler.subprocess.run", return_value=completed) as run_mock:
+            handle(_make_ctx("gain --history", tmp_path))
+
+        called = run_mock.call_args[0][0]
+        assert called == ["rtk", "gain", "--history"]
+
+
+# ---------------------------------------------------------------------------
+# Unknown subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestUnknown:
+    def test_unknown_returns_help(self, tmp_path):
+        from skills.core.rtk.handler import handle
+
+        result = handle(_make_ctx("nonsense", tmp_path))
+        assert "Unknown" in result
+        assert "/rtk" in result


### PR DESCRIPTION
## Summary

Closes #1295. Adds three optional layers of integration with [`rtk-ai/rtk`](https://github.com/rtk-ai/rtk), the Rust CLI proxy that compresses common dev-command output 60-90 % before Claude reads it. Strictly complementary to caveman (#1279): caveman trims what Claude *writes*, rtk trims what Claude *reads*. Composes multiplicatively.

`rtk` is **never** a Kōan dependency — every layer is opt-in, the binary is auto-detected, and absent rtk the codebase behaves identically to before.

## Layers

| Layer | What | Files |
|---|---|---|
| **L1 — Detection** | Cached, read-only probe of binary / version / `jq` / hook in `~/.claude/settings.json` / rtk's own config. One-line boot log. | `koan/app/rtk_detector.py`, `koan/app/run.py` |
| **L2 — Awareness** | Inject `rtk-awareness.md` into Claude's system prompt (mirrors `_get_caveman_section`). Cache-friendly slot in `build_agent_prompt_parts`. Per-project opt-out via `projects.yaml`. | `koan/app/prompt_builder.py`, `koan/system-prompts/rtk-awareness.md`, `koan/app/config.py`, `koan/app/projects_config.py`, `koan/app/config_validator.py` |
| **L3 — `/rtk` skill** | `status / setup (preview+confirm) / uninstall / gain / discover / on / off`. Hook installation **only** via explicit `/rtk setup confirm` — Kōan never silently mutates `~/.claude/settings.json`. | `koan/skills/core/rtk/SKILL.md`, `koan/skills/core/rtk/handler.py` |

## Default behavior

- `optimizations.rtk.enabled: auto` (default) — awareness fires iff the rtk binary is on PATH.
- Resolution order: `instance/.koan-rtk-override` > `optimizations.rtk.enabled` > detector.
- Per-project: `projects.<name>.rtk: false` opts out without touching globals.

## Test plan

- [x] `KOAN_ROOT=/tmp/test-koan-rtk .venv/bin/pytest koan/tests/test_rtk_detector.py -v` — 14 / 14 passed
- [x] `KOAN_ROOT=/tmp/test-koan-rtk .venv/bin/pytest koan/tests/test_rtk_skill.py -v` — 13 / 13 passed
- [x] `KOAN_ROOT=/tmp/test-koan-rtk .venv/bin/pytest koan/tests/test_prompt_builder.py -v` — 126 / 126 passed (10 new RTK tests)
- [x] **Full sweep**: `KOAN_ROOT=/tmp/test-koan-rtk .venv/bin/pytest koan/tests/ --ignore=koan/tests/test_dashboard.py` — **12,142 passed, zero regressions**
- [x] Lint gate: `koan/tests/test_silent_exceptions.py` passes (added stderr diagnostic to the new `except Exception` in `config.py`).
- [x] Manual: with rtk uninstalled, boot log shows `rtk: not installed`; with rtk installed (`brew install rtk`), boot log shows `rtk 0.28.x detected, hook: inactive` and `_get_rtk_section()` returns the awareness markdown.

## Out of scope (documented in `docs/rtk.md`)

- **Copilot provider** — rtk's Copilot mode is `deny-with-suggestion`, not transparent rewrite. Skip until upstream improves.
- **Read/Glob/Grep tool bypass** — rtk's hook only intercepts the Bash tool. Awareness section nudges Claude toward `rtk read` / `rtk grep`, but doesn't hard-restrict.
- **Windows native** — rtk's hook is Unix-only; awareness section still works.

## Next steps after merge

Per the issue's "Prototype First" recommendation: ship and run on a single instance for a week, measure savings via `/rtk gain` and `usage_tracker`. If the README's 60-80 % numbers hold up, no further work needed; if savings disappoint, reconsider tightening the awareness toward `rtk read`/`rtk grep` for Read-tool-bypass cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)