### PR TITLE
fix(notifications): don't mark foreign-repo notifications as read

### DIFF
--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -530,6 +530,40 @@ def resolve_project_from_notification(notification: dict) -> Optional[Tuple[str,
     return project_name, owner, repo
 
 
+def _skip_if_foreign_repo(
+    notification: dict, log_prefix: str,
+) -> Optional[Tuple[str, str, str]]:
+    """Resolve the project for ``notification`` or log a foreign-repo skip.
+
+    Centralizes the resolve-or-log boilerplate that previously lived in
+    ``process_single_notification``, ``_try_assignment_notification`` and
+    ``_try_subscription_notification``. Callers decide what to return on
+    a miss (``False``, ``(False, None)``, etc.) — this helper only does
+    the resolution and the debug log.
+
+    Args:
+        notification: A notification dict.
+        log_prefix: Short label included in the debug log so the source of
+            the skip is visible in ``/logs`` (e.g. ``"GitHub"`` for the
+            command path, ``"GitHub assign"`` for the assignment path).
+
+    Returns:
+        ``(project_name, owner, repo)`` when the repo is registered to
+        this instance, ``None`` otherwise.
+    """
+    project_info = resolve_project_from_notification(notification)
+    if project_info:
+        return project_info
+    repo_data = notification.get("repository", {})
+    full_name = repo_data.get("full_name", "?")
+    reason = notification.get("reason", "?")
+    log.debug(
+        "%s: repo %s (reason=%s) not in projects.yaml — ignoring notification",
+        log_prefix, full_name, reason,
+    )
+    return None
+
+
 def _fetch_and_filter_comment(notification: dict, bot_username: str, max_age_hours: int) -> Optional[dict]:
     """Fetch the triggering comment and check if notification should be skipped.
 
@@ -945,12 +979,12 @@ def _try_assignment_notification(
         mark_notification_read(notif_id)
         return False
 
-    # Resolve project
-    project_info = resolve_project_from_notification(notification)
+    # Foreign-repo skip: never write to shared GitHub state for a repo this
+    # instance doesn't own (would clear the notification from a sibling
+    # Kōan instance's inbox). The outer ownership gate already filters most
+    # of these out — this is defense in depth.
+    project_info = _skip_if_foreign_repo(notification, "GitHub assign")
     if not project_info:
-        repo_name = notification.get("repository", {}).get("full_name", "?")
-        log.debug("GitHub assign: repo %s not in projects.yaml", repo_name)
-        mark_notification_read(notif_id)
         return False
 
     project_name, owner, repo = project_info
@@ -1067,16 +1101,12 @@ def process_single_notification(
 
     comment_author = comment.get("user", {}).get("login", "")
 
-    # Resolve project — silently skip repos not registered to this instance.
-    # When a GitHub account is shared by multiple instances, each instance
-    # must only process notifications for its own projects.
-    project_info = resolve_project_from_notification(notification)
+    # Foreign-repo skip: never write to shared GitHub state for a repo this
+    # instance doesn't own (would clear the notification from a sibling
+    # Kōan instance's inbox). The outer ownership gate already filters most
+    # of these out — this is defense in depth.
+    project_info = _skip_if_foreign_repo(notification, "GitHub")
     if not project_info:
-        repo_data = notification.get("repository", {})
-        full_name = repo_data.get("full_name", "?")
-        reason = notification.get("reason", "?")
-        log.debug("GitHub: repo %s (reason=%s) not in projects.yaml — ignoring notification", full_name, reason)
-        mark_notification_read(str(notification.get("id", "")))
         return False, None
     project_name, owner, repo = project_info
     log.debug("GitHub: resolved project=%s from %s/%s", project_name, owner, repo)
@@ -1428,8 +1458,8 @@ def _try_subscription_notification(
     if not get_github_subscribe_enabled(config):
         return False
 
-    # Resolve project
-    project_info = resolve_project_from_notification(notification)
+    # Foreign-repo skip (defense in depth — outer gate filters most of these).
+    project_info = _skip_if_foreign_repo(notification, "GitHub subscribe")
     if not project_info:
         return False
 

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -689,6 +689,14 @@ def process_github_notifications(
 
     if force:
         _github_log("Forced notification check (via /check_notifications)")
+        # A forced poll is the user's "look again, fresh" lever — typically
+        # invoked after editing projects.yaml. Clear the in-process
+        # notification cache so previously-cached foreign-repo skips are
+        # re-evaluated against the current project list. Already-processed
+        # owned notifications stay protected by GitHub reactions and the
+        # persistent comment tracker, so clearing is safe.
+        with _notif_cache_lock:
+            _notif_cache.clear()
 
     # Retry any previously failed error replies before processing new ones.
     _retry_failed_replies()
@@ -823,10 +831,33 @@ def _process_one_notification(
     state is mutated through thread-safe APIs (lock-guarded caches, atomic
     file writes for missions).
     """
-    from app.github_command_handler import process_single_notification
+    from app.github_command_handler import (
+        process_single_notification,
+        resolve_project_from_notification,
+    )
     from app.github_notifications import mark_notification_read
 
     try:
+        # Ownership gate: when a GitHub identity is shared by multiple Kōan
+        # instances, each instance must leave foreign repos completely
+        # untouched. Marking the notification as read here would clear it
+        # from the shared bot inbox, hiding it from the instance that does
+        # own the repo.
+        #
+        # Cache foreign notifications in-process so we don't re-run the
+        # (potentially subprocess-heavy) project resolution on every poll
+        # cycle. The cache key includes ``updated_at`` so any new activity
+        # on the thread naturally invalidates the entry and we re-evaluate
+        # ownership. Kept inside the try/except so a crash in
+        # resolve_project_from_notification (e.g. corrupt projects.yaml,
+        # subprocess failure during remote discovery) is contained to this
+        # worker rather than propagating to the thread pool.
+        if resolve_project_from_notification(notif) is None:
+            repo = notif.get("repository", {}).get("full_name", "?")
+            log.debug("GitHub: skipping notification for foreign repo %s", repo)
+            _cache_notif(notif)
+            return False
+
         _log_notification(notif)
         success, error = process_single_notification(
             notif, registry, config, projects_config,

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -486,7 +486,14 @@ class TestProcessSingleNotification:
         self, mock_resolve, mock_comment, mock_stale, mock_self,
         mock_processed, mock_read, registry, sample_notification,
     ):
-        """When repo is not in projects.yaml, silently skip (shared GitHub account)."""
+        """When repo is not in projects.yaml, leave it untouched.
+
+        Marking the notification as read is a write to shared GitHub state.
+        With a shared bot identity across multiple Kōan instances, this
+        instance must not clear notifications belonging to a sibling
+        instance — leaving the notification unread lets the owning
+        instance process it on its next poll.
+        """
         mock_comment.return_value = {
             "id": 99999, "body": "@bot rebase", "user": {"login": "alice"},
         }
@@ -497,7 +504,7 @@ class TestProcessSingleNotification:
         )
         assert success is False
         assert error is None
-        mock_read.assert_called_once()
+        mock_read.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.check_already_processed", return_value=False)
@@ -509,7 +516,11 @@ class TestProcessSingleNotification:
         self, mock_resolve, mock_comment, mock_stale, mock_self,
         mock_processed, mock_read, registry,
     ):
