### PR TITLE
feat(implement): autonomous plan improvement loop replaces blocking gate

### DIFF
--- a/koan/app/plan_runner.py
+++ b/koan/app/plan_runner.py
@@ -317,6 +317,54 @@ def review_plan(plan_text: str, project_path: str, skill_dir) -> Tuple[bool, str
     return True, ""
 
 
+def improve_plan(
+    plan_text: str, issues_text: str, project_path: str, skill_dir
+) -> str:
+    """Run a codebase-grounded subagent to fix plan quality issues.
+
+    The improver explores the codebase to resolve ambiguities identified by
+    the reviewer (missing file paths, vague descriptions, etc.) and returns
+    a corrected plan.
+
+    Args:
+        plan_text: The plan that failed review.
+        issues_text: Bullet list of issues from the reviewer.
+        project_path: Project directory (for codebase exploration).
+        skill_dir: Skill directory for loading the improve prompt.
+
+    Returns:
+        Improved plan text, or original plan_text on failure.
+    """
+    from app.cli_provider import run_command
+
+    try:
+        prompt = load_prompt_or_skill(
+            skill_dir, "plan-improve", PLAN=plan_text, ISSUES=issues_text
+        )
+    except Exception as e:
+        print(f"[plan_runner] Improve prompt load failed: {e}", file=sys.stderr)
+        return plan_text
+
+    try:
+        output = run_command(
+            prompt, project_path,
+            allowed_tools=["Read", "Glob", "Grep"],
+            model_key="chat",
+            max_turns=5,
+            timeout=180,
+            max_turns_source=None,
+        )
+    except Exception as e:
+        print(f"[plan_runner] Improve subagent failed: {e}", file=sys.stderr)
+        return plan_text
+
+    if not output or not output.strip():
+        print("[plan_runner] Improve subagent returned empty — keeping original", file=sys.stderr)
+        return plan_text
+
+    return output.strip()
+
+
 def _review_loop(
     plan_text: str,
     project_path: str,

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -119,19 +119,29 @@ def run_implement(
     gate_result = _run_plan_review_gate(
         plan, project_path, notify_fn=notify_fn, issue_url=issue_url,
     )
-    if isinstance(gate_result, str):
-        plan = gate_result
+    improvement_context = ""
+    if isinstance(gate_result, _GateImproved):
+        plan = gate_result.plan
+        improvement_context = (
+            "\n\n## Plan Improvement Notes\n\n"
+            "The plan was autonomously improved before implementation. "
+            "The original plan had these issues that were addressed:\n"
+            f"{gate_result.issues_fixed}\n\n"
+            "The plan above is the corrected version. Pay attention to the "
+            "specific file paths and details added during improvement."
+        )
     elif gate_result is not None:
         return gate_result
 
     # Invoke Claude with the plan
+    effective_context = (context or "Implement the full plan.") + improvement_context
     try:
         output = _execute_implementation(
             project_path=project_path,
             issue_url=issue_url,
             issue_title=title,
             plan=plan,
-            context=context or "Implement the full plan.",
+            context=effective_context,
             skill_dir=skill_dir,
             issue_number=str(issue_number),
         )
@@ -270,17 +280,27 @@ def _write_plan_cache(project_path: str, plan_hash_hex: str) -> None:
         logger.warning("Plan-review cache write failed: %s", e)
 
 
+class _GateImproved:
+    """Result when the gate self-healed the plan."""
+
+    __slots__ = ("plan", "issues_fixed")
+
+    def __init__(self, plan: str, issues_fixed: str):
+        self.plan = plan
+        self.issues_fixed = issues_fixed
+
+
 def _run_plan_review_gate(
     plan: str,
     project_path: str,
     notify_fn=None,
     issue_url: str = "",
-) -> Union[None, str, Tuple[bool, str]]:
+) -> Union[None, _GateImproved, Tuple[bool, str]]:
     """Run plan-review gate with autonomous improvement loop.
 
     Returns:
         None — proceed with original plan (simple/cached/disabled).
-        str — proceed with this improved plan (gate self-healed).
+        _GateImproved — proceed with improved plan + context about what was fixed.
         (False, msg) — block (only on catastrophic internal error).
     """
     from app.plan_runner import improve_plan, is_simple_plan, review_plan
@@ -302,6 +322,7 @@ def _run_plan_review_gate(
 
     max_rounds = review_cfg.get("max_rounds", 3)
     current_plan = plan
+    all_issues: List[str] = []
 
     for round_num in range(1, max_rounds + 1):
         logger.info("Plan-review gate: round %d/%d...", round_num, max_rounds)
@@ -313,9 +334,10 @@ def _run_plan_review_gate(
             _write_plan_cache(project_path, final_hash)
             if current_plan != plan:
                 _post_improved_plan(current_plan, issue_url, notify_fn)
-                return current_plan
+                return _GateImproved(current_plan, "\n".join(all_issues))
             return None
 
+        all_issues.append(issues)
         logger.info(
             "Plan-review gate: ISSUES_FOUND (round %d) — improving...",
             round_num,
@@ -351,7 +373,7 @@ def _run_plan_review_gate(
 
     if current_plan != plan:
         _post_improved_plan(current_plan, issue_url, notify_fn)
-        return current_plan
+        return _GateImproved(current_plan, "\n".join(all_issues))
     return None
 
 

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -15,7 +15,7 @@ import hashlib
 import logging
 import re
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 from app.github import fetch_issue_with_comments
 from app.github_url_parser import is_jira_url, parse_github_url, parse_issue_url, parse_jira_url
@@ -115,11 +115,13 @@ def run_implement(
             "The issue should contain implementation phases."
         )
 
-    # Plan-review quality gate — cheap subagent check before expensive execution
+    # Plan-review quality gate with autonomous improvement loop
     gate_result = _run_plan_review_gate(
         plan, project_path, notify_fn=notify_fn, issue_url=issue_url,
     )
-    if gate_result is not None:
+    if isinstance(gate_result, str):
+        plan = gate_result
+    elif gate_result is not None:
         return gate_result
 
     # Invoke Claude with the plan
@@ -273,15 +275,16 @@ def _run_plan_review_gate(
     project_path: str,
     notify_fn=None,
     issue_url: str = "",
-) -> Optional[Tuple[bool, str]]:
-    """Run lightweight plan-review gate before expensive implementation.
+) -> Union[None, str, Tuple[bool, str]]:
+    """Run plan-review gate with autonomous improvement loop.
 
-    Returns None to proceed, or (False, message) to abort.
-    Fails open on reviewer errors — implementation proceeds.
+    Returns:
+        None — proceed with original plan (simple/cached/disabled).
+        str — proceed with this improved plan (gate self-healed).
+        (False, msg) — block (only on catastrophic internal error).
     """
-    from app.plan_runner import is_simple_plan, review_plan
+    from app.plan_runner import improve_plan, is_simple_plan, review_plan
 
-    # Pure string check first — avoids config I/O for trivial plans
     if is_simple_plan(plan):
         logger.debug("Plan is simple — skipping review gate")
         return None
@@ -292,49 +295,83 @@ def _run_plan_review_gate(
     if not review_cfg.get("implement_gate", True):
         return None
 
-    # Content-hash cache — skip review when plan hasn't changed
     current_hash = _plan_hash(plan)
     if _is_plan_cache_fresh(project_path, current_hash):
         logger.info("Plan-review gate: cache hit — skipping review")
         return None
 
-    # Always use the plan skill directory for the review prompt
-    logger.info("Running plan-review quality gate...")
-    approved, issues = review_plan(plan, project_path, _PLAN_SKILL_DIR)
+    max_rounds = review_cfg.get("max_rounds", 3)
+    current_plan = plan
 
-    if approved:
-        logger.info("Plan-review gate: APPROVED")
-        _write_plan_cache(project_path, current_hash)
-        return None
+    for round_num in range(1, max_rounds + 1):
+        logger.info("Plan-review gate: round %d/%d...", round_num, max_rounds)
+        approved, issues = review_plan(current_plan, project_path, _PLAN_SKILL_DIR)
 
-    logger.warning("Plan-review gate: ISSUES_FOUND")
-    msg = (
-        f"Plan review failed — fix these before re-running /implement:\n{issues}"
+        if approved:
+            logger.info("Plan-review gate: APPROVED (round %d)", round_num)
+            final_hash = _plan_hash(current_plan)
+            _write_plan_cache(project_path, final_hash)
+            if current_plan != plan:
+                _post_improved_plan(current_plan, issue_url, notify_fn)
+                return current_plan
+            return None
+
+        logger.info(
+            "Plan-review gate: ISSUES_FOUND (round %d) — improving...",
+            round_num,
+        )
+
+        if notify_fn and round_num == 1:
+            try:
+                notify_fn(
+                    f"🔧 Plan review found issues — auto-improving "
+                    f"(up to {max_rounds} rounds):\n{issues}"
+                )
+            except Exception:
+                logger.debug("Failed to send improvement notification", exc_info=True)
+
+        if round_num < max_rounds:
+            current_plan = improve_plan(
+                current_plan, issues, project_path, _PLAN_SKILL_DIR
+            )
+
+    # Exhausted all rounds — fail open, use best available plan
+    logger.warning(
+        "Plan-review gate: exhausted %d rounds — proceeding with best plan (fail open)",
+        max_rounds,
     )
-
-    # Notify user via Telegram with specific issues
     if notify_fn:
         try:
-            notify_fn(f"⚠️ Plan review gate blocked /implement:\n{issues}")
-        except Exception:
-            logger.debug("Failed to send plan-review gate notification", exc_info=True)
-
-    # Post issues as a comment on the GitHub issue for in-context visibility
-    if issue_url:
-        try:
-            from app.github import run_gh
-            comment_body = (
-                "### ⚠️ Plan Review — Issues Found\n\n"
-                "The plan-review quality gate found issues that should be "
-                "fixed before implementation:\n\n"
-                f"{issues}\n\n"
-                "_Fix these in the plan above, then re-run `/implement`._"
+            notify_fn(
+                f"⚠️ Plan review couldn't fully resolve issues after {max_rounds} "
+                "rounds — proceeding with implementation anyway (fail open)."
             )
-            run_gh("issue", "comment", issue_url, "--body", comment_body)
         except Exception:
-            logger.debug("Failed to post plan-review issues to GitHub", exc_info=True)
+            logger.debug("Failed to send exhaustion notification", exc_info=True)
 
-    return False, msg
+    if current_plan != plan:
+        _post_improved_plan(current_plan, issue_url, notify_fn)
+        return current_plan
+    return None
+
+
+def _post_improved_plan(
+    improved_plan: str, issue_url: str, notify_fn=None,
+) -> None:
+    """Post the autonomously improved plan as a new comment on the issue."""
+    if not issue_url:
+        return
+    try:
+        from app.github import run_gh
+        comment_body = (
+            "### 🔧 Plan Improved (auto)\n\n"
+            "The plan-review gate found issues and autonomously fixed them. "
+            "Proceeding with this improved version:\n\n"
+            f"{improved_plan}"
+        )
+        run_gh("issue", "comment", issue_url, "--body", comment_body)
+    except Exception:
+        logger.debug("Failed to post improved plan to GitHub", exc_info=True)
 
 
 def _build_prompt(

--- a/koan/skills/core/plan/prompts/plan-improve.md
+++ b/koan/skills/core/plan/prompts/plan-improve.md
@@ -1,4 +1,4 @@
-You are a plan improvement agent. A quality review found issues in an implementation plan. Your job is to fix those issues by exploring the codebase, resolving ambiguities, and producing a corrected plan.
+You are a plan improvement agent. A quality review found issues in an implementation plan. Your job is to fix those issues by exploring the codebase, resolving ambiguities, and producing a corrected plan that is as simple as possible.
 
 ## Original Plan
 
@@ -8,18 +8,31 @@ You are a plan improvement agent. A quality review found issues in an implementa
 
 {ISSUES}
 
+## Guiding Principles
+
+Simplicity and maintainability trump cleverness. Apply these when improving the plan:
+
+- **Smallest possible change**: Fix only what the reviewer flagged. Do not expand scope, add "nice to have" improvements, or refactor adjacent code. The best plan touches the fewest files.
+- **Reuse before creating**: Search for existing utilities, helpers, and patterns in the codebase. Prefer calling what already exists over writing new abstractions. New code is a liability.
+- **No premature abstraction**: If a plan introduces a new class, module, or abstraction layer, ask whether the same result can be achieved by extending an existing one or by writing straightforward inline code. Three similar lines are better than a helper nobody asked for.
+- **Fewer moving parts**: Prefer one file change over three. Prefer modifying an existing function over adding a new one. Prefer flat logic over layered indirection.
+- **Delete over add**: If fixing an issue reveals that a phase is unnecessary, remove it. Shorter plans are better plans.
+- **Test what matters**: Testing strategy should cover behavior, not implementation details. Name the existing test file to extend — don't propose new test infrastructure.
+
 ## Instructions
 
 1. **Analyze each issue**: For each reviewer finding, identify what concrete information is missing or wrong.
 
-2. **Explore the codebase**: Use Read, Glob, and Grep to find the actual file paths, function names, and patterns needed to fix the issues. Ground every fix in real code — do not guess paths or names.
+2. **Explore the codebase**: Use Read, Glob, and Grep to find the actual file paths, function names, and patterns needed to fix the issues. Ground every fix in real code — do not guess paths or names. Also look for existing implementations that the plan could reuse instead of building from scratch.
 
-3. **Resolve ambiguities**: For each issue, formulate the question it raises, find the answer in the codebase, and apply it. For example:
+3. **Resolve ambiguities with the simplest answer**: For each issue, find the answer in the codebase and pick the approach that adds the least code:
    - "No specific file path given" → grep for the relevant module, confirm the path, use it
-   - "Testing strategy missing" → find existing test files for the module, reference them
-   - "Phase too large" → read the files involved, decompose into smaller steps
+   - "Testing strategy missing" → find the existing test file for the module, add cases there
+   - "Phase too large" → split into smaller steps, but question whether all steps are necessary
 
-4. **Produce the fixed plan**: Output a complete, corrected plan that addresses every reviewer issue. Do not omit sections that were already fine — output the full plan.
+4. **Simplify while fixing**: If fixing an issue reveals that the plan is over-engineered (unnecessary layers, abstractions nobody needs, features beyond the stated goal), simplify it. A plan that does less but does it correctly is superior to one that does more.
+
+5. **Produce the fixed plan**: Output a complete, corrected plan that addresses every reviewer issue. Do not omit sections that were already fine — output the full plan.
 
 ## Output Format
 
@@ -29,4 +42,4 @@ Output ONLY the improved plan. No preamble, no "Here's the fixed plan:", no comm
 
 {@include plan-tail-sections}
 
-Reference actual file paths and function names discovered from the codebase. Every phase that touches code must name specific files.
+Reference actual file paths and function names discovered from the codebase. Every phase that touches code must name specific files. Prefer extending existing files over creating new ones.

--- a/koan/skills/core/plan/prompts/plan-improve.md
+++ b/koan/skills/core/plan/prompts/plan-improve.md
@@ -1,0 +1,32 @@
+You are a plan improvement agent. A quality review found issues in an implementation plan. Your job is to fix those issues by exploring the codebase, resolving ambiguities, and producing a corrected plan.
+
+## Original Plan
+
+{PLAN}
+
+## Issues Found by Reviewer
+
+{ISSUES}
+
+## Instructions
+
+1. **Analyze each issue**: For each reviewer finding, identify what concrete information is missing or wrong.
+
+2. **Explore the codebase**: Use Read, Glob, and Grep to find the actual file paths, function names, and patterns needed to fix the issues. Ground every fix in real code — do not guess paths or names.
+
+3. **Resolve ambiguities**: For each issue, formulate the question it raises, find the answer in the codebase, and apply it. For example:
+   - "No specific file path given" → grep for the relevant module, confirm the path, use it
+   - "Testing strategy missing" → find existing test files for the module, reference them
+   - "Phase too large" → read the files involved, decompose into smaller steps
+
+4. **Produce the fixed plan**: Output a complete, corrected plan that addresses every reviewer issue. Do not omit sections that were already fine — output the full plan.
+
+## Output Format
+
+Output ONLY the improved plan. No preamble, no "Here's the fixed plan:", no commentary after. Start directly with the plan title line.
+
+{@include plan-phases-format}
+
+{@include plan-tail-sections}
+
+Reference actual file paths and function names discovered from the codebase. Every phase that touches code must name specific files.

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -8,6 +8,7 @@ from app.github import fetch_issue_with_comments, detect_parent_repo
 from app.projects_config import get_project_submit_to_repository
 from skills.core.implement.implement_runner import (
     run_implement,
+    _GateImproved,
     _is_plan_content,
     _extract_latest_plan,
     _build_prompt,
@@ -217,7 +218,9 @@ class TestPlanReviewGate:
              patch(f"{_IMPL_MODULE}._write_plan_cache"), \
              patch(f"{_IMPL_MODULE}._post_improved_plan"):
             result = _run_plan_review_gate("## Phase 1\nDo stuff\n" * 10, "/project")
-            assert result == improved
+            assert isinstance(result, _GateImproved)
+            assert result.plan == improved
+            assert "missing file paths" in result.issues_fixed
 
     def test_issues_found_notifies_telegram_about_improvement(self):
         """When gate finds issues, notify_fn is called about auto-improvement."""
@@ -277,7 +280,8 @@ class TestPlanReviewGate:
             result = _run_plan_review_gate(
                 "## Phase 1\nDo stuff\n" * 10, "/project", notify_fn=notify,
             )
-            assert result == "improved"
+            assert isinstance(result, _GateImproved)
+            assert result.plan == "improved"
 
     def test_github_comment_failure_does_not_block_gate(self):
         """GitHub comment exception doesn't prevent gate from proceeding."""
@@ -294,7 +298,8 @@ class TestPlanReviewGate:
                 "## Phase 1\nDo stuff\n" * 10, "/project",
                 issue_url="https://github.com/o/r/issues/42",
             )
-            assert result == "improved"
+            assert isinstance(result, _GateImproved)
+            assert result.plan == "improved"
 
     def test_simple_plan_skips_review(self):
         """Simple plans bypass the review gate entirely — no config read needed."""
@@ -328,14 +333,15 @@ class TestPlanReviewGate:
             assert result is None
 
     def test_gate_improved_plan_used_for_implementation(self):
-        """Integration: run_implement uses improved plan from gate."""
+        """Integration: run_implement uses improved plan and context from gate."""
         notify = MagicMock()
         body = "### Summary\nPlan\n#### Phase 1: Do it"
         improved = "## Phase 1: koan/app/foo.py\nImproved plan"
+        gate_result = _GateImproved(improved, "- missing file paths")
         with patch(f"{_IMPL_MODULE}.fetch_issue_with_comments",
                     return_value=("Title", body, [])), \
              patch(f"{_IMPL_MODULE}._run_plan_review_gate",
-                    return_value=improved), \
+                    return_value=gate_result), \
              patch(f"{_IMPL_MODULE}._execute_implementation",
                     return_value="done") as mock_exec, \
              patch(f"{_IMPL_MODULE}._submit_implement_pr", return_value=None):
@@ -345,9 +351,10 @@ class TestPlanReviewGate:
                 notify_fn=notify,
             )
             assert ok
-            # Verify the improved plan was passed to implementation
             call_kwargs = mock_exec.call_args[1]
             assert call_kwargs["plan"] == improved
+            assert "Plan Improvement Notes" in call_kwargs["context"]
+            assert "missing file paths" in call_kwargs["context"]
 
     def test_gate_blocks_run_implement_on_tuple_failure(self):
         """Integration: run_implement returns failure when gate returns (False, msg)."""
@@ -390,7 +397,9 @@ class TestPlanReviewImprovementLoop:
              patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_cache, \
              patch(f"{_IMPL_MODULE}._post_improved_plan") as mock_post:
             result = _run_plan_review_gate(self._PLAN, "/project")
-            assert result == improved
+            assert isinstance(result, _GateImproved)
+            assert result.plan == improved
+            assert "missing paths" in result.issues_fixed
             mock_cache.assert_called_once()
             mock_post.assert_called_once()
 
@@ -405,8 +414,8 @@ class TestPlanReviewImprovementLoop:
              patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_cache, \
              patch(f"{_IMPL_MODULE}._post_improved_plan") as mock_post:
             result = _run_plan_review_gate(self._PLAN, "/project")
-            # Fail open: returns the improved plan (different from original)
-            assert result == "better but not perfect"
+            assert isinstance(result, _GateImproved)
+            assert result.plan == "better but not perfect"
             mock_cache.assert_not_called()
             mock_post.assert_called_once()
 

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -16,6 +16,7 @@ from skills.core.implement.implement_runner import (
     _is_plan_cache_fresh,
     _plan_hash,
     _plan_review_cache_path,
+    _post_improved_plan,
     _run_plan_review_gate,
     _submit_implement_pr,
     _write_plan_cache,
@@ -202,44 +203,53 @@ class TestPlanReviewGate:
             result = _run_plan_review_gate("## Phase 1\nDo stuff\n" * 10, "/project")
             assert result is None
 
-    def test_issues_found_aborts(self):
-        """When review_plan returns ISSUES_FOUND, gate returns (False, msg)."""
+    def test_issues_found_triggers_improvement_then_proceeds(self):
+        """When review finds issues, gate improves plan and proceeds (fail open)."""
         issues = "- Phase 1: missing file paths"
+        improved = "## Phase 1: Update koan/app/foo.py\nDo stuff"
         with patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
              patch("app.plan_runner.is_simple_plan", return_value=False), \
-             patch("app.plan_runner.review_plan", return_value=(False, issues)), \
-             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False):
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, issues), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value=improved), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
             result = _run_plan_review_gate("## Phase 1\nDo stuff\n" * 10, "/project")
-            assert result is not None
-            ok, msg = result
-            assert not ok
-            assert "missing file paths" in msg
-            assert "Plan review failed" in msg
+            assert result == improved
 
-    def test_issues_found_notifies_telegram(self):
-        """When gate rejects, notify_fn is called with specific issues."""
+    def test_issues_found_notifies_telegram_about_improvement(self):
+        """When gate finds issues, notify_fn is called about auto-improvement."""
         issues = "- Phase 1: missing file paths"
         notify = MagicMock()
         with patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
              patch("app.plan_runner.is_simple_plan", return_value=False), \
-             patch("app.plan_runner.review_plan", return_value=(False, issues)), \
-             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False):
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, issues), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value="improved"), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
             _run_plan_review_gate(
                 "## Phase 1\nDo stuff\n" * 10, "/project", notify_fn=notify,
             )
             notify.assert_called_once()
