### PR TITLE
fix(review): fall back to local git diff when PR has > 300 files

### DIFF
--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -149,6 +149,25 @@ def _diff_too_large(error_message: str) -> bool:
     return any(marker in error_message for marker in _DIFF_TOO_LARGE_MARKERS)
 
 
+def _token_fetch_url(
+    owner: str, repo: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Build an authenticated HTTPS fetch URL from ``gh auth token``.
+
+    Returns ``(url, token)``, or ``(None, None)`` when no token is
+    available. ``gh`` resolves the token from ``GH_TOKEN`` / ``GITHUB_TOKEN``
+    or its keyring; plain ``git`` reads none of those, so the token must be
+    embedded in the URL for HTTPS fetches to authenticate.
+    """
+    try:
+        token = run_gh("auth", "token").strip()
+    except (RuntimeError, OSError):
+        token = ""
+    if token:
+        return f"https://x-access-token:{token}@github.com/{owner}/{repo}.git", token
+    return None, None
+
+
 def _resolve_fetch_source(
     owner: str, repo: str, project_path: str,
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -167,14 +186,7 @@ def _resolve_fetch_source(
     remote = _find_remote_for_repo(owner, repo, project_path)
     if remote:
         return remote, None
-
-    try:
-        token = run_gh("auth", "token").strip()
-    except (RuntimeError, OSError):
-        token = ""
-    if token:
-        return f"https://x-access-token:{token}@github.com/{owner}/{repo}.git", token
-    return None, None
+    return _token_fetch_url(owner, repo)
 
 
 def _fetch_diff_locally(
@@ -192,7 +204,11 @@ def _fetch_diff_locally(
     300-file cap on ``gh pr diff`` because git itself has no such limit.
 
     The fetch source is the local remote matching ``owner/repo`` (whose
-    credentials already work); see :func:`_resolve_fetch_source`.
+    credentials already work); see :func:`_resolve_fetch_source`. If that
+    remote fetch fails — e.g. an HTTPS remote with no credential helper,
+    which dies with "could not read Username" — it retries once using an
+    authenticated ``gh auth token`` URL so the token in the environment is
+    actually used.
 
     Returns the raw diff text on success, or an empty string on any
     failure (network, missing branch, etc.). Temp refs are always cleaned
@@ -200,18 +216,6 @@ def _fetch_diff_locally(
     """
     head_ref = f"refs/koan-tmp/pr-{pr_number}-head"
     base_ref = f"refs/koan-tmp/pr-{pr_number}-base"
-
-    source, secret = _resolve_fetch_source(owner, repo, project_path)
-    if not source:
-        print(
-            f"[rebase_pr] local diff fallback: no usable fetch source for "
-            f"{owner}/{repo} (no matching remote and no gh token)",
-            file=sys.stderr,
-        )
-        return ""
-
-    def _redact(text: str) -> str:
-        return text.replace(secret, "***") if secret else text
 
     def _git(args: list, **kwargs) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -223,7 +227,11 @@ def _fetch_diff_locally(
             **kwargs,
         )
 
-    try:
+    def _attempt(source: str, secret: Optional[str]) -> Optional[str]:
+        """Fetch head + base from *source* and return the diff, or None on failure."""
+        def _redact(text: str) -> str:
+            return text.replace(secret, "***") if secret else text
+
         head_fetch = _git(
             ["fetch", "--no-tags", source, f"pull/{pr_number}/head:{head_ref}"],
         )
@@ -234,7 +242,7 @@ def _fetch_diff_locally(
                 f"failed: {_redact(stderr)[:200]}",
                 file=sys.stderr,
             )
-            return ""
+            return None
 
         base_fetch = _git(
             ["fetch", "--no-tags", source, f"{base_branch}:{base_ref}"],
@@ -246,7 +254,7 @@ def _fetch_diff_locally(
                 f"failed: {_redact(stderr)[:200]}",
                 file=sys.stderr,
             )
-            return ""
+            return None
 
         diff_result = _git(
             ["diff", f"{base_ref}...{head_ref}"],
@@ -258,11 +266,42 @@ def _fetch_diff_locally(
                 f"{_redact(diff_result.stderr)[:200]}",
                 file=sys.stderr,
             )
-            return ""
+            return None
         return diff_result.stdout
-    except (subprocess.TimeoutExpired, OSError) as e:
+
+    source, secret = _resolve_fetch_source(owner, repo, project_path)
+    if not source:
         print(
-            f"[rebase_pr] local diff fallback errored: {_redact(str(e))}",
+            f"[rebase_pr] local diff fallback: no usable fetch source for "
+            f"{owner}/{repo} (no matching remote and no gh token)",
+            file=sys.stderr,
+        )
+        return ""
+
+    try:
+        diff = _attempt(source, secret)
+        if diff is not None:
+            return diff
+
+        # The first source was a plain remote name (secret is None) whose
+        # transport failed — e.g. an HTTPS remote with no credential helper.
+        # Retry once with an authenticated token URL so GH_TOKEN is used.
+        if secret is None:
+            token_url, token = _token_fetch_url(owner, repo)
+            if token_url:
+                print(
+                    f"[rebase_pr] local diff fallback: remote fetch failed for "
+                    f"{owner}/{repo}; retrying with gh token URL",
+                    file=sys.stderr,
+                )
+                diff = _attempt(token_url, token)
+                if diff is not None:
+                    return diff
+        return ""
+    except (subprocess.TimeoutExpired, OSError) as e:
+        msg = str(e).replace(secret, "***") if secret else str(e)
+        print(
+            f"[rebase_pr] local diff fallback errored: {msg}",
             file=sys.stderr,
         )
         return ""

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -149,6 +149,34 @@ def _diff_too_large(error_message: str) -> bool:
     return any(marker in error_message for marker in _DIFF_TOO_LARGE_MARKERS)
 
 
+def _resolve_fetch_source(
+    owner: str, repo: str, project_path: str,
+) -> Tuple[Optional[str], Optional[str]]:
+    """Resolve a git fetch source for ``owner/repo`` from the local checkout.
+
+    Returns ``(source, secret)`` where *source* is a git remote name or URL
+    and *secret* is a token that must be redacted from logs (or ``None``).
+
+    Prefers the local remote whose URL matches ``owner/repo`` — its
+    credentials already work, since that is how Kōan fetches and pushes
+    (SSH key or git credential helper). Only when no matching remote exists
+    does it fall back to an authenticated HTTPS URL built from
+    ``gh auth token`` (a fresh ``https://github.com/...`` URL has no
+    credentials and prompts for a username on private repos).
+    """
+    remote = _find_remote_for_repo(owner, repo, project_path)
+    if remote:
+        return remote, None
+
+    try:
+        token = run_gh("auth", "token").strip()
+    except (RuntimeError, OSError):
+        token = ""
+    if token:
+        return f"https://x-access-token:{token}@github.com/{owner}/{repo}.git", token
+    return None, None
+
+
 def _fetch_diff_locally(
     project_path: str,
     owner: str,
@@ -159,17 +187,31 @@ def _fetch_diff_locally(
 ) -> str:
     """Fetch a PR diff from the local checkout when GitHub's API caps out.
 
-    Uses ``git fetch <url> pull/<N>/head`` and ``git fetch <url> <base>``
-    into temporary refs, then ``git diff base...head``. This bypasses the
+    Fetches the PR head (``pull/<N>/head``) and the base branch into
+    temporary refs, then runs ``git diff base...head``. This bypasses the
     300-file cap on ``gh pr diff`` because git itself has no such limit.
+
+    The fetch source is the local remote matching ``owner/repo`` (whose
+    credentials already work); see :func:`_resolve_fetch_source`.
 
     Returns the raw diff text on success, or an empty string on any
     failure (network, missing branch, etc.). Temp refs are always cleaned
     up, even on failure.
     """
-    url = f"https://github.com/{owner}/{repo}.git"
     head_ref = f"refs/koan-tmp/pr-{pr_number}-head"
     base_ref = f"refs/koan-tmp/pr-{pr_number}-base"
+
+    source, secret = _resolve_fetch_source(owner, repo, project_path)
+    if not source:
+        print(
+            f"[rebase_pr] local diff fallback: no usable fetch source for "
+            f"{owner}/{repo} (no matching remote and no gh token)",
+            file=sys.stderr,
+        )
+        return ""
+
+    def _redact(text: str) -> str:
+        return text.replace(secret, "***") if secret else text
 
     def _git(args: list, **kwargs) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -183,25 +225,25 @@ def _fetch_diff_locally(
 
     try:
         head_fetch = _git(
-            ["fetch", "--no-tags", url, f"pull/{pr_number}/head:{head_ref}"],
+            ["fetch", "--no-tags", source, f"pull/{pr_number}/head:{head_ref}"],
         )
         if head_fetch.returncode != 0:
             stderr = head_fetch.stderr.decode("utf-8", errors="replace")
             print(
                 f"[rebase_pr] local diff fallback: fetch of pull/{pr_number}/head "
-                f"failed: {stderr[:200]}",
+                f"failed: {_redact(stderr)[:200]}",
                 file=sys.stderr,
             )
             return ""
 
         base_fetch = _git(
-            ["fetch", "--no-tags", url, f"{base_branch}:{base_ref}"],
+            ["fetch", "--no-tags", source, f"{base_branch}:{base_ref}"],
         )
         if base_fetch.returncode != 0:
             stderr = base_fetch.stderr.decode("utf-8", errors="replace")
             print(
                 f"[rebase_pr] local diff fallback: fetch of base {base_branch} "
-                f"failed: {stderr[:200]}",
+                f"failed: {_redact(stderr)[:200]}",
                 file=sys.stderr,
             )
             return ""
@@ -213,14 +255,14 @@ def _fetch_diff_locally(
         if diff_result.returncode != 0:
             print(
                 f"[rebase_pr] local diff fallback: git diff failed: "
-                f"{diff_result.stderr[:200]}",
+                f"{_redact(diff_result.stderr)[:200]}",
                 file=sys.stderr,
             )
             return ""
         return diff_result.stdout
     except (subprocess.TimeoutExpired, OSError) as e:
         print(
-            f"[rebase_pr] local diff fallback errored: {e}",
+            f"[rebase_pr] local diff fallback errored: {_redact(str(e))}",
             file=sys.stderr,
         )
         return ""

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -13,6 +13,7 @@ Pipeline:
 6. Comment on the PR with a summary
 """
 
+import contextlib
 import json
 import re
 import subprocess
@@ -140,11 +141,110 @@ def severity_at_or_above(min_severity: str) -> List[str]:
     return list(SEVERITY_LEVELS[: idx + 1])
 
 
-def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
+_DIFF_TOO_LARGE_MARKERS = ("HTTP 406", "too_large", "exceeded the maximum")
+
+
+def _diff_too_large(error_message: str) -> bool:
+    """Return True if a gh-pr-diff error matches the > 300 files signature."""
+    return any(marker in error_message for marker in _DIFF_TOO_LARGE_MARKERS)
+
+
+def _fetch_diff_locally(
+    project_path: str,
+    owner: str,
+    repo: str,
+    pr_number: str,
+    base_branch: str,
+    timeout: int = 180,
+) -> str:
+    """Fetch a PR diff from the local checkout when GitHub's API caps out.
+
+    Uses ``git fetch <url> pull/<N>/head`` and ``git fetch <url> <base>``
+    into temporary refs, then ``git diff base...head``. This bypasses the
+    300-file cap on ``gh pr diff`` because git itself has no such limit.
+
+    Returns the raw diff text on success, or an empty string on any
+    failure (network, missing branch, etc.). Temp refs are always cleaned
+    up, even on failure.
+    """
+    url = f"https://github.com/{owner}/{repo}.git"
+    head_ref = f"refs/koan-tmp/pr-{pr_number}-head"
+    base_ref = f"refs/koan-tmp/pr-{pr_number}-base"
+
+    def _git(args: list, **kwargs) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args],
+            cwd=project_path,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            timeout=timeout,
+            **kwargs,
+        )
+
+    try:
+        head_fetch = _git(
+            ["fetch", "--no-tags", url, f"pull/{pr_number}/head:{head_ref}"],
+        )
+        if head_fetch.returncode != 0:
+            stderr = head_fetch.stderr.decode("utf-8", errors="replace")
+            print(
+                f"[rebase_pr] local diff fallback: fetch of pull/{pr_number}/head "
+                f"failed: {stderr[:200]}",
+                file=sys.stderr,
+            )
+            return ""
+
+        base_fetch = _git(
+            ["fetch", "--no-tags", url, f"{base_branch}:{base_ref}"],
+        )
+        if base_fetch.returncode != 0:
+            stderr = base_fetch.stderr.decode("utf-8", errors="replace")
+            print(
+                f"[rebase_pr] local diff fallback: fetch of base {base_branch} "
+                f"failed: {stderr[:200]}",
+                file=sys.stderr,
+            )
+            return ""
+
+        diff_result = _git(
+            ["diff", f"{base_ref}...{head_ref}"],
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if diff_result.returncode != 0:
+            print(
+                f"[rebase_pr] local diff fallback: git diff failed: "
+                f"{diff_result.stderr[:200]}",
+                file=sys.stderr,
+            )
+            return ""
+        return diff_result.stdout
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(
+            f"[rebase_pr] local diff fallback errored: {e}",
+            file=sys.stderr,
+        )
+        return ""
+    finally:
+        for ref in (head_ref, base_ref):
+            with contextlib.suppress(subprocess.TimeoutExpired, OSError):
+                _git(["update-ref", "-d", ref])
+
+
+def fetch_pr_context(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    project_path: Optional[str] = None,
+) -> dict:
     """Fetch PR details, diff, and all comments via gh CLI.
 
     Returns a dict with keys: title, body, branch, base, state, author, url,
     diff, review_comments, reviews, issue_comments.
+
+    When ``project_path`` is provided, oversized-PR diff failures
+    (GitHub HTTP 406: > 300 files) trigger a local ``git fetch`` +
+    ``git diff`` fallback. Without ``project_path``, the diff is left
+    empty and a warning is logged.
     """
     full_repo = f"{owner}/{repo}"
 
@@ -153,6 +253,13 @@ def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
         "pr", "view", pr_number, "--repo", full_repo, "--json",
         "title,body,headRefName,baseRefName,state,author,url,headRepositoryOwner",
     )
+
+    # Parse metadata up front — needed for the local-diff fallback so we
+    # know the base branch name before attempting the fetch.
+    try:
+        metadata = json.loads(pr_json)
+    except (json.JSONDecodeError, TypeError):
+        metadata = {}
 
     # Fetch review comment count from REST API for pending review detection.
     # GitHub counts pending (unsubmitted) review comments in PR metadata but
@@ -176,11 +283,39 @@ def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
     except (RuntimeError, ValueError):
         api_review_comment_count = 0
 
-    # Fetch PR diff (may fail for very large PRs — GitHub HTTP 406)
+    # Fetch PR diff. May fail for very large PRs — GitHub returns HTTP 406
+    # when a diff would contain more than 300 changed files. When that
+    # happens and we have a local checkout, fall back to ``git diff`` from
+    # the local repo, which has no such cap.
+    diff = ""
     try:
         diff = run_gh("pr", "diff", pr_number, "--repo", full_repo)
-    except RuntimeError:
-        diff = ""
+    except RuntimeError as e:
+        err_msg = str(e)
+        too_large = _diff_too_large(err_msg)
+        print(
+            f"[rebase_pr] PR diff fetch failed for #{pr_number} "
+            f"({'oversized — > 300 files' if too_large else 'gh error'}): "
+            f"{err_msg[:300]}",
+            file=sys.stderr,
+        )
+        if too_large and project_path:
+            base_branch = metadata.get("baseRefName") or "main"
+            diff = _fetch_diff_locally(
+                project_path, owner, repo, pr_number, base_branch,
+            )
+            if diff:
+                print(
+                    f"[rebase_pr] PR #{pr_number} diff fetched locally "
+                    f"({len(diff)} chars)",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    f"[rebase_pr] PR #{pr_number} local diff fallback "
+                    f"produced no output",
+                    file=sys.stderr,
+                )
 
     # Fetch review comments (inline code comments)
     try:
@@ -216,11 +351,6 @@ def fetch_pr_context(owner: str, repo: str, pr_number: str) -> dict:
     # Bot replies (rebase summaries, review results) are verbose and push
     # human comments out of the truncation window.
     issue_comments = _filter_bot_issue_comments(issue_comments)
-
-    try:
-        metadata = json.loads(pr_json)
-    except (json.JSONDecodeError, TypeError):
-        metadata = {}
 
     # Detect pending (unsubmitted) reviews: GitHub counts pending review
     # comments in the PR metadata but the API doesn't return them to other

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1236,7 +1236,9 @@ def run_review(
     notify_fn(f"Reviewing PR #{pr_number} ({full_repo})...")
     if concurrency_enabled and github_workers > 1:
         with ThreadPoolExecutor(max_workers=min(2, github_workers)) as pool:
-            f_context = pool.submit(fetch_pr_context, owner, repo, pr_number)
+            f_context = pool.submit(
+                fetch_pr_context, owner, repo, pr_number, project_path,
+            )
             f_comments = pool.submit(
                 fetch_repliable_comments, owner, repo, pr_number, True, bot_username,
             )
@@ -1247,7 +1249,7 @@ def run_review(
             repliable_comments = f_comments.result()
     else:
         try:
-            context = fetch_pr_context(owner, repo, pr_number)
+            context = fetch_pr_context(owner, repo, pr_number, project_path)
         except Exception as e:
             return False, f"Failed to fetch PR context: {e}", None
         repliable_comments = fetch_repliable_comments(

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -933,10 +933,11 @@ class TestFetchDiffLocally:
         assert diff == ""
         mock_run.assert_not_called()
 
+    @patch("app.rebase_pr._token_fetch_url", return_value=(None, None))
     @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
     @patch("app.rebase_pr.subprocess.run")
-    def test_returns_empty_on_fetch_failure(self, mock_run, _mock_src):
-        """Returns empty string when the PR head fetch fails."""
+    def test_returns_empty_on_fetch_failure(self, mock_run, _mock_src, _mock_tok):
+        """Returns empty string when the PR head fetch fails and no token retry is possible."""
         from app.rebase_pr import _fetch_diff_locally
 
         mock_run.side_effect = [
@@ -949,6 +950,64 @@ class TestFetchDiffLocally:
         diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
 
         assert diff == ""
+
+    @patch(
+        "app.rebase_pr._token_fetch_url",
+        return_value=("https://x-access-token:tok@github.com/o/r.git", "tok"),
+    )
+    @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
+    @patch("app.rebase_pr.subprocess.run")
+    def test_retries_with_token_url_when_remote_fetch_fails(
+        self, mock_run, _mock_src, _mock_tok,
+    ):
+        """An HTTPS remote without a helper fails, then the token-URL retry succeeds."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        mock_run.side_effect = [
+            # First attempt via "origin": head fetch fails (no credentials)
+            MagicMock(
+                returncode=128,
+                stderr=b"fatal: could not read Username for 'https://github.com'",
+            ),
+            # Retry attempt via token URL: head, base, diff all succeed
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stdout="diff --git a/f b/f\n+new", stderr=""),
+            # cleanup x2
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        assert "diff --git" in diff
+        # The retry (second call) must use the authenticated token URL
+        retry_head_args = mock_run.call_args_list[1].args[0]
+        assert any("x-access-token" in a for a in retry_head_args)
+
+    @patch("app.rebase_pr._token_fetch_url", return_value=(None, None))
+    @patch(
+        "app.rebase_pr._resolve_fetch_source",
+        return_value=("https://x-access-token:tok@github.com/o/r.git", "tok"),
+    )
+    @patch("app.rebase_pr.subprocess.run")
+    def test_no_token_retry_when_source_already_token_url(
+        self, mock_run, _mock_src, mock_tok,
+    ):
+        """If the resolved source is already a token URL, don't retry (would loop)."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        mock_run.side_effect = [
+            MagicMock(returncode=128, stderr=b"fatal: repository not found"),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        assert diff == ""
+        # secret was not None, so the token-URL retry path must be skipped
+        mock_tok.assert_not_called()
 
     @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
     @patch("app.rebase_pr.subprocess.run")
@@ -1026,6 +1085,32 @@ class TestResolveFetchSource:
 
         source, secret = _resolve_fetch_source("o", "r", "/tmp/co")
         assert source is None
+        assert secret is None
+
+
+class TestTokenFetchUrl:
+    @patch("app.rebase_pr.run_gh", return_value="ghs_abc")
+    def test_builds_authenticated_url(self, _mock_gh):
+        from app.rebase_pr import _token_fetch_url
+
+        url, secret = _token_fetch_url("o", "r")
+        assert url == "https://x-access-token:ghs_abc@github.com/o/r.git"
+        assert secret == "ghs_abc"
+
+    @patch("app.rebase_pr.run_gh", return_value="")
+    def test_returns_none_when_token_empty(self, _mock_gh):
+        from app.rebase_pr import _token_fetch_url
+
+        url, secret = _token_fetch_url("o", "r")
+        assert url is None
+        assert secret is None
+
+    @patch("app.rebase_pr.run_gh", side_effect=RuntimeError("not logged in"))
+    def test_returns_none_when_gh_fails(self, _mock_gh):
+        from app.rebase_pr import _token_fetch_url
+
+        url, secret = _token_fetch_url("o", "r")
+        assert url is None
         assert secret is None
 
 

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -896,8 +896,9 @@ class TestFetchPrContext:
 # ---------------------------------------------------------------------------
 
 class TestFetchDiffLocally:
+    @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
     @patch("app.rebase_pr.subprocess.run")
-    def test_runs_three_git_commands_and_returns_diff(self, mock_run):
+    def test_runs_three_git_commands_and_returns_diff(self, mock_run, _mock_src):
         """The fallback fetches PR head + base then runs git diff."""
         from app.rebase_pr import _fetch_diff_locally
 
@@ -916,12 +917,25 @@ class TestFetchDiffLocally:
         # The first three calls should be git fetch / fetch / diff in that order
         first_three = [c.args[0][:2] for c in mock_run.call_args_list[:3]]
         assert first_three == [["git", "fetch"], ["git", "fetch"], ["git", "diff"]]
-        # PR head fetch must use the pull/<N>/head refspec
+        # PR head fetch must use the pull/<N>/head refspec and the resolved remote
         head_fetch_args = mock_run.call_args_list[0].args[0]
+        assert "origin" in head_fetch_args
         assert any("pull/42/head" in a for a in head_fetch_args)
 
+    @patch("app.rebase_pr._resolve_fetch_source", return_value=(None, None))
     @patch("app.rebase_pr.subprocess.run")
-    def test_returns_empty_on_fetch_failure(self, mock_run):
+    def test_returns_empty_when_no_fetch_source(self, mock_run, _mock_src):
+        """No matching remote and no token → no fetch attempt, empty diff."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        assert diff == ""
+        mock_run.assert_not_called()
+
+    @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
+    @patch("app.rebase_pr.subprocess.run")
+    def test_returns_empty_on_fetch_failure(self, mock_run, _mock_src):
         """Returns empty string when the PR head fetch fails."""
         from app.rebase_pr import _fetch_diff_locally
 
@@ -936,8 +950,9 @@ class TestFetchDiffLocally:
 
         assert diff == ""
 
+    @patch("app.rebase_pr._resolve_fetch_source", return_value=("origin", None))
     @patch("app.rebase_pr.subprocess.run")
-    def test_cleans_up_temp_refs_on_success(self, mock_run):
+    def test_cleans_up_temp_refs_on_success(self, mock_run, _mock_src):
         """Temp refs are deleted after a successful diff."""
         from app.rebase_pr import _fetch_diff_locally
 
@@ -956,6 +971,62 @@ class TestFetchDiffLocally:
             if c.args[0][:2] == ["git", "update-ref"]
         ]
         assert len(cleanup_calls) == 2
+
+    @patch("app.rebase_pr._resolve_fetch_source")
+    @patch("app.rebase_pr.subprocess.run")
+    def test_redacts_token_from_error_logs(self, mock_run, mock_src, capsys):
+        """A token in an authenticated URL must not leak into stderr logs."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        token = "ghs_supersecret"
+        url = f"https://x-access-token:{token}@github.com/o/r.git"
+        mock_src.return_value = (url, token)
+        mock_run.side_effect = [
+            MagicMock(
+                returncode=128,
+                stderr=f"fatal: unable to access '{url}'".encode(),
+            ),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        captured = capsys.readouterr()
+        assert token not in captured.err
+        assert "***" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _resolve_fetch_source
+# ---------------------------------------------------------------------------
+
+class TestResolveFetchSource:
+    @patch("app.rebase_pr._find_remote_for_repo", return_value="origin")
+    def test_prefers_matching_remote(self, _mock_find):
+        from app.rebase_pr import _resolve_fetch_source
+
+        source, secret = _resolve_fetch_source("o", "r", "/tmp/co")
+        assert source == "origin"
+        assert secret is None
+
+    @patch("app.rebase_pr.run_gh", return_value="ghs_token123")
+    @patch("app.rebase_pr._find_remote_for_repo", return_value=None)
+    def test_falls_back_to_token_url(self, _mock_find, _mock_gh):
+        from app.rebase_pr import _resolve_fetch_source
+
+        source, secret = _resolve_fetch_source("o", "r", "/tmp/co")
+        assert source == "https://x-access-token:ghs_token123@github.com/o/r.git"
+        assert secret == "ghs_token123"
+
+    @patch("app.rebase_pr.run_gh", side_effect=RuntimeError("not logged in"))
+    @patch("app.rebase_pr._find_remote_for_repo", return_value=None)
+    def test_returns_none_when_no_remote_and_no_token(self, _mock_find, _mock_gh):
+        from app.rebase_pr import _resolve_fetch_source
+
+        source, secret = _resolve_fetch_source("o", "r", "/tmp/co")
+        assert source is None
+        assert secret is None
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -694,6 +694,99 @@ class TestFetchPrContext:
         assert context["branch"] == "feat/big"
         assert context["diff"] == ""  # Graceful fallback
 
+    @patch("app.rebase_pr._fetch_diff_locally")
+    @patch("app.github.subprocess.run")
+    def test_diff_406_falls_back_to_local_diff(
+        self, mock_run, mock_local,
+    ):
+        """When the diff endpoint returns 406 and project_path is set,
+        fetch_pr_context falls back to a local git diff."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "Huge PR",
+                "headRefName": "feat/huge",
+                "baseRefName": "develop",
+                "state": "OPEN",
+                "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/9",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            # Diff fails with 406
+            MagicMock(
+                returncode=1,
+                stderr="HTTP 406: diff exceeded the maximum number of files",
+            ),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        mock_local.return_value = "diff --git a/x b/x\n+local fallback diff"
+
+        context = fetch_pr_context("o", "r", "9", project_path="/tmp/checkout")
+
+        mock_local.assert_called_once_with(
+            "/tmp/checkout", "o", "r", "9", "develop",
+        )
+        assert "local fallback diff" in context["diff"]
+
+    @patch("app.rebase_pr._fetch_diff_locally")
+    @patch("app.github.subprocess.run")
+    def test_diff_406_without_project_path_skips_fallback(
+        self, mock_run, mock_local,
+    ):
+        """No project_path → no fallback attempt, diff stays empty."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "Huge PR",
+                "headRefName": "feat/huge",
+                "baseRefName": "main",
+                "state": "OPEN",
+                "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/9",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(
+                returncode=1,
+                stderr="HTTP 406: diff exceeded the maximum number of files",
+            ),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+
+        context = fetch_pr_context("o", "r", "9")
+
+        mock_local.assert_not_called()
+        assert context["diff"] == ""
+
+    @patch("app.rebase_pr._fetch_diff_locally")
+    @patch("app.github.subprocess.run")
+    def test_diff_non_406_failure_skips_fallback(
+        self, mock_run, mock_local,
+    ):
+        """Other gh failures (e.g. transient 5xx) should not trigger the
+        local fallback — only the 'too many files' signature does."""
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "PR",
+                "headRefName": "br",
+                "baseRefName": "main",
+                "state": "OPEN",
+                "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(returncode=1, stderr="HTTP 404: not found"),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+
+        context = fetch_pr_context("o", "r", "1", project_path="/tmp/checkout")
+
+        mock_local.assert_not_called()
+        assert context["diff"] == ""
+
     @patch("app.github.subprocess.run")
     def test_comments_fetch_failure_graceful(self, mock_run):
         """API failures on comments should not crash the fetch."""
@@ -796,6 +889,73 @@ class TestFetchPrContext:
         assert context["has_pending_reviews"] is True
         # retry_with_backoff sleeps once between the failed and successful attempt
         assert mock_sleep.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# _fetch_diff_locally
+# ---------------------------------------------------------------------------
+
+class TestFetchDiffLocally:
+    @patch("app.rebase_pr.subprocess.run")
+    def test_runs_three_git_commands_and_returns_diff(self, mock_run):
+        """The fallback fetches PR head + base then runs git diff."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        # head fetch, base fetch, diff, then two best-effort update-ref deletes
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stdout="diff --git a/f b/f\n+new", stderr=""),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        assert "diff --git" in diff
+        # The first three calls should be git fetch / fetch / diff in that order
+        first_three = [c.args[0][:2] for c in mock_run.call_args_list[:3]]
+        assert first_three == [["git", "fetch"], ["git", "fetch"], ["git", "diff"]]
+        # PR head fetch must use the pull/<N>/head refspec
+        head_fetch_args = mock_run.call_args_list[0].args[0]
+        assert any("pull/42/head" in a for a in head_fetch_args)
+
+    @patch("app.rebase_pr.subprocess.run")
+    def test_returns_empty_on_fetch_failure(self, mock_run):
+        """Returns empty string when the PR head fetch fails."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        mock_run.side_effect = [
+            MagicMock(returncode=128, stderr=b"fatal: couldn't find remote ref"),
+            # Cleanup calls still run
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        diff = _fetch_diff_locally("/tmp/co", "o", "r", "42", "main")
+
+        assert diff == ""
+
+    @patch("app.rebase_pr.subprocess.run")
+    def test_cleans_up_temp_refs_on_success(self, mock_run):
+        """Temp refs are deleted after a successful diff."""
+        from app.rebase_pr import _fetch_diff_locally
+
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stdout="+x", stderr=""),
+            MagicMock(returncode=0, stderr=b""),
+            MagicMock(returncode=0, stderr=b""),
+        ]
+
+        _fetch_diff_locally("/tmp/co", "o", "r", "7", "main")
+
+        cleanup_calls = [
+            c for c in mock_run.call_args_list
+            if c.args[0][:2] == ["git", "update-ref"]
+        ]
+        assert len(cleanup_calls) == 2
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -692,7 +692,7 @@ class TestRunReview:
         assert "42" in summary
         assert review_data is not None
         assert review_data["review_summary"]["lgtm"] is True
-        mock_fetch.assert_called_once_with("owner", "repo", "42")
+        mock_fetch.assert_called_once_with("owner", "repo", "42", "/tmp/project")
         mock_claude.assert_called_once()
         mock_gh.assert_called_once()  # post comment
         assert mock_notify.call_count >= 2


### PR DESCRIPTION
GitHub's pr-diff endpoint returns HTTP 406 for diffs with more than 300 changed files, which made /review fail with the misleading "PR has no diff — nothing to review" message on huge PRs. The underlying gh error was also silently swallowed, so operators had no clue what failed.

Fix both:
- fetch_pr_context() now logs the gh error message and classifies it as "oversized" when it matches the 406/too_large signature.
- On 406, when project_path is available, fall back to a local `git fetch <url> pull/<N>/head` + `git diff base...head` from the checkout. Git has no file-count cap, so PRs of any size now produce a diff that the review pipeline (and compressor) can work with.
- review_runner threads project_path through to fetch_pr_context so the fallback path is reachable from /review.