-        """Notification with no valid full_name is silently skipped."""
+        """Notification with no valid full_name is silently skipped.
+
+        Same contract as ``test_unknown_repo_silently_skipped``: no write to
+        shared GitHub state — the notification is left unread.
+        """
         notif = {
             "id": "12345", "reason": "mention",
             "updated_at": "2026-02-11T20:00:00Z",
@@ -529,7 +540,7 @@ class TestProcessSingleNotification:
         )
         assert success is False
         assert error is None
-        mock_read.assert_called_once_with("12345")
+        mock_read.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.check_already_processed", return_value=False)
@@ -3373,7 +3384,13 @@ class TestTryAssignmentNotification:
     def test_unknown_repo_skipped(
         self, review_notification, review_registry,
     ):
-        """Notifications from unknown repos are skipped."""
+        """Notifications from unknown repos are skipped without side effects.
+
+        Marking the notification as read is a write to shared GitHub state.
+        With a shared bot identity, this instance must leave foreign repos
+        untouched so the sibling instance that owns the repo can process
+        them on its next poll.
+        """
         with patch("app.github_command_handler.is_notification_stale", return_value=False), \
              patch("app.github_command_handler.resolve_project_from_notification",
                    return_value=None), \
@@ -3383,7 +3400,7 @@ class TestTryAssignmentNotification:
             )
 
         assert result is False
-        mock_mark.assert_called_once()
+        mock_mark.assert_not_called()
 
     def test_no_subject_url_skipped(self, review_registry):
         """Notifications without a subject URL are skipped."""
@@ -3780,3 +3797,38 @@ class TestTryAssignmentNotificationClosedSubject:
         assert result is False
         mock_notify.assert_called_once()
         assert mock_notify.call_args[0][3] == "merged"  # subject_state
