### PR TITLE
feat: forward mission result text to outbox for SKIP/FAIL/ERROR outcomes

### DIFF
--- a/docs/github-commands.md
+++ b/docs/github-commands.md
@@ -251,7 +251,7 @@ The helper is `app.external_skill_dispatch.try_dispatch_custom_handler`. It also
 
 - **Jira source**: the issue the comment is on.
 - **GitHub source**: the first `FOO-123`-style key found in the issue title, then body.
-- If the author already typed a key (e.g. `@bot cpfix CPANEL-1`), it's passed through verbatim.
+- If the author already typed a key (e.g. `@bot myfix PROJ-1`), it's passed through verbatim.
 
 ### Help grouping: the `integrations` group
 

--- a/docs/jira-integration.md
+++ b/docs/jira-integration.md
@@ -110,7 +110,7 @@ When `jira.enabled: true`, Koan validates the configuration at startup and warns
 
 Jira reuses the same `github_enabled: true` skill flag for command discovery — **both GitHub and Jira dispatch the exact same set of commands**. No separate Jira flag is needed.
 
-> **Custom skills under `instance/skills/<scope>/`** (e.g. the cPanel integration shipping `/cp_fix` and `/cp_plan`) are exposed here the same way: set `github_enabled: true` and `group: integrations` in their SKILL.md. Such skills with a `handler.py` are dispatched **in-process** by the Jira bridge — not queued as slash missions — and the handler automatically receives the originating Jira issue key in `ctx.args` when the commenter omitted one. See `koan/skills/README.md` for the full pattern.
+> **Custom skills under `instance/skills/<scope>/`** (e.g. a team-specific integration shipping `/my_fix` and `/my_plan`) are exposed here the same way: set `github_enabled: true` and `group: integrations` in their SKILL.md. Such skills with a `handler.py` are dispatched **in-process** by the Jira bridge — not queued as slash missions — and the handler automatically receives the originating Jira issue key in `ctx.args` when the commenter omitted one. See `koan/skills/README.md` for the full pattern.
 
 | Command | Aliases | What it does | Context-aware |
 |---------|---------|--------------|---------------|

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -144,6 +144,16 @@ skill_timeout: 7200
 # Default: 300 (5 minutes).
 # post_mission_timeout: 300
 
+# Forward Claude's final result text to outbox.md when a mission's outcome is an
+# alert (SKIP / FAIL / ERROR / BLOCKED, "permission deadlock", "no PR opened",
+# etc.) or when the mission title matches a skill that opted in via SKILL.md
+# (see "Result forwarding" in koan/skills/README.md — set `forward_result: true`
+# on the skill's SKILL.md frontmatter to enable). Guarantees the user sees the
+# result on Telegram even when the Claude session's sandbox blocked writes to
+# instance/.
+# Default: true. Set to false to silence the forwarder entirely.
+# notify_mission_results: true
+
 # Stagnation detection — abort Claude sessions stuck in a loop long before
 # mission_timeout would kill them, saving quota.
 # How it works: a daemon thread samples the subprocess stdout every

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -582,6 +582,27 @@ def get_post_mission_timeout() -> int:
     return _safe_int(config.get("post_mission_timeout", 300), 300)
 
 
+def get_notify_mission_results() -> bool:
+    """Whether to forward Claude's mission result text to outbox.md.
+
+    When True, the post-mission pipeline appends the Claude session's final
+    result string to outbox.md whenever it indicates an alert outcome
+    (SKIP/FAIL/ERROR/BLOCKED) or comes from a skill that opted in via
+    ``forward_result: true`` in its SKILL.md. Guarantees the user sees the
+    result on Telegram even when the Claude session's sandbox blocked writes
+    to instance/.
+
+    Config key: notify_mission_results (default: True).
+    """
+    config = _load_config()
+    val = config.get("notify_mission_results", True)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, str):
+        return val.strip().lower() not in ("false", "no", "0", "off")
+    return True
+
+
 # Default effort levels per autonomous mode.
 # Keys are autonomous modes, values are Claude CLI --effort levels.
 # "medium" is the provider default when no flag is passed — omitted here

--- a/koan/app/external_skill_dispatch.py
+++ b/koan/app/external_skill_dispatch.py
@@ -7,7 +7,7 @@ a ``handler.py`` that is invoked in-process — exactly the path Telegram takes
 via ``command_handlers._dispatch_skill``.
 
 Without this helper, a GitHub/Jira @mention for a custom skill would queue a
-``/cp_fix …`` slash mission that has no registered runner and no ``_runner.py``
+``/my_fix …`` slash mission that has no registered runner and no ``_runner.py``
 file, so ``skill_dispatch.build_skill_command()`` would return None.
 
 What this module does:
@@ -36,7 +36,7 @@ from app.skills import Skill, SkillContext, SkillError, execute_skill
 
 log = logging.getLogger(__name__)
 
-# Matches Jira-style keys like ``CPANEL-123`` or ``FOO-9``.
+# Matches Jira-style keys like ``PROJ-123`` or ``FOO-9``.
 # Kept loose (2+ letters, any uppercase prefix) so it works across projects.
 _JIRA_KEY_RE = re.compile(r"\b[A-Z][A-Z0-9]+-\d+\b")
 
