### PR TITLE
feat(hooks): discover skill-bound lifecycle modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 export
 
 .PHONY: install onboard setup start stop status restart
-.PHONY: clean say migrate test test-strict coverage sync-instance rename-project release
+.PHONY: clean say migrate test test-skills test-strict coverage sync-instance rename-project release
 .PHONY: awake run errand-run errand-awake dashboard
 .PHONY: ollama logs ssh-forward
 .PHONY: install-systemctl-service uninstall-systemctl-service
@@ -52,12 +52,25 @@ say: setup
 test: setup
 	$(VENV)/bin/pip install -q pytest pytest-cov 2>/dev/null
 	cd koan && KOAN_ROOT=/tmp/test-koan PYTHONPATH=. ../$(PYTHON) -m pytest tests/ -v --cov=app --cov-report=term-missing --cov-report=html:htmlcov
+	@$(MAKE) --no-print-directory test-skills
+
+test-skills: setup
+	@if [ -d instance/skills ] && find -L instance/skills -path '*/tests/test_*.py' -print -quit 2>/dev/null | grep -q .; then \
+		echo "→ running skill-local tests (instance/skills/**/tests)"; \
+		KOAN_REPO=$(PWD) KOAN_ROOT=/tmp/test-koan PYTHONPATH=koan $(PYTHON) -m pytest instance/skills/ -v; \
+	else \
+		echo "→ no skill-local tests found under instance/skills/**/tests/ — skipping"; \
+	fi
 
 test-strict: setup
 	@echo "→ running full test suite in strict mode (0 failures required)"
 	$(VENV)/bin/pip install -q pytest pytest-cov 2>/dev/null
 	@cd koan && KOAN_ROOT=/tmp/test-koan PYTHONPATH=. ../$(PYTHON) -m pytest tests/ -q --tb=short \
 		|| (echo "✗ tests failed — aborting" && exit 1)
+	@if [ -d instance/skills ] && find -L instance/skills -path '*/tests/test_*.py' -print -quit 2>/dev/null | grep -q .; then \
+		KOAN_REPO=$(PWD) KOAN_ROOT=/tmp/test-koan PYTHONPATH=koan $(PYTHON) -m pytest instance/skills/ -q --tb=short \
+			|| (echo "✗ skill-local tests failed — aborting" && exit 1); \
+	fi
 	@echo "✓ all tests passed"
 
 release: setup

--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,7 @@ test: setup
 
 test-skills: setup
 	@if [ -d instance/skills ] && find -L instance/skills -path '*/tests/test_*.py' -print -quit 2>/dev/null | grep -q .; then \
+		$(VENV)/bin/pip install -q pytest pytest-cov 2>/dev/null; \
 		echo "→ running skill-local tests (instance/skills/**/tests)"; \
 		KOAN_REPO=$(PWD) KOAN_ROOT=/tmp/test-koan PYTHONPATH=koan $(PYTHON) -m pytest instance/skills/ -v; \
 	else \

--- a/instance.example/hooks/README.md
+++ b/instance.example/hooks/README.md
@@ -1,14 +1,33 @@
 # Hooks
 
-Place `.py` files in this directory to extend Koan's lifecycle with custom logic.
+Koan discovers lifecycle hooks from two locations at startup:
 
-## How it works
+1. **Instance-wide hooks** — `.py` files in `instance/hooks/` that export a
+   `HOOKS` dict. These run for every event, across all skills and projects.
+2. **Skill-bound hooks** — `<event>.py` files placed next to a custom skill's
+   `handler.py` (e.g. `instance/skills/<scope>/<name>/post_mission.py`).
+   These run *after* instance-wide hooks and let a skill own its full
+   workflow without touching Koan core.
 
-At startup, Koan discovers all `.py` files in `instance/hooks/` (files starting with `_` are skipped). Each module must define a `HOOKS` dict mapping event names to handler functions. Handlers receive a single `ctx` dict with event-specific context.
+Hooks are **fire-and-forget**: errors are logged to stderr but never block the
+agent. Files starting with `_` or `.` are skipped.
 
-Hooks are **fire-and-forget**: errors are logged to stderr but never block the agent.
+## Scope & trust
 
