### PR TITLE
fix(restart): per-process restart markers

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -751,8 +751,8 @@ def main():
             # right after so the check below finds nothing.
             if first_poll:
                 # Check if we're coming back from a /restart before clearing
-                was_restart = check_restart(str(KOAN_ROOT))
-                clear_restart(str(KOAN_ROOT))
+                was_restart = check_restart(str(KOAN_ROOT), target="bridge")
+                clear_restart(str(KOAN_ROOT), target="bridge")
                 clear_shutdown(str(KOAN_ROOT))
                 first_poll = False
 
@@ -775,7 +775,7 @@ def main():
             # Check for restart signal (set by /restart command).
             # Only react to files created AFTER we started — stale files
             # were already cleared above after the first poll.
-            if check_restart(str(KOAN_ROOT), since=startup_time):
+            if check_restart(str(KOAN_ROOT), since=startup_time, target="bridge"):
                 log("init", "Restart signal detected. Re-executing...")
                 release_pidfile(pidfile_lock, KOAN_ROOT, "awake")
                 reexec_bridge()

--- a/koan/app/restart_manager.py
+++ b/koan/app/restart_manager.py
@@ -1,17 +1,22 @@
 """Restart signal management for Kōan processes.
 
-Provides file-based restart signaling between bridge and run loop:
-- Bridge creates .koan-restart to signal both processes
-- run.py checks at loop start and exits with code 42
-- Bridge detects the signal and re-execs itself via os.execv()
+Provides file-based restart signaling between bridge and run loop.
+
+Two consumers (bridge and runner) each get their own marker so a fast
+wrapper-restart of the runner can no longer wipe the signal before the
+bridge's polling tick sees it.  The legacy single-file marker is also
+written so a pre-upgrade incarnation polling ``.koan-restart`` can still
+detect the request and re-exec into the new code.
 
 The restart flow:
-1. User sends /restart on Telegram
-2. Bridge writes .koan-restart
-3. Bridge sends ack to Telegram
-4. Bridge re-execs itself (os.execv replaces process in-place)
-5. run.py detects .koan-restart at next iteration, exits with code 42
-6. Wrapper re-launches run.py
+1. ``request_restart`` writes ``.koan-restart-bridge``,
+   ``.koan-restart-run`` and (for backward compat) ``.koan-restart``.
+2. Bridge's main loop notices ``.koan-restart-bridge`` and re-execs via
+   ``os.execv`` (same PID, fresh interpreter).
+3. Runner's main loop notices ``.koan-restart-run`` and exits with
+   ``RESTART_EXIT_CODE``; its wrapper relaunches it.
+4. Each process clears only its own marker on startup, so neither can
+   silence the signal for the other.
 
 Exit code 42 is the restart sentinel — any other exit is a real stop.
 """
@@ -21,37 +26,68 @@ import os
 import sys
 import time
 from pathlib import Path
+from typing import Optional
 
 from app.signals import RESTART_FILE
 RESTART_EXIT_CODE = 42
 
+# Per-consumer marker files. The legacy ``RESTART_FILE`` (``.koan-restart``)
+# is kept for backward compatibility: a pre-upgrade bridge that is still
+# polling the old single-file marker can pick up the first post-upgrade
+# request and re-exec into the new code.
+RESTART_BRIDGE_FILE = ".koan-restart-bridge"
+RESTART_RUN_FILE = ".koan-restart-run"
+
+_TARGET_FILES = {
+    "bridge": RESTART_BRIDGE_FILE,
+    "run": RESTART_RUN_FILE,
+    None: RESTART_FILE,
+}
+
+
+def _marker_path(koan_root: str, target: Optional[str]) -> str:
+    try:
+        fname = _TARGET_FILES[target]
+    except KeyError as exc:
+        raise ValueError(
+            f"Unknown restart target {target!r}; "
+            f"expected one of {sorted(k for k in _TARGET_FILES if k)!r} or None"
+        ) from exc
+    return os.path.join(koan_root, fname)
+
 
 def request_restart(koan_root: str) -> None:
-    """Create the restart signal file.
+    """Create restart signal files for both consumers (and the legacy file).
 
-    Both processes check for this file:
-    - run.py: at loop start, exits with code 42
-    - awake.py: in main loop, triggers os.execv()
+    Writes three markers so each consumer can clear its own without
+    silencing the other, and so a pre-upgrade incarnation still polling
+    the legacy ``.koan-restart`` will also wake up and re-exec.
     """
     from app.utils import atomic_write
 
-    atomic_write(
-        Path(koan_root) / RESTART_FILE,
-        f"restart requested at {time.strftime('%H:%M:%S')}\n",
-    )
+    body = f"restart requested at {time.strftime('%H:%M:%S')}\n"
+    for fname in _TARGET_FILES.values():
+        atomic_write(Path(koan_root) / fname, body)
 
 
-def check_restart(koan_root: str, since: float = 0) -> bool:
-    """Check if a restart has been requested.
+def check_restart(
+    koan_root: str,
+    since: float = 0,
+    target: Optional[str] = None,
+) -> bool:
+    """Check if a restart has been requested for ``target``.
 
     Args:
         koan_root: Root path for the koan installation.
-        since: If > 0, only return True if the file was modified after this
-               timestamp.  Used to ignore stale restart signals left over
-               from a previous process incarnation (prevents restart loops
-               when Telegram re-delivers the /restart message).
+        since: If > 0, only return True if the marker was modified after
+            this timestamp.  Used to ignore stale restart signals left
+            over from a previous process incarnation (prevents restart
+            loops when Telegram re-delivers the /restart message).
+        target: ``"bridge"`` or ``"run"`` to check the per-consumer
+            marker.  ``None`` (default) checks the legacy single marker
+            for backward compatibility.
     """
-    restart_file = os.path.join(koan_root, RESTART_FILE)
+    restart_file = _marker_path(koan_root, target)
     if not os.path.isfile(restart_file):
         return False
     try:
@@ -62,9 +98,13 @@ def check_restart(koan_root: str, since: float = 0) -> bool:
     return True
 
 
