### PR TITLE
fix(review): recover review JSON from preamble with brace tokens and …

### DIFF
--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -641,12 +641,13 @@ def _format_error_hunter_findings(findings: list) -> str:
     return "\n".join(lines).rstrip()
 
 
-def _extract_review_body(raw_output: str) -> str:
+def _extract_review_body(raw_output: str) -> Optional[str]:
     """Extract structured review from Claude's raw output.
 
-    Tries to find markdown-structured review content. If the output
-    looks like JSON, attempts to parse and format it as markdown.
-    Falls back to the full output if no structure is detected.
+    Tries to find markdown-structured review content. If the output looks
+    like JSON, attempts to parse and format it as markdown. Returns None
+    when no structure can be recovered — callers MUST NOT post raw model
+    output to a PR (see the guardrail in ``run_review``).
     """
     # Look for the new format: ## PR Review — ...
     match = re.search(r'(## PR Review\b.*)', raw_output, re.DOTALL)
@@ -670,27 +671,88 @@ def _extract_review_body(raw_output: str) -> str:
         except (json.JSONDecodeError, ValueError):
             pass
 
-    # Fall back to full output (Claude may format differently)
-    return raw_output.strip()
+    # No structured review could be recovered. Signal failure rather than
+    # leaking raw narration / JSON to the PR.
+    return None
+
+
+def _is_parseable_json(text: str) -> bool:
+    """Return True if ``text`` parses as any JSON value (object, array, scalar)."""
+    try:
+        json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return False
+    return True
+
+
+def _loads_object_or_none(candidate: str) -> Optional[dict]:
+    """json.loads ``candidate``, returning the dict or None on failure.
+
+    Extracted so callers can attempt parsing inside a loop without a
+    per-iteration try/except (PERF203).
+    """
+    try:
+        decoded = json.loads(candidate)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    return decoded if isinstance(decoded, dict) else None
+
+
+def _match_balanced_object(text: str, start: int) -> Optional[str]:
+    """Return the balanced ``{ ... }`` substring beginning at ``start``.
+
+    Tracks string context so braces inside JSON string values — and any
+    markdown code fences embedded in those strings — do not affect nesting
+    depth. Returns None if the braces never balance.
+    """
+    depth = 0
+    in_string = False
+    escape = False
+    for i in range(start, len(text)):
+        c = text[i]
+        if escape:
+            escape = False
+            continue
+        if c == "\\":
+            escape = True
+            continue
+        if c == '"':
+            in_string = not in_string
+            continue
+        if in_string:
+            continue
+        if c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:i + 1]
+    return None
 
 
 def _extract_json_text(text: str) -> Optional[str]:
     """Extract a JSON object string from text that may contain surrounding prose.
 
-    Tries multiple strategies:
-    1. Direct parse of the full text (pure JSON)
-    2. Strip markdown code fences (```json ... ```)
-    3. Extract JSON from code fences anywhere in the text
-    4. Find the outermost { ... } in the text
+    Tries, in order:
+    1. Direct parse of the full text (pure JSON).
+    2. Strip markdown code fences wrapping the entire text (```json ... ```).
+    3. Scan every ``{`` in the text, brace-match a balanced object at each
+       (respecting string context), and return the largest substring that
+       decodes to a JSON object.
+
+    Strategy 3 is deliberately robust to two failure modes that previously
+    caused raw model output to be posted to a PR: preamble prose containing
+    brace-like tokens (e.g. GitHub Actions ``${{ ... }}`` expressions, whose
+    leading ``{`` would otherwise hijack a first-brace-only matcher) and
+    markdown code fences embedded inside JSON string values (which defeat
+    fence-based regexes). The largest balanced object wins because the review
+    object always wraps its nested file-comment objects.
     """
     stripped = text.strip()
 
     # Strategy 1: pure JSON
-    try:
-        json.loads(stripped)
+    if _is_parseable_json(stripped):
         return stripped
-    except (json.JSONDecodeError, ValueError):
-        pass
 
     # Strategy 2: text wrapped entirely in code fences
     fence_stripped = stripped
@@ -701,54 +763,23 @@ def _extract_json_text(text: str) -> Optional[str]:
     if fence_stripped.endswith("```"):
         fence_stripped = fence_stripped[:-3]
     fence_stripped = fence_stripped.strip()