-## Hook module format
+Both flavors execute with the agent's full process privileges. Anything dropped
+under `instance/hooks/` or `instance/skills/<scope>/<name>/<event>.py` runs:
+
+- at **startup** (the module is imported and its top-level code executes), and
+- on **every** matching lifecycle event — for every project, every mission,
+  regardless of whether the skill that owns the hook was the one invoked.
+
+A skill-bound `post_mission.py` does **not** auto-filter to missions targeting
+its own skill. If you want skill-scoped behaviour, gate it explicitly inside
+`run()` (see the example below). Treat the `instance/skills/` tree as trusted
+code: a third-party skill cloned in from a Git remote can do anything your
+agent process can do.
+
+## Instance-wide hook format
 
 ```python
 def on_post_mission(ctx):
@@ -22,6 +41,34 @@ HOOKS = {
 }
 ```
 
+## Skill-bound hook format
+
+Drop a file named after the event (e.g. `post_mission.py`) inside your skill
+directory and export a `run(ctx)` function. No `HOOKS` dict required — the
+file name *is* the event name.
+
+```
+instance/skills/my/fix/
+├── SKILL.md
+├── handler.py          # runs at command receipt
+└── post_mission.py     # runs after every mission — gate inside run()
+```
+
+The hook fires on every `post_mission` event, not only on missions that
+invoked this skill. Filter explicitly when you want skill-scoped behaviour:
+
+```python
+# instance/skills/my/fix/post_mission.py
+def run(ctx):
+    # Skip missions that don't belong to this skill.
+    if "/myfix" not in ctx.get("mission_title", ""):
+        return
+    # ... skill-owned post-mission work ...
+```
+
+Recognized filenames: `session_start.py`, `session_end.py`, `pre_mission.py`,
+`post_mission.py`.
+
 ## Available events
 
 | Event | When | Context keys |
