### PR TITLE
feat(audit): write local security files for high+ findings instead of redacted issues

### DIFF
--- a/koan/skills/core/audit/audit_runner.py
+++ b/koan/skills/core/audit/audit_runner.py
@@ -487,26 +487,36 @@ def create_issues(
                         finding, ecosystem, package_name,
                         target_repo, project_path,
                     )
-                    pvrs_status = "submitted"
                     advisory_url = advisory_url.strip() if advisory_url else ""
                     if advisory_url:
+                        pvrs_status = "submitted"
                         issue_urls.append(advisory_url)
                         created_count += 1
                         created_entries.append((finding, advisory_url))
+                    else:
+                        pvrs_status = "failed"
                 except Exception as e:
                     pvrs_status = "failed"
                     print(
-                        f"[audit] PVRS failed for '{title}': {e}",
+                        f"[audit] PVRS failed for '{title}': {repr(e)}",
                         file=sys.stderr,
                     )
 
             # Always write local file for high+ findings
             if instance_dir:
-                file_path = _write_local_finding(
-                    finding, project_name, instance_dir,
-                    pvrs_status=pvrs_status,
-                    advisory_url=advisory_url,
-                )
+                try:
+                    file_path = _write_local_finding(
+                        finding, project_name, instance_dir,
+                        pvrs_status=pvrs_status,
+                        advisory_url=advisory_url,
+                    )
+                except Exception as e:
+                    print(
+                        f"[audit] Failed to write local finding for "
+                        f"'{title}': {repr(e)}",
+                        file=sys.stderr,
+                    )
+                    continue
                 local_files.append((finding, file_path))
                 relative = f"security/{project_name}/{file_path.name}"
                 if notify_fn:
@@ -515,12 +525,14 @@ def create_issues(
                         f"  \U0001f4a1 Suggested: /fix {project_name} "
                         f"Understand and fix the issue described by {relative}"
                     )
-                continue
+            elif pvrs_status != "submitted":
+                print(
+                    f"[audit] No instance_dir configured — cannot store "
+                    f"high-severity finding '{title}' locally",
+                    file=sys.stderr,
+                )
 
-            # No instance_dir and PVRS didn't succeed: fall through to
-            # public issue as last resort (legacy behavior).
-            if pvrs_status == "submitted":
-                continue
+            continue
 
         # Public issue path (medium/low, or high fallback without instance_dir)
         # Dedup: skip if fingerprint matches an already-open audit issue.
