### PR TITLE
fix(skills): reload modules updated since process boot

### DIFF
--- a/koan/app/skills.py
+++ b/koan/app/skills.py
@@ -33,6 +33,7 @@ import os
 import re
 import subprocess
 import sys
+import time
 from collections import namedtuple
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -568,6 +569,11 @@ def execute_skill(skill: Skill, ctx: SkillContext) -> Optional[Union[str, SkillE
     return None
 
 
+# Captured at import time so first-time observations in
+# _refresh_stale_app_modules can tell whether a module's source file has been
+# rewritten by auto-update since this process started (Python had no chance to
+# pick up the new content because sys.modules still holds the pre-update copy).
+_PROCESS_START_TIME: float = time.time()
 # mtime cache: module_name -> last-seen mtime (float)
 _module_mtimes: Dict[str, float] = {}
 
@@ -675,9 +681,14 @@ def _refresh_stale_app_modules() -> None:
         cached_mtime = _module_mtimes.get(name)
         if cached_mtime is not None and current_mtime == cached_mtime:
             continue
-        # First time we see this module, or mtime changed
-        if cached_mtime is not None:
-            # mtime actually changed — reload
+        # Reload when either: (a) we have a baseline and the file changed, or
+        # (b) this is the first observation but the file was modified after the
+        # process started — i.e. auto-update rewrote it before we built a baseline.
+        should_reload = (
+            cached_mtime is not None
+            or current_mtime > _PROCESS_START_TIME
+        )
+        if should_reload:
             try:
                 importlib.reload(mod)
                 _log.debug("Reloaded stale module %s", name)

--- a/koan/tests/test_skills.py
+++ b/koan/tests/test_skills.py
@@ -2249,9 +2249,11 @@ class TestRefreshStaleAppModules:
         _module_mtimes.pop("app.refreshable_test", None)
 
     def test_first_encounter_caches_mtime_without_reload(self, monkeypatch, tmp_path):
-        """First time seeing a module just caches mtime, does not reload."""
+        """First time seeing a module just caches mtime, does not reload —
+        provided the file is no newer than the process start time."""
         import importlib as _importlib
 
+        from app import skills as _skills
         from app.skills import _module_mtimes, _refresh_stale_app_modules
 
         fake_file = tmp_path / "first_seen.py"
@@ -2263,6 +2265,12 @@ class TestRefreshStaleAppModules:
         # Ensure not in mtime cache
         _module_mtimes.pop("app.first_seen_test", None)
 
+        # Pretend the process started well after the file's mtime, so the
+        # first-encounter fast path applies (auto-update did not touch it).
+        monkeypatch.setattr(
+            _skills, "_PROCESS_START_TIME", fake_file.stat().st_mtime + 60,
+        )
+
         reload_calls = []
         original_reload = _importlib.reload
         monkeypatch.setattr(
@@ -2272,12 +2280,55 @@ class TestRefreshStaleAppModules:
 
         _refresh_stale_app_modules()
 
-        assert not reload_calls, "First encounter should not trigger reload"
+        assert not reload_calls, "First encounter of an old file should not reload"
         assert "app.first_seen_test" in _module_mtimes
 
         # Cleanup
         sys.modules.pop("app.first_seen_test", None)
         _module_mtimes.pop("app.first_seen_test", None)
+
+    def test_first_encounter_reloads_when_file_newer_than_process_start(
+        self, monkeypatch, tmp_path,
+    ):
+        """If a module's source file was modified after the process started
+        (auto-update path), the very first observation must trigger a reload
+        even though no baseline mtime exists yet. Regression test for the
+        ``cannot import name 'PROJECT_NAME_CHARS' from 'app.utils'`` failure
+        on the first /list after an auto-update added a new symbol."""
+        import importlib as _importlib
+
+        from app import skills as _skills
+        from app.skills import _module_mtimes, _refresh_stale_app_modules
+
+        fake_file = tmp_path / "post_update.py"
+        fake_file.write_text("X = 1")
+        fake_mod = MagicMock()
+        fake_mod.__file__ = str(fake_file)
+
+        monkeypatch.setitem(sys.modules, "app.post_update_test", fake_mod)
+        # No cached mtime: this is the first observation of the module.
+        _module_mtimes.pop("app.post_update_test", None)
+
+        # Pretend the process started before the file was written.
+        file_mtime = fake_file.stat().st_mtime
+        monkeypatch.setattr(_skills, "_PROCESS_START_TIME", file_mtime - 60)
+
+        reload_calls = []
+        monkeypatch.setattr(
+            _importlib, "reload",
+            lambda m: reload_calls.append(m),
+        )
+
+        _refresh_stale_app_modules()
+
+        assert reload_calls == [fake_mod], (
+            "First observation of a file newer than process start must reload"
+        )
+        assert _module_mtimes.get("app.post_update_test") == file_mtime
+
+        # Cleanup
+        sys.modules.pop("app.post_update_test", None)
+        _module_mtimes.pop("app.post_update_test", None)
 
     def test_failed_reload_evicts_module(self, monkeypatch, tmp_path):
         """If reload fails, the module is evicted from sys.modules."""


### PR DESCRIPTION
The stale-module detector in `_refresh_stale_app_modules` only reloaded
`app.*` modules whose mtime had changed since a previously cached value.
On the very first observation of a module the function silently recorded
the current mtime without reloading, on the assumption that the first
encounter happens during a fresh boot when in-memory and on-disk content
already agree.

That assumption breaks when auto-update (or a manual `git pull`) rewrites
a file BEFORE the first post-update skill invocation. The new file mtime
is then recorded as the baseline while `sys.modules` still holds the
pre-update module, and no later refresh ever notices the divergence.

Reproduction: a Kōan process booted before `5742248`
(`refactor(missions): consolidate project-tag regexes`) pulled the
commit, then received `/list`. The handler does
`from app.utils import PROJECT_NAME_CHARS` and crashed with:

    Skill error (core.list): cannot import name 'PROJECT_NAME_CHARS'
    from 'app.utils' (.../koan/app/utils.py)

Because the trap is "any new symbol added to any `app.*` module after
the process started", every future addition to `app.utils` (or any
sibling) would re-trigger the same failure on first use after update.

Fix: capture `_PROCESS_START_TIME = time.time()` when `app.skills` is
imported, and treat a first-time observation as stale whenever the
source file's mtime is greater than that timestamp. Clean boots stay
zero-cost (file mtime ≤ process start ⇒ skip the reload, just record
the baseline) while post-update first observations now reload as
intended.

Tests: update the existing "first encounter, no reload" case to stub
`_PROCESS_START_TIME` past the fake file's mtime so it keeps exercising
the old-file branch, and add a new regression test asserting that a
first observation of a file newer than process start triggers
`importlib.reload`. Operators carrying the bad state need a one-time
restart; the fix prevents recurrence for any future `app.*` addition.
