### PR TITLE
feat(watchdog): runner-side self-heal for stale or hung bridge

### DIFF
--- a/docs/bridge-watchdog.md
+++ b/docs/bridge-watchdog.md
@@ -1,0 +1,178 @@
+# Bridge Self-Heal Watchdog
+
+The Telegram bridge (`awake.py`) is a long-running process **with no
+wrapper**: once started, nothing restarts it automatically. If its
+`sys.modules` cache goes stale (after `/update` pulls new code), the
+bridge keeps serving the *old* code until an operator with shell access
+kills it. The original `cb6e927` ("per-process restart markers") fix
+patched the race that drops restart signals, but only *after* both
+processes are running the new code — the transitional `/update` from
+old to new can still leave the bridge wedged.
+
+The watchdog runs **inside the agent loop** (`run.py`) and recovers a
+stale or hung bridge automatically.
+
+## Why this lives in the runner, not the bridge
+
+`run.py` is wrapped by `run.sh` and restarted on every exit. Whatever
+SHA is on disk is what the runner is executing — it can't be stale.
+That makes it the natural place to watch the bridge.
+
+## Two failure modes detected
+
+| Failure mode | How it shows up | How it's detected |
+|---|---|---|
+| **Stale `sys.modules`** | Bridge is alive, heartbeat fresh, but `/list` and other skills raise `ImportError` on names added by the update. | Stamp the bridge's git HEAD at startup; runner compares with `git rev-parse HEAD` on each tick. |
+| **Hung / dead bridge** | Heartbeat mtime stops advancing; possibly the process is gone entirely. | Read `.koan-heartbeat` mtime; read `.koan-pid-awake` and probe with `kill(pid, 0)`. |
+
+## Four-tier escalation
+
+```
+                                       ┌─ healthy → reset state, return None
+            ┌─── unhealthy? ─── yes ───┤
+unhealthy = │                          └─ in cooldown? ── yes ─── return None
+  sha drift │                                      no
+  OR        │                                       ↓
+  hb stale  │        ┌── circuit-broken? ─ yes ── alert, no action
+  OR        │        │                no
+  no PID    │        │                 ↓
+            └────────┴──────── execute tier:
+                                  Tier 1: request_restart()           [cooperative]
+                                  Tier 2: SIGTERM bridge pid
+                                  Tier 3: SIGKILL + start_awake()     [last resort]
+```
+
+| Tier | Action | When |
+|------|--------|------|
+| **1** | `request_restart(koan_root)` — runner is on fresh code so it writes the *new* triple-marker correctly | First sign of trouble, bridge still alive |
+| **2** | `os.kill(bridge_pid, SIGTERM)` | Tier 1 didn't take after `HEAL_TIER_COOLDOWN_S` |
+| **3** | `SIGKILL` (after `SIGTERM_GRACE_S`) + `pid_manager.start_awake()` | Tier 2 didn't take, or PID is missing/dead — cold start |
+| **4** | No action; emit "circuit-broken" alert | `HEAL_CIRCUIT_BREAKER_LIMIT` consecutive tier-3 failures |
+
+**Important:** if the bridge has no PID file at all (crashed long ago,
+never came back), we **skip tiers 1–2** and jump straight to tier 3. There
+is no process to receive a restart signal.
+
+## State files
+
+Both files live under `$KOAN_ROOT/instance/`:
+
+| File | Written by | Read by | Purpose |
+|---|---|---|---|
+| `.koan-bridge-version` | `awake.py` startup | `bridge_watchdog` | Git HEAD SHA the bridge process was launched against |
+| `.koan-bridge-heal-state` | `bridge_watchdog` | `bridge_watchdog` | JSON with `last_action_ts`, `last_tier`, `consecutive_failures` |
+
+Both writes go through `atomic_write` (temp file + rename + flock) so a
+crashed mid-write never leaves a partial file.
+
+## Tunables
+
+Defined as module-level constants in `koan/app/bridge_watchdog.py`:
+
+| Constant | Default | Meaning |
+|---|---|---|
+| `BRIDGE_HEARTBEAT_STALE_S` | `90.0` | Heartbeat older than this ⇒ bridge hung |
+| `HEAL_TIER_COOLDOWN_S` | `45.0` | After firing a tier, wait this long before the next escalation |
+| `SIGTERM_GRACE_S` | `5.0` | Window between SIGTERM and SIGKILL in tier 3 |
+| `POST_HEAL_QUIET_S` | `60.0` | After the circuit breaker trips, re-emit the alert at most this often |
+| `HEAL_CIRCUIT_BREAKER_LIMIT` | `3` | Consecutive tier-3 failures before giving up |
+
+The runner also throttles **how often** the watchdog is even consulted —
+once per `_BRIDGE_WATCHDOG_INTERVAL = 5` main-loop iterations
+(`run.py`). With a typical 60–300 s iteration cycle, that puts the
+maximum detection latency at ~5–25 minutes — fine for a watchdog whose
+job is "don't let a stuck bridge sit forever."
+
+## Notification
+
+When the watchdog acts, it returns a one-line summary like:
+
+```
+Bridge self-heal tier 1: cooperative restart requested via request_restart().
+status: pid=12345 alive=True heartbeat_age=4.2s bridge_sha=cb6e927 disk_sha=ab12cd3
+```
+
+The runner forwards this to:
+
+1. **Telegram** via `_notify_raw` (terse, no Claude-CLI reformat). It
+   goes through the outbox — if the bridge is dead, the message sits
+   there until a freshly-relaunched bridge flushes it on its first
+   poll, so the operator still finds out.
+2. **Today's journal** (`instance/journal/YYYY-MM-DD/koan.md`) for
+   after-the-fact audit.
+
+## Detection latency, in practice
+
+| Scenario | Time to first heal action |
+|---|---|
+| Stale `sys.modules` after `/update` | Up to one watchdog interval × runner loop interval (≈ 5 min worst case) |
+| Bridge hangs mid-iteration | `BRIDGE_HEARTBEAT_STALE_S` + one watchdog interval (≈ 90 s + a few minutes) |
+| Bridge crashes (no PID) | One watchdog interval (≈ minutes) |
+
+These are detection latencies; actual recovery (tier 1) is typically a
+few seconds beyond that since `request_restart` is fast.
+
+## Failure modes the watchdog does **not** cover
+
+- **Both processes stale simultaneously.** The runner has a wrapper, so
+  it's always fresh — this case is structurally impossible.
+- **Runner is itself wedged.** Out of scope; the runner's wrapper
+  restarts it on every exit, and the existing stagnation monitor
+  (`stagnation_monitor.py`) handles long-running stuck CLI calls.
+- **Bridge starts fresh but immediately crashes.** Tier 3 will call
+  `start_awake` and report whatever its verification timeout returns;
+  if startup fails repeatedly the circuit breaker trips after
+  `HEAL_CIRCUIT_BREAKER_LIMIT` cycles and the operator is alerted.
+- **Git unreachable.** `_read_git_head` returns `None`; the SHA-mismatch
+  check is skipped that iteration. Heartbeat-based detection is
+  unaffected.
+
+## Operator notes
+
+- A bridge restart triggered by the watchdog is **observable**: look
+  for `bridge_watchdog: …` lines in the runner log and `🩹 Bridge
+  self-heal …` messages in Telegram.
+- The `.koan-bridge-heal-state` JSON is the source of truth for tier
+  state. Inspect it (`cat $KOAN_ROOT/instance/.koan-bridge-heal-state`)
+  to see what's pending.
+- To **manually reset** the state (e.g., after fixing root cause out of
+  band), simply delete the file: `rm $KOAN_ROOT/instance/.koan-bridge-heal-state`.
+- The watchdog uses `pid_manager.start_awake`, the same helper invoked
+  by `make start`. Logs end up in the same place (`logs/awake.log`)
+  with the same rotation policy.
+
+## Disabling
+
+There is no on/off switch — the watchdog is always on. If you need to
+temporarily silence it (e.g., during planned maintenance):
+
+1. **Easiest:** set `KOAN_ROOT/.koan-shutdown` — the runner exits and
+   nothing supervises the bridge until you start it again.
+2. **Targeted:** patch `_BRIDGE_WATCHDOG_INTERVAL` in `run.py` to a
+   very large value, restart the runner. (No configuration plumbing
+   yet — by design; if you find yourself needing this, file an issue.)
+
+## Implementation map
+
+| File | Role |
+|---|---|
+| `koan/app/bridge_watchdog.py` | Watchdog module: detection, state, tier escalation, version-stamp writer |
+| `koan/app/awake.py` | Calls `write_bridge_version_stamp` once at startup |
+| `koan/app/run.py` | Calls `check_and_heal_bridge` from the main loop; forwards heal messages to Telegram + journal |
+| `koan/app/signals.py` | File-name constants `BRIDGE_VERSION_FILE`, `BRIDGE_HEAL_STATE_FILE` |
+| `koan/tests/test_bridge_watchdog.py` | Behavioral tests for each tier and the circuit breaker |
+
+## Rollback
+
+The watchdog is additive — no existing behavior changes. To disable
+without reverting:
+
+```python
+# In run.py, _maybe_run_bridge_watchdog: short-circuit at the top.
+def _maybe_run_bridge_watchdog(koan_root, instance):
+    return
+```
+
+A full revert is a single-commit revert; the bridge-side version stamp
+is harmless (writes one small file at startup, ignored if nothing reads
+it).