@@ -632,9 +644,11 @@ def _write_local_finding(
 
     from app.utils import atomic_write
 
-    today = datetime.now().strftime("%Y%m%d")
+    now = datetime.now()
+    today = now.strftime("%Y%m%d")
     slug = _slugify_finding_title(finding.title)
-    filename = f"{today}.{finding.severity}.{slug}.md"
+    title_hash = hashlib.sha256(finding.title.encode()).hexdigest()[:6]
+    filename = f"{today}.{finding.severity}.{slug}.{title_hash}.md"
 
     security_dir = Path(instance_dir) / "security" / project_name
     os.makedirs(security_dir, exist_ok=True)
@@ -649,7 +663,7 @@ def _write_local_finding(
         f"| Severity | {finding.severity} |\n"
         f"| Category | {finding.category} |\n"
         f"| Location | `{finding.location}` |\n"
-        f"| Detected | {datetime.now().strftime('%Y-%m-%d')} |\n"
+        f"| Detected | {now.strftime('%Y-%m-%d')} |\n"
         f"| PVRS | {pvrs_status} |\n"
         f"| Advisory | {advisory_line} |\n\n"
         f"## Problem\n\n{finding.problem}\n\n"

--- a/koan/skills/core/audit/audit_runner.py
+++ b/koan/skills/core/audit/audit_runner.py
@@ -223,12 +223,16 @@ class IssueCreationResult(NamedTuple):
 
     ``created_entries`` pairs each newly-created issue with its
     originating finding so callers can filter by severity for auto-fix.
+
+    ``local_files`` pairs each high+ finding with its local security
+    file path (written regardless of PVRS outcome).
     """
 
     urls: List[str]
     created: int
     reused: int
     created_entries: Tuple = ()
+    local_files: Tuple = ()
 
 
 _FINGERPRINT_MARKER_RE = re.compile(
@@ -393,6 +397,7 @@ def create_issues(
     pvrs_mode: str = "auto",
     pvrs_threshold: str = "high",
     project_name: str = "",
+    instance_dir: str = "",
 ) -> IssueCreationResult:
     """Create GitHub issues (or PVRS reports) for each finding.
 
@@ -459,73 +464,92 @@ def create_issues(
     created_count = 0
     reused_count = 0
     created_entries: List[Tuple[AuditFinding, str]] = []
+    local_files: List[Tuple[AuditFinding, Path]] = []
 
     for i, finding in enumerate(findings, 1):
         title = finding.title
-        use_pvrs = pvrs_available and _should_use_pvrs(
-            finding.severity, pvrs_threshold,
-        )
+        is_high_severity = _should_use_pvrs(finding.severity, pvrs_threshold)
+        use_pvrs = pvrs_available and is_high_severity
 
-        # Dedup applies to the public-issue path only — PVRS advisories
-        # live in a private endpoint not covered by `gh issue list`.
-        if not use_pvrs:
-            existing_url = _find_existing_match(finding, existing_index)
-            if existing_url:
-                reused_count += 1
-                issue_urls.append(existing_url)
+        # High+ severity: attempt PVRS then write local file
+        if is_high_severity:
+            if notify_fn:
+                notify_fn(
+                    f"  \U0001f512 {i}/{len(findings)}: {title}"
+                )
+
+            advisory_url = ""
+            pvrs_status = "disabled"
+
+            if use_pvrs:
+                try:
+                    advisory_url = _submit_pvrs_report(
+                        finding, ecosystem, package_name,
+                        target_repo, project_path,
+                    )
+                    pvrs_status = "submitted"
+                    advisory_url = advisory_url.strip() if advisory_url else ""
+                    if advisory_url:
+                        issue_urls.append(advisory_url)
+                        created_count += 1
+                        created_entries.append((finding, advisory_url))
+                except Exception as e:
+                    pvrs_status = "failed"
+                    print(
+                        f"[audit] PVRS failed for '{title}': {e}",
+                        file=sys.stderr,
+                    )
+
+            # Always write local file for high+ findings
+            if instance_dir:
+                file_path = _write_local_finding(
+                    finding, project_name, instance_dir,
+                    pvrs_status=pvrs_status,
+                    advisory_url=advisory_url,
+                )
+                local_files.append((finding, file_path))
+                relative = f"security/{project_name}/{file_path.name}"
                 if notify_fn:
                     notify_fn(
-                        f"  ↩️ {i}/{len(findings)}: "
-                        f"already tracked — {existing_url}"
+                        f"  \U0001f4c4 {relative}\n"
+                        f"  \U0001f4a1 Suggested: /fix {project_name} "
+                        f"Understand and fix the issue described by {relative}"
                     )
                 continue
 
+            # No instance_dir and PVRS didn't succeed: fall through to
+            # public issue as last resort (legacy behavior).
+            if pvrs_status == "submitted":
+                continue
+
+        # Public issue path (medium/low, or high fallback without instance_dir)
+        # Dedup: skip if fingerprint matches an already-open audit issue.
+        existing_url = _find_existing_match(finding, existing_index)
+        if existing_url:
+            reused_count += 1
+            issue_urls.append(existing_url)
+            if notify_fn:
+                notify_fn(
+                    f"  \u21a9\ufe0f {i}/{len(findings)}: "
+                    f"already tracked \u2014 {existing_url}"
+                )
+            continue
+
         if notify_fn:
-            channel = "\U0001f512 PVRS" if use_pvrs else "\U0001f4dd issue"
             notify_fn(
-                f"  {channel} {i}/{len(findings)}: {title}"
+                f"  \U0001f4dd issue {i}/{len(findings)}: {title}"
             )
 
         try:
-            if use_pvrs:
-                url = _submit_pvrs_report(
-                    finding, ecosystem, package_name,
-                    target_repo, project_path,
-                )
-            else:
-                url = _submit_public_issue(
-                    finding, target_repo, project_path,
-                )
+            url = _submit_public_issue(
+                finding, target_repo, project_path,
+            )
         except Exception as e:
-            # PVRS fallback: try public issue if PVRS submission failed
-            if use_pvrs:
-                print(
-                    f"[audit] PVRS failed for '{title}', "
-                    f"falling back to redacted public issue: {e}",
-                    file=sys.stderr,
-                )
-                if notify_fn:
-                    notify_fn(
-                        f"  \u26a0\ufe0f PVRS failed for '{title}', "
-                        f"creating redacted placeholder issue"
-                    )
-                try:
-                    url = _submit_redacted_fallback_issue(
-                        finding, target_repo, project_path,
-                    )
-                except Exception as e2:
-                    print(
-                        f"[audit] Fallback issue also failed for "
-                        f"'{title}': {e2}",
-                        file=sys.stderr,
-                    )
-                    continue
-            else:
-                print(
-                    f"[audit] Failed to create issue '{title}': {e}",
-                    file=sys.stderr,
-                )
-                continue
+            print(
+                f"[audit] Failed to create issue '{title}': {e}",
+                file=sys.stderr,
+            )
+            continue
 
         url = url.strip() if url else ""
         if url:
@@ -540,6 +564,7 @@ def create_issues(
         created=created_count,
         reused=reused_count,
         created_entries=tuple(created_entries),
+        local_files=tuple(local_files),
     )
 
 
@@ -582,37 +607,58 @@ def _submit_public_issue(
     )
 
 
-def _submit_redacted_fallback_issue(
+def _slugify_finding_title(title: str) -> str:
+    """Convert a finding title to a filesystem-safe slug."""
+    slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
+    return slug[:60]
+
+
+def _write_local_finding(
     finding: AuditFinding,
-    target_repo: Optional[str],
-    project_path: str,
-) -> str:
-    """Create a redacted public issue when PVRS submission fails.
+    project_name: str,
+    instance_dir: str,
+    pvrs_status: str = "disabled",
+    advisory_url: str = "",
+) -> Path:
+    """Write a security finding to a local markdown file.
 
-    Omits exploit details to avoid leaking vulnerability information publicly.
-    The issue serves as a placeholder directing maintainers to investigate
-    via private channels.
+    Always called for high+ severity findings regardless of PVRS outcome.
+    The file serves as the local source of truth for security findings.
+
+    Returns:
+        Path to the written file.
     """
-    from app.github import issue_create
+    import os
 
-    redacted_body = (
-        "A security finding was identified during an automated audit but "
-        "could not be submitted via Private Vulnerability Reporting (PVRS).\n\n"
-        f"**Severity**: {finding.severity}\n"
-        f"**Category**: {finding.category}\n\n"
-        "Details have been withheld from this public issue to prevent "
-        "disclosure of exploitable vulnerabilities. Please review the audit "
-        "logs or contact the security team for full details.\n\n"
-        "---\n"
-        "\U0001f916 Created by K\u014dan from audit session"
+    from app.utils import atomic_write
+
+    today = datetime.now().strftime("%Y%m%d")
+    slug = _slugify_finding_title(finding.title)
+    filename = f"{today}.{finding.severity}.{slug}.md"
+
+    security_dir = Path(instance_dir) / "security" / project_name
+    os.makedirs(security_dir, exist_ok=True)
+
+    file_path = security_dir / filename
+
+    advisory_line = advisory_url if advisory_url else "—"
+    content = (
+        f"# {finding.title}\n\n"
+        f"| Field | Value |\n"
+        f"|-------|-------|\n"
+        f"| Severity | {finding.severity} |\n"
+        f"| Category | {finding.category} |\n"
+        f"| Location | `{finding.location}` |\n"
+        f"| Detected | {datetime.now().strftime('%Y-%m-%d')} |\n"
+        f"| PVRS | {pvrs_status} |\n"
+        f"| Advisory | {advisory_line} |\n\n"
+        f"## Problem\n\n{finding.problem}\n\n"
+        f"## Why This Matters\n\n{finding.why}\n\n"
+        f"## Suggested Fix\n\n{finding.suggested_fix}\n"
     )
 
-    return issue_create(
-        title=f"[Security] {finding.severity} finding — details withheld (PVRS unavailable)",
-        body=redacted_body,
-        repo=target_repo,
-        cwd=project_path,
-    )
+    atomic_write(file_path, content)
+    return file_path
 
 
 # ---------------------------------------------------------------------------
@@ -892,7 +938,7 @@ def run_audit(
         result = create_issues(
             findings, project_path, notify_fn=notify_fn,
             pvrs_mode=pvrs_mode, pvrs_threshold=pvrs_threshold,
-            project_name=project_name,
+            project_name=project_name, instance_dir=instance_dir,
         )
 
     # Step 6: Auto-fix — queue /fix missions for high-severity new issues
@@ -928,12 +974,16 @@ def run_audit(
             f"Report saved to {report_path.name} (no GitHub issues created)."
         )
     else:
+        parts = []
+        if result.created and result.reused:
+            parts.append(f"{result.created} new")
+        elif result.created:
+            parts.append(f"{result.created} GitHub issues created")
         if result.reused:
-            issue_summary = (
-                f"{result.created} new, {result.reused} already tracked"
-            )
-        else:
-            issue_summary = f"{result.created} GitHub issues created"
+            parts.append(f"{result.reused} already tracked")
+        if result.local_files:
+            parts.append(f"{len(result.local_files)} local security files")
+        issue_summary = ", ".join(parts) if parts else "no issues created"
         fix_summary = f", {auto_fix_count} auto-fix queued" if auto_fix_count else ""
         summary = (
             f"Audit complete: {len(findings)} findings, "

--- a/koan/tests/test_audit.py
+++ b/koan/tests/test_audit.py
@@ -441,7 +441,7 @@ class TestCreateIssues:
     @patch("app.github.list_open_audit_issues", return_value=[])
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.issue_create")
-    def test_creates_issues_for_findings(self, mock_create, mock_repo, mock_list):
+    def test_creates_issues_for_findings(self, mock_create, mock_repo, mock_list, tmp_path):
         mock_create.side_effect = [
             "https://github.com/o/r/issues/1\n",
             "https://github.com/o/r/issues/2\n",
@@ -450,13 +450,17 @@ class TestCreateIssues:
             AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p1"),
             AuditFinding(title="fix B", severity="low", location="b.py:2", problem="p2"),
         ]
-        result = create_issues(findings, "/path/proj")
+        result = create_issues(
+            findings, "/path/proj",
+            instance_dir=str(tmp_path), project_name="proj",
+        )
 
-        assert len(result.urls) == 2
-        assert result.created == 2
-        assert result.reused == 0
-        assert mock_create.call_count == 2
-        # Check repo targeting
+        # high → local file, low → public issue
+        assert len(result.urls) == 1
+        assert result.created == 1
+        assert len(result.local_files) == 1
+        assert mock_create.call_count == 1
+        # Check repo targeting on the public issue
         assert mock_create.call_args_list[0][1]["repo"] == "upstream/repo"
 
     @patch("app.github.list_open_audit_issues", return_value=[])
@@ -465,7 +469,7 @@ class TestCreateIssues:
     def test_no_upstream_uses_local(self, mock_create, mock_repo, mock_list):
         mock_create.return_value = "https://github.com/o/r/issues/1\n"
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p"),
         ]
         create_issues(findings, "/path/proj")
         assert mock_create.call_args[1]["repo"] is None
@@ -479,7 +483,7 @@ class TestCreateIssues:
             "https://github.com/o/r/issues/2\n",
         ]
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p1"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p1"),
             AuditFinding(title="fix B", severity="low", location="b.py:2", problem="p2"),
         ]
         notify = MagicMock()
@@ -496,7 +500,7 @@ class TestCreateIssues:
     @patch("app.github.issue_create", side_effect=RuntimeError("API error"))
     def test_continues_on_failure(self, mock_create, mock_repo, mock_list):
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p"),
             AuditFinding(title="fix B", severity="low", location="b.py:2", problem="q"),
         ]
         result = create_issues(findings, "/path/proj")
@@ -516,7 +520,7 @@ class TestCreateIssuesDedup:
         self, mock_create, mock_repo, mock_list,
     ):
         existing = AuditFinding(
-            title="fix A", severity="high",
+            title="fix A", severity="medium",
             location="a.py:1", category="bug", problem="p",
         )
         mock_list.return_value = [
@@ -529,7 +533,7 @@ class TestCreateIssuesDedup:
         ]
         findings = [
             AuditFinding(
-                title="fix A", severity="high",
+                title="fix A", severity="medium",
                 location="a.py:1", category="bug", problem="p",
             ),
         ]
@@ -553,7 +557,7 @@ class TestCreateIssuesDedup:
         # run must reuse the existing issue rather than duplicate it.
         first_run = AuditFinding(
             title="Race in WS reconnect",
-            severity="high",
+            severity="medium",
             location="ws_client.py:142",
             category="concurrency",
             problem="race condition",
@@ -571,7 +575,7 @@ class TestCreateIssuesDedup:
         findings = [
             AuditFinding(
                 title="Potential race condition in websocket reconnect handler",
-                severity="high",
+                severity="medium",
                 location="ws_client.py:142",
                 category="concurrency",
                 problem="race condition",
@@ -604,7 +608,7 @@ class TestCreateIssuesDedup:
         mock_create.return_value = "https://github.com/o/r/issues/20\n"
         findings = [
             AuditFinding(
-                title="fix A", severity="high",
+                title="fix A", severity="medium",
                 location="a.py:1", category="bug", problem="p",
             ),
         ]
@@ -622,7 +626,7 @@ class TestCreateIssuesDedup:
         self, mock_create, mock_repo, mock_list,
     ):
         existing = AuditFinding(
-            title="fix A", severity="high",
+            title="fix A", severity="medium",
             location="a.py:1", category="bug", problem="p",
         )
         mock_list.return_value = [
@@ -636,7 +640,7 @@ class TestCreateIssuesDedup:
         mock_create.return_value = "https://github.com/o/r/issues/2\n"
         findings = [
             AuditFinding(
-                title="fix A", severity="high",
+                title="fix A", severity="medium",
                 location="a.py:1", category="bug", problem="p",
             ),
             AuditFinding(
@@ -668,7 +672,7 @@ class TestCreateIssuesDedup:
             "https://github.com/o/r/issues/11\n",
         ]
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p"),
             AuditFinding(title="fix B", severity="low", location="b.py:2", problem="q"),
         ]
 
@@ -688,7 +692,7 @@ class TestCreateIssuesDedup:
         # returns []; we must not block on dedup — create as before.
         mock_create.return_value = "https://github.com/o/r/issues/1\n"
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p"),
         ]
 
         result = create_issues(findings, "/path/proj")
@@ -698,7 +702,7 @@ class TestCreateIssuesDedup:
 
     def test_fingerprint_embedded_in_issue_body(self):
         finding = AuditFinding(
-            title="fix A", severity="high",
+            title="fix A", severity="medium",
             location="a.py:1", category="bug", problem="p",
         )
         body = _build_issue_body(finding)
@@ -1341,7 +1345,7 @@ class TestIssueCreationResultCreatedEntries:
             "https://github.com/o/r/issues/2\n",
         ]
         findings = [
-            AuditFinding(title="fix A", severity="high", location="a.py:1", problem="p1"),
+            AuditFinding(title="fix A", severity="medium", location="a.py:1", problem="p1"),
             AuditFinding(title="fix B", severity="low", location="b.py:2", problem="p2"),
         ]
 
@@ -1358,7 +1362,7 @@ class TestIssueCreationResultCreatedEntries:
     @patch("app.github.issue_create")
     def test_reused_not_in_created_entries(self, mock_create, mock_repo, mock_list):
         existing = AuditFinding(
-            title="fix A", severity="high",
+            title="fix A", severity="medium",
             location="a.py:1", category="bug", problem="p",
         )
         mock_list.return_value = [{
@@ -1370,7 +1374,7 @@ class TestIssueCreationResultCreatedEntries:
 
         findings = [
             AuditFinding(
-                title="fix A", severity="high",
+                title="fix A", severity="medium",
                 location="a.py:1", category="bug", problem="p",
             ),
             AuditFinding(

--- a/koan/tests/test_pvrs.py
+++ b/koan/tests/test_pvrs.py
@@ -20,6 +20,8 @@ from skills.core.audit.audit_runner import (
     AuditFinding,
     _build_advisory_description,
     _should_use_pvrs,
+    _slugify_finding_title,
+    _write_local_finding,
     create_issues,
 )
 
@@ -331,49 +333,65 @@ class TestCreateIssuesPvrsRouting:
     @patch("app.github.security_advisory_report")
     @patch("app.github.issue_create")
     def test_routes_critical_high_to_pvrs(
-        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo,
+        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo, tmp_path,
     ):
         mock_pvrs.return_value = "https://github.com/o/r/security/advisories/GHSA-1"
         mock_issue.return_value = "https://github.com/o/r/issues/1\n"
 
         findings = self._make_findings()
-        result = create_issues(findings, "/path/proj", pvrs_threshold="high")
+        result = create_issues(
+            findings, "/path/proj", pvrs_threshold="high",
+            instance_dir=str(tmp_path), project_name="proj",
+        )
 
         # critical + high → PVRS (2 calls)
         assert mock_pvrs.call_count == 2
         # medium + low → public issues (2 calls)
         assert mock_issue.call_count == 2
         assert len(result.urls) == 4
+        # Local files written for high+ findings
+        assert len(result.local_files) == 2
 
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.check_pvrs_enabled", return_value=False)
     @patch("app.github.issue_create")
-    def test_all_public_when_pvrs_disabled(
-        self, mock_issue, mock_check, mock_repo,
+    def test_high_get_local_files_when_pvrs_disabled(
+        self, mock_issue, mock_check, mock_repo, tmp_path,
     ):
         mock_issue.return_value = "https://github.com/o/r/issues/1\n"
         findings = self._make_findings()
-        result = create_issues(findings, "/path/proj")
+        result = create_issues(
+            findings, "/path/proj", instance_dir=str(tmp_path),
+            project_name="proj",
+        )
 
-        # All go to public issues
-        assert mock_issue.call_count == 4
-        assert len(result.urls) == 4
+        # medium + low → public issues (2 calls), critical + high → local files
+        assert mock_issue.call_count == 2
+        assert len(result.local_files) == 2
+        # Local files exist on disk
+        for finding, path in result.local_files:
+            assert path.exists()
+            content = path.read_text()
+            assert finding.title in content
 
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.issue_create")
-    def test_pvrs_mode_false_skips_detection(self, mock_issue, mock_repo):
+    def test_pvrs_mode_false_skips_detection(self, mock_issue, mock_repo, tmp_path):
         """When pvrs_mode='false', PVRS detection is never called."""
         mock_issue.return_value = "https://github.com/o/r/issues/1\n"
         findings = self._make_findings()
 
         # Should NOT call check_pvrs_enabled at all
         with patch("app.github.check_pvrs_enabled") as mock_check:
-            create_issues(
+            result = create_issues(
                 findings, "/path/proj", pvrs_mode="false",
+                instance_dir=str(tmp_path), project_name="proj",
             )
             mock_check.assert_not_called()
 
-        assert mock_issue.call_count == 4
+        # medium + low → public issues, critical + high → local files
+        assert mock_issue.call_count == 2
+        assert len(result.local_files) == 2
 
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.check_pvrs_enabled", return_value=True)
@@ -381,7 +399,7 @@ class TestCreateIssuesPvrsRouting:
     @patch("app.github.security_advisory_report")
     @patch("app.github.issue_create")
     def test_pvrs_mode_true_skips_detection(
-        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo,
+        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo, tmp_path,
     ):
         """When pvrs_mode='true', check_pvrs_enabled is NOT called."""
         mock_pvrs.return_value = "https://github.com/advisory/1"
@@ -390,6 +408,7 @@ class TestCreateIssuesPvrsRouting:
         findings = self._make_findings()
         create_issues(
             findings, "/path/proj", pvrs_mode="true", pvrs_threshold="high",
+            instance_dir=str(tmp_path), project_name="proj",
         )
 
         # check_pvrs_enabled should NOT be called when pvrs_mode is "true"
@@ -403,31 +422,33 @@ class TestCreateIssuesPvrsRouting:
     @patch("app.github.security_advisory_report",
            side_effect=RuntimeError("403 Forbidden"))
     @patch("app.github.issue_create")
-    def test_pvrs_failure_falls_back_to_public_issue(
-        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo,
+    def test_pvrs_failure_writes_local_file(
+        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo, tmp_path,
     ):
-        """When PVRS submission fails, fall back to a public issue."""
-        mock_issue.return_value = "https://github.com/o/r/issues/1\n"
+        """When PVRS submission fails, write local file (no public issue)."""
         findings = [self._make_findings()[0]]  # critical only
 
         notify = MagicMock()
         result = create_issues(
             findings, "/path/proj", notify_fn=notify,
-            pvrs_threshold="high",
+            pvrs_threshold="high", instance_dir=str(tmp_path),
+            project_name="proj",
         )
 
-        # PVRS was attempted, then redacted fallback issue created
+        # PVRS was attempted but no public issue created
         assert mock_pvrs.call_count == 1
-        assert mock_issue.call_count == 1
-        assert len(result.urls) == 1
-        # Fallback issue title is redacted (no finding title leaked)
-        title_arg = mock_issue.call_args[1]["title"]
-        assert "PVRS unavailable" in title_arg
-        assert "details withheld" in title_arg
-        # Body must NOT contain exploit details
-        body_arg = mock_issue.call_args[1]["body"]
-        assert "RCE via deserialization" not in body_arg
-        assert "withheld" in body_arg
+        assert mock_issue.call_count == 0
+        assert len(result.urls) == 0
+        # Local file was written with full details
+        assert len(result.local_files) == 1
+        finding, path = result.local_files[0]
+        assert path.exists()
+        content = path.read_text()
+        assert "RCE via deserialization" in content
+        assert "failed" in content
+        # Notification includes file path and fix suggestion
+        all_calls = [c.args[0] for c in notify.call_args_list]
+        assert any("/fix" in c for c in all_calls)
 
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.check_pvrs_enabled", return_value=True)
@@ -435,7 +456,7 @@ class TestCreateIssuesPvrsRouting:
     @patch("app.github.security_advisory_report")
     @patch("app.github.issue_create")
     def test_threshold_critical_only(
-        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo,
+        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo, tmp_path,
     ):
         """With threshold='critical', only critical goes to PVRS."""
         mock_pvrs.return_value = "https://github.com/advisory/1"
@@ -444,20 +465,22 @@ class TestCreateIssuesPvrsRouting:
         findings = self._make_findings()
         create_issues(
             findings, "/path/proj", pvrs_threshold="critical",
+            instance_dir=str(tmp_path), project_name="proj",
         )
 
         assert mock_pvrs.call_count == 1  # only critical
-        assert mock_issue.call_count == 3  # high + medium + low
+        # high + medium + low → public issues (critical → local file only)
+        assert mock_issue.call_count == 3
 
     @patch("app.github.resolve_target_repo", return_value="upstream/repo")
     @patch("app.github.check_pvrs_enabled", return_value=True)
     @patch("app.github.detect_ecosystem", return_value="pip")
     @patch("app.github.security_advisory_report")
     @patch("app.github.issue_create")
-    def test_notify_fn_reports_pvrs_channel(
-        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo,
+    def test_notify_fn_reports_pvrs_and_local_file(
+        self, mock_issue, mock_pvrs, mock_eco, mock_check, mock_repo, tmp_path,
     ):
-        """notify_fn should indicate when PVRS is active."""
+        """notify_fn should indicate PVRS status and local file path."""
         mock_pvrs.return_value = "https://github.com/advisory/1"
         mock_issue.return_value = "https://github.com/o/r/issues/1\n"
 
@@ -465,14 +488,16 @@ class TestCreateIssuesPvrsRouting:
         findings = self._make_findings()[:2]  # critical + high
         create_issues(
             findings, "/path/proj", notify_fn=notify,
-            pvrs_threshold="high",
+            pvrs_threshold="high", instance_dir=str(tmp_path),
+            project_name="proj",
         )
 
         all_calls = [c.args[0] for c in notify.call_args_list]
         # Should have PVRS-enabled announcement
         assert any("PVRS enabled" in c for c in all_calls)
-        # Should have PVRS channel markers for findings
-        assert any("PVRS" in c and "1/" in c for c in all_calls)
+        # Should have local file path and fix suggestion
+        assert any("security/proj/" in c for c in all_calls)
+        assert any("/fix" in c for c in all_calls)
 
 
 # ---------------------------------------------------------------------------
@@ -563,10 +588,121 @@ class TestPvrsIntegration:
 
         assert success
         assert "2 findings" in summary
-        # critical → PVRS, medium → public issue
+        # critical → PVRS + local file, medium → public issue
         assert mock_pvrs.call_count == 1
         assert mock_issue.call_count == 1
 
-        # Verify report saved with channel annotation
-        report = (instance_dir / "memory" / "projects" / "proj" / "audit.md").read_text()
-        assert "private" in report  # PVRS finding annotated
+        # Verify local security file written for critical finding
+        security_dir = instance_dir / "security" / "proj"
+        security_files = list(security_dir.glob("*.critical.*.md"))
+        assert len(security_files) == 1
+        content = security_files[0].read_text()
+        assert "SQL injection in login" in content
+        assert "submitted" in content
+
+
+# ---------------------------------------------------------------------------
+# _slugify_finding_title
+# ---------------------------------------------------------------------------
+
+class TestSlugifyFindingTitle:
+    def test_basic(self):
+        assert _slugify_finding_title("SQL Injection in Auth") == "sql-injection-in-auth"
+
+    def test_special_chars(self):
+        assert _slugify_finding_title("XSS via <script> tag") == "xss-via-script-tag"
+
+    def test_truncates_long_titles(self):
+        long_title = "a" * 100
+        assert len(_slugify_finding_title(long_title)) == 60
+
+    def test_strips_leading_trailing_hyphens(self):
+        assert _slugify_finding_title("---hello---") == "hello"
+
+    def test_empty_string(self):
+        assert _slugify_finding_title("") == ""
+
+    def test_unicode(self):
+        assert _slugify_finding_title("Vulnérabilité d'injection") == "vuln-rabilit-d-injection"
+
+
+# ---------------------------------------------------------------------------
+# _write_local_finding
+# ---------------------------------------------------------------------------
+
+class TestWriteLocalFinding:
+    def _make_finding(self):
+        return AuditFinding(
+            title="SQL injection in login",
+            severity="critical",
+            category="injection",
+            location="auth.py:42-48",
+            problem="Direct string concatenation in SQL query",
+            why="Allows authentication bypass",
+            suggested_fix="Use parameterized queries",
+        )
+
+    def test_creates_file_at_expected_path(self, tmp_path):
+        finding = self._make_finding()
+        path = _write_local_finding(finding, "myapp", str(tmp_path))
+
+        assert path.exists()
+        assert path.parent.name == "myapp"
+        assert path.parent.parent.name == "security"
+        assert "critical" in path.name
+        assert "sql-injection-in-login" in path.name
+        assert path.name.endswith(".md")
+
+    def test_file_contains_full_details(self, tmp_path):
+        finding = self._make_finding()
+        path = _write_local_finding(finding, "myapp", str(tmp_path))
+
+        content = path.read_text()
+        assert "# SQL injection in login" in content
+        assert "critical" in content
+        assert "injection" in content
+        assert "`auth.py:42-48`" in content
+        assert "Direct string concatenation" in content
+        assert "Allows authentication bypass" in content
+        assert "Use parameterized queries" in content
+
+    def test_pvrs_status_submitted(self, tmp_path):
+        finding = self._make_finding()
+        path = _write_local_finding(
+            finding, "myapp", str(tmp_path),
+            pvrs_status="submitted",
+            advisory_url="https://github.com/o/r/security/advisories/GHSA-1",
+        )
+        content = path.read_text()
+        assert "submitted" in content
+        assert "GHSA-1" in content
+
+    def test_pvrs_status_failed(self, tmp_path):
+        finding = self._make_finding()
+        path = _write_local_finding(
+            finding, "myapp", str(tmp_path), pvrs_status="failed",
+        )
+        content = path.read_text()
+        assert "failed" in content
+
+    def test_pvrs_status_disabled(self, tmp_path):
+        finding = self._make_finding()
+        path = _write_local_finding(
+            finding, "myapp", str(tmp_path), pvrs_status="disabled",
+        )
+        content = path.read_text()
+        assert "disabled" in content
+
+    def test_creates_directory_structure(self, tmp_path):
+        finding = self._make_finding()
+        _write_local_finding(finding, "new-project", str(tmp_path))
+
+        assert (tmp_path / "security" / "new-project").is_dir()
+
+    def test_idempotent_overwrite(self, tmp_path):
+        finding = self._make_finding()
+        path1 = _write_local_finding(finding, "myapp", str(tmp_path))
+        path2 = _write_local_finding(finding, "myapp", str(tmp_path))
+
+        assert path1 == path2
+        assert path1.exists()

--- a/koan/tests/test_security_learnings.py
+++ b/koan/tests/test_security_learnings.py
@@ -551,7 +551,7 @@ class TestRunAuditIntegration:
         def _fake_run_audit_cli(prompt, project_path):
             return canned_output
 
-        def _fake_create_issues(findings, project_path, notify_fn=None, pvrs_mode="auto", pvrs_threshold="high", project_name=""):
+        def _fake_create_issues(findings, project_path, notify_fn=None, pvrs_mode="auto", pvrs_threshold="high", project_name="", instance_dir=""):
             from skills.core.audit.audit_runner import IssueCreationResult
             return IssueCreationResult(
                 created=0, reused=0,


### PR DESCRIPTION
When PVRS submission fails or is unavailable, findings are now saved to
`instance/security/<project>/<date>.<severity>.<slug>.md` with full details
instead of creating useless redacted public GitHub issues. The operator gets
a Telegram notification with the file path and a suggested /fix command.

High+ severity findings always produce a local file (dual-write when PVRS
succeeds). Medium/low findings still go to public GitHub issues as before.

- Add _write_local_finding() + _slugify_finding_title() helpers
- Add instance_dir param to create_issues(), IssueCreationResult.local_files
- Remove _submit_redacted_fallback_issue() (dead code)
- Add instance.example/security/.gitkeep

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