-            assert "missing file paths" in notify.call_args[0][0]
+            assert "auto-improving" in notify.call_args[0][0]
 
-    def test_issues_found_posts_github_comment(self):
-        """When gate rejects and issue_url provided, posts comment to GitHub."""
+    def test_improvement_posts_improved_plan_to_github(self):
+        """When gate improves plan, posts improved version as GitHub comment."""
         issues = "- Phase 1: missing file paths"
+        improved = "## Phase 1: Update koan/app/foo.py\nFixed plan"
         with patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
              patch("app.plan_runner.is_simple_plan", return_value=False), \
-             patch("app.plan_runner.review_plan", return_value=(False, issues)), \
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, issues), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value=improved), \
              patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
              patch("app.github.run_gh") as mock_gh:
             _run_plan_review_gate(
                 "## Phase 1\nDo stuff\n" * 10, "/project",
@@ -249,37 +259,42 @@ class TestPlanReviewGate:
             args = mock_gh.call_args[0]
             assert args[0] == "issue"
             assert args[1] == "comment"
-            assert "https://github.com/o/r/issues/42" in args
-            assert "missing file paths" in args[-1]
+            assert "Improved" in args[-1]
+            assert improved in args[-1]
 
-    def test_notify_failure_does_not_block_gate(self):
-        """notify_fn exception doesn't prevent gate from returning result."""
+    def test_notify_failure_does_not_block_improvement(self):
+        """notify_fn exception doesn't prevent gate from proceeding."""
         notify = MagicMock(side_effect=RuntimeError("send failed"))
         with patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
              patch("app.plan_runner.is_simple_plan", return_value=False), \
-             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
-             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False):
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, "issues"), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value="improved"), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
             result = _run_plan_review_gate(
                 "## Phase 1\nDo stuff\n" * 10, "/project", notify_fn=notify,
             )
