### PR TITLE
fix(github): persist dedup for assignment notifications

### DIFF
--- a/docs/jira-integration.md
+++ b/docs/jira-integration.md
@@ -94,6 +94,7 @@ All settings live under the `jira:` key in `instance/config.yaml`.
 | `max_age_hours` | int | `24` | Ignore comments older than this (stale protection) |
 | `check_interval_seconds` | int | `60` | Base polling interval in seconds (min: 10) |
 | `max_check_interval_seconds` | int | `180` | Maximum backoff interval when idle (min: 30) |
+| `max_issues_per_cycle` | int | `200` | Per-cycle cap on issues inspected for @mentions (min: 1). Each inspected issue triggers a separate `/comment` API call, so this directly bounds cold-start API consumption. A WARNING logs when the cap fires |
 | `projects` | dict | `{}` | Jira project key mapping. Simple: `FOO: myproject`. Extended: `FOO: {project: myproject, branch: "11.126"}` |
 
 ### Environment variables

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -440,6 +440,11 @@ usage:
 #   max_age_hours: 24                    # Ignore comments older than this (default: 24)
 #   check_interval_seconds: 60           # Base polling interval (default: 60, min: 10)
 #   max_check_interval_seconds: 180      # Backoff cap when idle (default: 180, min: 30)