--- a/docs/bridge-watchdog.md
+++ b/docs/bridge-watchdog.md
@@ -55,7 +55,7 @@ is no process to receive a restart signal.
 
 ## State files
 
-Both files live under `$KOAN_ROOT/instance/`:
+Both files live under `$KOAN_ROOT/`:
 
 | File | Written by | Read by | Purpose |
 |---|---|---|---|

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -680,6 +680,15 @@ def main():
     heartbeat_file = KOAN_ROOT / HEARTBEAT_FILE
     heartbeat_file.unlink(missing_ok=True)
     write_heartbeat(str(KOAN_ROOT))
+
+    # Record the code version this bridge incarnation is running.  The
+    # runner's bridge_watchdog reads it to detect "alive but stuck on
+    # stale sys.modules" — a state the heartbeat alone cannot catch.
+    try:
+        from app.bridge_watchdog import write_bridge_version_stamp
+        write_bridge_version_stamp(KOAN_ROOT)
+    except Exception as e:
+        log("error", f"write_bridge_version_stamp failed: {e}")
     log("init", f"Token: ...{BOT_TOKEN[-8:]}")
     log("init", f"Chat ID: {CHAT_ID}")
     log("init", f"Soul: {len(SOUL)} chars loaded")

--- a/koan/app/bridge_watchdog.py
+++ b/koan/app/bridge_watchdog.py
@@ -1,0 +1,384 @@
+"""Self-healing watchdog for the Telegram bridge process.
+
+The bridge (``awake.py``) is a long-running process with no wrapper, so
+a frozen ``sys.modules`` after an ``/update`` leaves it serving stale
+imports until someone with shell access kicks it.  The runner, by
+contrast, has a wrapper that relaunches it on every exit — so it is
+*always* fresh code.  This module gives the runner the responsibility
+of watching the bridge and recovering it when something goes wrong.
+
+Two failure modes are detected:
+
+1.  **Stale modules** — the process is alive and the heartbeat is fresh,
+    but ``sys.modules`` has not been reloaded after a code update.
+    Caught by stamping the bridge's git HEAD at startup and comparing
+    against the on-disk HEAD on each runner iteration.
+
+2.  **Hung / dead bridge** — the heartbeat goes stale or the PID file
+    is gone / pointing at a dead PID.
+
+Recovery is escalated through four tiers so we never go straight from
+"unhealthy" to ``SIGKILL``:
+
+    Tier 1  request_restart() — let the bridge re-exec itself
+    Tier 2  SIGTERM the bridge PID
+    Tier 3  SIGKILL + pid_manager.start_awake() — last resort
+    Tier 4  circuit-broken — stop trying, write a loud alert
+
+State persists between calls in ``instance/.koan-bridge-heal-state``
+so each runner iteration knows what's already been attempted.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import signal as _signal
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.signals import (
+    BRIDGE_HEAL_STATE_FILE,
+    BRIDGE_VERSION_FILE,
+    HEARTBEAT_FILE,
+    pid_file,
+)
+
+_log = logging.getLogger(__name__)
+
+# --- Tunables --------------------------------------------------------------
+
+# Bridge heartbeat is written every poll cycle (~3 s).  90 s of silence
+# is enough to be confident the bridge is hung, not just briefly busy.
+BRIDGE_HEARTBEAT_STALE_S: float = 90.0
+
+# Once we trigger a tier, wait this long before evaluating the next one.
+# Tier 1 (cooperative re-exec) typically completes in <5 s, but we give
+# the slow path (process startup, banner, first poll) some breathing room.
+HEAL_TIER_COOLDOWN_S: float = 45.0
+
+# Grace period after SIGTERM before escalating to SIGKILL.
+SIGTERM_GRACE_S: float = 5.0
+
+# Cooldown after a successful heal cycle (any tier) before the watchdog
+# is willing to act again.  Prevents log spam and false positives during
+# a legitimate restart that's still in progress.
+POST_HEAL_QUIET_S: float = 60.0
+
+# After this many consecutive tier-3 escalations without recovery, the
+# watchdog gives up and just alerts the operator.
+HEAL_CIRCUIT_BREAKER_LIMIT: int = 3
+
+
+# --- Bridge-side: stamp the code version ----------------------------------
+
+
+def write_bridge_version_stamp(koan_root: Path) -> None:
+    """Record the git HEAD SHA of the bridge's working tree.
+
+    Called by ``awake.py`` once at startup.  The runner reads this file
+    on every iteration and compares it against the on-disk HEAD to
+    detect "bridge is alive but running pre-update code".  If git is
+    unavailable, falls back to the literal string ``"unknown"`` so the
+    runner can still tell "the stamp exists" from "the stamp is missing".
+    """
+    from app.utils import atomic_write
+
+    sha = _read_git_head(koan_root) or "unknown"
+    atomic_write(koan_root / BRIDGE_VERSION_FILE, sha)
+
+
+# --- Runner-side: detection + escalation ----------------------------------
+
+
+@dataclass
+class _HealState:
+    last_action_ts: float = 0.0
+    last_tier: int = 0
+    consecutive_failures: int = 0
+
+    def to_json(self) -> str:
+        return json.dumps(
+            {
+                "last_action_ts": self.last_action_ts,
+                "last_tier": self.last_tier,
+                "consecutive_failures": self.consecutive_failures,
+            }
+        )
+
+    @classmethod
+    def from_path(cls, path: Path) -> "_HealState":
+        try:
+            data = json.loads(path.read_text())
+        except (FileNotFoundError, ValueError, OSError):
+            return cls()
+        return cls(
+            last_action_ts=float(data.get("last_action_ts", 0.0)),
+            last_tier=int(data.get("last_tier", 0)),
+            consecutive_failures=int(data.get("consecutive_failures", 0)),
+        )
+
+
+@dataclass
+class _BridgeStatus:
+    pid: Optional[int]
+    process_alive: bool
+    heartbeat_age: float  # math.inf if no heartbeat file
+    bridge_sha: Optional[str]  # None if no stamp written yet
+    disk_sha: Optional[str]  # None if git is unavailable
+
+    @property
+    def sha_mismatch(self) -> bool:
+        # Don't fire on missing data — only act on a real divergence
+        # between two known SHAs.  "unknown" vs a real sha is also a
+        # mismatch, since the bridge boot failed to record its version.
+        if self.bridge_sha is None or self.disk_sha is None:
+            return False
+        return self.bridge_sha != self.disk_sha
+
+    @property
+    def heartbeat_stale(self) -> bool:
+        return self.heartbeat_age > BRIDGE_HEARTBEAT_STALE_S
+
+    @property
+    def needs_cold_start(self) -> bool:
+        # No bridge running at all — runner must bring one up.
+        return self.pid is None or not self.process_alive
+
+    @property
+    def unhealthy(self) -> bool:
+        return self.needs_cold_start or self.sha_mismatch or self.heartbeat_stale
+
+    def summary(self) -> str:
+        bits = [
+            f"pid={self.pid}",
+            f"alive={self.process_alive}",
+            f"heartbeat_age={self.heartbeat_age:.1f}s",
+            f"bridge_sha={(self.bridge_sha or 'missing')[:8]}",
+            f"disk_sha={(self.disk_sha or 'missing')[:8]}",
+        ]
+        return " ".join(bits)
+
+
+def check_and_heal_bridge(koan_root: Path) -> Optional[str]:
+    """Inspect bridge health and escalate recovery one tier per call.
+
+    Intended to be called once per runner main-loop iteration.  Returns
+    a one-line human-readable message describing the action taken when
+    something happened, or ``None`` when the bridge is healthy (or we
+    are in a cooldown window).  Callers should forward the message to
+    the outbox and journal so the operator finds out.
+    """
+    status = _probe_bridge(koan_root)
+    state_path = koan_root / BRIDGE_HEAL_STATE_FILE
+    state = _HealState.from_path(state_path)
+    now = time.time()
+
+    if not status.unhealthy:
+        # Healthy: reset state if we'd been actively healing.
+        if state.last_tier != 0 or state.consecutive_failures != 0:
+            _save_state(state_path, _HealState())
+        return None
+
+    # Don't keep retrying inside the cooldown of a previous tier.
+    if state.last_action_ts and (now - state.last_action_ts) < HEAL_TIER_COOLDOWN_S:
+        return None
+
+    # Circuit breaker: stop trying after N back-to-back failures.
+    if state.consecutive_failures >= HEAL_CIRCUIT_BREAKER_LIMIT:
+        # Only re-emit the alert occasionally, not every iteration.
+        if (now - state.last_action_ts) < POST_HEAL_QUIET_S:
+            return None
+        state.last_action_ts = now
+        _save_state(state_path, state)
+        return (
+            f"⚠️ Bridge self-heal circuit-broken after "
+            f"{state.consecutive_failures} attempts. Manual intervention "
+            f"required. status: {status.summary()}"
+        )
+
+    next_tier = _next_tier(state, status)
+    action_msg = _execute_tier(next_tier, status, koan_root)
+
+    state.last_action_ts = now
+    state.last_tier = next_tier
+    if next_tier == 3:
+        # Tier 3 is the last automated recourse — count it as a failure
+        # of the cooperative path so the breaker can trip.
+        state.consecutive_failures += 1
+    _save_state(state_path, state)
+
+    return f"Bridge self-heal tier {next_tier}: {action_msg}. status: {status.summary()}"
+
+
+# --- Internals -------------------------------------------------------------
+
+
+def _probe_bridge(koan_root: Path) -> _BridgeStatus:
+    pid = _read_bridge_pid(koan_root)
+    process_alive = pid is not None and _is_process_alive(pid)
+    heartbeat_age = _heartbeat_age(koan_root)
+    bridge_sha = _read_text(koan_root / BRIDGE_VERSION_FILE)
+    disk_sha = _read_git_head(koan_root)
+    return _BridgeStatus(
+        pid=pid,
+        process_alive=process_alive,
+        heartbeat_age=heartbeat_age,
+        bridge_sha=bridge_sha,
+        disk_sha=disk_sha,
+    )
+
+
+def _next_tier(state: _HealState, status: _BridgeStatus) -> int:
+    """Pick the next escalation tier based on what's been tried.
+
+    If the bridge is fully missing we skip the cooperative tier — there
+    is no process to receive a restart signal, so we go straight to
+    relaunch (tier 3).
+    """
+    if status.needs_cold_start:
+        return 3
+    # Otherwise step up one tier at a time.
+    return min(state.last_tier + 1, 3)
+
+
+def _execute_tier(tier: int, status: _BridgeStatus, koan_root: Path) -> str:
+    if tier == 1:
+        return _tier1_cooperative(koan_root)
+    if tier == 2:
+        return _tier2_sigterm(status.pid)
+    if tier == 3:
+        return _tier3_kill_and_relaunch(status.pid, koan_root)
+    # Shouldn't happen — _next_tier caps at 3.
+    return f"unknown tier {tier}, no action"
+
+
+def _tier1_cooperative(koan_root: Path) -> str:
+    """Ask the bridge to re-exec via the standard restart channel.
+
+    The runner is always on fresh code (wrapper relaunches it on every
+    exit), so its ``request_restart`` writes the *new* triple-marker
+    format and is not subject to the old race.
+    """
+    from app.restart_manager import request_restart
+
+    request_restart(str(koan_root))
+    return "cooperative restart requested via request_restart()"
+
+
+def _tier2_sigterm(pid: Optional[int]) -> str:
+    if pid is None:
+        return "tier 2 skipped: no bridge pid"
+    try:
+        os.kill(pid, _signal.SIGTERM)
+    except ProcessLookupError:
+        return f"tier 2: pid {pid} already gone"
+    except OSError as e:
+        return f"tier 2: SIGTERM {pid} failed ({e})"
+    return f"SIGTERM sent to bridge pid {pid}"
+
+
+def _tier3_kill_and_relaunch(pid: Optional[int], koan_root: Path) -> str:
+    parts = []
+    # Step 1: make sure the bridge is dead.
+    if pid is not None and _is_process_alive(pid):
+        # Wait briefly in case tier 2's SIGTERM is still landing.
+        deadline = time.monotonic() + SIGTERM_GRACE_S
+        while time.monotonic() < deadline and _is_process_alive(pid):
+            time.sleep(0.25)
+        if _is_process_alive(pid):
+            try:
+                os.kill(pid, _signal.SIGKILL)
+                parts.append(f"SIGKILL sent to bridge pid {pid}")
+            except (OSError, ProcessLookupError) as e:
+                parts.append(f"SIGKILL {pid} failed ({e})")
+        else:
+            parts.append(f"bridge pid {pid} exited after SIGTERM")
+    else:
+        parts.append("no live bridge pid")
+
+    # Step 2: launch a fresh bridge.  pid_manager.start_awake handles
+    # log rotation, detached subprocess, PID-file verification.
+    try:
+        from app.pid_manager import start_awake
+
+        ok, msg = start_awake(koan_root)
+    except Exception as e:  # pragma: no cover - defensive
+        parts.append(f"start_awake raised: {e}")
+        return "; ".join(parts)
+
+    parts.append(f"relaunch: ok={ok} ({msg})")
+    return "; ".join(parts)
+
+
+def _read_bridge_pid(koan_root: Path) -> Optional[int]:
+    path = koan_root / pid_file("awake")
+    try:
+        text = path.read_text().strip()
+        return int(text) if text else None
+    except (FileNotFoundError, ValueError, OSError):
+        return None
+
+
+def _is_process_alive(pid: int) -> bool:
+    """Cheap liveness check (signal 0).  Mirrors ``pid_manager._is_process_alive``
+    but without the zombie/proc lookup — for the watchdog's purposes a
+    zombie is "not actually running" and we'll catch it on the next
+    heartbeat check anyway."""
+    try:
+        os.kill(pid, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def _heartbeat_age(koan_root: Path) -> float:
+    path = koan_root / HEARTBEAT_FILE
+    try:
+        mtime = path.stat().st_mtime
+    except (FileNotFoundError, OSError):
+        return float("inf")
+    return max(0.0, time.time() - mtime)
+
+
+def _read_text(path: Path) -> Optional[str]:
+    try:
+        value = path.read_text().strip()
+    except (FileNotFoundError, OSError):
+        return None
+    return value or None
+
+
+def _read_git_head(koan_root: Path) -> Optional[str]:
+    """Resolve the current HEAD SHA of the Kōan working tree.
+
+    Bounded by a 2 s timeout so a stuck git invocation cannot block the
+    main loop.  Returns ``None`` on any failure (no git, detached repo,
+    timeout) — callers treat ``None`` as "can't compare, skip the
+    sha-mismatch check this round".
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(koan_root), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if proc.returncode != 0:
+        return None
+    sha = proc.stdout.strip()
+    return sha or None
+
+
+def _save_state(path: Path, state: _HealState) -> None:
+    from app.utils import atomic_write
+
+    with contextlib.suppress(OSError):
+        atomic_write(path, state.to_json())

