### PR TITLE
fix: update codex full access flag

### DIFF
--- a/docs/provider-codex.md
+++ b/docs/provider-codex.md
@@ -90,8 +90,8 @@ Codex event shapes for the final answer.
 
 | Kōan Setting          | Codex Flag       | Behavior                        |
 |-----------------------|------------------|---------------------------------|
-| `skip_permissions: false` | `--sandbox workspace-write` | Workspace writes + on-request approvals |
-| `skip_permissions: true`  | `--yolo`        | No approvals, no sandbox        |
+| `skip_permissions: false` | `--sandbox workspace-write` | Workspace writes, but `.git` may be read-only |
+| `skip_permissions: true`  | `--dangerously-bypass-approvals-and-sandbox` | No approvals, no sandbox |
 
 ### Feature Mapping
 
@@ -165,8 +165,11 @@ not scan normal command output for generic billing or credit words.
 
 Codex does not support per-tool allow/disallow flags. Tool access is
 controlled by sandbox policies. Use `skip_permissions: true` (maps to
-`--yolo`) for full access, or the default `--sandbox workspace-write`
-for workspace-scoped writes.
+`--dangerously-bypass-approvals-and-sandbox`) for full access, or the
+default `--sandbox workspace-write` for workspace-scoped writes. In some
+deployments, `workspace-write` allows source edits but mounts `.git`
+read-only; use full access only when Kōan already runs in a trusted
+external sandbox and Codex should create branches, commits, pushes, and PRs.
 
 ### System prompt not taking effect
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -277,10 +277,12 @@ tools:
 # Can also be set via KOAN_CLI_PROVIDER env var (overrides this)
 cli_provider: "claude"
 
-# Skip permission prompts — adds --dangerously-skip-permissions to Claude CLI.
-# WARNING: Does NOT work when Koan runs as root (Claude CLI rejects it).
-# For MCP tools, use .claude/settings.local.json allowlists instead.
-# See docs/provider-claude.md for details.
+# Skip permission prompts/sandboxing for CLI providers.
+# Claude: adds --dangerously-skip-permissions; does not work when Koan runs as root.
+# Codex: adds --dangerously-bypass-approvals-and-sandbox so Codex can use git
+# directly. Only enable this when Koan already runs in a trusted external sandbox.
+# For MCP tools, use provider-specific allowlists/settings instead.
+# See docs/provider-claude.md and docs/provider-codex.md for details.
 # skip_permissions: false
 
 # MCP server configuration — paths to MCP config JSON files.

--- a/koan/app/provider/codex.py
+++ b/koan/app/provider/codex.py
@@ -59,7 +59,7 @@ class CodexProvider(CLIProvider):
     - No --append-system-prompt (falls back to prepend via base class)
     - No --max-turns (runs to completion)
     - Output: --json flag for JSONL events (not --output-format)