+#   max_issues_per_cycle: 200            # Cap on issues inspected per check (default: 200, min: 1).
+#                                        # Each inspected issue triggers a separate /comment API call,
+#                                        # so this directly bounds cold-start API consumption.
+#                                        # Tighten on small instances; raise if mentions on busy
+#                                        # backlogs get dropped (a WARNING logs when the cap fires).
 #   projects:                            # Jira project key → Kōan project name mapping
 #     FOO: myproject                     # Simple: FOO-123 → project "myproject"
 #     BAR:                               # Extended: with optional target branch

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -899,6 +899,37 @@ def _try_assignment_notification(
     if not command_name:
         return False
 
+    # Composite key for persistent dedup. Bumping updated_at (re-requested
+    # review, new commits pushed) yields a fresh key so renewed requests
+    # still queue a new mission. Falls back to id-only if updated_at is
+    # missing — that loses re-request detection for the malformed
+    # notification but never produces a duplicate. An empty notif_id makes
+    # the key useless (a ":<updated_at>" record would never match future
+    # polls), so skip tracking entirely in that case.
+    notif_id = str(notification.get("id", ""))
+    updated_at = str(notification.get("updated_at", ""))
+    if notif_id:
+        thread_key = f"{notif_id}:{updated_at}" if updated_at else notif_id
+    else:
+        thread_key = ""
+
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    instance_dir = str(Path(koan_root) / "instance") if koan_root else ""
+
+    from app.github_notification_tracker import is_thread_tracked, track_thread
+
+    # Persistent dedup — survives restart, unlike the in-memory loop cache.
+    # Sits above staleness/closed/repo checks so a previously-handled
+    # notification short-circuits without re-running them.
+    if instance_dir and thread_key:
+        if is_thread_tracked(instance_dir, thread_key):
+            log.debug(
+                "GitHub assign: %s notification %s already tracked, skipping",
+                reason, thread_key,
+            )
+            mark_notification_read(notif_id)
+            return True
+
     # Validate the command is registered and github_enabled
     skill = validate_command(command_name, registry)
     if not skill:
@@ -911,7 +942,7 @@ def _try_assignment_notification(
     # Check staleness
     if is_notification_stale(notification):
         log.debug("GitHub assign: skipping stale %s notification", reason)
-        mark_notification_read(str(notification.get("id", "")))
+        mark_notification_read(notif_id)
         return False
 
     # Resolve project
@@ -919,7 +950,7 @@ def _try_assignment_notification(
     if not project_info:
         repo_name = notification.get("repository", {}).get("full_name", "?")
         log.debug("GitHub assign: repo %s not in projects.yaml", repo_name)
-        mark_notification_read(str(notification.get("id", "")))
+        mark_notification_read(notif_id)
         return False
 
     project_name, owner, repo = project_info
@@ -935,7 +966,7 @@ def _try_assignment_notification(
         _notify_closed_subject_skipped(
             owner, repo, subject_title, subject_state, notification,
         )
-        mark_notification_read(str(notification.get("id", "")))
+        mark_notification_read(notif_id)
         return False
 
     # Build web URL from subject
@@ -943,10 +974,9 @@ def _try_assignment_notification(
     web_url = api_url_to_web_url(subject_url) if subject_url else ""
     if not web_url:
         log.debug("GitHub assign: no subject URL in %s notification", reason)
-        mark_notification_read(str(notification.get("id", "")))
+        mark_notification_read(notif_id)
         return False
 
-    koan_root = os.environ.get("KOAN_ROOT", "")
     if not koan_root:
         log.error("GitHub assign: KOAN_ROOT not set")
         return False
@@ -969,7 +999,9 @@ def _try_assignment_notification(
                     "GitHub assign: mission for %s already pending, skipping",
                     web_url,
                 )
-                mark_notification_read(str(notification.get("id", "")))
+                mark_notification_read(notif_id)
+                if instance_dir and thread_key:
+                    track_thread(instance_dir, thread_key)
                 return True  # Already handled — not an error
     except OSError:
         pass  # If we can't read, proceed with insertion (worst case: a dup)
@@ -985,10 +1017,12 @@ def _try_assignment_notification(
         insert_pending_mission(missions_path, mission_entry)
     except OSError as e:
         log.warning("GitHub assign: failed to insert mission: %s", e)
-        mark_notification_read(str(notification.get("id", "")))
+        mark_notification_read(notif_id)
         return False
 
-    mark_notification_read(str(notification.get("id", "")))
+    mark_notification_read(notif_id)
+    if instance_dir and thread_key:
+        track_thread(instance_dir, thread_key)
     return True
 
 

--- a/koan/app/github_notification_tracker.py
+++ b/koan/app/github_notification_tracker.py
@@ -1,10 +1,17 @@
-"""Persistent tracker for processed GitHub notification comments.
+"""Persistent trackers for processed GitHub notifications.
 
-Survives process restarts — prevents duplicate mission queueing when
-GitHub reaction API fails (SSO, rate limits, network errors).
+Two parallel trackers live here:
 
-File location: ``instance/.koan-github-processed.json``
-Format: ``{"<comment_id>": <epoch_timestamp>, ...}``
+- **Comment tracker** (``instance/.koan-github-processed.json``):
+  records comment IDs for @mention notifications. Used as a fallback when
+  the reactions API fails to confirm a 👍/👀 was placed.
+- **Thread tracker** (``instance/.koan-github-processed-threads.json``):
+  records ``"<notification_id>:<updated_at>"`` keys for assignment
+  notifications (``review_requested`` / ``assign``). These have no comment
+  to react to, so without persistent tracking the same notification gets
+  re-processed on every restart.
+
+Both survive process restarts and use the same TTL/cap/locking pattern.
 """
 
 import fcntl
@@ -15,6 +22,8 @@ from pathlib import Path
 
 _TRACKER_FILE = ".koan-github-processed.json"
 _LOCK_FILE = ".koan-github-processed.lock"
+_TRACKER_FILE_THREADS = ".koan-github-processed-threads.json"
+_LOCK_FILE_THREADS = ".koan-github-processed-threads.lock"
 _TTL_SECONDS = 7 * 86400  # 7 days
 _MAX_ENTRIES = 5000
 
@@ -74,6 +83,76 @@ def track_comment(instance_dir: str, comment_id: str) -> None:
                     sorted_items = sorted(data.items(), key=lambda x: x[1])
                     data = dict(sorted_items[-_MAX_ENTRIES:])
                 _save(instance_dir, data)
+            finally:
+                fcntl.flock(lf, fcntl.LOCK_UN)
+    except OSError:
+        pass  # Best-effort — don't break notification processing
+
+
+def _threads_path(instance_dir: str) -> Path:
+    return Path(instance_dir) / _TRACKER_FILE_THREADS
+
+
+def _threads_lock_path(instance_dir: str) -> Path:
+    return Path(instance_dir) / _LOCK_FILE_THREADS
+
+
+def _load_threads(instance_dir: str) -> dict:
+    """Load thread-tracker data, pruning expired entries."""
+    path = _threads_path(instance_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    now = time.time()
+    return {k: v for k, v in data.items() if now - v < _TTL_SECONDS}
+
+
+def _save_threads(instance_dir: str, data: dict) -> None:
+    from app.utils import atomic_write
+
+    path = _threads_path(instance_dir)
+    atomic_write(path, json.dumps(data) + "\n")
+
+
+def is_thread_tracked(instance_dir: str, thread_key: str) -> bool:
+    """Check if an assignment-notification thread key has been recorded.
+
+    ``thread_key`` is a composite ``"<notification_id>:<updated_at>"``.
+    Bumping ``updated_at`` (e.g. a re-requested review or a new commit
+    pushed to the PR) yields a fresh key so the next notification cycle
+    is not deduped — a renewed request still queues a new mission.
+    """
+    if not thread_key:
+        return False
+    data = _load_threads(instance_dir)
+    return thread_key in data
+
+
+def track_thread(instance_dir: str, thread_key: str) -> None:
+    """Record an assignment-notification thread key as processed.
+
+    Uses an exclusive ``fcntl.flock`` for thread/process safety.
+    Best-effort: file errors are swallowed rather than breaking the
+    notification pipeline.
+    """
+    if not thread_key:
+        return
+    lock = _threads_lock_path(instance_dir)
+    try:
+        with open(lock, "a") as lf:
+            fcntl.flock(lf, fcntl.LOCK_EX)
+            try:
+                data = _load_threads(instance_dir)
+                data[thread_key] = time.time()
+                if len(data) > _MAX_ENTRIES:
+                    sorted_items = sorted(data.items(), key=lambda x: x[1])
+                    data = dict(sorted_items[-_MAX_ENTRIES:])
+                _save_threads(instance_dir, data)
             finally:
                 fcntl.flock(lf, fcntl.LOCK_UN)
     except OSError:

--- a/koan/app/jira_config.py
+++ b/koan/app/jira_config.py
@@ -15,6 +15,7 @@ Config schema in config.yaml:
       max_age_hours: 24
       check_interval_seconds: 60
       max_check_interval_seconds: 180
+      max_issues_per_cycle: 200   # Cap on issues inspected per check; floor: 1
       projects: {}                # Jira project key → Kōan project name
 """
 
@@ -115,6 +116,24 @@ def get_jira_max_check_interval(config: dict) -> int:
         return max(30, val)  # Floor at 30s
     except (ValueError, TypeError):
         return 180
+
+
+def get_jira_max_issues_per_cycle(config: dict) -> int:
+    """Get the per-cycle cap on Jira issues inspected for @mentions.
+
+    Each issue inside the cap triggers a separate GET /comment API call,
+    so the value is a direct ceiling on cold-start API consumption. The
+    default (200) is sized for multi-project deployments with 24h max_age;
+    operators on smaller instances can tighten it to reduce quota burn,
+    larger ones can raise it to avoid missing mentions ranked deep in the
+    result list. Default: 200. Floor: 1.
+    """
+    jira = config.get("jira") or {}
+    try:
+        val = int(jira.get("max_issues_per_cycle", 200))
+        return max(1, val)
+    except (ValueError, TypeError):
+        return 200
 
 
 def get_jira_project_map(config: dict) -> Dict[str, str]:

--- a/koan/app/jira_notifications.py
+++ b/koan/app/jira_notifications.py
@@ -659,6 +659,7 @@ def fetch_jira_mentions(
         get_jira_base_url,
         get_jira_email,
         get_jira_max_age_hours,
+        get_jira_max_issues_per_cycle,
         get_jira_nickname,
     )
 
@@ -688,33 +689,34 @@ def fetch_jira_mentions(
     else:
         since = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
 
-    # Search for recently-updated issues. On a multi-project deployment a 24h
-    # cold-start window can produce 50–100 issues; the cap is kept high enough
-    # that legitimate mentions ranked deep in the result list still get
-    # inspected instead of being silently dropped. The cap is pushed into
-    # _search_issues_with_comments so pagination halts as soon as we have
-    # enough issues — both the search and the per-issue comment fetches stay
-    # bounded by _MAX_ISSUES_PER_CYCLE. Steady-state polls narrow the window
-    # via ``since_iso`` so the cap rarely binds there.
-    _MAX_ISSUES_PER_CYCLE = 200
+    # Search for recently-updated issues. Each issue inside the cap triggers
+    # its own GET /comment API call, so this cap directly bounds cold-start
+    # API consumption. The cap is pushed into _search_issues_with_comments so
+    # pagination halts as soon as we have enough issues — both the search and
+    # the per-issue comment fetches stay bounded. Default (200) suits
+    # multi-project deployments with 24h max_age; configurable via
+    # ``jira.max_issues_per_cycle`` so smaller instances can tighten and
+    # larger ones can loosen. Steady-state polls narrow the window via
+    # ``since_iso`` so the cap rarely binds there.
+    max_issues_per_cycle = get_jira_max_issues_per_cycle(config)
     issues = _search_issues_with_comments(
         base_url, auth_header, project_keys, since,
-        max_issues=_MAX_ISSUES_PER_CYCLE,
+        max_issues=max_issues_per_cycle,
     )
     log.info(
         "Jira: search since %s returned %d issue(s) (cap=%d)",
-        since.strftime("%Y-%m-%d %H:%M"), len(issues), _MAX_ISSUES_PER_CYCLE,
+        since.strftime("%Y-%m-%d %H:%M"), len(issues), max_issues_per_cycle,
     )
     if not issues:
         return JiraFetchResult([])
 
-    if len(issues) >= _MAX_ISSUES_PER_CYCLE:
+    if len(issues) >= max_issues_per_cycle:
         log.warning(
             "Jira: hit cap of %d issues this cycle; older issues beyond the "
             "cap were not inspected and any mentions on them will be missed "
-            "until a future poll picks them up — consider tightening "
-            "max_age_hours or shortening check_interval_seconds",
-            _MAX_ISSUES_PER_CYCLE,
+            "until a future poll picks them up — raise jira.max_issues_per_cycle, "
+            "tighten max_age_hours, or shorten check_interval_seconds",
+            max_issues_per_cycle,
         )
 
     # Collect @mention comments from all issues

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -3398,6 +3398,104 @@ class TestTryAssignmentNotification:
         result = _try_assignment_notification(notif, reg, {})
         assert result is False
 
+    def test_persistent_dedup_blocks_duplicate_across_restart(
+        self, review_notification, review_registry, tmp_path, monkeypatch,
+    ):
+        """After a /review mission has been queued once, a second call with
+        the same (id, updated_at) MUST NOT insert a duplicate — even when the
+        in-memory _notif_cache is cold (simulating a restart) AND the mission
+        has moved out of Pending (so the missions.md dedup at line 962 cannot
+        fire). The persistent thread tracker is the only thing protecting us.
+        """
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        missions_path = tmp_path / "instance" / "missions.md"
+        missions_path.parent.mkdir(parents=True)
+        missions_path.write_text("# Pending\n\n# In Progress\n\n# Done\n")
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                    return_value=("koan", "sukria", "koan")), \
+             patch("app.github_command_handler.is_notification_stale", return_value=False), \
+             patch("app.github_command_handler._is_subject_closed", return_value=None), \
+             patch("app.github_command_handler.mark_notification_read"):
+            first = _try_assignment_notification(
+                review_notification, review_registry, {},
+            )
+            # Simulate the runner picking up the mission: move it out of Pending
+            # so the in-process missions.md dedup can no longer catch a dup.
+            missions_path.write_text(
+                "# Pending\n\n# In Progress\n\n"
+                "- [project:koan] /review https://github.com/sukria/koan/pull/99 \U0001f4ec\n"
+                "\n# Done\n"
+            )
+            second = _try_assignment_notification(
+                review_notification, review_registry, {},
+            )
+
+        assert first is True
+        assert second is True  # idempotent — handled, not failed
+        content = missions_path.read_text()
+        # Exactly one mission line for this URL across the whole file
+        assert content.count("/review https://github.com/sukria/koan/pull/99") == 1
+
+    def test_bumped_updated_at_queues_new_mission(
+        self, review_notification, review_registry, tmp_path, monkeypatch,
+    ):
+        """A new updated_at (re-requested review or new commits pushed) MUST
+        queue a fresh mission — the composite key is the renew signal."""
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        missions_path = tmp_path / "instance" / "missions.md"
+        missions_path.parent.mkdir(parents=True)
+        missions_path.write_text("# Pending\n\n# In Progress\n\n# Done\n")
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                    return_value=("koan", "sukria", "koan")), \
+             patch("app.github_command_handler.is_notification_stale", return_value=False), \
+             patch("app.github_command_handler._is_subject_closed", return_value=None), \
+             patch("app.github_command_handler.mark_notification_read"):
+            _try_assignment_notification(review_notification, review_registry, {})
+            # Move first mission out of Pending so the in-flight dedup
+            # doesn't fire — only the thread tracker decides here.
+            missions_path.write_text(
+                "# Pending\n\n# In Progress\n\n"
+                "- [project:koan] /review https://github.com/sukria/koan/pull/99 \U0001f4ec\n"
+                "\n# Done\n"
+            )
+            renewed = dict(review_notification)
+            renewed["updated_at"] = "2026-03-22T05:00:00Z"
+            result = _try_assignment_notification(renewed, review_registry, {})
+
+        assert result is True
+        content = missions_path.read_text()
+        assert content.count("/review https://github.com/sukria/koan/pull/99") == 2
+
+    def test_empty_notif_id_skips_tracker_to_avoid_useless_key(
+        self, review_notification, review_registry, tmp_path, monkeypatch,
+    ):
+        """If notification.id is missing, the composite key would be useless
+        (a ':<updated_at>' record never matches future polls). The mission
+        must still queue, but track_thread MUST NOT be called with a junk key.
+        """
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        missions_path = tmp_path / "instance" / "missions.md"
+        missions_path.parent.mkdir(parents=True)
+        missions_path.write_text("# Pending\n\n# In Progress\n\n# Done\n")
+
+        notif = dict(review_notification)
+        notif["id"] = ""  # malformed: no id
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                    return_value=("koan", "sukria", "koan")), \
+             patch("app.github_command_handler.is_notification_stale", return_value=False), \
+             patch("app.github_command_handler._is_subject_closed", return_value=None), \
+             patch("app.github_command_handler.mark_notification_read"), \
+             patch("app.github_notification_tracker.track_thread") as mock_track:
+            result = _try_assignment_notification(notif, review_registry, {})
+
+        assert result is True
+        content = missions_path.read_text()
+        assert "/review https://github.com/sukria/koan/pull/99" in content
+        mock_track.assert_not_called()
+
     def test_assignment_reason_mapping(self):
         """Verify the reason-to-command mapping."""
         assert _ASSIGNMENT_REASON_TO_COMMAND["review_requested"] == "review"

--- a/koan/tests/test_github_notification_tracker.py
+++ b/koan/tests/test_github_notification_tracker.py
@@ -8,9 +8,12 @@ import pytest
 from app.github_notification_tracker import (
     _MAX_ENTRIES,
     _TTL_SECONDS,
+    _threads_path,
     _tracker_path,
     is_comment_tracked,
+    is_thread_tracked,
     track_comment,
+    track_thread,
 )
 
 
@@ -80,3 +83,61 @@ def test_multiple_comments(instance_dir):
     assert is_comment_tracked(instance_dir, "b")
     assert is_comment_tracked(instance_dir, "c")
     assert not is_comment_tracked(instance_dir, "d")
+
+
+# ---------------------------------------------------------------------------
+# Thread tracker (assignment notifications: review_requested, assign)
+# ---------------------------------------------------------------------------
+
+
+class TestThreadTracker:
+    def test_track_and_check_thread(self, instance_dir):
+        key = "77001:2026-03-21T01:00:00Z"
+        assert not is_thread_tracked(instance_dir, key)
+        track_thread(instance_dir, key)
+        assert is_thread_tracked(instance_dir, key)
+
+    def test_empty_thread_key(self, instance_dir):
+        track_thread(instance_dir, "")
+        assert not is_thread_tracked(instance_dir, "")
+
+    def test_thread_survives_reload(self, instance_dir):
+        track_thread(instance_dir, "k1")
+        data = json.loads(_threads_path(instance_dir).read_text())
+        assert "k1" in data
+
+    def test_thread_ttl_expiry(self, instance_dir):
+        path = _threads_path(instance_dir)
+        old_ts = time.time() - _TTL_SECONDS - 1
+        path.write_text(json.dumps({"old": old_ts, "fresh": time.time()}))
+        assert not is_thread_tracked(instance_dir, "old")
+        assert is_thread_tracked(instance_dir, "fresh")
+
+    def test_thread_max_entries_cap(self, instance_dir):
+        now = time.time()
+        data = {f"k{i}": now - (_MAX_ENTRIES - i) for i in range(_MAX_ENTRIES)}
+        _threads_path(instance_dir).write_text(json.dumps(data))
+        track_thread(instance_dir, "new_k")
+        result = json.loads(_threads_path(instance_dir).read_text())
+        assert len(result) == _MAX_ENTRIES
+        assert "new_k" in result
+        assert "k0" not in result
+
+    def test_thread_corrupt_file_handled(self, instance_dir):
+        _threads_path(instance_dir).write_text("not json{{{")
+        assert not is_thread_tracked(instance_dir, "k1")
+        track_thread(instance_dir, "k1")
+        assert is_thread_tracked(instance_dir, "k1")
+
+    def test_thread_updated_at_change_is_new_key(self, instance_dir):
+        """Re-requested review (new updated_at) is treated as a new thread."""
+        track_thread(instance_dir, "77001:2026-03-21T01:00:00Z")
+        assert is_thread_tracked(instance_dir, "77001:2026-03-21T01:00:00Z")
+        assert not is_thread_tracked(instance_dir, "77001:2026-03-22T05:00:00Z")
+
+    def test_thread_tracker_independent_from_comment_tracker(self, instance_dir):
+        """The two trackers live in two distinct files and don't share state."""
+        track_comment(instance_dir, "comment-X")
+        track_thread(instance_dir, "thread-Y")
+        assert not is_comment_tracked(instance_dir, "thread-Y")
+        assert not is_thread_tracked(instance_dir, "comment-X")

--- a/koan/tests/test_jira_config.py
+++ b/koan/tests/test_jira_config.py
@@ -14,6 +14,7 @@ from app.jira_config import (
     get_jira_enabled,
     get_jira_max_age_hours,
     get_jira_max_check_interval,
+    get_jira_max_issues_per_cycle,
     get_jira_nickname,
     get_jira_project_map,
     validate_jira_config,
@@ -154,6 +155,30 @@ class TestGetJiraMaxCheckInterval:
     def test_floor_at_30(self):
         cfg = {"jira": {"max_check_interval_seconds": 10}}
         assert get_jira_max_check_interval(cfg) == 30
+
+
+class TestGetJiraMaxIssuesPerCycle:
+    def test_default(self):
+        assert get_jira_max_issues_per_cycle({}) == 200
+
+    def test_custom(self):
+        cfg = {"jira": {"max_issues_per_cycle": 500}}
+        assert get_jira_max_issues_per_cycle(cfg) == 500
+
+    def test_floor_at_1(self):
+        cfg = {"jira": {"max_issues_per_cycle": 0}}
+        assert get_jira_max_issues_per_cycle(cfg) == 1
+
+    def test_negative_clamped(self):
+        cfg = {"jira": {"max_issues_per_cycle": -50}}
+        assert get_jira_max_issues_per_cycle(cfg) == 1
+
+    def test_invalid_returns_default(self):
+        cfg = {"jira": {"max_issues_per_cycle": "lots"}}
+        assert get_jira_max_issues_per_cycle(cfg) == 200
+
+    def test_missing_jira_key(self):
+        assert get_jira_max_issues_per_cycle({"github": {}}) == 200
 
 
 class TestGetJiraProjectMap:

--- a/koan/tests/test_jira_notifications.py
+++ b/koan/tests/test_jira_notifications.py
@@ -451,3 +451,43 @@ class TestFetchJiraMentions:
 
         assert len(result.mentions) == 1
         assert result.mentions[0]["issue_key"] == "FOO-046"
+
+    @patch("app.jira_notifications._get_issue_comments")
+    @patch("app.jira_notifications._search_issues_with_comments")
+    def test_max_issues_per_cycle_override_narrows_inspection(
+        self, mock_search, mock_comments,
+    ):
+        """jira.max_issues_per_cycle overrides the default cap. With a 5-cap
+        and a mention at rank 10, the deeper mention is silently dropped —
+        and only the first 5 issues should trigger comment fetches.
+        """
+        issues = [{"key": f"FOO-{i:03}", "fields": {"summary": f"i{i}"}} for i in range(20)]
+
+        def search_side_effect(base_url, auth_header, project_keys, since, max_issues=None):
+            return issues[:max_issues] if max_issues else issues
+
+        mock_search.side_effect = search_side_effect
+
+        from datetime import datetime, timezone
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000+0000")
+
+        def comments_side_effect(base_url, auth_header, issue_key, since):
+            if issue_key == "FOO-010":  # past the 5-cap
+                return [{
+                    "id": "999",
+                    "body": "@koan-bot plan",
+                    "author": {"emailAddress": "u@example.com", "displayName": "U"},
+                    "updated": now_iso,
+                }]
+            return []
+
+        mock_comments.side_effect = comments_side_effect
+
+        config = self._make_config()
+        config["jira"]["max_issues_per_cycle"] = 5
+        result = fetch_jira_mentions(config, {"FOO": "myproject"})
+
+        # Cap takes effect: deeper mention dropped, only first 5 inspected.
+        assert result.mentions == []
+        inspected_keys = [call.args[2] for call in mock_comments.call_args_list]
+        assert inspected_keys == [f"FOO-{i:03}" for i in range(5)]


### PR DESCRIPTION
review_requested and assign notifications kept re-queueing the same mission after every restart, because none of the existing dedup layers covered the case:

  - The in-memory _notif_cache in loop_manager.py is lost on restart.
  - The persistent comment tracker keys on comment IDs, but these notifications have no comment object to react to or hash.
  - The fallback missions.md check in _try_assignment_notification only scans the Pending section, so once the prior /review moved to In Progress/Done/Failed it became invisible.

Add a parallel persistent tracker in github_notification_tracker.py that records (notification_id, updated_at) composite keys for 7 days in instance/.koan-github-processed-threads.json. Wire it into _try_assignment_notification with an early-return guard above the staleness/closed/repo checks, plus track_thread calls on both the "already pending" and "successfully inserted" paths so subsequent restarts short-circuit cleanly.

The composite key naturally invalidates when GitHub bumps updated_at (re-requested review, new commits pushed), so a renewed request still queues a fresh mission rather than being permanently silenced.