### PR TITLE
fix(pvrs): use raw JSON body for security advisory submissions

### DIFF
--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -290,17 +290,21 @@ def issue_edit(number, body, cwd=None):
 
 
 def api(endpoint, method="GET", jq=None, input_data=None, cwd=None,
-        extra_args=None, timeout=30):
+        extra_args=None, timeout=30, raw_body=False):
     """Call ``gh api`` for lower-level GitHub API access.
 
     Args:
         endpoint: API path (e.g. ``repos/owner/repo/pulls/1/comments``).
         method: HTTP method (default GET).
         jq: Optional jq filter applied server-side.
-        input_data: If provided, passed via stdin (``-F body=@-``).
+        input_data: If provided, passed via stdin. Uses ``--input -``
+            when ``raw_body=True`` (sends stdin as the raw HTTP body),
+            otherwise uses ``-F body=@-`` (wraps stdin in a ``body`` field).
         cwd: Working directory.
         extra_args: Additional arguments for ``gh api``.
         timeout: Seconds before the subprocess is killed (default 30).
+        raw_body: When True, send input_data as the raw HTTP request body
+            via ``--input -`` instead of wrapping in ``-F body=@-``.
 
     Returns:
         Stripped stdout string.
@@ -313,7 +317,10 @@ def api(endpoint, method="GET", jq=None, input_data=None, cwd=None,
     if extra_args:
         args.extend(extra_args)
     if input_data is not None:
-        args.extend(["-F", "body=@-"])
+        if raw_body:
+            args.extend(["--input", "-"])
+        else:
+            args.extend(["-F", "body=@-"])
 
     return run_gh(*args, cwd=cwd, stdin_data=input_data, timeout=timeout)
 
@@ -811,6 +818,7 @@ def security_advisory_report(
         f"repos/{repo}/security-advisories/reports",
         method="POST",
         input_data=payload,
+        raw_body=True,
         cwd=cwd,
         timeout=30,
     )

--- a/koan/tests/test_pvrs.py
+++ b/koan/tests/test_pvrs.py
@@ -74,9 +74,10 @@ class TestSecurityAdvisoryReport:
         )
         assert url == "https://github.com/o/r/security/advisories/GHSA-1234"
 
-        # Verify the API was called with POST
+        # Verify the API was called with POST and raw_body=True
         call_args = mock_api.call_args
         assert call_args[1]["method"] == "POST"
+        assert call_args[1]["raw_body"] is True
         assert "security-advisories/reports" in call_args[0][0]
 
     @patch("app.leak_detector.scan_and_redact", side_effect=lambda x, **kw: x)


### PR DESCRIPTION
## Summary

**Commit 1 — fix(pvrs): raw JSON body for PVRS submissions**
- The `api()` function was using `-F body=@-` to pass JSON payloads to `gh api`, which wraps stdin in a `{"body": "..."}` form field. This breaks the PVRS endpoint which expects raw JSON with top-level keys (`summary`, `description`, `severity`, `vulnerabilities[]`).
- Added `raw_body=True` parameter to `api()` that switches to `--input -` (raw HTTP body). Applied to `security_advisory_report()`.
- Closed 4 dummy "PVRS unavailable" issues (#1490, #1487, #1392, #1389).

**Commit 2 — feat(audit): local security files for high+ findings**
- When PVRS fails or is disabled, high+ findings are now saved to `instance/security/<project>/<date>.<severity>.<slug>.md` with **full details** instead of creating useless redacted public GitHub issues.
- The operator gets a Telegram notification with the file path and a suggested `/fix` command.
- High+ findings always produce a local file (dual-write when PVRS succeeds).
- Medium/low findings still go to public GitHub issues (unchanged).
- Removed `_submit_redacted_fallback_issue()` entirely.

## Test plan

- [x] All 58 PVRS-specific tests pass (`test_pvrs.py`) — including 13 new tests for `_slugify_finding_title` and `_write_local_finding`
- [x] All 109 audit tests pass (`test_audit.py`)
- [x] Full test suite passes (13,965 tests)
- [x] Lint clean
- [ ] Verify next `/audit` or `/security_audit` run creates local files in `instance/security/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)