+
+
+class TestSkipIfForeignRepo:
+    """_skip_if_foreign_repo centralizes the resolve-or-log boilerplate."""
+
+    def test_returns_project_info_for_owned_repo(self):
+        from app.github_command_handler import _skip_if_foreign_repo
+
+        notif = {"repository": {"full_name": "owner/repo"}}
+        with patch(
+            "app.github_command_handler.resolve_project_from_notification",
+            return_value=("repo", "owner", "repo"),
+        ):
+            result = _skip_if_foreign_repo(notif, "GitHub")
+
+        assert result == ("repo", "owner", "repo")
+
+    def test_logs_and_returns_none_for_foreign_repo(self, caplog):
+        import logging
+        from app.github_command_handler import _skip_if_foreign_repo
+
+        notif = {
+            "repository": {"full_name": "stranger/repo"},
+            "reason": "mention",
+        }
+        with patch(
+            "app.github_command_handler.resolve_project_from_notification",
+            return_value=None,
+        ), caplog.at_level(logging.DEBUG, logger="app.github_command_handler"):
+            result = _skip_if_foreign_repo(notif, "GitHub assign")
+
+        assert result is None
+        assert "GitHub assign" in caplog.text
+        assert "stranger/repo" in caplog.text
+        assert "reason=mention" in caplog.text

--- a/koan/tests/test_github_notif_logging.py
+++ b/koan/tests/test_github_notif_logging.py
@@ -238,10 +238,13 @@ class TestProcessSingleNotificationLogging:
                 notif, MagicMock(), {}, None, "bot", 24,
             )
 
-        # Unknown repos are silently skipped (shared GitHub account support)
+        # Unknown repos are silently skipped (shared GitHub account support).
+        # The notification must NOT be marked as read — that would clear it
+        # from the inbox of the sibling Kōan instance that owns the repo.
         assert "not in projects.yaml" in caplog.text
         assert "ignoring notification" in caplog.text
         assert success is False
+        mock_read.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.check_user_permission", return_value=False)
@@ -421,6 +424,8 @@ class TestProcessNotificationsIntegration:
         }
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications", return_value=self._make_fetch_result([fake_notif])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification", return_value=(True, None)):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
 
@@ -480,6 +485,8 @@ class TestProcessNotificationsIntegration:
         side_effects = [(True, None), (True, None), (False, None)]
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications", return_value=self._make_fetch_result(notifs)), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification", side_effect=side_effects):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
 

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -816,6 +816,8 @@ class TestGitHubNotificationBackoff:
         fake_notif = {"id": "1", "subject": {"url": "https://api.github.com/repos/o/r/issues/1"}}
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications", return_value=FetchResult([fake_notif], [])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification", return_value=(True, None)):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
 
@@ -1139,6 +1141,8 @@ class TestDrainNotifications:
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications",
                    return_value=FetchResult(actionable, drain)), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification", return_value=(True, None)), \
              patch("app.loop_manager._notify_mission_from_mention"):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
@@ -1500,6 +1504,8 @@ class TestProcessNotificationsConsoleOutput:
         }
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications", return_value=FetchResult([fake_notif], [])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("koan", "sukria", "koan")), \
              patch("app.github_command_handler.process_single_notification", return_value=(True, None)), \
              patch("app.loop_manager._notify_mission_from_mention"):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
@@ -1534,6 +1540,8 @@ class TestProcessNotificationsConsoleOutput:
         }
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications", return_value=FetchResult([fake_notif], [])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("koan", "sukria", "koan")), \
              patch("app.github_command_handler.process_single_notification", return_value=(False, "Permission denied")), \
              patch("app.loop_manager._post_error_for_notification"):
             result = process_github_notifications(str(tmp_path), str(tmp_path))
@@ -2181,6 +2189,8 @@ class TestNotificationCache:
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications",
                    return_value=FetchResult([notif1, notif2], [])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification",
                    return_value=(True, None)) as mock_process:
             process_github_notifications(str(tmp_path), str(tmp_path))
@@ -2458,6 +2468,8 @@ class TestErrorReplyRetryQueue:
         with patch("app.projects_config.load_projects_config", return_value={}), \
              patch("app.github_notifications.fetch_unread_notifications",
                    return_value=FetchResult([notif], [])), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "o", "r")), \
              patch("app.github_command_handler.process_single_notification",
                    side_effect=mock_process), \
              patch("app.loop_manager._post_error_for_notification",
@@ -2742,7 +2754,11 @@ class TestConcurrentNotificationProcessing:
                 raise RuntimeError("boom")
             return True, None
 
+        # Pretend both notifications belong to this instance so the
+        # ownership gate in _process_one_notification lets them through.
         with patch("app.github_command_handler.process_single_notification", side_effect=fake_inner), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("proj", "owner", "repo")), \
              patch("app.github_notifications.mark_notification_read"), \
              patch("app.loop_manager._notify_mission_from_mention"):
             for notif in (good_notif, bad_notif):