@@ -129,7 +129,7 @@ def try_dispatch_custom_handler(
 
     Args:
         skill: The resolved Skill object (already validated as github_enabled).
-        command_name: The command the user typed (e.g. "cpfix").
+        command_name: The command the user typed (e.g. "myfix").
         context: Free-form text the user appended after the command.
         source: Where the mention came from — ``"github"`` or ``"jira"``.
         jira_issue_key: The Jira issue key for Jira-sourced mentions.

--- a/koan/app/jira_notifications.py
+++ b/koan/app/jira_notifications.py
@@ -323,7 +323,7 @@ def acknowledge_jira_comment(issue_key: str, command_name: str, base_url: str, a
     for the remainder of the ``max_age_hours`` window.
 
     Args:
-        issue_key: Jira issue key (e.g. "CPANEL-52372").
+        issue_key: Jira issue key (e.g. "PROJ-52372").
         command_name: The command being executed (e.g. "fix").
         base_url: Jira instance base URL (e.g. https://myorg.atlassian.net).
         auth_header: Basic auth header value.
@@ -538,7 +538,7 @@ def fetch_jira_issue(
     Uses the Jira config from config.yaml to authenticate.
 
     Args:
-        issue_key: Jira issue key (e.g. "CPANEL-52372").
+        issue_key: Jira issue key (e.g. "PROJ-52372").
 
     Returns:
         Tuple of (title, body, comments) where comments is a list of

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -20,12 +20,13 @@ CLI interface:
 
 import json
 import os
+import re
 import sys
 import threading
 import time
 from datetime import date, datetime
 from pathlib import Path
-from typing import Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # Maximum wall-clock time for the entire post-mission pipeline (seconds).
 # Individual steps have their own timeouts (tests: 120s, reflection: 60s,
@@ -835,6 +836,159 @@ def _notify_pipeline_failures(
         _log_runner("error", f"Pipeline failure notification failed: {e}")
 
 
+# Alert markers are matched case-insensitively. Word boundaries (\b) keep
+# short fragments like "no PR" from triggering on prose ("no problem",
+# "no projects"). Markdown-bolded markers (**SKIP**, **FAIL**, …) match
+# without word boundaries because the ** delimiters already anchor them.
+_RESULT_ALERT_REGEX = re.compile(
+    r"""
+    \*\*\s*(?:skip|fail(?:ed)?|error|blocked)\s*\*\*    # **SKIP**, **FAIL**, **FAILED**, **ERROR**, **BLOCKED**
+    | \b(?:skip|fail|error|blocked)\s*[—–\-]{1,2}       # SKIP —, FAIL --, ERROR -, etc.
+    | \bmission\s+(?:blocked|aborted)\b
+    | \bpermission\s+deadlock\b
+    | \bhard\s+stop\b
+    | \bno\s+branch,?\s+no\s+commits\b
+    | \bno\s+PR\b                                       # word-bounded — no "no problem"/"no projects"
+    | \bno\s+code\s+changes\b
+    | \bcould(?:\s+not|n[’']?t)\s+execute\b             # could not / couldn't / couldn’t execute
+    | \bnever\s+produced\b
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+_RESULT_FORWARD_MAX_CHARS = 4000
+
+# Lazy registry cache — skills rarely change at runtime, so we build the
+# registry once per process. Rebuild requires a restart, matching how skill
+# registration works elsewhere.
+_skill_registry_cache: Optional[Any] = None
+
+
+def _resolve_forward_result_markers() -> list:
+    """Collect mission-title markers from skills with ``forward_result: true``.
+
+    Builds the skill registry lazily from the koan core skills directory plus
+    the operator's ``$KOAN_ROOT/instance/skills/`` tree. Each opted-in skill
+    contributes auto-derived slash-command forms (``/{cmd.name}``,
+    ``/{alias}``, ``/{scope}.{name}``) and any explicit ``title_markers``.
+    """
+    global _skill_registry_cache
+    try:
+        if _skill_registry_cache is None:
+            from app.skills import build_registry
+            extra_dirs = []
+            koan_root = os.environ.get("KOAN_ROOT")
+            if koan_root:
+                instance_skills = Path(koan_root) / "instance" / "skills"
+                if instance_skills.is_dir():
+                    extra_dirs.append(instance_skills)
+            _skill_registry_cache = build_registry(extra_dirs)
+        from app.skills import collect_forward_result_markers
+        return collect_forward_result_markers(_skill_registry_cache)
+    except Exception as e:
+        _log_runner("error", f"Forward-result marker resolution failed: {e}")
+        return []
+
+
+def _should_forward_result(mission_title: str, result_text: str) -> Tuple[bool, bool]:
+    """Decide whether to forward this mission's result to outbox.
+
+    Returns ``(should_forward, is_alert)``. ``is_alert`` only governs the
+    icon (⚠️ for alerts, ℹ️ for customer-facing successes); the caller picks
+    its own notification priority.
+    """
+    body = (result_text or "").strip()
+    if not body:
+        return (False, False)
+
+    is_alert = bool(_RESULT_ALERT_REGEX.search(body))
+
+    lowered_title = (mission_title or "").lower()
+    markers = _resolve_forward_result_markers()
+    is_customer_facing = any(
+        marker in lowered_title for marker in markers if marker
+    )
+
+    return (is_alert or is_customer_facing, is_alert)
+
+
+def _notify_mission_result(
+    mission_title: str,
+    instance_dir: str,
+    stdout_file: str,
+    start_time: int,
+    exit_code: int,
+    outbox_baseline_mtime: Optional[float] = None,
+) -> None:
+    """Forward the Claude session's result text to outbox.md.
+
+    Activates when the result text is either an alert outcome
+    (SKIP/FAIL/ERROR/BLOCKED) or a skill that opted into result forwarding
+    via ``forward_result: true`` in its SKILL.md, on both successful and
+    failed Claude exits — failure exits often carry the most useful error
+    context, so they are forwarded too.
+
+    Idempotency: skipped silently when the Claude session itself wrote to
+    outbox.md during execution. The caller should pass
+    ``outbox_baseline_mtime`` captured **before** any post-mission step ran,
+    so writes from later pipeline steps (failure notifier, reflection,
+    pr_review_learning, …) do not suppress this notification. When
+    ``outbox_baseline_mtime`` is None, the current mtime is read at call
+    time (legacy/test path).
+    """
+    try:
+        from app.config import get_notify_mission_results
+        if not get_notify_mission_results():
+            return
+    except Exception as e:
+        # Fail open: default-True if config check is broken
+        _log_runner("error", f"notify_mission_results config check failed: {e}")
+
+    try:
+        result_text = _read_stdout_summary(stdout_file, max_chars=_RESULT_FORWARD_MAX_CHARS)
+        should_forward, is_alert = _should_forward_result(mission_title, result_text)
+        if not should_forward:
+            return
+
+        outbox_path = Path(instance_dir) / "outbox.md"
+
+        try:
+            mtime: Optional[float]
+            if outbox_baseline_mtime is not None:
+                mtime = outbox_baseline_mtime
+            elif outbox_path.exists():
+                mtime = outbox_path.stat().st_mtime
+            else:
+                mtime = None
+            if start_time > 0 and mtime is not None and mtime > start_time:
+                return
+        except OSError:
+            pass
+
+        title_short = (mission_title or "").strip()
+        if len(title_short) > 120:
+            title_short = title_short[:117] + "…"
+
+        icon = "⚠️" if is_alert else "ℹ️"
+        # Non-zero exits get the alert icon even when the body lacks keyword
+        # markers — the failure itself is the signal.
+        if exit_code != 0:
+            icon = "⚠️"
+        prefix_line = f"{icon} {title_short}" if title_short else icon
+
+        body = result_text.strip()
+        msg = f"{prefix_line}\n\n{body}\n"
+
+        from app.utils import append_to_outbox
+        from app.notify import NotificationPriority
+        # Customer-facing mission completions are responses to user commands —
+        # always send at ACTION priority so they pass the default min_priority
+        # filter. is_alert only affects the visual icon (⚠️ vs ℹ️).
+        append_to_outbox(outbox_path, msg, priority=NotificationPriority.ACTION)
+    except Exception as e:
+        _log_runner("error", f"Mission result notification failed: {e}")
+
+
 def _fire_post_mission_hook(
     instance_dir: str,
     project_name: str,
@@ -919,6 +1073,19 @@ def run_post_mission(
     }
 
     tracker = _PipelineTracker()
+
+    # Snapshot outbox.md mtime BEFORE any post-mission step runs, so the
+    # mission-result notifier can distinguish "Claude wrote during the
+    # session" from "a later pipeline step (failure notifier, reflection,
+    # pr_review_learning, …) wrote to outbox." Without this snapshot, any
+    # downstream outbox write would erroneously suppress the result body.
+    _outbox_baseline_mtime: Optional[float] = None
+    try:
+        _outbox_path = Path(instance_dir) / "outbox.md"
+        if _outbox_path.exists():
+            _outbox_baseline_mtime = _outbox_path.stat().st_mtime
+    except OSError:
+        _outbox_baseline_mtime = None
 
     # Overall pipeline deadline — prevents accumulated steps from blocking
     # the agent loop indefinitely.
@@ -1175,6 +1342,22 @@ def run_post_mission(
 
         # Notify user of pipeline failures via outbox (retried by bridge)
         _notify_pipeline_failures(tracker, mission_title, instance_dir)
+
+        # Forward Claude's result text to outbox so SKIP/ERROR/BLOCKED
+        # outcomes (and customer-facing skill results) reach Telegram even
+        # when the session's sandbox blocked writes to instance/.
+        # The baseline mtime captured at function entry lets the notifier
+        # ignore writes made by later pipeline steps (failure notifier,
+        # reflection, pr_review_learning) when deciding whether the Claude
+        # session itself already informed the user.
+        _notify_mission_result(
+            mission_title=mission_title,
+            instance_dir=instance_dir,
+            stdout_file=stdout_file,
+            start_time=start_time,
+            exit_code=exit_code,
+            outbox_baseline_mtime=_outbox_baseline_mtime,
+        )
 
         return result
     finally:

--- a/koan/app/skills.py
+++ b/koan/app/skills.py
@@ -88,6 +88,18 @@ class Skill:
     # are also free to keep an explicit ``caveman: false`` to document
     # intent, even though it matches the default.
     caveman_enabled: bool = False
+    # ``forward_result_enabled`` follows the SKILL.md frontmatter
+    # ``forward_result:`` flag. When True, the post-mission pipeline forwards
+    # the Claude session's result text to outbox.md so the user sees the
+    # response to their slash command / @mention. Auto-derived markers
+    # (slash-command forms of every command + alias, plus ``/{scope}.{name}``)
+    # are matched against the mission title in addition to any explicit
+    # ``title_markers``.
+    forward_result_enabled: bool = False
+    # ``title_markers`` — optional list of additional mission-title substrings
+    # that should also flag a mission as belonging to this skill, for the case
+    # where a handler emits plain-text titles without the slash command.
+    title_markers: List[str] = field(default_factory=list)
 
     @property
     def qualified_name(self) -> str:
@@ -242,6 +254,16 @@ def parse_skill_md(path: Path) -> Optional[Skill]:
     github_enabled = _parse_bool_flag(meta, "github_enabled")
     github_context_aware = _parse_bool_flag(meta, "github_context_aware")
     caveman_enabled = _parse_bool_flag(meta, "caveman")
+    forward_result_enabled = _parse_bool_flag(meta, "forward_result")
+
+    # Parse title_markers (optional inline list or comma-separated scalar).
+    title_markers_raw = meta.get("title_markers", [])
+    if isinstance(title_markers_raw, list):
+        title_markers = [str(m).strip() for m in title_markers_raw if str(m).strip()]
+    elif isinstance(title_markers_raw, str) and title_markers_raw.strip():
+        title_markers = [s.strip() for s in title_markers_raw.split(",") if s.strip()]
+    else:
+        title_markers = []
 
     # Parse audience (default: "bridge" for backward compatibility)
     audience = meta.get("audience", DEFAULT_AUDIENCE).lower()
@@ -274,6 +296,8 @@ def parse_skill_md(path: Path) -> Optional[Skill]:
         group=group,
         emoji=emoji,
         caveman_enabled=caveman_enabled,
+        forward_result_enabled=forward_result_enabled,
+        title_markers=title_markers,
     )
 
 
@@ -473,6 +497,35 @@ class SkillRegistry:
 
     def __contains__(self, qualified_name: str) -> bool:
         return qualified_name in self._skills
+
+
+def collect_forward_result_markers(registry: "SkillRegistry") -> List[str]:
+    """Return mission-title substrings for every skill that opted into result forwarding.
+
+    For each skill with ``forward_result_enabled``:
+      - emit ``/{cmd.name}`` and ``/{alias}`` for every command + alias,
+      - emit ``/{scope}.{name}`` (the scoped form used when a project tag is
+        present — see ``command_handlers._queue_cli_skill_mission``),
+      - emit every entry from ``title_markers`` (for handler-composed
+        plain-text mission titles).
+
+    All markers are lower-cased and deduplicated so the caller can do a flat
+    case-insensitive substring check against the mission title.
+    """
+    markers: set[str] = set()
+    for skill in registry.list_all():
+        if not skill.forward_result_enabled:
+            continue
+        markers.add(f"/{skill.scope}.{skill.name}".lower())
+        for cmd in skill.commands:
+            markers.add(f"/{cmd.name}".lower())
+            for alias in cmd.aliases:
+                markers.add(f"/{alias}".lower())
+        for raw in skill.title_markers:
+            text = (raw or "").strip().lower()
+            if text:
+                markers.add(text)
+    return sorted(markers)
 
 
 # ---------------------------------------------------------------------------

--- a/koan/skills/README.md
+++ b/koan/skills/README.md
@@ -61,6 +61,8 @@ handler: handler.py
 | `github_enabled` | no | Set to `true` to allow triggering via GitHub @mentions (default: `false`) |
 | `github_context_aware` | no | Set to `true` if the skill accepts additional context after the command (default: `false`) |
 | `caveman` | no | Set to `true` to opt this skill into the [caveman](#caveman-output-optimization) output optimization. Defaults to `false` (caveman does not apply unless explicitly opted in). |
+| `forward_result` | no | Set to `true` to forward Claude's final result text to outbox.md when a mission for this skill completes. See [Result forwarding](#result-forwarding). Defaults to `false`. |
+| `title_markers` | no | Optional list of additional mission-title substrings to match against this skill (case-insensitive). Used when a handler emits a plain-text mission title without the slash command. Defaults to `[]`. |
 
 ### Audience
 
@@ -116,27 +118,55 @@ Custom skills under `instance/skills/<scope>/` opt in the same way — add `gith
 ```yaml
 ---
 name: fix
-scope: cp
+scope: my_team
 group: integrations
 emoji: 🐛
 github_enabled: true
 github_context_aware: true
 handler: handler.py
 commands:
-  - name: cp_fix
-    aliases: [cpfix]
+  - name: my_fix
+    aliases: [myfix]
 ---
 ```
 
-When the skill has a `handler.py`, the GitHub / Jira bridge invokes the handler **in-process** at notification time (the same path Telegram uses) instead of queueing a `/cp_fix …` slash mission. The handler is expected to queue whatever mission it needs via `insert_pending_mission` — mirroring `instance/skills/cp/fix/handler.py`.
+When the skill has a `handler.py`, the GitHub / Jira bridge invokes the handler **in-process** at notification time (the same path Telegram uses) instead of queueing a `/my_fix …` slash mission. The handler is expected to queue whatever mission it needs via `insert_pending_mission` — mirroring `instance/skills/<scope>/<name>/handler.py`.
 
 **Auto-feeding the source issue.** When the author doesn't include a Jira key in the command text, the bridge appends one automatically:
 
 - **Jira source**: the issue the comment was posted on.
 - **GitHub source**: the first Jira key found in the issue/PR title, then body.
-- **Author override**: if the author already typed a key (e.g. `@bot cpfix CPANEL-1`), that key is used verbatim and no auto-feed happens.
+- **Author override**: if the author already typed a key (e.g. `@bot myfix PROJ-1`), that key is used verbatim and no auto-feed happens.
 
 This keeps the handler logic untouched — the detection lives at the dispatch boundary (`app.external_skill_dispatch.augment_args_with_issue_key`).
+
+### Result forwarding
+
+Skills with `forward_result: true` opt into post-mission **result forwarding** — when the mission completes, the Claude session's final result text is appended to `instance/outbox.md` (and from there relayed to Telegram) so the user sees the response to their slash command / @mention even when the Claude session's sandbox blocked direct writes to `instance/`.
+
+The runtime auto-derives mission-title markers for every opted-in skill:
+
+- `/{cmd.name}` and `/{alias}` for every command + alias in `commands:`,
+- `/{scope}.{name}` (the scoped form Telegram queues when a `[project:…]` tag is present).
+
+If the skill's handler composes a plain-text mission title without the slash command, list any extra substrings under `title_markers:` so the runtime can still recognise the result as belonging to the skill.
+
+Forwarding is also triggered, regardless of `forward_result`, when the result body contains alert markers (`**SKIP**` / `**FAIL**` / `**ERROR**` / `**BLOCKED**`, `permission deadlock`, `no PR opened`, etc.) — those always reach Telegram.
+
+```yaml
+---
+name: fix
+scope: my_team
+forward_result: true
+title_markers:
+  - "my-custom-workflow"          # matches handler-composed long-form titles
+commands:
+  - name: my_fix
+    aliases: [myfix]
+---
+```
+
+The global on/off switch is `notify_mission_results:` in `instance/config.yaml` (default: `true`).
 
 ### Commands
 

--- a/koan/tests/test_external_skill_dispatch.py
+++ b/koan/tests/test_external_skill_dispatch.py
@@ -31,14 +31,14 @@ def _make_custom_skill(tmp_path: Path, handler_src: str) -> Skill:
     handler_path = skill_dir / "handler.py"
     handler_path.write_text(handler_src)
     return Skill(
-        name="cp_fix",
-        scope="cp",
+        name="my_fix",
+        scope="my_team",
         description="Test custom skill",
         handler_path=handler_path,
         skill_dir=skill_dir,
         github_enabled=True,
         github_context_aware=True,
-        commands=[SkillCommand(name="cp_fix", aliases=["cpfix"])],
+        commands=[SkillCommand(name="my_fix", aliases=["myfix"])],
     )
 
 
@@ -60,42 +60,42 @@ def _make_core_skill() -> Skill:
 class TestAugmentArgs:
     def test_returns_context_unchanged_when_jira_key_already_present(self):
         out = augment_args_with_issue_key(
-            "focus on race CPANEL-999",
-            jira_issue_key="CPANEL-1",
+            "focus on race PROJ-999",
+            jira_issue_key="PROJ-1",
         )
-        assert out == "focus on race CPANEL-999"
+        assert out == "focus on race PROJ-999"
 
     def test_appends_jira_source_key_when_missing(self):
         out = augment_args_with_issue_key(
             "focus on the race",
-            jira_issue_key="CPANEL-456",
+            jira_issue_key="PROJ-456",
         )
-        assert out == "focus on the race CPANEL-456"
+        assert out == "focus on the race PROJ-456"
 
     def test_uses_jira_key_even_when_github_sources_also_present(self):
         # Jira source wins over GitHub title/body fallbacks.
         out = augment_args_with_issue_key(
             "",
-            jira_issue_key="CPANEL-10",
-            github_title="references CPANEL-99",
-            github_body="and CPANEL-88",
+            jira_issue_key="PROJ-10",
+            github_title="references PROJ-99",
+            github_body="and PROJ-88",
         )
-        assert out == "CPANEL-10"
+        assert out == "PROJ-10"
 
     def test_falls_back_to_github_title(self):
         out = augment_args_with_issue_key(
             "please fix",
-            github_title="Bug: CPANEL-321 breaks login",
+            github_title="Bug: PROJ-321 breaks login",
         )
-        assert out == "please fix CPANEL-321"
+        assert out == "please fix PROJ-321"
 
     def test_falls_back_to_github_body_when_title_has_none(self):
         out = augment_args_with_issue_key(
             "",
             github_title="just a bug",
-            github_body="tracked as CPANEL-77 in jira",
+            github_body="tracked as PROJ-77 in jira",
         )
-        assert out == "CPANEL-77"
+        assert out == "PROJ-77"
 
     def test_leaves_context_alone_when_nothing_found(self):
         out = augment_args_with_issue_key(
@@ -154,7 +154,7 @@ class TestTryDispatchCustomHandler:
         monkeypatch.delenv("KOAN_ROOT", raising=False)
         skill = _make_custom_skill(tmp_path, "def handle(ctx):\n    return 'ok'\n")
         assert try_dispatch_custom_handler(
-            skill, "cp_fix", "", source="github",
+            skill, "my_fix", "", source="github",
         ) is None
 
     def test_invokes_custom_handler_and_returns_reply(self, tmp_path):
@@ -165,12 +165,12 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "do the thing",
+            skill, "my_fix", "do the thing",
             source="github",
             github_body="nothing",
         )
 
-        assert reply == "args='do the thing' cmd='cp_fix'"
+        assert reply == "args='do the thing' cmd='my_fix'"
 
     def test_jira_key_auto_fed_from_jira_source(self, tmp_path):
         handler_src = (
@@ -180,12 +180,12 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "",
+            skill, "my_fix", "",
             source="jira",
-            jira_issue_key="CPANEL-42",
+            jira_issue_key="PROJ-42",
         )
 
-        assert reply == "got:CPANEL-42"
+        assert reply == "got:PROJ-42"
 
     def test_jira_key_auto_fed_from_github_title(self, tmp_path):
         handler_src = (
@@ -195,13 +195,13 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "",
+            skill, "my_fix", "",
             source="github",
-            github_title="CPANEL-789 breaks",
+            github_title="PROJ-789 breaks",
             github_body="body text",
         )
 
-        assert reply == "got:CPANEL-789"
+        assert reply == "got:PROJ-789"
 
     def test_user_context_with_key_preserved(self, tmp_path):
         handler_src = (
@@ -210,14 +210,14 @@ class TestTryDispatchCustomHandler:
         )
         skill = _make_custom_skill(tmp_path, handler_src)
 
-        # Author typed CPANEL-1; source issue is CPANEL-999. Author wins.
+        # Author typed PROJ-1; source issue is PROJ-999. Author wins.
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "CPANEL-1 please",
+            skill, "my_fix", "PROJ-1 please",
             source="jira",
-            jira_issue_key="CPANEL-999",
+            jira_issue_key="PROJ-999",
         )
 
-        assert reply == "got:CPANEL-1 please"
+        assert reply == "got:PROJ-1 please"
 
     def test_returns_empty_string_when_handler_returns_none(self, tmp_path):
         # Handler returning None means "no user-visible reply" — caller should
@@ -226,7 +226,7 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "context",
+            skill, "my_fix", "context",
             source="github",
         )
 
@@ -240,7 +240,7 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "ctx", source="github",
+            skill, "my_fix", "ctx", source="github",
         )
 
         # SkillError is surfaced as its message string, not None.
@@ -257,7 +257,7 @@ class TestTryDispatchCustomHandler:
         skill = _make_custom_skill(tmp_path, handler_src)
 
         reply = try_dispatch_custom_handler(
-            skill, "cp_fix", "", source="github",
+            skill, "my_fix", "", source="github",
             jira_issue_key=None,
         )
 

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -742,14 +742,14 @@ class TestProcessNotificationCustomHandler:
 
     def _registry_with_custom_skill(self, handler_path: Path):
         skill = Skill(
-            name="cp_fix",
-            scope="cp",
-            description="cPanel fix",
+            name="my_fix",
+            scope="my_team",
+            description="Team-specific fix",
             handler_path=handler_path,
             skill_dir=handler_path.parent,
             github_enabled=True,
             github_context_aware=True,
-            commands=[SkillCommand(name="cp_fix", aliases=["cpfix"])],
+            commands=[SkillCommand(name="my_fix", aliases=["myfix"])],
         )
         reg = SkillRegistry()
         reg._register(skill)
@@ -772,7 +772,7 @@ class TestProcessNotificationCustomHandler:
         ``insert_pending_mission`` from the slash-mission branch."""
         # Handler writes a marker file so we can see it ran.
         marker = tmp_path / "ran.txt"
-        handler_dir = tmp_path / "skills" / "cp" / "fix"
+        handler_dir = tmp_path / "skills" / "my_team" / "fix"
         handler_dir.mkdir(parents=True)
         handler = handler_dir / "handler.py"
         handler.write_text(
@@ -784,13 +784,13 @@ class TestProcessNotificationCustomHandler:
 
         # Notification subject title carries a Jira key that should be
         # auto-fed when the user omits one from the command.
-        sample_notification["subject"]["title"] = "Broken login CPANEL-123"
+        sample_notification["subject"]["title"] = "Broken login PROJ-123"
 
         registry = self._registry_with_custom_skill(handler)
-        mock_resolve.return_value = ("cp", "sukria", "koan")
+        mock_resolve.return_value = ("my_team", "alice", "koan")
         mock_get_comment.return_value = {
             "id": 99999,
-            "body": "@testbot cpfix",
+            "body": "@testbot myfix",
             "user": {"login": "alice"},
             "url": "https://api.github.com/x",
         }
@@ -806,22 +806,22 @@ class TestProcessNotificationCustomHandler:
         assert error is None
         # Handler ran inline and saw the auto-fed Jira key from the title.
         assert marker.exists()
-        assert marker.read_text() == "CPANEL-123"
+        assert marker.read_text() == "PROJ-123"
         # The slash-mission path was bypassed — no direct insert_pending_mission
         # call from process_single_notification itself.
         # (The handler may insert its own mission through utils, but that
         # would also hit mock_insert, so assert *either* zero calls or that
         # no GitHub-flavoured slash mission was queued.)
         for call in mock_insert.call_args_list:
-            assert "/cp_fix" not in str(call), (
-                "slash mission /cp_fix should NOT have been queued from GitHub path"
+            assert "/my_fix" not in str(call), (
+                "slash mission /my_fix should NOT have been queued from GitHub path"
             )
             assert "📬" not in str(call), (
                 "📬-marked GitHub mission should NOT have been queued"
             )
         # Notification bookkeeping still happened.
         mock_react.assert_called_once()
-        assert sample_notification["_koan_command"] == "cpfix"
+        assert sample_notification["_koan_command"] == "myfix"
         assert sample_notification["_koan_author"] == "alice"
 
 
@@ -2475,9 +2475,9 @@ class TestFormatHelpListMessage:
     def test_integrations_group_renders(self):
         """Custom skills with group=integrations get a dedicated section."""
         custom = Skill(
-            name="cp_fix", scope="cp", group="integrations", emoji="🐛",
+            name="my_fix", scope="my_team", group="integrations", emoji="🐛",
             github_enabled=True, github_context_aware=True,
-            commands=[SkillCommand(name="cp_fix", description="Fix a cp bug", aliases=["cpfix"])],
+            commands=[SkillCommand(name="my_fix", description="Fix a team bug", aliases=["myfix"])],
         )
         core = Skill(
             name="rebase", scope="core", group="pr", emoji="🔄",
@@ -2489,8 +2489,8 @@ class TestFormatHelpListMessage:
         reg._register(custom)
         msg = format_help_list_message(reg, "koanbot")
         assert "### Integrations" in msg
-        assert "`@koanbot cp_fix`" in msg
-        assert "`cpfix`" in msg
+        assert "`@koanbot my_fix`" in msg
+        assert "`myfix`" in msg
         # Integrations section comes after core groups (placed last in _GROUP_LABELS).
         assert msg.index("### Pull Requests") < msg.index("### Integrations")
 

--- a/koan/tests/test_jira_command_handler.py
+++ b/koan/tests/test_jira_command_handler.py
@@ -352,18 +352,18 @@ class TestCustomHandlerDispatch:
     of queueing a slash mission that has no runner module."""
 
     def _make_custom_registry(self, handler_path: Path):
-        """Registry where 'cpfix' maps to a custom skill backed by handler_path."""
+        """Registry where 'myfix' maps to a custom skill backed by handler_path."""
         from app.skills import Skill, SkillCommand, SkillRegistry
 
         skill = Skill(
-            name="cp_fix",
-            scope="cp",
-            description="cPanel fix",
+            name="my_fix",
+            scope="my_team",
+            description="Team-specific fix",
             handler_path=handler_path,
             skill_dir=handler_path.parent,
             github_enabled=True,
             github_context_aware=True,
-            commands=[SkillCommand(name="cp_fix", aliases=["cpfix"])],
+            commands=[SkillCommand(name="my_fix", aliases=["myfix"])],
         )
         registry = SkillRegistry()
         registry._register(skill)
@@ -381,7 +381,7 @@ class TestCustomHandlerDispatch:
 
         # Handler writes a marker file so we can assert it actually ran.
         marker = tmp_path / "handler_ran.txt"
-        handler_dir = tmp_path / "skills" / "cp" / "fix"
+        handler_dir = tmp_path / "skills" / "my_team" / "fix"
         handler_dir.mkdir(parents=True)
         handler = handler_dir / "handler.py"
         handler.write_text(
@@ -392,11 +392,11 @@ class TestCustomHandlerDispatch:
         )
 
         registry = self._make_custom_registry(handler)
-        cpfix_mention = dict(
+        myfix_mention = dict(
             mention,
-            body_text="@koan-bot cp_fix",
-            issue_key="CPANEL-555",
-            issue_url="https://test.atlassian.net/browse/CPANEL-555",
+            body_text="@koan-bot my_fix",
+            issue_key="PROJ-555",
+            issue_url="https://test.atlassian.net/browse/PROJ-555",
         )
 
         monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
@@ -408,28 +408,28 @@ class TestCustomHandlerDispatch:
              patch("app.jira_command_handler._notify_mission_from_jira"):
 
             success, error = process_jira_mention(
-                cpfix_mention, registry, basic_config, set(),
+                myfix_mention, registry, basic_config, set(),
             )
 
         assert success is True
         assert error is None
         # Handler actually ran and saw the auto-fed Jira key.
         assert marker.exists()
-        assert marker.read_text() == "CPANEL-555"
-        # The slash-mission path did NOT run — missions.md still empty of cp_fix.
-        assert "/cp_fix" not in missions_path.read_text()
+        assert marker.read_text() == "PROJ-555"
+        # The slash-mission path did NOT run — missions.md still empty of my_fix.
+        assert "/my_fix" not in missions_path.read_text()
 
     def test_user_provided_key_wins_over_source_issue(
         self, tmp_path, monkeypatch, mention, basic_config,
     ):
-        """If the author typed CPANEL-1 but source issue is CPANEL-999, the
+        """If the author typed PROJ-1 but source issue is PROJ-999, the
         author's key is passed through unchanged."""
         instance_dir = tmp_path / "instance"
         instance_dir.mkdir()
         (instance_dir / "missions.md").write_text("# Pending\n\n# In Progress\n\n# Done\n")
 
         marker = tmp_path / "handler_ran.txt"
-        handler_dir = tmp_path / "skills" / "cp" / "fix"
+        handler_dir = tmp_path / "skills" / "my_team" / "fix"
         handler_dir.mkdir(parents=True)
         handler = handler_dir / "handler.py"
         handler.write_text(
@@ -442,8 +442,8 @@ class TestCustomHandlerDispatch:
         registry = self._make_custom_registry(handler)
         author_mention = dict(
             mention,
-            body_text="@koan-bot cp_fix CPANEL-1 please",
-            issue_key="CPANEL-999",
+            body_text="@koan-bot my_fix PROJ-1 please",
+            issue_key="PROJ-999",
         )
 
         monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
@@ -461,5 +461,5 @@ class TestCustomHandlerDispatch:
         assert success is True
         # Author's key is preserved — the source issue is NOT appended.
         content = marker.read_text()
-        assert "CPANEL-1" in content
-        assert "CPANEL-999" not in content
+        assert "PROJ-1" in content
+        assert "PROJ-999" not in content

--- a/koan/tests/test_mission_runner_notify_result.py
+++ b/koan/tests/test_mission_runner_notify_result.py
@@ -1,0 +1,469 @@
+"""Tests for _notify_mission_result — forwards Claude result text to outbox.md."""
+
+import json
+import os
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+def _write_claude_stdout(path: Path, result_text: str) -> None:
+    """Write a minimal Claude --output-format=json result blob to path."""
+    blob = {
+        "type": "result",
+        "subtype": "success",
+        "is_error": False,
+        "result": result_text,
+    }
+    path.write_text(json.dumps(blob))
+
+
+# A single hook used across tests to make customer-facing detection
+# deterministic without requiring a real skill registry. Individual tests
+# pass the markers they want via the ``markers`` argument to ``patch``.
+_MARKER_PATCH_TARGET = "app.mission_runner._resolve_forward_result_markers"
+
+
+class TestShouldForwardResult:
+    def test_empty_body_returns_false(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            assert _should_forward_result("any title", "") == (False, False)
+            assert _should_forward_result("any title", "   \n  ") == (False, False)
+
+    def test_skip_marker_flags_alert(self):
+        from app.mission_runner import _should_forward_result
+        body = "🏁 [my_team] **SKIP — PROJ-53396**\n\nReason..."
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, alert = _should_forward_result("any title", body)
+        assert forward is True
+        assert alert is True
+
+    def test_error_marker_flags_alert(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, alert = _should_forward_result("", "Result body **ERROR** here")
+        assert forward and alert
+
+    def test_blocked_marker_flags_alert(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, alert = _should_forward_result("", "Mission blocked: no access")
+        assert forward and alert
+
+    def test_customer_facing_title_forwards_even_on_success(self):
+        """A registered skill that opted into forward_result is recognised
+        via the markers returned by the registry — even when the body has
+        no alert keywords."""
+        from app.mission_runner import _should_forward_result
+        title = "Use the my-custom-workflow agent to resolve issue PROJ-1"
+        body = "Done. PR opened: #42"
+        with patch(_MARKER_PATCH_TARGET, return_value=["my-custom-workflow"]):
+            forward, alert = _should_forward_result(title, body)
+        assert forward is True
+        assert alert is False
+
+    def test_neutral_title_and_neutral_body_does_not_forward(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, _ = _should_forward_result(
+                "Refactor cache layer", "Refactored 3 files, all tests pass."
+            )
+        assert forward is False
+
+    def test_no_pr_word_boundary_does_not_match_no_problem(self):
+        """Regression: 'no PR' must not match 'no problem' / 'no projects'."""
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            for body in (
+                "No problem — refactor complete.",
+                "Found no projects with stale branches.",
+                "no prior context needed.",
+                "no protected branches affected.",
+            ):
+                forward, alert = _should_forward_result("Refactor", body)
+                assert forward is False, f"false-positive on: {body!r}"
+                assert alert is False
+
+    def test_no_pr_with_word_boundary_does_match(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, alert = _should_forward_result(
+                "Refactor", "Branch pushed but no PR opened — see logs."
+            )
+        assert forward and alert
+
+    def test_couldnt_execute_variants_match(self):
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            for body in (
+                "could not execute the migration step",
+                "couldn't execute the test harness",
+                "couldn’t execute the test harness",  # typographic apostrophe
+            ):
+                forward, alert = _should_forward_result("any", body)
+                assert forward and alert, f"missed alert on: {body!r}"
+
+    def test_empty_marker_list_means_no_customer_facing_match(self):
+        """When no skill has opted in, customer-facing detection is off and
+        only body alerts can trigger forwarding."""
+        from app.mission_runner import _should_forward_result
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, _ = _should_forward_result(
+                "Use the my-custom-workflow agent on PROJ-1",
+                "Done. PR opened: #42",
+            )
+        assert forward is False
+
+
+class TestNotifyMissionResult:
+    def test_writes_action_priority_for_skip_outcome(self, instance_dir, tmp_path):
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(
+            stdout_file, "🏁 [my_team] **SKIP — PROJ-53396**\n\nNo access."
+        )
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        _notify_mission_result(
+            mission_title="Run the my-custom-workflow agent to resolve PROJ-53396",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+        )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "**SKIP — PROJ-53396**" in content
+        assert "[priority:action]" in content
+        assert "PROJ-53396" in content
+        assert "⚠️" in content  # Alert icon stays even when priority is ACTION
+
+    def test_writes_info_icon_for_customer_facing_success(
+        self, instance_dir, tmp_path
+    ):
+        """A skill opted into result forwarding gets ℹ️ on a non-alert body."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "Done. PR #42 opened.")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        with patch(_MARKER_PATCH_TARGET, return_value=["my-custom-workflow"]):
+            _notify_mission_result(
+                mission_title="Run the my-custom-workflow agent to resolve PROJ-99",
+                instance_dir=str(instance_dir),
+                stdout_file=str(stdout_file),
+                start_time=start_ts,
+                exit_code=0,
+            )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "[priority:action]" in content
+        assert "PR #42" in content
+        assert "ℹ️" in content  # Non-alert icon for success bodies
+
+    def test_permission_deadlock_flagged_as_alert(self, instance_dir, tmp_path):
+        """A body containing 'permission deadlock' gets the alert icon
+        regardless of skill registration."""
+        from app.mission_runner import _notify_mission_result, _should_forward_result
+
+        body = (
+            "The agent ran for ~21 minutes and 298 tool calls in an isolated "
+            "worktree but never produced any code changes. It hit a permission "
+            "deadlock: the session sandbox blocks Write, Edit, and "
+            "Bash(git checkout/commit/push)."
+        )
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            forward, alert = _should_forward_result(
+                "Run the my-custom-workflow agent to resolve PROJ-53396", body
+            )
+        assert forward and alert
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, body)
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        _notify_mission_result(
+            mission_title="Run the my-custom-workflow agent to resolve PROJ-53396",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+        )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "[priority:action]" in content
+        assert "⚠️" in content
+        assert "permission deadlock" in content
+
+    def test_skips_when_outbox_already_modified_after_start(
+        self, instance_dir, tmp_path
+    ):
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "🏁 [my_team] **SKIP — X-1**\n\nReason")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts + 10, start_ts + 10))
+        before = (instance_dir / "outbox.md").read_text()
+
+        _notify_mission_result(
+            mission_title="Run the my-custom-workflow agent to resolve X-1",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+        )
+
+        assert (instance_dir / "outbox.md").read_text() == before
+
+    def test_forwards_on_non_zero_exit_with_alert_body(
+        self, instance_dir, tmp_path
+    ):
+        """Non-zero exits forward when body has alert markers — failures
+        carry the most useful error context."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "🏁 **SKIP** — sandbox blocked write")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        _notify_mission_result(
+            mission_title="Run the my-custom-workflow agent to resolve X-1",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=1,
+        )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "**SKIP**" in content
+        assert "⚠️" in content  # Non-zero exit is always rendered as alert
+        assert "[priority:action]" in content
+
+    def test_non_zero_exit_forces_alert_icon_even_for_customer_facing(
+        self, instance_dir, tmp_path
+    ):
+        """Even a customer-facing mission gets the alert icon on failure."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "Done. PR #42 opened.")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        with patch(_MARKER_PATCH_TARGET, return_value=["my-custom-workflow"]):
+            _notify_mission_result(
+                mission_title="Run the my-custom-workflow agent to resolve X-9",
+                instance_dir=str(instance_dir),
+                stdout_file=str(stdout_file),
+                start_time=start_ts,
+                exit_code=2,
+            )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "⚠️" in content
+        assert "ℹ️" not in content
+
+    def test_truncates_long_result(self, instance_dir, tmp_path):
+        from app.mission_runner import (
+            _notify_mission_result,
+            _RESULT_FORWARD_MAX_CHARS,
+        )
+
+        stdout_file = tmp_path / "stdout.json"
+        big = "🏁 **SKIP — X-1**\n\n" + ("x" * 10_000)
+        _write_claude_stdout(stdout_file, big)
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        _notify_mission_result(
+            mission_title="t",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+        )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert len(content) < _RESULT_FORWARD_MAX_CHARS + 300
+
+    def test_disabled_by_config_flag(self, instance_dir, tmp_path):
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "🏁 **SKIP** — X")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        with patch(
+            "app.config.get_notify_mission_results", return_value=False
+        ):
+            _notify_mission_result(
+                mission_title="t",
+                instance_dir=str(instance_dir),
+                stdout_file=str(stdout_file),
+                start_time=start_ts,
+                exit_code=0,
+            )
+
+        assert (instance_dir / "outbox.md").read_text() == ""
+
+    def test_baseline_mtime_overrides_current_mtime_for_idempotency(
+        self, instance_dir, tmp_path
+    ):
+        """H1 fix: when a baseline mtime is passed, late pipeline writes to
+        outbox don't suppress the result notification.
+
+        Simulates the production sequence:
+          - mission starts at T
+          - Claude session runs, exits without writing to outbox
+          - run_post_mission captures baseline mtime = T-10 (pre-Claude)
+          - a later pipeline step (e.g. _notify_pipeline_failures) writes,
+            bumping current mtime to T+5
+          - _notify_mission_result is called and MUST still forward.
+        """
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(
+            stdout_file, "🏁 **SKIP** — sandbox blocked work"
+        )
+
+        start_ts = int(time.time()) - 60
+        baseline_mtime = float(start_ts - 10)  # pre-Claude snapshot
+        # Simulate a late pipeline write that bumped mtime to "after start":
+        os.utime(instance_dir / "outbox.md", (start_ts + 5, start_ts + 5))
+        # Pre-fill the file with the late-pipeline warning so we can verify
+        # our notification is appended, not replaced:
+        (instance_dir / "outbox.md").write_text("⚠️ Pipeline issues: …\n")
+        os.utime(instance_dir / "outbox.md", (start_ts + 5, start_ts + 5))
+
+        _notify_mission_result(
+            mission_title="any",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+            outbox_baseline_mtime=baseline_mtime,
+        )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "**SKIP**" in content, "baseline-mtime path must forward"
+        assert "Pipeline issues" in content, "must append, not replace"
+
+    def test_baseline_mtime_after_start_still_skips(self, instance_dir, tmp_path):
+        """Baseline mtime > start_time means Claude itself wrote to outbox
+        during the session — still skip to avoid double-notification."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "🏁 **SKIP** — X")
+
+        start_ts = int(time.time()) - 60
+        baseline_mtime = float(start_ts + 10)  # Claude wrote during session
+        os.utime(instance_dir / "outbox.md", (start_ts - 100, start_ts - 100))
+        before = (instance_dir / "outbox.md").read_text()
+
+        _notify_mission_result(
+            mission_title="any",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+            outbox_baseline_mtime=baseline_mtime,
+        )
+
+        assert (instance_dir / "outbox.md").read_text() == before
+
+    def test_customer_facing_markers_come_from_skill_registry(
+        self, instance_dir, tmp_path
+    ):
+        """M2 redesign: customer-facing detection is skill-driven via the
+        SKILL.md ``forward_result: true`` opt-in (exposed through
+        ``_resolve_forward_result_markers``). A brand-new marker provided by
+        a skill the runtime has no built-in knowledge of must work without
+        config edits."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "Operation complete — PR #99.")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        with patch(
+            _MARKER_PATCH_TARGET,
+            return_value=["/my_fix", "my-custom-workflow"],
+        ):
+            _notify_mission_result(
+                mission_title="/my_fix PROJ-1 please",
+                instance_dir=str(instance_dir),
+                stdout_file=str(stdout_file),
+                start_time=start_ts,
+                exit_code=0,
+            )
+
+        content = (instance_dir / "outbox.md").read_text()
+        assert "PR #99" in content
+        assert "[priority:action]" in content
+
+    def test_empty_registry_means_no_customer_facing_forwarding(
+        self, instance_dir, tmp_path
+    ):
+        """With no skill opted into forward_result, customer-facing detection
+        is fully off — only body alerts can still trigger forwarding."""
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "Done. PR #7 opened.")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        with patch(_MARKER_PATCH_TARGET, return_value=[]):
+            _notify_mission_result(
+                mission_title="/my_fix PROJ-1",
+                instance_dir=str(instance_dir),
+                stdout_file=str(stdout_file),
+                start_time=start_ts,
+                exit_code=0,
+            )
+
+        assert (instance_dir / "outbox.md").read_text() == ""
+
+    def test_neutral_mission_with_neutral_body_does_not_post(
+        self, instance_dir, tmp_path
+    ):
+        from app.mission_runner import _notify_mission_result
+
+        stdout_file = tmp_path / "stdout.json"
+        _write_claude_stdout(stdout_file, "Refactored 3 files. Tests pass.")
+
+        start_ts = int(time.time()) - 60
+        os.utime(instance_dir / "outbox.md", (start_ts - 10, start_ts - 10))
+
+        _notify_mission_result(
+            mission_title="Refactor cache layer",
+            instance_dir=str(instance_dir),
+            stdout_file=str(stdout_file),
+            start_time=start_ts,
+            exit_code=0,
+        )
+
+        assert (instance_dir / "outbox.md").read_text() == ""

--- a/koan/tests/test_skill_dispatch.py
+++ b/koan/tests/test_skill_dispatch.py
@@ -1097,7 +1097,7 @@ class TestValidateSkillArgs:
 
     def test_fix_jira_url_accepted(self):
         """Jira URLs are valid for /fix."""
-        assert validate_skill_args("fix", "https://org.atlassian.net/browse/CPANEL-52372") is None
+        assert validate_skill_args("fix", "https://org.atlassian.net/browse/PROJ-52372") is None
 
     def test_fix_pr_url_accepted(self):
         """PR URLs are valid for /fix — same as /implement."""

--- a/koan/tests/test_skills.py
+++ b/koan/tests/test_skills.py
@@ -350,6 +350,220 @@ class TestParseSkillMd:
         assert skill.cli_skill is None
 
 
+class TestForwardResultFrontmatter:
+    """Tests for forward_result + title_markers SKILL.md fields."""
+
+    def test_forward_result_defaults_to_false(self, tmp_path):
+        skill_dir = tmp_path / "scope" / "neutral"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(textwrap.dedent("""\
+            ---
+            name: neutral
+            scope: scope
+            commands:
+              - name: neutral
+            ---
+        """))
+        skill = parse_skill_md(skill_md)
+        assert skill is not None
+        assert skill.forward_result_enabled is False
+        assert skill.title_markers == []
+
+    def test_forward_result_true_parsed(self, tmp_path):
+        skill_dir = tmp_path / "scope" / "fwd"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(textwrap.dedent("""\
+            ---
+            name: fwd
+            scope: scope
+            forward_result: true
+            commands:
+              - name: fwd
+            ---
+        """))
+        skill = parse_skill_md(skill_md)
+        assert skill is not None
+        assert skill.forward_result_enabled is True
+
+    def test_forward_result_truthy_variants(self, tmp_path):
+        """Accepts 'true', 'yes', '1' via shared _parse_bool_flag helper."""
+        for raw in ("true", "yes", "1"):
+            skill_dir = tmp_path / f"v_{raw}" / "fwd"
+            skill_dir.mkdir(parents=True)
+            skill_md = skill_dir / "SKILL.md"
+            skill_md.write_text(textwrap.dedent(f"""\
+                ---
+                name: fwd
+                scope: scope
+                forward_result: {raw}
+                commands:
+                  - name: fwd
+                ---
+            """))
+            skill = parse_skill_md(skill_md)
+            assert skill is not None
+            assert skill.forward_result_enabled is True, raw
+
+    def test_forward_result_falsy_variants(self, tmp_path):
+        for raw in ("false", "no", "0", ""):
+            skill_dir = tmp_path / f"v_{raw or 'empty'}" / "fwd"
+            skill_dir.mkdir(parents=True)
+            skill_md = skill_dir / "SKILL.md"
+            skill_md.write_text(textwrap.dedent(f"""\
+                ---
+                name: fwd
+                scope: scope
+                forward_result: {raw}
+                commands:
+                  - name: fwd
+                ---
+            """))
+            skill = parse_skill_md(skill_md)
+            assert skill is not None
+            assert skill.forward_result_enabled is False, raw
+
+    def test_title_markers_inline_list(self, tmp_path):
+        skill_dir = tmp_path / "scope" / "fwd"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(textwrap.dedent("""\
+            ---
+            name: fwd
+            scope: scope
+            forward_result: true
+            title_markers: ["my-custom-workflow", "another-marker"]
+            commands:
+              - name: fwd
+            ---
+        """))
+        skill = parse_skill_md(skill_md)
+        assert skill is not None
+        assert skill.title_markers == ["my-custom-workflow", "another-marker"]
+
+    def test_title_markers_default_empty_when_omitted(self, tmp_path):
+        skill_dir = tmp_path / "scope" / "fwd"
+        skill_dir.mkdir(parents=True)
+        skill_md = skill_dir / "SKILL.md"
+        skill_md.write_text(textwrap.dedent("""\
+            ---
+            name: fwd
+            scope: scope
+            forward_result: true
+            commands:
+              - name: fwd
+            ---
+        """))
+        skill = parse_skill_md(skill_md)
+        assert skill is not None
+        assert skill.title_markers == []
+
+
+class TestCollectForwardResultMarkers:
+    """Tests for the collect_forward_result_markers registry helper."""
+
+    def test_empty_for_registry_with_no_opt_in(self):
+        from app.skills import (
+            Skill,
+            SkillCommand,
+            SkillRegistry,
+            collect_forward_result_markers,
+        )
+        reg = SkillRegistry()
+        reg._register(Skill(
+            name="neutral",
+            scope="core",
+            commands=[SkillCommand(name="neutral")],
+        ))
+        assert collect_forward_result_markers(reg) == []
+
+    def test_auto_derives_slash_markers_from_commands_and_aliases(self):
+        from app.skills import (
+            Skill,
+            SkillCommand,
+            SkillRegistry,
+            collect_forward_result_markers,
+        )
+        reg = SkillRegistry()
+        reg._register(Skill(
+            name="fix",
+            scope="my_team",
+            forward_result_enabled=True,
+            commands=[SkillCommand(name="my_fix", aliases=["myfix"])],
+        ))
+        markers = collect_forward_result_markers(reg)
+        # Auto-derived markers cover slash command, alias, and scoped form.
+        assert "/my_fix" in markers
+        assert "/myfix" in markers
+        assert "/my_team.fix" in markers
+
+    def test_includes_explicit_title_markers(self):
+        from app.skills import (
+            Skill,
+            SkillCommand,
+            SkillRegistry,
+            collect_forward_result_markers,
+        )
+        reg = SkillRegistry()
+        reg._register(Skill(
+            name="fix",
+            scope="my_team",
+            forward_result_enabled=True,
+            title_markers=["my-custom-workflow", "Long Phrase With Spaces"],
+            commands=[SkillCommand(name="my_fix")],
+        ))
+        markers = collect_forward_result_markers(reg)
+        assert "my-custom-workflow" in markers
+        assert "long phrase with spaces" in markers  # lower-cased
+
+    def test_skips_skills_without_forward_result(self):
+        from app.skills import (
+            Skill,
+            SkillCommand,
+            SkillRegistry,
+            collect_forward_result_markers,
+        )
+        reg = SkillRegistry()
+        reg._register(Skill(
+            name="opt_in",
+            scope="a",
+            forward_result_enabled=True,
+            commands=[SkillCommand(name="opt_in")],
+        ))
+        reg._register(Skill(
+            name="opt_out",
+            scope="a",
+            forward_result_enabled=False,
+            commands=[SkillCommand(name="opt_out")],
+        ))
+        markers = collect_forward_result_markers(reg)
+        assert "/opt_in" in markers
+        assert "/opt_out" not in markers
+
+    def test_markers_are_distinct_and_lowercased(self):
+        from app.skills import (
+            Skill,
+            SkillCommand,
+            SkillRegistry,
+            collect_forward_result_markers,
+        )
+        reg = SkillRegistry()
+        reg._register(Skill(
+            name="fix",
+            scope="my_team",
+            forward_result_enabled=True,
+            title_markers=["MY-CUSTOM-WORKFLOW", "my-custom-workflow"],
+            commands=[SkillCommand(name="my_fix", aliases=["my_fix"])],  # dup alias
+        ))
+        markers = collect_forward_result_markers(reg)
+        # Lower-cased and deduplicated.
+        assert markers == sorted(set(markers))
+        assert all(m == m.lower() for m in markers)
+        assert "my-custom-workflow" in markers
+        assert "MY-CUSTOM-WORKFLOW" not in markers
+
+
 # ---------------------------------------------------------------------------
 # SkillRegistry
 # ---------------------------------------------------------------------------
@@ -607,16 +821,16 @@ class TestSkillRegistry:
                 description: Plan
             ---
         """))
-        custom_dir = tmp_path / "cp" / "fix"
+        custom_dir = tmp_path / "my_team" / "fix"
         custom_dir.mkdir(parents=True)
         (custom_dir / "SKILL.md").write_text(textwrap.dedent("""\
             ---
             name: fix
-            scope: cp
+            scope: my_team
             group: integrations
             commands:
-              - name: cp_fix
-                description: Fix cPanel bug
+              - name: my_fix
+                description: Fix a team-specific bug
             ---
         """))
         registry = SkillRegistry(tmp_path)


### PR DESCRIPTION
Adds _notify_mission_result() to the post-mission pipeline so the Claude session's final result string reaches Telegram even when the session's sandbox blocked writes to instance/outbox.md. Activates when the result contains alert markers (SKIP/FAIL/ERROR/BLOCKED, "permission deadlock", "hard stop", etc.) or when the mission title matches a customer-facing skill (/cpfix, wp-bug-resolver).

Idempotent: skipped silently when the session has already written to outbox.md after the mission start time. Posts at ACTION priority so the message clears the default min_priority filter; the alert flag only toggles the icon (⚠️ for alerts, ℹ️ for customer-facing success).

Gated by the new notify_mission_results config key (default: True) so operators can opt out.