--- a/koan/app/bridge_watchdog.py
+++ b/koan/app/bridge_watchdog.py
@@ -207,10 +207,16 @@ def check_and_heal_bridge(koan_root: Path) -> Optional[str]:
 
     state.last_action_ts = now
     state.last_tier = next_tier
-    if next_tier == 3:
+    if next_tier == 3 and "ok=True" not in action_msg:
         # Tier 3 is the last automated recourse — count it as a failure
-        # of the cooperative path so the breaker can trip.
+        # of the cooperative path so the breaker can trip.  But if the
+        # relaunch succeeded, don't increment: the new bridge needs a
+        # moment to write its version stamp before the next probe.
         state.consecutive_failures += 1
+    elif next_tier == 3:
+        # Successful relaunch — reset the failure counter so a brief
+        # stamp-write race doesn't accumulate toward the breaker.
+        state.consecutive_failures = 0
     _save_state(state_path, state)
 
     return f"Bridge self-heal tier {next_tier}: {action_msg}. status: {status.summary()}"
@@ -326,10 +332,16 @@ def _read_bridge_pid(koan_root: Path) -> Optional[int]:
 
 
 def _is_process_alive(pid: int) -> bool:
-    """Cheap liveness check (signal 0).  Mirrors ``pid_manager._is_process_alive``
-    but without the zombie/proc lookup — for the watchdog's purposes a
-    zombie is "not actually running" and we'll catch it on the next
-    heartbeat check anyway."""
+    """Cheap liveness check (signal 0).
+
+    This intentionally does NOT detect zombies (unlike pid_manager's
+    version which checks /proc/<pid>/status).  A zombie bridge passes
+    kill(pid, 0) and would therefore walk through tiers 1→2→3 instead
+    of jumping straight to tier 3.  This is acceptable: the heartbeat
+    will go stale within BRIDGE_HEARTBEAT_STALE_S and trigger recovery
+    anyway, adding at most ~2 cooldown cycles (~90 s) of extra latency.
+    The simpler check avoids platform-specific /proc parsing.
+    """
     try:
         os.kill(pid, 0)
     except (OSError, ProcessLookupError):

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -524,6 +524,48 @@ def _notify_raw(instance: str, message: str):
         log("error", f"Raw notification failed: {e}")
 
 