-def clear_restart(koan_root: str) -> None:
-    """Remove the restart signal file."""
-    path = os.path.join(koan_root, RESTART_FILE)
+def clear_restart(koan_root: str, target: Optional[str] = None) -> None:
+    """Remove the restart signal file for ``target``.
+
+    A consumer should only clear its own marker so the other consumer
+    can still observe the request on its next poll tick.
+    """
+    path = _marker_path(koan_root, target)
     with contextlib.suppress(FileNotFoundError):
         os.remove(path)
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -731,7 +731,7 @@ def handle_pause(
             if Path(koan_root, CYCLE_FILE).exists():
                 log("pause", "Update signal detected while paused")
                 break
-            if check_restart(koan_root):
+            if check_restart(koan_root, target="run"):
                 break
             time.sleep(5)
 
@@ -782,7 +782,7 @@ def main_loop():
     Path(koan_root, SHUTDOWN_FILE).unlink(missing_ok=True)
     Path(koan_root, CYCLE_FILE).unlink(missing_ok=True)
     Path(koan_root, ABORT_FILE).unlink(missing_ok=True)
-    clear_restart(koan_root)
+    clear_restart(koan_root, target="run")
 
     # Install SIGINT handler
     signal.signal(signal.SIGINT, _on_sigint)
@@ -851,9 +851,9 @@ def main_loop():
                 break
 
             # --- Restart check ---
-            if check_restart(koan_root, since=start_time):
+            if check_restart(koan_root, since=start_time, target="run"):
                 log("koan", "Restart requested. Exiting for re-launch...")
-                clear_restart(koan_root)
+                clear_restart(koan_root, target="run")
                 sys.exit(RESTART_EXIT_CODE)
 
             # --- Pause mode ---

--- a/koan/tests/test_restart.py
+++ b/koan/tests/test_restart.py
@@ -258,7 +258,7 @@ class TestMainLoopRestartDetection:
         source = inspect.getsource(main)
         while_idx = source.index("while True:")
         # clear_restart should appear inside the loop (after first poll)
-        clear_idx = source.index("clear_restart(str(KOAN_ROOT))", while_idx)
+        clear_idx = source.index("clear_restart(str(KOAN_ROOT)", while_idx)
         assert clear_idx > while_idx
         # And it should be guarded by first_poll
         assert "first_poll" in source

--- a/koan/tests/test_restart_manager.py
+++ b/koan/tests/test_restart_manager.py
@@ -5,8 +5,12 @@ import time
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 
+import pytest
+
 from app.restart_manager import (
     RESTART_FILE,
+    RESTART_BRIDGE_FILE,
+    RESTART_RUN_FILE,
     RESTART_EXIT_CODE,
     request_restart,
     check_restart,
@@ -54,13 +58,14 @@ class TestRequestRestart:
         assert "restart requested at" in content
 
     def test_uses_atomic_write(self, tmp_path):
-        """request_restart should use atomic_write for thread safety."""
+        """request_restart should use atomic_write for thread safety,
+        once per consumer marker plus the legacy single-file marker."""
         with patch("app.utils.atomic_write") as mock_aw:
             request_restart(str(tmp_path))
-            mock_aw.assert_called_once()
-            # First arg should be a Path
-            call_path = mock_aw.call_args[0][0]
-            assert str(call_path).endswith(RESTART_FILE)
+            written = [str(call.args[0]) for call in mock_aw.call_args_list]
+            assert any(p.endswith(RESTART_BRIDGE_FILE) for p in written)
+            assert any(p.endswith(RESTART_RUN_FILE) for p in written)
+            assert any(p.endswith(RESTART_FILE) for p in written)
 
 
 # ---------------------------------------------------------------------------
@@ -236,3 +241,64 @@ class TestRestartWorkflow:
         assert check_restart(root) is True
         clear_restart(root)
         assert check_restart(root) is False
+
+
+# ---------------------------------------------------------------------------
+# Per-process restart markers (race-fix)
+# ---------------------------------------------------------------------------
+
+
+class TestPerProcessRestartMarkers:
+    """Each process polls its own marker so a fast wrapper-restart of one
+    consumer cannot wipe the signal before the other consumer's poll tick.
+
+    Regression for the ``/update`` race: the runner used to write a single
+    ``.koan-restart`` file, exit with code 42, and have its wrapper relaunch
+    it within ~1 s; the fresh runner's startup ``clear_restart`` then
+    wiped the file before the bridge's 3 s poll tick could observe it,
+    leaving the bridge with a stale ``sys.modules`` and ``/list`` broken.
+    """
+
+    def test_request_restart_writes_all_three_markers(self, tmp_path):
+        request_restart(str(tmp_path))
+        assert (tmp_path / RESTART_BRIDGE_FILE).exists()
+        assert (tmp_path / RESTART_RUN_FILE).exists()
+        assert (tmp_path / RESTART_FILE).exists(), (
+            "legacy marker must still be written so a pre-upgrade bridge "
+            "polling .koan-restart can re-exec into the new code"
+        )
+
+    def test_check_restart_target_isolation(self, tmp_path):
+        """Writing only one consumer's marker must not satisfy the other."""
+        (tmp_path / RESTART_BRIDGE_FILE).write_text("restart")
+        assert check_restart(str(tmp_path), target="bridge") is True
+        assert check_restart(str(tmp_path), target="run") is False
+        # And the legacy single-marker check still has its own file.
+        assert check_restart(str(tmp_path), target=None) is False
+
+    def test_clear_restart_target_isolation(self, tmp_path):
+        """clear_restart for one target must leave the other intact."""
+        request_restart(str(tmp_path))
+        clear_restart(str(tmp_path), target="run")
+        assert not (tmp_path / RESTART_RUN_FILE).exists()
+        assert (tmp_path / RESTART_BRIDGE_FILE).exists()
+        # Legacy file is also untouched — only its own consumer clears it.
+        assert (tmp_path / RESTART_FILE).exists()
+
+    def test_runner_wrapper_restart_does_not_silence_bridge(self, tmp_path):
+        """Simulate the /update race directly: a request_restart followed
+        immediately by the runner's wrapper-restart clear leaves the bridge
+        marker fully intact and detectable on a later poll tick."""
+        startup_time = time.time() - 60  # bridge has been up for a while
+        request_restart(str(tmp_path))
+        # Simulate the fresh runner's L785 startup wipe.
+        clear_restart(str(tmp_path), target="run")
+        # Bridge's poll tick now sees its own marker as fresh.
+        assert check_restart(
+            str(tmp_path), since=startup_time, target="bridge"
+        ) is True
+
+    @pytest.mark.parametrize("fn", [check_restart, clear_restart])
+    def test_unknown_target_raises(self, tmp_path, fn):
+        with pytest.raises(ValueError):
+            fn(str(tmp_path), target="runner")  # type: ignore[arg-type]

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -1586,7 +1586,7 @@ class TestMainLoop:
         # Create restart file AFTER startup (via side_effect) so startup
         # cleanup doesn't remove it before the loop's restart check runs.
         def startup_creates_restart(*args, **kwargs):
-            restart_file = koan_root / ".koan-restart"
+            restart_file = koan_root / ".koan-restart-run"
             restart_file.write_text("restart")
             future = time.time() + 3600
             os.utime(str(restart_file), (future, future))
@@ -1604,16 +1604,16 @@ class TestMainLoop:
     @patch("app.run.acquire_pidfile")
     @patch("app.run.release_pidfile")
     def test_restart_file_cleared_before_exit(self, mock_release, mock_acquire, mock_startup, mock_subproc, koan_root):
-        """Regression: run.py must clear .koan-restart before sys.exit(RESTART_EXIT_CODE)
-        to prevent the restarted process from seeing a stale file and
-        entering a restart loop."""
+        """Regression: run.py must clear its per-process restart marker before
+        sys.exit(RESTART_EXIT_CODE) to prevent the restarted process from
+        seeing a stale file and entering a restart loop."""
         from app.run import main_loop
         from app.restart_manager import RESTART_EXIT_CODE
 
         os.environ["KOAN_ROOT"] = str(koan_root)
         os.environ["KOAN_PROJECTS"] = f"test:{koan_root}"
 
-        restart_file = koan_root / ".koan-restart"
+        restart_file = koan_root / ".koan-restart-run"
 
         def startup_creates_restart(*args, **kwargs):
             restart_file.write_text("restart")
@@ -1627,9 +1627,9 @@ class TestMainLoop:
             with patch("app.run._notify"):
                 main_loop()
         assert exc.value.code == RESTART_EXIT_CODE
-        # The restart file must be deleted BEFORE exit
+        # The runner's per-process marker must be deleted BEFORE exit
         assert not restart_file.exists(), \
-            ".koan-restart was not cleared before exit — restart loop risk"
+            ".koan-restart-run was not cleared before exit — restart loop risk"
 
     @patch("app.run.subprocess.run")
     @patch("app.run.run_startup", return_value=(5, 10, "koan/"))
@@ -1648,8 +1648,8 @@ class TestMainLoop:
         os.environ["KOAN_PROJECTS"] = f"test:{koan_root}"
         (koan_root / ".koan-project").write_text("test")
 
-        # Simulate stale .koan-restart from a previous session
-        (koan_root / ".koan-restart").write_text("stale restart")
+        # Simulate stale .koan-restart-run from a previous session
+        (koan_root / ".koan-restart-run").write_text("stale restart")
 
         # Startup creates a stop file so the loop exits cleanly
         def startup_then_stop(*args, **kwargs):
@@ -1663,8 +1663,8 @@ class TestMainLoop:
 
         # Startup ran (stale restart didn't cause immediate exit)
         mock_startup.assert_called_once()
-        # The restart file was cleared
-        assert not (koan_root / ".koan-restart").exists()
+        # The runner's per-process marker was cleared
+        assert not (koan_root / ".koan-restart-run").exists()
 
     @patch("app.run.subprocess.run")
     @patch("app.run.run_startup", return_value=(5, 10, "koan/"))
@@ -4503,7 +4503,7 @@ class TestRestartManagerIntegration:
              patch("app.run.check_restart", side_effect=[False, True]) as mock_check:
             result = handle_pause(str(koan_root), instance, 5)
             assert result is None  # breaks out of pause loop
-            mock_check.assert_called_with(str(koan_root))
+            mock_check.assert_called_with(str(koan_root), target="run")
 
     @patch("app.run.subprocess.run")
     @patch("app.run.run_startup", return_value=(5, 10, "koan/"))
@@ -4526,7 +4526,7 @@ class TestRestartManagerIntegration:
         with patch("app.run._notify"), \
              patch("app.run.clear_restart") as mock_clear:
             main_loop()
-            mock_clear.assert_called_once_with(str(koan_root))
+            mock_clear.assert_called_once_with(str(koan_root), target="run")
 
     @patch("app.run.subprocess.run")
     @patch("app.run.run_startup", return_value=(5, 10, "koan/"))


### PR DESCRIPTION
`request_restart` previously wrote a single shared `.koan-restart`
marker that both the bridge (`awake.py`) and the runner (`run.py`)
polled. The runner's wrapper-restart cycle is fast: after
`request_restart`, the runner exits with code 42, its wrapper relaunches
it, and the fresh runner's startup wipe (`run.py:785`) deletes the
marker within ~1 s. The bridge polls every `POLL_INTERVAL` (≈3 s) at
`awake.py:778`, so the marker was usually gone before the bridge's next
tick, and the bridge never re-execed.

Observable failure: after `/update`, the runner pulled the new code and
the runner process did restart, but the bridge kept its pre-update
Python interpreter alive. The bridge's `sys.modules['app.utils']`
remained the stale copy, so `/list` raised
`cannot import name 'PROJECT_NAME_CHARS' from 'app.utils'` even after
the upstream stale-module fix (`75bf3e2`) had landed on disk — the
detector itself was in the stale `sys.modules`.

Give each consumer its own marker file (`.koan-restart-bridge`,
`.koan-restart-run`). `request_restart` writes both, plus the legacy
`.koan-restart` for backward compatibility so a pre-upgrade bridge
still polling the old name can pick up the first post-upgrade request
and re-exec into the new code. `check_restart` and `clear_restart`
take an optional `target=` ("bridge" / "run" / None); each consumer
only clears its own marker, so the runner's startup wipe can no longer
silence the bridge's signal. Unknown targets raise `ValueError` to
catch typos at call sites.

Bridge calls in `awake.py` (L754, L755, L778) pass `target="bridge"`.
Runner calls in `run.py` (L734, L785, L854, L856) pass `target="run"`.
The pause-loop check at L734 keeps its existing no-`since` semantics
because the startup clear at L785 already handles stale markers from
a previous incarnation.

Tests:
- `TestPerProcessRestartMarkers` in `test_restart_manager.py` adds 5
  cases including a direct race regression
  (`test_runner_wrapper_restart_does_not_silence_bridge`).
- `test_uses_atomic_write` now asserts all three markers are written.
- `test_run.py` and `test_restart.py` updated to expect the new
  `target=` kwarg and the per-process marker filenames.