-    if fence_stripped != stripped:
-        try:
-            json.loads(fence_stripped)
-            return fence_stripped
-        except (json.JSONDecodeError, ValueError):
-            pass
+    if fence_stripped != stripped and _is_parseable_json(fence_stripped):
+        return fence_stripped
 
-    # Strategy 3: code fences embedded in surrounding text
-    fence_match = re.search(r'```(?:json)?\s*(\{.*?\})\s*```', stripped, re.DOTALL)
-    if fence_match:
-        candidate = fence_match.group(1).strip()
-        try:
-            json.loads(candidate)
-            return candidate
-        except (json.JSONDecodeError, ValueError):
-            pass
-
-    # Strategy 4: find outermost { ... } with brace matching
-    start = stripped.find("{")
-    if start != -1:
-        depth = 0
-        in_string = False
-        escape = False
-        for i in range(start, len(stripped)):
-            c = stripped[i]
-            if escape:
-                escape = False
-                continue
-            if c == "\\":
-                escape = True
-                continue
-            if c == '"':
-                in_string = not in_string
-                continue
-            if in_string:
-                continue
-            if c == "{":
-                depth += 1
-            elif c == "}":
-                depth -= 1
-                if depth == 0:
-                    candidate = stripped[start:i + 1]
-                    try:
-                        json.loads(candidate)
-                        return candidate
-                    except (json.JSONDecodeError, ValueError):
-                        break
-    return None
+    # Strategy 3: scan every '{' and keep the largest balanced object that
+    # decodes to a JSON object.
+    best: Optional[str] = None
+    pos = stripped.find("{")
+    while pos != -1:
+        candidate = _match_balanced_object(stripped, pos)
+        if (
+            candidate is not None
+            and _loads_object_or_none(candidate) is not None
+            and (best is None or len(candidate) > len(best))
+        ):
+            best = candidate
+        pos = stripped.find("{", pos + 1)
+    return best
 
 
 def _parse_review_json(raw_output: str) -> Optional[dict]:
@@ -788,6 +819,13 @@ _SEVERITY_HEADING = {
     "warning": "Important",
     "suggestion": "Suggestions",
 }
+
+# Posted to the PR when the model's output cannot be parsed into the structured
+# review format. A short placeholder is posted instead of raw narration / JSON.
+_UNPARSEABLE_REVIEW_NOTICE = (
+    "⚠️ The automated review could not be formatted into the standard "
+    "structure. Re-run `/review` to retry."
+)
 
 
 def _format_review_as_markdown(review_data: dict, title: str = "", bot_username: str = "") -> str:
@@ -1372,6 +1410,20 @@ def run_review(
             file=sys.stderr,
         )
         review_body = _extract_review_body(raw_output)
+        if review_body is None:
+            # Guardrail: never post raw model output (narration / JSON) to a PR.
+            # Post a short placeholder and alert a human to re-run.
+            print(
+                "[review_runner] review output unparseable; "
+                "posting placeholder notice",
+                file=sys.stderr,
+            )
+            notify_fn(
+                f"⚠️ Review for PR #{pr_number}: model output couldn't be "
+                "parsed into the structured format; posted a placeholder. "
+                "Re-run /review to retry."
+            )
+            review_body = _UNPARSEABLE_REVIEW_NOTICE
 
     # Step 6: Post replies to user comments
     reply_count = 0

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -255,15 +255,15 @@ class TestExtractReviewBody:
         result = _extract_review_body(raw)
         assert result.startswith("## PR Review")
 
-    def test_fallback_to_full_output(self):
-        """When no structured format found, returns full text."""
+    def test_unstructured_output_returns_none(self):
+        """Guardrail: when no structured review can be recovered, returns None
+        rather than leaking raw model output to the PR."""
         raw = "This is a freeform review. Code is fine."
-        result = _extract_review_body(raw)
-        assert result == raw
+        assert _extract_review_body(raw) is None
 
-    def test_empty_input(self):
-        """Empty input returns empty string."""
-        assert _extract_review_body("") == ""
+    def test_empty_input_returns_none(self):
+        """Empty input yields no structured review -> None."""
+        assert _extract_review_body("") is None
 
     def test_whitespace_stripped(self):
         """Leading/trailing whitespace is removed."""