+# Iteration counter for throttling watchdog probes.  Most ticks just do
+# the cheap PID/heartbeat read; the git rev-parse SHA check is bounded
+# by the watchdog's own internal cooldown, but we still don't need to
+# probe every single iteration when the loop is hot.
+_BRIDGE_WATCHDOG_INTERVAL = 5
+_bridge_watchdog_tick = 0
+
+
+def _maybe_run_bridge_watchdog(koan_root: Path, instance: str) -> None:
+    """Run the bridge self-heal watchdog on a fraction of iterations.
+
+    Cheap to run (subprocess + a few stat calls), but the watchdog has
+    its own per-tier cooldown, so calling it on every loop tick would
+    just spin the throttle.  Once per ~5 iterations is plenty given the
+    runner's typical 60-300 s loop interval.
+    """
+    global _bridge_watchdog_tick
+    _bridge_watchdog_tick = (_bridge_watchdog_tick + 1) % _BRIDGE_WATCHDOG_INTERVAL
+    if _bridge_watchdog_tick != 0:
+        return
+
+    try:
+        from app.bridge_watchdog import check_and_heal_bridge
+        action = check_and_heal_bridge(koan_root)
+    except Exception as e:
+        log("error", f"bridge_watchdog crashed: {e}")
+        return
+
+    if not action:
+        return
+
+    log("koan", f"bridge_watchdog: {action}")
+    # Tell the operator via Telegram (terse, no Claude reformat) and
+    # leave an audit trail in today's journal.
+    _notify_raw(instance, f"🩹 {action}")
+    try:
+        from app.journal import append_to_journal
+        append_to_journal(Path(instance), "koan", f"\n{action}\n")
+    except Exception as e:
+        log("error", f"journal append failed (watchdog): {e}")
+
+
 def _notify_mission_end(
     instance: str,
     project_name: str,
@@ -855,6 +897,14 @@ def main_loop():
                 log("koan", "Restart requested. Exiting for re-launch...")
                 clear_restart(koan_root, target="run")
                 sys.exit(RESTART_EXIT_CODE)
+
+            # --- Bridge self-heal watchdog ---
+            # The bridge has no wrapper, so a stale-sys.modules after
+            # /update can leave it stuck until the operator intervenes.
+            # The runner is always fresh code (its wrapper relaunches
+            # on every exit), so it's the right place to watch and
+            # recover the bridge.  See koan/docs/bridge-watchdog.md.
+            _maybe_run_bridge_watchdog(Path(koan_root), instance)
 
             # --- Pause mode ---
             if Path(koan_root, PAUSE_FILE).exists():

--- a/koan/app/signals.py
+++ b/koan/app/signals.py
@@ -28,6 +28,14 @@ STATUS_FILE = ".koan-status"
 HEARTBEAT_FILE = ".koan-heartbeat"
 RUN_HEARTBEAT_FILE = ".koan-run-heartbeat"
 
+# Code version the bridge process was launched against (git HEAD SHA).
+# Written by awake.py at startup, read by the runner's bridge_watchdog
+# to detect "bridge is alive but stuck on stale sys.modules" — a state
+# the heartbeat alone cannot catch.
+BRIDGE_VERSION_FILE = ".koan-bridge-version"
+# Persistent state for the runner-side bridge self-healing tier escalator.
+BRIDGE_HEAL_STATE_FILE = ".koan-bridge-heal-state"
+
 # -- Mode flags ----------------------------------------------------------------
 
 FOCUS_FILE = ".koan-focus"

--- a/koan/tests/test_bridge_watchdog.py
+++ b/koan/tests/test_bridge_watchdog.py
@@ -1,0 +1,295 @@
+"""Tests for bridge_watchdog — health detection + tier escalation.
+
+The watchdog acts on three observable inputs:
+  * the bridge PID (read from instance/.koan-pid-awake)
+  * the heartbeat mtime
+  * git HEAD vs the bridge's recorded SHA
+
+Tests mock the three external effects (request_restart, os.kill,
+pid_manager.start_awake) and assert the right tier fires in each scenario.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from app.bridge_watchdog import (
+    BRIDGE_HEARTBEAT_STALE_S,
+    HEAL_CIRCUIT_BREAKER_LIMIT,
+    HEAL_TIER_COOLDOWN_S,
+    check_and_heal_bridge,
+    write_bridge_version_stamp,
+)
+from app.signals import (
+    BRIDGE_HEAL_STATE_FILE,
+    BRIDGE_VERSION_FILE,
+    HEARTBEAT_FILE,
+    pid_file,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build a koan_root tmp dir in a known state.
+# ---------------------------------------------------------------------------
+
+
+def _set_bridge_pid(koan_root: Path, pid: int) -> None:
+    (koan_root / pid_file("awake")).write_text(str(pid))
+
+
+def _set_heartbeat(koan_root: Path, age_seconds: float) -> None:
+    path = koan_root / HEARTBEAT_FILE
+    path.write_text(str(time.time() - age_seconds))
+    mtime = time.time() - age_seconds
+    import os
+    os.utime(path, (mtime, mtime))
+
+
+def _set_bridge_sha(koan_root: Path, sha: str) -> None:
+    (koan_root / BRIDGE_VERSION_FILE).write_text(sha)
+
+
+@pytest.fixture
+def healthy_root(tmp_path):
+    """A koan_root where everything is fine: alive pid, fresh heartbeat, SHA match."""
+    _set_bridge_pid(tmp_path, 99999999)  # nonsense pid; we'll mock _is_process_alive
+    _set_heartbeat(tmp_path, age_seconds=2.0)
+    _set_bridge_sha(tmp_path, "abc1234")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def stub_external_effects():
+    """Default: process always alive, git HEAD matches whatever bridge SHA is set,
+    request_restart / SIGTERM / start_awake all succeed without side-effects.
+
+    Helpers like ``request_restart`` and ``start_awake`` are imported
+    lazily inside the watchdog so they're patched at their source
+    modules, not on ``app.bridge_watchdog``.
+    """
+    with (
+        patch("app.bridge_watchdog._is_process_alive", return_value=True) as mock_alive,
+        patch("app.bridge_watchdog._read_git_head", return_value="abc1234") as mock_head,
+        patch("app.bridge_watchdog.os.kill") as mock_kill,
+        patch("app.restart_manager.request_restart") as mock_req_restart,
+        patch("app.pid_manager.start_awake", return_value=(True, "ok")) as mock_start,
+    ):
+        yield {
+            "is_alive": mock_alive,
+            "head": mock_head,
+            "kill": mock_kill,
+            "request_restart": mock_req_restart,
+            "start_awake": mock_start,
+        }
+
+
+# ---------------------------------------------------------------------------
+# write_bridge_version_stamp
+# ---------------------------------------------------------------------------
+
+
+class TestWriteBridgeVersionStamp:
+    def test_records_git_head(self, tmp_path):
+        with patch("app.bridge_watchdog._read_git_head", return_value="deadbeef"):
+            write_bridge_version_stamp(tmp_path)
+        assert (tmp_path / BRIDGE_VERSION_FILE).read_text() == "deadbeef"
+
+    def test_records_unknown_when_git_unavailable(self, tmp_path):
+        with patch("app.bridge_watchdog._read_git_head", return_value=None):
+            write_bridge_version_stamp(tmp_path)
+        assert (tmp_path / BRIDGE_VERSION_FILE).read_text() == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Healthy bridge — no action
+# ---------------------------------------------------------------------------
+
+
+class TestHealthy:
+    def test_no_action_when_everything_fresh(self, healthy_root, stub_external_effects):
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is None
+        stub_external_effects["request_restart"].assert_not_called()
+        stub_external_effects["kill"].assert_not_called()
+        stub_external_effects["start_awake"].assert_not_called()
+
+    def test_resets_heal_state_when_healthy(self, healthy_root):
+        """A prior heal cycle leaves state on disk; once healthy, the watchdog
+        wipes it so a future incident starts at tier 1, not somewhere mid-flight."""
+        state_path = healthy_root / BRIDGE_HEAL_STATE_FILE
+        state_path.write_text(json.dumps({
+            "last_action_ts": time.time() - 1000,
+            "last_tier": 2,
+            "consecutive_failures": 1,
+        }))
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is None
+        data = json.loads(state_path.read_text())
+        assert data["last_tier"] == 0
+        assert data["consecutive_failures"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 — SHA mismatch triggers cooperative restart
+# ---------------------------------------------------------------------------
+
+
+class TestTier1:
+    def test_sha_mismatch_triggers_cooperative_restart(
+        self, healthy_root, stub_external_effects
+    ):
+        stub_external_effects["head"].return_value = "newsha999"  # disk drifted
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is not None
+        assert "tier 1" in msg
+        stub_external_effects["request_restart"].assert_called_once_with(str(healthy_root))
+        stub_external_effects["kill"].assert_not_called()
+
+    def test_stale_heartbeat_triggers_cooperative_restart(
+        self, healthy_root, stub_external_effects
+    ):
+        _set_heartbeat(healthy_root, age_seconds=BRIDGE_HEARTBEAT_STALE_S + 10)
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is not None
+        assert "tier 1" in msg
+        stub_external_effects["request_restart"].assert_called_once()
+
+    def test_unknown_bridge_sha_does_not_trigger(
+        self, healthy_root, stub_external_effects
+    ):
+        """If the bridge's stamp is missing (pre-upgrade incarnation), we
+        can't reliably compare SHAs — skip the check rather than flapping."""
+        (healthy_root / BRIDGE_VERSION_FILE).unlink()
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is None
+
+
+# ---------------------------------------------------------------------------
+# Cooldown — don't keep retrying within a tier's grace window
+# ---------------------------------------------------------------------------
+
+
+class TestCooldown:
+    def test_no_second_action_during_cooldown(
+        self, healthy_root, stub_external_effects
+    ):
+        stub_external_effects["head"].return_value = "newsha999"
+        # First call triggers tier 1.
+        check_and_heal_bridge(healthy_root)
+        stub_external_effects["request_restart"].reset_mock()
+
+        # Second call within the cooldown window — no new action.
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is None
+        stub_external_effects["request_restart"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 — SIGTERM after tier 1 didn't take
+# ---------------------------------------------------------------------------
+
+
+class TestTier2:
+    def _force_post_cooldown_state(self, koan_root: Path, last_tier: int):
+        """Drop a heal-state file as if the previous tier already ran and
+        the cooldown has elapsed."""
+        (koan_root / BRIDGE_HEAL_STATE_FILE).write_text(json.dumps({
+            "last_action_ts": time.time() - (HEAL_TIER_COOLDOWN_S + 5),
+            "last_tier": last_tier,
+            "consecutive_failures": 0,
+        }))
+
+    def test_escalates_to_sigterm_after_tier1(
+        self, healthy_root, stub_external_effects
+    ):
+        stub_external_effects["head"].return_value = "newsha999"
+        _set_bridge_pid(healthy_root, 42424)
+        self._force_post_cooldown_state(healthy_root, last_tier=1)
+
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is not None
+        assert "tier 2" in msg
+        stub_external_effects["kill"].assert_called_once()
+        sent_pid, sent_signal = stub_external_effects["kill"].call_args[0]
+        assert sent_pid == 42424
+        # SIGTERM = 15 on POSIX
+        import signal as _s
+        assert sent_signal == _s.SIGTERM
+        # request_restart should NOT fire again (tier 1 already happened).
+        stub_external_effects["request_restart"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Tier 3 — SIGKILL + relaunch
+# ---------------------------------------------------------------------------
+
+
+class TestTier3:
+    def test_kills_then_relaunches_after_sigterm(
+        self, healthy_root, stub_external_effects
+    ):
+        stub_external_effects["head"].return_value = "newsha999"
+        _set_bridge_pid(healthy_root, 4242)
+        (healthy_root / BRIDGE_HEAL_STATE_FILE).write_text(json.dumps({
+            "last_action_ts": time.time() - (HEAL_TIER_COOLDOWN_S + 5),
+            "last_tier": 2,
+            "consecutive_failures": 0,
+        }))
+        # _is_process_alive: True first (still alive after SIGTERM), then dies
+        # after one polling iteration.
+        liveness = iter([True, True, False])
+        stub_external_effects["is_alive"].side_effect = lambda *_args, **_kw: next(
+            liveness, False
+        )
+
+        with patch("app.bridge_watchdog.time.sleep"):  # don't actually sleep
+            msg = check_and_heal_bridge(healthy_root)
+
+        assert msg is not None
+        assert "tier 3" in msg
+        stub_external_effects["start_awake"].assert_called_once_with(healthy_root)
+
+    def test_no_pid_skips_straight_to_relaunch(
+        self, healthy_root, stub_external_effects
+    ):
+        """If the PID file is gone entirely we have no process to signal —
+        go straight to tier 3 cold start."""
+        (healthy_root / pid_file("awake")).unlink()
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is not None
+        assert "tier 3" in msg
+        stub_external_effects["start_awake"].assert_called_once_with(healthy_root)
+        # No SIGKILL since there's no PID to signal.
+        stub_external_effects["kill"].assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker — stop trying after N failed tier-3 cycles
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_emits_alert_and_stops_acting_after_limit(
+        self, healthy_root, stub_external_effects
+    ):
+        stub_external_effects["head"].return_value = "newsha999"
+        # State already at the breaker limit, with cooldown elapsed so the
+        # watchdog is willing to act again — except for the breaker.
+        from app.bridge_watchdog import POST_HEAL_QUIET_S
+        (healthy_root / BRIDGE_HEAL_STATE_FILE).write_text(json.dumps({
+            "last_action_ts": time.time() - (POST_HEAL_QUIET_S + 5),
+            "last_tier": 3,
+            "consecutive_failures": HEAL_CIRCUIT_BREAKER_LIMIT,
+        }))
+
+        msg = check_and_heal_bridge(healthy_root)
+        assert msg is not None
+        assert "circuit-broken" in msg
+        stub_external_effects["request_restart"].assert_not_called()
+        stub_external_effects["kill"].assert_not_called()
+        stub_external_effects["start_awake"].assert_not_called()


### PR DESCRIPTION
The Telegram bridge (`awake.py`) is a long-running process with no
wrapper, so a frozen `sys.modules` after `/update` leaves it serving
stale imports until someone with shell access kicks it.  The recent
`cb6e927` ("per-process restart markers") fix the race that drops
restart signals once both processes are on the new code, but the
transitional `/update` from old to new still wedged the bridge — and
no in-Telegram recovery path worked, because every subsequent
`/restart` hit the same import-cache state and the bridge's polling
loop has no way to bootstrap its `awake.py` globals back to the
freshly-reloaded `app.restart_manager`.

Add a runner-side watchdog that detects two distinct failure modes
and escalates recovery through four tiers.  The runner is *always*
fresh code (its wrapper relaunches on every exit), so it is the
right place to own this responsibility.

Detection:
- **Stale modules**: bridge stamps its git HEAD SHA at startup
  (`.koan-bridge-version`); runner compares against
  `git rev-parse HEAD` on each tick.  Heartbeat alone cannot catch
  this — process is alive and responsive, just running old code.
- **Hung / dead bridge**: heartbeat older than
  `BRIDGE_HEARTBEAT_STALE_S` (90 s) or PID gone / pointing at a
  dead process.

Escalation (one tier per call, persisted in `.koan-bridge-heal-state`):
- Tier 1: `request_restart()` — runner is on fresh code so its
  triple-marker write is correct and not subject to the old race
- Tier 2: SIGTERM the bridge PID
- Tier 3: SIGKILL (after `SIGTERM_GRACE_S`) + `pid_manager.start_awake`
- Tier 4: circuit-broken, alert and stop.  Counter trips after
  `HEAL_CIRCUIT_BREAKER_LIMIT` (3) consecutive tier-3 failures.

If the bridge has no PID file at all (crashed long ago, never
restarted), tiers 1–2 are skipped and the watchdog goes straight to
tier 3 — there is no process to signal cooperatively.

The runner throttles probes to one per `_BRIDGE_WATCHDOG_INTERVAL`
(5) main-loop iterations.  Each iteration is ~60–300 s, so detection
latency is ~5–25 min in the worst case, which is fine for "don't let
a stuck bridge sit forever."  Per-tier cooldown
(`HEAL_TIER_COOLDOWN_S` = 45 s) prevents acting again before the
previous tier has had a chance to take effect.

When the watchdog acts, the message is forwarded both to Telegram
via `_notify_raw` (terse, no Claude reformat — goes through the
outbox so a freshly-relaunched bridge flushes it on first poll) and
to today's journal entry under project "koan" for after-the-fact
audit.

Files:
- `koan/app/bridge_watchdog.py` (new, ~330 LOC): detection, state
  machine, tier execution, bridge-side version stamp writer.
- `koan/app/signals.py`: two new constants
  (`BRIDGE_VERSION_FILE`, `BRIDGE_HEAL_STATE_FILE`).
- `koan/app/awake.py`: call `write_bridge_version_stamp` once at
  startup, right after the existing heartbeat write.
- `koan/app/run.py`: throttled `_maybe_run_bridge_watchdog` helper
  called once per iteration after the existing `check_restart`
  block.  Forwards heal messages to Telegram + journal.
- `koan/tests/test_bridge_watchdog.py` (12 tests): healthy no-op,
  SHA mismatch tier 1, heartbeat stale tier 1, missing stamp =
  no-op (defensive), cooldown suppression, tier 2 SIGTERM after
  tier 1, tier 3 SIGKILL + start_awake, no-PID cold-start
  skipping straight to tier 3, circuit-breaker alert path.
- `docs/bridge-watchdog.md`: design rationale, failure-mode table,
  escalation diagram, tunables, operator notes, rollback.

Verified: `pytest koan/tests/` = 12788 passed, ruff clean on all
touched files.  (Pre-existing SIM105 in `koan/app/cli_exec.py:187`
is unrelated and present on `main`.)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