-            assert result is not None
-            assert not result[0]
+            assert result == "improved"
 
     def test_github_comment_failure_does_not_block_gate(self):
-        """GitHub comment exception doesn't prevent gate from returning result."""
+        """GitHub comment exception doesn't prevent gate from proceeding."""
         with patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
              patch("app.plan_runner.is_simple_plan", return_value=False), \
-             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, "issues"), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value="improved"), \
              patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
              patch("app.github.run_gh", side_effect=RuntimeError("gh failed")):
             result = _run_plan_review_gate(
                 "## Phase 1\nDo stuff\n" * 10, "/project",
                 issue_url="https://github.com/o/r/issues/42",
             )
-            assert result is not None
-            assert not result[0]
+            assert result == "improved"
 
     def test_simple_plan_skips_review(self):
         """Simple plans bypass the review gate entirely — no config read needed."""
@@ -312,8 +327,30 @@ class TestPlanReviewGate:
             result = _run_plan_review_gate("## Phase 1\nDo stuff\n" * 10, "/project")
             assert result is None
 
-    def test_gate_blocks_run_implement(self):
-        """Integration: run_implement returns failure when gate rejects the plan."""
+    def test_gate_improved_plan_used_for_implementation(self):
+        """Integration: run_implement uses improved plan from gate."""
+        notify = MagicMock()
+        body = "### Summary\nPlan\n#### Phase 1: Do it"
+        improved = "## Phase 1: koan/app/foo.py\nImproved plan"
+        with patch(f"{_IMPL_MODULE}.fetch_issue_with_comments",
+                    return_value=("Title", body, [])), \
+             patch(f"{_IMPL_MODULE}._run_plan_review_gate",
+                    return_value=improved), \
+             patch(f"{_IMPL_MODULE}._execute_implementation",
+                    return_value="done") as mock_exec, \
+             patch(f"{_IMPL_MODULE}._submit_implement_pr", return_value=None):
+            ok, msg = run_implement(
+                "/project",
+                "https://github.com/o/r/issues/42",
+                notify_fn=notify,
+            )
+            assert ok
+            # Verify the improved plan was passed to implementation
+            call_kwargs = mock_exec.call_args[1]
+            assert call_kwargs["plan"] == improved
+
+    def test_gate_blocks_run_implement_on_tuple_failure(self):
+        """Integration: run_implement returns failure when gate returns (False, msg)."""
         notify = MagicMock()
         body = "### Summary\nPlan\n#### Phase 1: Do it"
         with patch(f"{_IMPL_MODULE}.fetch_issue_with_comments",
@@ -329,6 +366,120 @@ class TestPlanReviewGate:
             assert not ok
             assert "Plan review failed" in msg
             mock_exec.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Plan review improvement loop
+# ---------------------------------------------------------------------------
+
+class TestPlanReviewImprovementLoop:
+    """Tests for the autonomous plan improvement loop in the review gate."""
+
+    _PLAN = "## Phase 1\nDo stuff\n" * 10
+
+    def test_improvement_loop_succeeds_on_second_round(self):
+        """Improve once, second review passes — returns improved plan."""
+        improved = "## Phase 1: koan/app/foo.py\nConcrete plan"
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, "missing paths"), (True, "")]), \
+             patch("app.plan_runner.improve_plan", return_value=improved), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_cache, \
+             patch(f"{_IMPL_MODULE}._post_improved_plan") as mock_post:
+            result = _run_plan_review_gate(self._PLAN, "/project")
+            assert result == improved
+            mock_cache.assert_called_once()
+            mock_post.assert_called_once()
+
+    def test_improvement_loop_exhausts_all_rounds_fails_open(self):
+        """All rounds fail — returns improved plan anyway (fail open)."""
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 2}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
+             patch("app.plan_runner.improve_plan", return_value="better but not perfect"), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_cache, \
+             patch(f"{_IMPL_MODULE}._post_improved_plan") as mock_post:
+            result = _run_plan_review_gate(self._PLAN, "/project")
+            # Fail open: returns the improved plan (different from original)
+            assert result == "better but not perfect"
+            mock_cache.assert_not_called()
+            mock_post.assert_called_once()
+
+    def test_exhausted_with_unchanged_plan_returns_none(self):
+        """If improve_plan returns the same text, gate returns None (use original)."""
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 2}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
+             patch("app.plan_runner.improve_plan", return_value=self._PLAN), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_cache, \
+             patch(f"{_IMPL_MODULE}._post_improved_plan") as mock_post:
+            result = _run_plan_review_gate(self._PLAN, "/project")
+            assert result is None
+            mock_cache.assert_not_called()
+            mock_post.assert_not_called()
+
+    def test_improve_plan_called_with_issues(self):
+        """improve_plan receives the issues text from the reviewer."""
+        issues = "- Phase 1: no file paths\n- Phase 3: too large"
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 3}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan",
+                    side_effect=[(False, issues), (True, "")]), \
+             patch("app.plan_runner.improve_plan",
+                    return_value="fixed") as mock_improve, \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache"), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
+            _run_plan_review_gate(self._PLAN, "/project")
+            mock_improve.assert_called_once()
+            args = mock_improve.call_args[0]
+            assert args[0] == self._PLAN
+            assert args[1] == issues
+            assert args[2] == "/project"
+
+    def test_improvement_not_called_on_last_round(self):
+        """On the final round, don't waste tokens improving — just fail open."""
+        call_count = 0
+
+        def counting_improve(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            return "improved"
+
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 2}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
+             patch("app.plan_runner.improve_plan", side_effect=counting_improve), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
+            _run_plan_review_gate(self._PLAN, "/project")
+            # max_rounds=2: round 1 review fails → improve, round 2 review fails → stop
+            assert call_count == 1
+
+    def test_exhaustion_notifies_user(self):
+        """When all rounds exhausted, user is notified about fail-open."""
+        notify = MagicMock()
+        with patch("app.config.get_plan_review_config",
+                    return_value={"implement_gate": True, "max_rounds": 2}), \
+             patch("app.plan_runner.is_simple_plan", return_value=False), \
+             patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
+             patch("app.plan_runner.improve_plan", return_value="improved"), \
+             patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
+            _run_plan_review_gate(self._PLAN, "/project", notify_fn=notify)
+            # First call: improvement notification, second: exhaustion notification
+            assert notify.call_count == 2
+            exhaustion_msg = notify.call_args_list[1][0][0]
+            assert "couldn't fully resolve" in exhaustion_msg
 
 
 # ---------------------------------------------------------------------------