@@ -378,6 +378,48 @@ class TestExtractJsonText:
         assert "file_comments" in data
         assert "review_summary" in data
 
+    def test_preamble_with_github_actions_expression(self):
+        """Regression: preamble mentioning ${{ ... }} must not hijack extraction.
+
+        The first '{' in the text is inside a GitHub Actions expression, which
+        a first-brace-only matcher would latch onto and fail. The real object
+        must still be recovered.
+        """
+        obj = {"file_comments": [], "review_summary": {"lgtm": True}}
+        text = (
+            "The workflow uses `${{ steps.parse.outputs.name }}` inline in a "
+            "shell block (an injection vector).\n\n" + json.dumps(obj)
+        )
+        result = _extract_json_text(text)
+        assert result is not None
+        assert json.loads(result)["review_summary"]["lgtm"] is True
+
+    def test_returns_largest_object_skipping_decoys(self):
+        """Picks the largest valid object, skipping a small decoy {} and a
+        brace-token from preamble."""
+        big = {"file_comments": [], "review_summary": {"summary": "x" * 50}}
+        text = "Note ${{ x }} and an empty {} then:\n\n" + json.dumps(big)
+        result = _extract_json_text(text)
+        assert result is not None
+        assert json.loads(result) == big
+
+    def test_object_with_embedded_code_fences_in_strings(self):
+        """JSON whose string values contain ``` fences must still extract.
+
+        Fence-regex strategies break on embedded fences; the brace-matcher
+        respects string context and recovers the whole object.
+        """
+        obj = {
+            "file_comments": [],
+            "review_summary": {
+                "summary": "Use:\n```bash\ngh pr create || echo done\n```\nDone.",
+            },
+        }
+        text = "Here is the review:\n\n```json\n" + json.dumps(obj) + "\n```\n"
+        result = _extract_json_text(text)
+        assert result is not None
+        assert "```bash" in json.loads(result)["review_summary"]["summary"]
+
 
 # ---------------------------------------------------------------------------
 # _parse_review_json
@@ -412,6 +454,58 @@ LGTM_REVIEW_JSON = {
         "checklist": [],
     },
 }
+
+# Mirrors the real PR #40 regression: workflow-file review where the model
+# emitted narration containing a ${{ ... }} expression *before* a fenced JSON
+# object whose string values themselves contain ```bash code fences.
+_PR40_REVIEW_OBJ = {
+    "file_comments": [
+        {
+            "file": ".github/workflows/evaluate.yml",
+            "line_start": 88,
+            "line_end": 88,
+            "severity": "critical",
+            "title": "Command injection via expression interpolation",
+            "comment": "Move the value into an env block:\n```bash\nenv:\n  NAME: ${{ steps.parse.outputs.name }}\n```\nThen reference $NAME.",
+            "code_snippet": "run: echo ${{ steps.parse.outputs.name }}",
+        },
+        {
+            "file": ".github/workflows/evaluate.yml",
+            "line_start": 90,
+            "line_end": 90,
+            "severity": "warning",
+            "title": "`|| echo` swallows all failures",
+            "comment": "Check the exit code instead.",
+            "code_snippet": "|| echo \"exists\"",
+        },
+        {
+            "file": "scripts/validate.js",
+            "line_start": 10,
+            "line_end": 10,
+            "severity": "suggestion",
+            "title": "Reject symlinks in traversal",
+            "comment": "Use isSymbolicLink().",
+            "code_snippet": "",
+        },
+    ],
+    "review_summary": {
+        "lgtm": False,
+        "summary": "Solid security-focused PR with two items to address.",
+        "checklist": [
+            {"item": "No command injection", "passed": False, "finding_ref": "critical #1"},
+        ],
+    },
+    "comment_replies": [],
+}
+
+PR40_LIKE_RAW = (
+    "Now I have the full picture. The workflow uses "
+    "`${{ steps.parse.outputs.name }}` inline in shell `run:` blocks "
+    "(a known GitHub Actions injection vector).\n\n"
+    "Let me also verify the parse step is safe.\n\n"
+    "Good — the parse step uses `${GITHUB_REF#refs/tags/}` which is safe.\n\n"
+    "```json\n" + json.dumps(_PR40_REVIEW_OBJ) + "\n```\n"
+)
 
 
 class TestParseReviewJson:
