### PR TITLE
test(jira): cover spaced nicknames in parse_jira_mention_command

### DIFF
--- a/koan/tests/test_jira_notifications.py
+++ b/koan/tests/test_jira_notifications.py
@@ -151,6 +151,23 @@ class TestParseJiraMentionCommand:
         assert result is not None
         assert result[0] == "rebase"
 
+    @pytest.mark.parametrize("text,nick,expected", [
+        # Jira renders multi-word display names with their literal space
+        # in the ADF mention.attrs.text field.
+        ("@My Bot plan", "My Bot", ("plan", "")),
+        ("@My Bot plan FOO-123", "My Bot", ("plan", "FOO-123")),
+        # Case-insensitive — clients render mentions inconsistently.
+        ("@my bot plan", "My Bot", ("plan", "")),
+    ])
+    def test_spaced_nickname(self, text, nick, expected):
+        """Nicknames containing spaces must match.
+
+        Regression guard: re.escape() correctly handles the space; a future
+        refactor that drops re.escape or uses plain f-string interpolation
+        would silently break any nickname that contains a space.
+        """
+        assert parse_jira_mention_command(text, nick) == expected
+
 
 class TestResolveProjectFromJiraKey:
     def test_basic_mapping(self):


### PR DESCRIPTION
Every existing test in TestParseJiraMentionCommand uses a single-token nickname ("koan-bot"). None exercises the regex against a nickname containing whitespace, which leaves a gap: a refactor that drops re.escape() or interpolates the nickname directly into the pattern would silently break any deployment whose configured nickname has a space — and such deployments do exist in practice, because Jira's ADF mention.attrs.text preserves the literal display-name spacing.

Add three parametrized cases exercising:
  - the basic spaced-nickname mention,
  - a mention followed by command-context (ensures the trailing capture group isn't disrupted by the whitespace in the nickname),
  - a fully-lowercased mention (locks in the re.IGNORECASE flag, which clients sometimes rely on when rendering mentions).

No production code changes.