@@ -409,15 +560,17 @@ class TestPlanReviewCache:
             _run_plan_review_gate("## Phase 1\nDo stuff", "/project")
             mock_write.assert_called_once()
 
-    def test_rejected_does_not_write_cache(self):
-        """When review rejects, cache is NOT written."""
+    def test_exhausted_rounds_does_not_write_cache(self):
+        """When improvement exhausts all rounds (fail open), cache is NOT written."""
         with patch("app.plan_runner.is_simple_plan", return_value=False), \
              patch("app.config.get_plan_review_config",
-                    return_value={"implement_gate": True}), \
+                    return_value={"implement_gate": True, "max_rounds": 2}), \
              patch(f"{_IMPL_MODULE}._is_plan_cache_fresh", return_value=False), \
              patch("app.plan_runner.review_plan", return_value=(False, "issues")), \
-             patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_write:
-            _run_plan_review_gate("## Phase 1\nDo stuff", "/project")
+             patch("app.plan_runner.improve_plan", return_value="still bad"), \
+             patch(f"{_IMPL_MODULE}._write_plan_cache") as mock_write, \
+             patch(f"{_IMPL_MODULE}._post_improved_plan"):
+            _run_plan_review_gate("## Phase 1\nDo stuff\n" * 10, "/project")
             mock_write.assert_not_called()
 
 


### PR DESCRIPTION
The /implement review gate no longer blocks and waits for human fixes when
plan quality issues are found. Instead it spawns a codebase-grounded
improver subagent that resolves the issues autonomously (up to 3 rounds),
posts the improved plan to the GitHub issue, and proceeds with implementation.
Falls open after exhausting retries.

Closes #757

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