@@ -492,6 +586,24 @@ class TestParseReviewJson:
         )
         result = _parse_review_json(raw)
         assert result is not None
+
+    def test_pr40_regression_parses_and_renders_buckets(self):
+        """The PR #40 regression end-to-end: narration with a ${{ }} expression
+        plus a fenced JSON object containing embedded ```bash fences must parse
+        and render into severity buckets (not be posted as raw JSON)."""
+        result = _parse_review_json(PR40_LIKE_RAW)
+        assert result is not None
+        assert {"file_comments", "review_summary"} <= result.keys()
+        assert len(result["file_comments"]) == 3
+
+        md = _format_review_as_markdown(result, title="Security hardening")
+        assert "## PR Review — Security hardening" in md
+        assert "### 🔴 Blocking" in md
+        assert "### 🟡 Important" in md
+        assert "### 🟢 Suggestions" in md
+        # The raw JSON envelope must not leak into the rendered comment.
+        assert '"file_comments"' not in md
+        assert "```json" not in md
 
 
 # ---------------------------------------------------------------------------
@@ -729,6 +841,43 @@ class TestRunReview:
         # Claude called twice (initial + retry)
         assert mock_claude.call_count == 2
         mock_gh.assert_called_once()
+
+    @patch("app.review_runner._fetch_pr_commit_shas", return_value=[])
+    @patch("app.review_runner._run_error_hunter", return_value="")
+    @patch("app.review_runner.fetch_repliable_comments", return_value=[])
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner._run_claude_review")
+    @patch("app.review_runner.fetch_pr_context")
+    def test_unparseable_output_posts_placeholder_not_raw(
+        self, mock_fetch, mock_claude, mock_gh, mock_repliable,
+        _mock_hunter, _mock_shas, pr_context, review_skill_dir,
+    ):
+        """Guardrail: when neither attempt yields parseable/structured output,
+        post a short placeholder (never the raw narration) and alert a human."""
+        mock_fetch.return_value = pr_context
+        raw_junk = (
+            "Sorry — I was unable to produce a structured review here; "
+            "these are some loose notes about the diff."
+        )
+        mock_claude.return_value = (raw_junk, "")
+        mock_notify = MagicMock()
+
+        success, summary, review_data = run_review(
+            "owner", "repo", "42", "/tmp/project",
+            notify_fn=mock_notify,
+            skill_dir=review_skill_dir,
+        )
+
+        assert review_data is None
+        assert mock_claude.call_count == 2  # initial + retry
+        mock_gh.assert_called_once()
+
+        posted_body = mock_gh.call_args.args[-1]
+        assert "could not be formatted" in posted_body
+        assert "loose notes about the diff" not in posted_body  # raw never posted
+
+        alerts = [str(c.args[0]) for c in mock_notify.call_args_list if c.args]
+        assert any("couldn't be parsed" in a for a in alerts)
 
     @patch("app.review_runner._reflect_findings", side_effect=lambda findings, *a, **kw: findings)
     @patch("app.review_runner.fetch_repliable_comments", return_value=[])


### PR DESCRIPTION
…embedded fences

Code reviews were posting the model's raw output (thinking narration plus a fenced JSON dump) to the PR instead of the formatted severity buckets. The JSON-extraction helper introduced in 2d79bb91 failed on two inputs that occur together when reviewing a GitHub Actions workflow:

- Its brace-matcher started at the first `{`, which landed inside a `${{ ... }}` expression quoted in the model's preamble, and gave up on the first parse failure — never reaching the real review object.
- Its fence-based strategies broke on ``` code fences the model embedded inside JSON string values.

With no JSON recovered, the fallback posted the raw output verbatim.

Replace the fragile fence-regex + first-brace-only logic with a scan over every `{` that returns the largest balanced JSON object (string-aware matcher, so braces and fences inside string values no longer interfere). As a guardrail, _extract_review_body now returns None on genuine failure and run_review posts a short placeholder note plus a Telegram alert rather than ever leaking raw model output to a PR.

Verified by replaying the real failing PR payload through the parser: it now renders proper severity buckets with no JSON envelope.