@@ -2752,6 +2768,195 @@ class TestConcurrentNotificationProcessing:
 
         # First notif succeeded; second crashed but returned False instead of raising.
         assert results == [True, False]
+
+
+class TestForeignRepoOwnershipGate:
+    """Verify _process_one_notification leaves foreign repos completely untouched.
+
+    When a GitHub identity is shared by multiple Kōan instances, this
+    instance must not call ``process_single_notification`` (which writes to
+    missions.md) nor ``mark_notification_read`` (which writes to shared
+    GitHub state) for repos it does not own. Leaving the notification
+    unread is what lets a sibling instance process it on its next poll.
+
+    The notification IS, however, cached in-process so we don't re-run the
+    project resolution on every poll cycle.
+    """
+
+    def test_foreign_repo_skipped_with_no_shared_state_writes(self):
+        from app.loop_manager import _process_one_notification
+
+        notif = {
+            "id": "42",
+            "subject": {"url": ""},
+            "repository": {"full_name": "someone-else/their-repo"},
+        }
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=None) as mock_resolve, \
+             patch("app.github_command_handler.process_single_notification") as mock_process, \
+             patch("app.github_notifications.mark_notification_read") as mock_read, \
+             patch("app.loop_manager._cache_notif") as mock_cache:
+            result = _process_one_notification(
+                notif, MagicMock(), {}, {}, {"bot_username": "bot", "max_age": 24},
+            )
+
+        # Gate must short-circuit before any side effects on shared state.
+        assert result is False
+        mock_resolve.assert_called_once_with(notif)
+        mock_process.assert_not_called()
+        mock_read.assert_not_called()
+        # In-process cache IS written so subsequent polls skip the resolve walk.
+        mock_cache.assert_called_once_with(notif)
+
+    def test_worker_survives_exception_in_resolve(self, caplog):
+        """A crash inside resolve_project_from_notification must not kill
+        the worker thread. The gate sits inside the existing try/except so
+        any exception (corrupt projects.yaml, subprocess failure during
+        remote discovery, etc.) is logged and the worker returns False.
+        """
+        import logging
+        from app.loop_manager import _process_one_notification
+
+        notif = {
+            "id": "999",
+            "subject": {"url": ""},
+            "repository": {"full_name": "owner/repo"},
+        }
+
+        with patch(
+            "app.github_command_handler.resolve_project_from_notification",
+            side_effect=RuntimeError("corrupt projects.yaml"),
+        ), patch("app.github_command_handler.process_single_notification") as mock_process, \
+             patch("app.github_notifications.mark_notification_read") as mock_read, \
+             caplog.at_level(logging.WARNING, logger="app.loop_manager"):
+            result = _process_one_notification(
+                notif, MagicMock(), {}, {}, {"bot_username": "bot", "max_age": 24},
+            )
+
+        assert result is False
+        # Crash was contained — no downstream side effects ran.
+        mock_process.assert_not_called()
+        mock_read.assert_not_called()
+        assert "corrupt projects.yaml" in caplog.text
+
+    def test_foreign_repo_cache_prevents_repeated_resolution(self):
+        """After the gate trips once, _is_notif_cached must return True so the
+        notification is filtered out before reaching _process_one_notification
+        on the next poll."""
+        from app.loop_manager import (
+            _cache_notif,
+            _is_notif_cached,
+            _notif_cache,
+            _notif_cache_lock,
+        )
+
+        notif = {
+            "id": "777",
+            "updated_at": "2026-05-21T10:00:00Z",
+            "repository": {"full_name": "someone-else/their-repo"},
+        }
+        # Clean slate
+        with _notif_cache_lock:
+            _notif_cache.clear()
+
+        assert _is_notif_cached(notif) is False
+        _cache_notif(notif)
+        assert _is_notif_cached(notif) is True
+
+        # Activity on the thread (new updated_at) re-opens the gate
+        notif_updated = dict(notif, updated_at="2026-05-21T11:00:00Z")
+        assert _is_notif_cached(notif_updated) is False
+
+
+class TestForcePollClearsNotifCache:
+    """A forced poll (``force=True``) is the user's "look again, fresh"
+    lever — typically invoked after editing projects.yaml. It must clear
+    the in-process notification cache so previously-cached foreign-repo
+    skips are re-evaluated against the current project list.
+    """
+
+    def setup_method(self):
+        from app.loop_manager import reset_github_backoff
+        reset_github_backoff()
+
+    @patch("app.loop_manager._load_github_config")
+    @patch("app.loop_manager._build_skill_registry")
+    @patch("app.loop_manager._get_known_repos_from_projects")
+    @patch("app.utils.load_config")
+    def test_force_clears_cache(
+        self, mock_config, mock_repos, mock_registry, mock_gh_config, tmp_path
+    ):
+        from app.github_notifications import FetchResult
+        from app.loop_manager import (
+            _cache_notif,
+            _is_notif_cached,
+            process_github_notifications,
+        )
+
+        mock_config.return_value = {}
+        mock_gh_config.return_value = {"bot_username": "bot", "max_age": 24}
+        mock_registry.return_value = MagicMock()
+        mock_repos.return_value = set()
+
+        # Seed the cache with a previously-cached foreign-repo notification.
+        stale = {"id": "stale-1", "updated_at": "2026-05-21T09:00:00Z",
+                 "repository": {"full_name": "stranger/repo"}}
+        _cache_notif(stale)
+        assert _is_notif_cached(stale) is True
+
+        with patch("app.projects_config.load_projects_config", return_value={}), \
+             patch("app.github_notifications.fetch_unread_notifications",
+                   return_value=FetchResult([], [])):
+            process_github_notifications(
+                str(tmp_path), str(tmp_path), force=True,
+            )
+
+        # Forced poll cleared the cache — the stale entry is gone, so the
+        # bot would re-evaluate that notification on a future fetch.
+        assert _is_notif_cached(stale) is False
+
+    @patch("app.loop_manager._load_github_config")
+    @patch("app.loop_manager._build_skill_registry")
+    @patch("app.loop_manager._get_known_repos_from_projects")
+    @patch("app.utils.load_config")
+    def test_non_forced_poll_preserves_cache(
+        self, mock_config, mock_repos, mock_registry, mock_gh_config, tmp_path
+    ):
+        from app.github_notifications import FetchResult
+        from app.loop_manager import (
+            _cache_notif,
+            _is_notif_cached,
+            process_github_notifications,
+        )
+
+        mock_config.return_value = {}
+        mock_gh_config.return_value = {"bot_username": "bot", "max_age": 24}
+        mock_registry.return_value = MagicMock()
+        mock_repos.return_value = set()
+
+        notif = {"id": "keep-1", "updated_at": "2026-05-21T09:00:00Z",
+                 "repository": {"full_name": "stranger/repo"}}
+        _cache_notif(notif)
+        assert _is_notif_cached(notif) is True
+
+        with patch("app.projects_config.load_projects_config", return_value={}), \
+             patch("app.github_notifications.fetch_unread_notifications",
+                   return_value=FetchResult([], [])):
+            process_github_notifications(
+                str(tmp_path), str(tmp_path), force=True,  # force needed to bypass throttle
+            )
+        # Re-seed for the non-force run (the previous force-call cleared it).
+        _cache_notif(notif)
+        assert _is_notif_cached(notif) is True
+
+        # A non-forced poll must leave the cache alone.
+        with patch("app.projects_config.load_projects_config", return_value={}), \
+             patch("app.github_notifications.fetch_unread_notifications",
+                   return_value=FetchResult([], [])):
+            process_github_notifications(str(tmp_path), str(tmp_path))
+
+        assert _is_notif_cached(notif) is True
 
 
 class TestGithubParallelWorkersConfig:


### PR DESCRIPTION
When multiple Kōan instances share a single GitHub bot identity, each
    instance must only touch notifications for its own registered projects.
    Commit ebe23b0 ("filter all notifications by registered projects") added
    a second-layer filter inside process_single_notification and
    _try_assignment_notification, but those branches still call
    mark_notification_read() for unknown repos — a write to shared GitHub
    state that clears the notification from the inbox of the sibling
    instance that actually owns the repo.

    The bug surfaces whenever the fetch_unread_notifications known_repos
    filter is bypassed, which happens when _get_known_repos_from_projects
    returns None (no project has github_url set, cold start before
    ensure_github_urls runs, or lazy workspace-cache population).

    Fix: add a single ownership gate at the top of _process_one_notification
    (loop_manager.py) that early-returns when
    resolve_project_from_notification yields None, and strip the redundant
    mark_notification_read calls from the two inner foreign-repo branches.
    The three defense layers (fetch filter, ownership gate, inner branches)
    now agree on the same invariant: never write to shared GitHub state for
    a repo this instance does not own.