@@ -29,7 +76,11 @@ HOOKS = {
 | `session_start` | After startup completes | `instance_dir`, `koan_root` |
 | `session_end` | On shutdown (finally block) | `instance_dir`, `total_runs` |
 | `pre_mission` | Before Claude execution | `instance_dir`, `project_name`, `project_path`, `mission_title`, `autonomous_mode`, `run_num` |
-| `post_mission` | After post-mission pipeline | `instance_dir`, `project_name`, `project_path`, `exit_code`, `mission_title`, `duration_minutes`, `result` |
+| `post_mission` | After post-mission pipeline | `instance_dir`, `project_name`, `project_path`, `exit_code`, `mission_title`, `duration_minutes`, `result`, `result_text` |
+
+`result_text` is the truncated Claude stdout summary (up to 4000 chars) —
+useful for parsing JIRA keys, PR URLs, or `RESULT:` lines without re-reading
+the stdout capture file.
 
 ## Tips
 
@@ -37,3 +88,45 @@ HOOKS = {
 - Hooks are discovered once at startup. Restart to pick up new hooks.
 - Use `.py.example` extension for template files to prevent auto-discovery.
 - The `result` dict in `post_mission` is a snapshot copy — modifying it has no effect.
+
+## Testing skill-bound hooks
+
+A skill that ships a hook should ship its tests alongside, so the hook and
+its verification travel together (especially important when the skill lives
+in a separate git repo symlinked into `instance/skills`).
+
+Convention:
+
+```
+instance/skills/my/fix/
+├── SKILL.md
+├── handler.py
+├── post_mission.py            # the hook
+└── tests/
+    ├── conftest.py            # bootstraps sys.path + KOAN_ROOT
+    └── test_post_mission.py
+```
+
+The `conftest.py` injects `<koan>/koan` into `sys.path` so `app.*` imports
+resolve, and sets `KOAN_ROOT` if unset. Copy it verbatim from an existing
+skill (e.g. `instance/skills/<scope>/<name>/tests/conftest.py`).
+
+Run skill-local tests:
+
+```bash
+make test-skills           # discovers and runs every instance/skills/**/tests/
+make test                  # repo tests + skill tests (chained)
+```
+
+Direct invocation also works:
+
+```bash
+# From the koan workspace root:
+pytest instance/skills/<scope>/<name>/tests/ -v
+
+# From the skill's tests directory:
+cd instance/skills/<scope>/<name>/tests && pytest .
+
+# From anywhere else, point at the koan workspace:
+KOAN_REPO=/path/to/koan pytest /path/to/koan/instance/skills/<scope>/<name>/tests/
+```

--- a/koan/app/hooks.py
+++ b/koan/app/hooks.py
@@ -1,10 +1,20 @@
 """Hook system for extensible pre/post-action events.
 
-Discovers hook modules from instance/hooks/ at startup and provides
-fire-and-forget event dispatching. Hook modules are .py files with a
-HOOKS dict mapping event names to callables.
+Discovers lifecycle hooks from two locations at startup:
 
-Example hook module (instance/hooks/my_hook.py):
+1. Instance-wide hooks: ``instance/hooks/<name>.py`` — any module name; the
+   module exports a ``HOOKS`` dict mapping event names to callables. These
+   run first for every event, across all skills and projects.
+
+2. Skill-bound hooks: ``instance/skills/<scope>/<name>/<event>.py`` — the
+   filename is the event name (e.g. ``post_mission.py``) and the module
+   exports a ``run(ctx)`` function. These run after instance-wide hooks and
+   let a custom skill own its lifecycle behavior without touching Kōan core.
+
+Both flavors are fire-and-forget: errors are logged to stderr but never
+block the agent loop.
+
+Example instance-wide hook (instance/hooks/my_hook.py):
 
     def on_post_mission(ctx):
         print(f"Mission completed: {ctx['mission_title']}")
@@ -12,6 +22,13 @@ Example hook module (instance/hooks/my_hook.py):
     HOOKS = {
         "post_mission": on_post_mission,
     }
+
+Example skill-bound hook (instance/skills/my/fix/post_mission.py):
+
+    def run(ctx):
+        if "myfix" not in ctx.get("mission_title", ""):
+            return
+        # ... skill-owned post-mission work ...
 
 Supported events:
     - session_start: Fired after startup completes
@@ -39,6 +56,14 @@ from typing import Callable, Dict, List, Optional
 from app.automation_rules import AutomationRule, load_rules
 
 
+_VALID_SKILL_HOOK_EVENTS = (
+    "session_start",
+    "session_end",
+    "pre_mission",
+    "post_mission",
+)
+
+
 class HookRegistry:
     """Discovers and manages hook modules from a directory."""
 
@@ -48,6 +73,11 @@ class HookRegistry:
         # Per-rule fire timestamps for the loop guard: {rule_id: [timestamp, ...]}
         self._rule_fire_times: Dict[str, List[float]] = defaultdict(list)
         self._discover(hooks_dir)
+        # Also discover skill-bound hooks under instance/skills/<scope>/<name>/.
+        # Instance-wide hooks above are registered first, so they fire first
+        # for each event; skill-bound hooks run afterward.
+        if instance_dir:
+            self._discover_skill_hooks(Path(instance_dir) / "skills")
 
     def _discover(self, hooks_dir: Path) -> None:
         """Scan hooks_dir for .py files and register their HOOKS dicts."""
@@ -82,6 +112,60 @@ class HookRegistry:
         for event_name, handler in hooks_dict.items():
             if callable(handler):
                 self._handlers.setdefault(event_name, []).append(handler)
+
+    def _discover_skill_hooks(self, skills_root: Path) -> None:
+        """Scan instance/skills/<scope>/<name>/ for <event>.py lifecycle modules.
+
+        Convention: the file name is the event name (e.g. ``post_mission.py``)
+        and the module exports a ``run(ctx)`` function. This lets a custom
+        skill own its lifecycle behavior alongside its handler.py without
+        touching Kōan core.
+        """
+        if not skills_root.is_dir():
+            return
+
+        for scope_dir in sorted(skills_root.iterdir()):
+            if not scope_dir.is_dir() or scope_dir.name.startswith((".", "_")):
+                continue
+            for skill_dir in sorted(scope_dir.iterdir()):
+                if not skill_dir.is_dir() or skill_dir.name.startswith((".", "_")):
+                    continue
+                for event_name in _VALID_SKILL_HOOK_EVENTS:
+                    hook_file = skill_dir / f"{event_name}.py"
+                    if not hook_file.is_file():
+                        continue
+                    try:
+                        self._load_skill_module(
+                            hook_file, event_name, scope_dir.name, skill_dir.name,
+                        )
+                    except Exception as exc:
+                        print(
+                            f"[hooks] Failed to load skill hook "
+                            f"{scope_dir.name}/{skill_dir.name}/{hook_file.name}: {exc}",
+                            file=sys.stderr,
+                        )
+
+    def _load_skill_module(
+        self, path: Path, event_name: str, scope: str, name: str,
+    ) -> None:
+        """Load a skill hook module and register its ``run`` function."""
+        module_name = f"koan_skill_hook_{scope}_{name}_{event_name}"
+        spec = importlib.util.spec_from_file_location(module_name, path)
+        if spec is None or spec.loader is None:
+            return
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+
+        handler = getattr(module, "run", None)
+        if not callable(handler):
+            print(
+                f"[hooks] Skill hook {scope}/{name}/{event_name}.py has no "
+                f"callable run() — skipping.",
+                file=sys.stderr,
+            )
+            return
+        self._handlers.setdefault(event_name, []).append(handler)
 
     def fire(self, event: str, **kwargs) -> Dict[str, str]:
         """Call all handlers for event, catching exceptions per-handler.

--- a/koan/app/hooks.py
+++ b/koan/app/hooks.py
@@ -130,6 +130,9 @@ class HookRegistry:
             for skill_dir in sorted(scope_dir.iterdir()):
                 if not skill_dir.is_dir() or skill_dir.name.startswith((".", "_")):
                     continue
+                # Only probe known event filenames — any other .py file in the
+                # skill directory (handler.py, helpers.py, utils.py, …) is
+                # silently ignored, not registered under a nonsense event.
                 for event_name in _VALID_SKILL_HOOK_EVENTS:
                     hook_file = skill_dir / f"{event_name}.py"
                     if not hook_file.is_file():

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -998,12 +998,26 @@ def _fire_post_mission_hook(
     mission_title: str,
     duration_minutes: int,
     result: dict,
+    stdout_file: Optional[str] = None,
 ) -> Dict[str, str]:
     """Fire post_mission hooks with full context.
+
+    When ``stdout_file`` is provided, the truncated stdout summary is
+    pre-read and passed to hooks as ``result_text`` so individual hooks
+    can inspect the mission output without re-implementing file I/O.
 
     Returns a dict mapping failed handler names to error messages.
     Empty dict means all hooks succeeded.
     """
+    result_text = ""
+    if stdout_file:
+        try:
+            result_text = _read_stdout_summary(
+                stdout_file, max_chars=_RESULT_FORWARD_MAX_CHARS,
+            )
+        except Exception as e:
+            _log_runner("error", f"post_mission hook stdout read failed: {e}")
+
     try:
         from app.hooks import fire_hook
         return fire_hook(
@@ -1015,6 +1029,7 @@ def _fire_post_mission_hook(
             mission_title=mission_title,
             duration_minutes=duration_minutes,
             result=dict(result),
+            result_text=result_text,
         )
     except Exception as e:
         _log_runner("error", f"post_mission hook error: {e}")
@@ -1198,6 +1213,7 @@ def run_post_mission(
             _fire_post_mission_hook(
                 instance_dir, project_name, project_path,
                 exit_code, mission_title, duration_minutes, result,
+                stdout_file=stdout_file,
             )
             result["pipeline_steps"] = tracker.to_dict()
             _write_pipeline_summary(
@@ -1324,6 +1340,7 @@ def run_post_mission(
             hook_failures = _fire_post_mission_hook(
                 instance_dir, project_name, project_path,
                 exit_code, mission_title, duration_minutes, result,
+                stdout_file=stdout_file,
             )
             if hook_failures:
                 failed_names = ", ".join(sorted(hook_failures))

--- a/koan/tests/test_skill_bound_hooks.py
+++ b/koan/tests/test_skill_bound_hooks.py
@@ -1,0 +1,177 @@
+"""Tests for skill-bound hook discovery in app.hooks.
+
+Skill-bound hooks live at ``instance/skills/<scope>/<name>/<event>.py`` and
+export a ``run(ctx)`` function. These tests verify the registry finds them,
+fires them with the documented context, and isolates errors.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from app.hooks import HookRegistry, fire_hook, init_hooks, reset_registry
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    reset_registry()
+    yield
+    reset_registry()
+
+
+@pytest.fixture
+def instance_dir(tmp_path):
+    """Create an instance directory layout with empty hooks/ and skills/."""
+    inst = tmp_path / "instance"
+    (inst / "hooks").mkdir(parents=True)
+    (inst / "skills").mkdir()
+    return inst
+
+
+def _write_skill_hook(
+    instance_dir: Path,
+    scope: str,
+    name: str,
+    event: str,
+    code: str,
+) -> Path:
+    skill_dir = instance_dir / "skills" / scope / name
+    skill_dir.mkdir(parents=True, exist_ok=True)
+    path = skill_dir / f"{event}.py"
+    path.write_text(code)
+    return path
+
+
+def _write_instance_hook(instance_dir: Path, name: str, code: str) -> Path:
+    path = instance_dir / "hooks" / f"{name}.py"
+    path.write_text(code)
+    return path
+
+
+class TestSkillBoundDiscovery:
+    def test_discovers_skill_hook(self, instance_dir):
+        _write_skill_hook(
+            instance_dir, "my", "fix", "post_mission",
+            "def run(ctx): pass\n",
+        )
+        registry = HookRegistry(instance_dir / "hooks", instance_dir=str(instance_dir))
+        assert registry.has_hooks("post_mission")
+
+    def test_ignores_unknown_event_filename(self, instance_dir):
+        _write_skill_hook(
+            instance_dir, "my", "fix", "random_event",
+            "def run(ctx): pass\n",
+        )
+        registry = HookRegistry(instance_dir / "hooks", instance_dir=str(instance_dir))
+        assert not registry.has_hooks("random_event")
+        assert not registry.has_hooks("post_mission")
+
+    def test_ignores_module_without_run(self, instance_dir, capsys):
+        _write_skill_hook(
+            instance_dir, "my", "fix", "post_mission",
+            "x = 42\n",
+        )
+        registry = HookRegistry(instance_dir / "hooks", instance_dir=str(instance_dir))
+        assert not registry.has_hooks("post_mission")
+        captured = capsys.readouterr()
+        assert "no callable run()" in captured.err
+
+    def test_isolates_load_errors(self, instance_dir, capsys):
+        _write_skill_hook(
+            instance_dir, "broken", "skill", "post_mission",
+            "def run(\n",  # syntax error
+        )
+        _write_skill_hook(
+            instance_dir, "my", "fix", "post_mission",
+            "def run(ctx): ctx.setdefault('hits', []).append('my_fix')\n",
+        )
+        registry = HookRegistry(instance_dir / "hooks", instance_dir=str(instance_dir))
+        assert registry.has_hooks("post_mission")
+        captured = capsys.readouterr()
+        assert "Failed to load skill hook" in captured.err
+
+    def test_skips_underscore_dirs(self, instance_dir):
+        _write_skill_hook(
+            instance_dir, "_private", "x", "post_mission",
+            "def run(ctx): pass\n",
+        )
+        _write_skill_hook(
+            instance_dir, "my", "_pycache_", "post_mission",
+            "def run(ctx): pass\n",
+        )
+        registry = HookRegistry(instance_dir / "hooks", instance_dir=str(instance_dir))
+        assert not registry.has_hooks("post_mission")
+
+    def test_instance_hook_runs_before_skill_hook(self, instance_dir, tmp_path):
+        order_file = tmp_path / "order.txt"
+        _write_instance_hook(
+            instance_dir, "global",
+            f"def h(ctx):\n"
+            f"    with open({str(order_file)!r}, 'a') as f:\n"
+            f"        f.write('global\\n')\n"
+            f"HOOKS = {{'post_mission': h}}\n",
+        )
+        _write_skill_hook(
+            instance_dir, "my", "fix", "post_mission",
+            f"def run(ctx):\n"
+            f"    with open({str(order_file)!r}, 'a') as f:\n"
+            f"        f.write('skill\\n')\n",
+        )
+
+        init_hooks(str(instance_dir))
+        fire_hook("post_mission", instance_dir=str(instance_dir))
+
+        order = order_file.read_text().splitlines()
+        assert order == ["global", "skill"]
+
+    def test_fire_runs_skill_hook_with_ctx(self, instance_dir, tmp_path):
+        capture = tmp_path / "ctx.txt"
+        _write_skill_hook(
+            instance_dir, "my", "fix", "post_mission",
+            f"def run(ctx):\n"
+            f"    with open({str(capture)!r}, 'w') as f:\n"
+            f"        f.write(repr(sorted(ctx.keys())))\n",
+        )
+        init_hooks(str(instance_dir))
+        fire_hook(
+            "post_mission",
+            instance_dir=str(instance_dir),
+            mission_title="/myfix ACME-1",
+            exit_code=0,
+            result_text="RESULT: SUCCESS",
+        )
+        keys_repr = capture.read_text()
+        assert "instance_dir" in keys_repr
+        assert "mission_title" in keys_repr
+        assert "result_text" in keys_repr
+
+    def test_skill_hook_error_isolated(self, instance_dir, tmp_path, capsys):
+        marker = tmp_path / "ok_ran.txt"
+        _write_skill_hook(
+            instance_dir, "my", "broken", "post_mission",
+            "def run(ctx): raise RuntimeError('boom')\n",
+        )
+        _write_skill_hook(
+            instance_dir, "my", "ok", "post_mission",
+            f"def run(ctx):\n"
+            f"    with open({str(marker)!r}, 'w') as f:\n"
+            f"        f.write('ran')\n",
+        )
+        init_hooks(str(instance_dir))
+        failures = fire_hook("post_mission")
+        # Broken hook's error is captured.
+        assert any("boom" in msg for msg in failures.values())
+        # Sibling hook still executed despite the broken one.
+        assert marker.read_text() == "ran"
+        # Only the broken hook is recorded as failed; the sibling is not.
+        assert len(failures) == 1
+        assert any("broken" in name for name in failures)
+        captured = capsys.readouterr()
+        assert "post_mission" in captured.err
+
+    def test_no_skill_dir_does_not_crash(self, tmp_path):
+        inst = tmp_path / "instance"
+        (inst / "hooks").mkdir(parents=True)
+        # Note: no skills/ directory.
+        registry = HookRegistry(inst / "hooks", instance_dir=str(inst))
+        assert not registry.has_hooks("post_mission")


### PR DESCRIPTION
Lets a custom skill own its full mission lifecycle (e.g. enforce a JIRA outcome comment after every fix mission) without touching Kōan core. Previously hooks could only live in instance/hooks/ and were instance-wide; skill authors had no way to ship pre/post-mission logic alongside their handler.py.

HookRegistry now also walks instance/skills/<scope>/<name>/ for files named after a known event (session_start.py, session_end.py, pre_mission.py, post_mission.py) and registers each module's run(ctx) as a handler for that event. Instance-wide hooks still fire first; skill-bound hooks run after. Errors stay isolated per handler.

mission_runner._fire_post_mission_hook now pre-reads the truncated Claude stdout via _read_stdout_summary and passes it to hooks as ctx['result_text'], so hooks can parse JIRA keys / PR URLs / RESULT lines without re-implementing file I/O.

Makefile gains a test-skills target that auto-discovers instance/skills/**/tests/test_*.py (handles symlinked skill repos via find -L) and runs them with KOAN_REPO + PYTHONPATH set up. It chains into make test and make test-strict so skill regressions surface in the regular suite; skipped cleanly when no skill tests exist.

instance.example/hooks/README.md documents both hook flavors, the new result_text ctx key, and the convention for shipping tests alongside a skill (tests/conftest.py template + pytest invocation recipes).

Tested: 224 koan tests pass (52 existing hook + 9 new skill-bound discovery + 163 mission_runner); 6 pre-existing environment failures are unrelated (confirmed via git stash). Tests cover discovery, ordering, error isolation, ctx contents, and the missing-skills-dir edge case.