### PR TITLE
fix(messaging): load every provider module on first call

### DIFF
--- a/koan/app/messaging/__init__.py
+++ b/koan/app/messaging/__init__.py
@@ -24,6 +24,12 @@ _providers: Dict[str, Type[MessagingProvider]] = {}
 _instance: Optional[MessagingProvider] = None
 _instance_lock = threading.Lock()
 
+# Set to True after ``_ensure_providers_loaded`` walks ``_PROVIDER_MODULES``
+# once.  Tracking loop completion explicitly — rather than inferring it from
+# ``bool(_providers)`` — avoids skipping unloaded modules when something
+# imported a single provider as a side-effect before the loader ran.
+_modules_loaded: bool = False
+
 # List of known provider modules for auto-loading
 _PROVIDER_MODULES = [
     "app.messaging.telegram",
@@ -144,13 +150,23 @@ def _resolve_provider_name() -> str:
 
 
 def _ensure_providers_loaded():
-    """Import provider modules to trigger registration."""
-    if _providers:
-        return
+    """Import provider modules to trigger registration.
 
+    Short-circuits on the explicit ``_modules_loaded`` flag rather than
+    ``bool(_providers)``.  The latter looks like the same check but is
+    wrong: if anything imports e.g. ``app.messaging.telegram`` first
+    (which the default startup path does), ``_providers`` becomes
+    ``{"telegram": ...}`` without this loader ever running, and a later
+    request for ``matrix`` / ``slack`` would skip the import loop and
+    leave them unregistered.
+    """
+    global _modules_loaded
+    if _modules_loaded:
+        return
     for module_name in _PROVIDER_MODULES:
         with contextlib.suppress(ImportError):
             __import__(module_name)
+    _modules_loaded = True
 
 
 __all__ = [

--- a/koan/tests/test_matrix_provider.py
+++ b/koan/tests/test_matrix_provider.py
@@ -299,7 +299,39 @@ class TestSendTyping:
 
 class TestRegistry:
     def test_matrix_registered(self):
-        """Matrix should auto-register when the messaging package loads providers."""
-        from app.messaging import _ensure_providers_loaded, _providers
-        _ensure_providers_loaded()
-        assert "matrix" in _providers
+        """Matrix should auto-register when the messaging package loads providers.
+
+        Runs in a fresh subprocess: ``_providers`` is process-wide module
+        state that other tests (notably ``clean_registry`` in
+        ``test_messaging_provider.py``) can clear *after* the provider
+        modules are already cached in ``sys.modules``.  Once that happens
+        no in-process call to ``_ensure_providers_loaded`` can repopulate
+        the registry — the decorators won't re-run for cached modules.
+        A clean subprocess sidesteps the whole ordering problem.
+        """
+        import os
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        koan_pkg = Path(__file__).resolve().parents[1]  # …/koan
+        script = (
+            "from app.messaging import _ensure_providers_loaded, _providers\n"
+            "_ensure_providers_loaded()\n"
+            "assert 'matrix' in _providers, sorted(_providers)\n"
+        )
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(koan_pkg),
+            "KOAN_ROOT": os.environ.get("KOAN_ROOT", "/tmp/test-koan"),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )

--- a/koan/tests/test_messaging_provider.py
+++ b/koan/tests/test_messaging_provider.py
@@ -213,6 +213,98 @@ class TestProviderRegistry:
 
 
 # ---------------------------------------------------------------------------
+# _ensure_providers_loaded — order independence & idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestEnsureProvidersLoaded:
+    """Regression: ``_ensure_providers_loaded`` must load every module in
+    ``_PROVIDER_MODULES`` even when ``_providers`` is already populated by
+    a prior partial import.
+
+    Previously the loader short-circuited as soon as ``_providers`` was
+    non-empty.  That was a latent production bug: any process that
+    imported the default ``telegram`` provider at startup (the normal
+    path) could never resolve ``matrix`` or ``slack`` afterwards.  It
+    also caused ``test_matrix_registered`` to flap under xdist depending
+    on which sibling test happened to import ``telegram`` first.
+    """
+
+    def test_loads_matrix_when_telegram_imported_first(self):
+        """Run in a fresh subprocess so Python's import cache cannot
+        bypass the @register_provider decorators (the cache makes this
+        scenario untestable in-process — once telegram is imported in
+        the test runner, re-importing it is a no-op even if _providers
+        was cleared by a fixture)."""
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        koan_pkg = Path(__file__).resolve().parents[1]  # …/koan
+        script = (
+            "import app.messaging.telegram  # noqa: F401\n"
+            "from app.messaging import _ensure_providers_loaded, _providers\n"
+            "assert sorted(_providers) == ['telegram'], sorted(_providers)\n"
+            "_ensure_providers_loaded()\n"
+            "missing = {'telegram', 'slack', 'matrix'} - set(_providers)\n"
+            "assert not missing, f'missing providers after load: {missing}'\n"
+        )
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(koan_pkg),
+            # Provider modules require a writable KOAN_ROOT at import.
+            "KOAN_ROOT": os.environ.get("KOAN_ROOT", "/tmp/test-koan"),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    def test_idempotent_when_called_repeatedly(self):
+        """Calling the loader N times must converge to the same registry.
+
+        Runs in a fresh subprocess so the in-process import cache and any
+        ``clean_registry`` mutations from sibling tests cannot mask
+        repeat-call drift.
+        """
+        import subprocess
+        import sys
+        from pathlib import Path
+
+        koan_pkg = Path(__file__).resolve().parents[1]
+        script = (
+            "from app.messaging import _ensure_providers_loaded, _providers\n"
+            "_ensure_providers_loaded()\n"
+            "snapshot = dict(_providers)\n"
+            "_ensure_providers_loaded()\n"
+            "_ensure_providers_loaded()\n"
+            "assert dict(_providers) == snapshot, "
+            "f'registry drifted: {snapshot} -> {dict(_providers)}'\n"
+        )
+        env = {
+            **os.environ,
+            "PYTHONPATH": str(koan_pkg),
+            "KOAN_ROOT": os.environ.get("KOAN_ROOT", "/tmp/test-koan"),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=15,
+            env=env,
+        )
+        assert result.returncode == 0, (
+            f"subprocess failed:\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Provider name resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
`_ensure_providers_loaded` short-circuited the moment `_providers` was
non-empty:

    def _ensure_providers_loaded():
        if _providers:
            return
        for module_name in _PROVIDER_MODULES:
            __import__(module_name)

The intent ("skip the loop on repeat calls") was fine; the sentinel was
wrong.  `_providers` becomes non-empty as a side-effect of *any* code
importing one of the provider modules — including the default startup
path where the bridge imports `app.messaging.telegram` before anything
asks for the full provider list.  Once that happens, the very first
`_ensure_providers_loaded` call hits the early return, the `matrix` /
`slack` imports never run, and `_create_provider("matrix")` SystemExits
with `Unknown messaging provider: 'matrix'` even though the module
ships on disk.

Symptom on CI: `test_matrix_provider.py::TestRegistry::test_matrix_registered`
flapped under pytest-xdist depending on whether a sibling test (e.g.
`test_telegram_provider.py`'s module-level `from app.messaging.telegram
import TelegramProvider`) had already populated `_providers` in the
worker before the matrix test ran.

Fix: track loop-completion explicitly with a `_modules_loaded` flag
rather than inferring it from `bool(_providers)`.  Same short-circuit
on repeat calls, correct semantics on the first one.

Tests:
- `TestEnsureProvidersLoaded.test_loads_matrix_when_telegram_imported_first`
  reproduces the production scenario in a fresh subprocess.  Verified
  the test fails without the fix:
      AssertionError: missing providers after load: {'matrix', 'slack'}
- `test_idempotent_when_called_repeatedly` (also subprocess) guards
  against future regressions where repeat calls might drift.
- `test_matrix_provider.py::TestRegistry::test_matrix_registered`
  switched to the same subprocess pattern so it no longer flaps
  based on cross-file test ordering: `_providers` is process-wide
  module state and the `clean_registry` fixture in
  `test_messaging_provider.py` can leave the in-process registry out
  of sync with `sys.modules`, which no in-process call to
  `_ensure_providers_loaded` can recover from (cached modules don't
  re-run their `@register_provider` decorators).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