-    - Permissions: --yolo (equivalent to Claude's --dangerously-skip-permissions)
+    - Permissions: --dangerously-bypass-approvals-and-sandbox for full access
     - MCP: configured via config.toml, not CLI flags
 
     Configuration (config.yaml):
@@ -78,7 +78,7 @@ class CodexProvider(CLIProvider):
         return shutil.which("codex") is not None
 
     def build_permission_args(self, skip_permissions: bool = False) -> List[str]:
-        # Codex equivalent: --yolo bypasses approvals and sandbox entirely.
+        # Codex equivalent: bypass approvals and sandbox entirely.
         #
         # When skip_permissions=False we use --sandbox workspace-write
         # (replaces deprecated --full-auto) because Kōan runs headless
@@ -89,7 +89,7 @@ class CodexProvider(CLIProvider):
         # TODO: for read-only contexts (chat, review mode) a future
         # enhancement could pass --sandbox read-only instead.
         if skip_permissions:
-            return ["--yolo"]
+            return ["--dangerously-bypass-approvals-and-sandbox"]
         return ["--sandbox", "workspace-write"]
 
     def build_prompt_args(self, prompt: str) -> List[str]:
@@ -246,7 +246,8 @@ class CodexProvider(CLIProvider):
 
             codex exec [exec-flags] "prompt"
 
-        Permission flags (``--sandbox workspace-write``, ``--yolo``) and ``--model``
+        Permission flags (``--sandbox workspace-write``,
+        ``--dangerously-bypass-approvals-and-sandbox``) and ``--model``
         are ``exec`` subcommand flags in current Codex CLI (>= 0.1),
         so they must come *after* the ``exec`` keyword.  The prompt is
         the final positional argument.

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2091,6 +2091,22 @@ def _run_iteration(
         # Build CLI command (provider-agnostic with per-project overrides)
         from app.mission_runner import build_mission_command
         from app.debug import debug_log as _debug_log
+        if provider_name == "codex":
+            try:
+                from app.config import get_skip_permissions
+                _codex_full_access = get_skip_permissions()
+            except Exception as e:
+                _codex_full_access = False
+                _debug_log(f"[run] codex skip_permissions check failed: {e}")
+            _mission_mode = (autonomous_mode or "implement").lower()
+            if not _codex_full_access and _mission_mode in {"implement", "deep"}:
+                log(
+                    "warning",
+                    "Codex workspace-write sandbox may make .git read-only; "
+                    "branch, commit, push, and PR creation can fail. "
+                    "Set skip_permissions: true when Koan runs in a trusted "
+                    "external sandbox and Codex should use git directly.",
+                )
 
         # Generate plugin directory so Claude CLI can discover Kōan skills
         plugin_dirs = None

--- a/koan/tests/test_codex_provider.py
+++ b/koan/tests/test_codex_provider.py
@@ -153,9 +153,11 @@ class TestCodexProvider:
 
     # -- Permission args --
 
-    def test_permission_args_yolo(self):
-        """skip_permissions=True maps to --yolo."""
-        assert self.provider.build_permission_args(True) == ["--yolo"]
+    def test_permission_args_full_access(self):
+        """skip_permissions=True bypasses Codex approvals and sandbox."""
+        assert self.provider.build_permission_args(True) == [
+            "--dangerously-bypass-approvals-and-sandbox"
+        ]
 
     def test_permission_args_sandbox(self):
         """skip_permissions=False maps to --sandbox workspace-write."""
@@ -184,7 +186,7 @@ class TestCodexBuildCommand:
     def test_with_skip_permissions(self):
         cmd = self.provider.build_command(prompt="hello", skip_permissions=True)
         assert cmd[0] == "codex"
-        assert "--yolo" in cmd
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "--sandbox" not in cmd
         assert "exec" in cmd
         assert "hello" in cmd
@@ -202,12 +204,12 @@ class TestCodexBuildCommand:
         exec_idx = cmd.index("exec")
         assert model_idx > exec_idx
 
-    def test_yolo_after_exec(self):
+    def test_full_access_after_exec(self):
         """Permission flags must appear after 'exec'."""
         cmd = self.provider.build_command(prompt="hello", skip_permissions=True)
-        yolo_idx = cmd.index("--yolo")
+        full_access_idx = cmd.index("--dangerously-bypass-approvals-and-sandbox")
         exec_idx = cmd.index("exec")
-        assert yolo_idx > exec_idx
+        assert full_access_idx > exec_idx
 
     def test_system_prompt_prepended(self):
         """System prompt is prepended to user prompt (no native flag)."""
@@ -269,7 +271,7 @@ class TestCodexBuildCommand:
         )
         assert cmd[0] == "codex"
         assert cmd[1] == "exec"
-        assert "--yolo" in cmd
+        assert "--dangerously-bypass-approvals-and-sandbox" in cmd
         assert "--model" in cmd
         # Prompt is the last element and contains both system + user prompt
         prompt_text = cmd[-1]

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -1341,7 +1341,9 @@ class TestCodexProvider:
             assert p.is_available() is True
         with patch("app.provider.codex.shutil.which", return_value=None):
             assert p.is_available() is False
-        assert p.build_permission_args(True) == ["--yolo"]
+        assert p.build_permission_args(True) == [
+            "--dangerously-bypass-approvals-and-sandbox"
+        ]
         assert p.build_permission_args(False) == ["--sandbox", "workspace-write"]
         assert p.build_prompt_args("hi") == ["exec", "hi"]
         assert p.build_tool_args(allowed_tools=["Bash"]) == []
@@ -1358,7 +1360,11 @@ class TestCodexProvider:
         from app.provider.codex import CodexProvider
         p = CodexProvider()
         cmd = p.build_command(prompt="hello", model="gpt-5", skip_permissions=True)
-        assert cmd[0] == "codex" and "--yolo" in cmd and "exec" in cmd
+        assert (
+            cmd[0] == "codex"
+            and "--dangerously-bypass-approvals-and-sandbox" in cmd
+            and "exec" in cmd
+        )
 
     def test_build_command_prepends_system_prompt(self):
         from app.provider.codex import CodexProvider


### PR DESCRIPTION
Replace deprecated --yolo with --dangerously-bypass-approvals-and-sandbox for Codex full-access mode. Warn at mission start when Codex runs without skip_permissions in implement/deep modes, since workspace-write may mount .git read-only and block branch/commit/push/PR operations.