### PR TITLE
fix(skills): /implement and /fix commit onto base branch when base_branch is not main/master (#1588)

### DIFF
--- a/koan/app/pr_submit.py
+++ b/koan/app/pr_submit.py
@@ -9,7 +9,7 @@ import logging
 import os
 import subprocess
 from pathlib import Path
-from typing import List, Optional
+from typing import Callable, List, Optional
 
 from app.git_utils import (
     get_commit_subjects as _git_get_commit_subjects,
@@ -112,11 +112,14 @@ def submit_draft_pr(
     pr_body: str,
     issue_url: Optional[str] = None,
     base_branch: Optional[str] = None,
+    notify_fn: Optional[Callable[[str], None]] = None,
 ) -> Optional[str]:
     """Push branch and create a draft PR.
 
     Handles the full PR submission pipeline:
-    1. Check current branch (skip if on main/master)
+    1. Resolve the project's base branch; abort if HEAD is *on* that base
+       branch (or on main/master) — committing there means the skill failed
+       to create a feature branch and there's nothing diff-able to push.
     2. Check for existing PR on this branch
     3. Push branch to origin
     4. Resolve submit target (config, fork detection, fallback)
@@ -135,13 +138,34 @@ def submit_draft_pr(
         base_branch: Optional target branch for the PR (e.g. "11.126").
             When set, overrides the auto-resolved base branch for both
             commit diffing and the PR's --base flag.
+        notify_fn: Optional callable invoked with a one-line human-readable
+            reason when PR submission fails (push error, gh error, no commits,
+            HEAD landed on the base branch). Lets callers surface the failure
+            to Telegram instead of leaving it in logs only.
 
     Returns:
         PR URL on success, or None on failure.
     """
     branch = get_current_branch(project_path)
-    if branch in ("main", "master"):
-        logger.info("On %s — skipping PR creation", branch)
+
+    # Resolve the effective base branch up-front: it gates both the "HEAD is
+    # on the base" guard below AND the empty-diff check further down. Before
+    # this fix, the guard hardcoded `("main", "master")` and let projects
+    # configured with `base_branch: staging` (or any non-main/master base)
+    # slip through, so Claude would commit straight onto staging and the
+    # post-implementation PR submission silently no-op'd on the empty diff.
+    effective_base = base_branch or resolve_base_branch(project_name, project_path)
+
+    if branch == effective_base or branch in ("main", "master"):
+        reason = (
+            f"HEAD is on the base branch '{branch}' — the skill committed "
+            "without first creating a feature branch, so there is nothing "
+            "to push as a PR. The commits remain on your local base branch "
+            "until you move them onto a feature branch manually."
+        )
+        logger.warning(reason)
+        if notify_fn:
+            notify_fn(f"❌ PR creation aborted: {reason}")
         return None
 
     # Check for existing PR on this branch
@@ -157,10 +181,14 @@ def submit_draft_pr(
         logger.debug("No existing PR found (or check failed): %s", e)
 
     # Verify we have commits to submit
-    effective_base = base_branch or resolve_base_branch(project_name, project_path)
     commits = get_commit_subjects(project_path, base_branch=effective_base)
     if not commits:
-        logger.info("No commits on branch — skipping PR creation")
+        reason = (
+            f"No commits found on '{branch}' relative to '{effective_base}'."
+        )
+        logger.info("%s — skipping PR creation", reason)
+        if notify_fn:
+            notify_fn(f"❌ PR creation skipped: {reason}")
         return None
 
     # Push branch
@@ -170,7 +198,10 @@ def submit_draft_pr(
             cwd=project_path, timeout=120,
         )
     except (RuntimeError, OSError, subprocess.SubprocessError) as e:
-        logger.warning("Failed to push branch: %s", e)
+        reason = f"git push failed: {str(e)[:300]}"
+        logger.warning(reason)
+        if notify_fn:
+            notify_fn(f"❌ PR creation failed — {reason}")
         return None
 
     # Resolve where to submit
@@ -195,7 +226,10 @@ def submit_draft_pr(
     try:
         pr_url = pr_create(**pr_kwargs)
     except (RuntimeError, OSError, subprocess.SubprocessError) as e:
-        logger.warning("Failed to create PR: %s", e)
+        reason = f"gh pr create failed: {str(e)[:300]}"
+        logger.warning(reason)
+        if notify_fn:
+            notify_fn(f"❌ PR creation failed — {reason}")
         return None
 
     # Comment on the source issue with the PR link. The issue may live in

--- a/koan/skills/core/fix/fix_runner.py
+++ b/koan/skills/core/fix/fix_runner.py
@@ -110,6 +110,15 @@ def run_fix(
     # Build full issue body (include relevant comments)
     full_body = _build_issue_body(body, comments)
 
+    # Resolve effective base branch once and feed it through the whole
+    # pipeline: the fix prompt needs it so Claude knows which branch counts
+    # as "the base" for this project (e.g. `staging`), and the post-fix PR
+    # submission + base-branch guard reuse the same resolution.
+    from app.projects_config import resolve_base_branch
+    effective_base_branch = base_branch or resolve_base_branch(
+        project_name, project_path,
+    )
+
     # Invoke Claude with the fix prompt
     print("[fix] Invoking Claude for fix", flush=True)
     try:
@@ -123,6 +132,7 @@ def run_fix(
             issue_number=str(issue_number),
             project_name=project_name,
             instance_dir=instance_dir,
+            base_branch=effective_base_branch,
         )
     except Exception as e:
         return False, f"Fix failed: {str(e)[:300]}"
@@ -142,10 +152,12 @@ def run_fix(
             issue_url=issue_url,
             base_branch=base_branch,
             project_name=project_name,
+            notify_fn=notify_fn,
         )
 
     # Build notification and summary
     branch = get_current_branch(project_path)
+    on_base_branch = branch in (effective_base_branch, "main", "master")
     if pr_url:
         notify_fn(
             f"✅ Fix complete for issue {label}"
@@ -155,10 +167,10 @@ def run_fix(
             f"Fix complete for {label}{context_label}"
             f"\nDraft PR: {pr_url}"
         )
-    elif branch not in ("main", "master"):
+    elif not on_base_branch:
         skip_reason = (
             " (PR creation skipped)" if provider != "github"
-            else " (PR creation failed)"
+            else " (PR creation failed — see prior message for details)"
         )
         notify_fn(
             f"✅ Fix complete for issue {label}"
@@ -171,11 +183,14 @@ def run_fix(
     else:
         notify_fn(
             f"⚠️ Fix complete for issue {label}"
-            f"{context_label} — changes landed on {branch}, no PR created"
+            f"{context_label} — changes landed on the base branch "
+            f"`{branch}`, no PR created. The skill failed to create a "
+            "feature branch; move the commits onto a feature branch "
+            "manually before pushing."
         )
         summary = (
             f"Fix complete for {label}{context_label}"
-            f" (on {branch}, no PR)"
+            f" (on base branch {branch}, no PR)"
         )
 
     return True, summary
@@ -213,12 +228,17 @@ def _execute_fix(
     issue_number: str = "",
     project_name: str = "",
     instance_dir: str = "",
+    base_branch: Optional[str] = None,
 ) -> str:
     """Execute the fix via Claude CLI."""
     from app.config import get_branch_prefix
+    from app.projects_config import resolve_base_branch
     from app.skill_memory import build_memory_block_for_skill
 
     branch_prefix = get_branch_prefix()
+    effective_base = base_branch or resolve_base_branch(
+        project_name or guess_project_name(project_path), project_path,
+    )
     project_memory = build_memory_block_for_skill(
         project_path,
         f"{issue_title}\n{issue_body}",
@@ -231,6 +251,7 @@ def _execute_fix(
         branch_prefix=branch_prefix,
         issue_number=issue_number,
         project_memory=project_memory,
+        base_branch=effective_base,
     )
 
     from app.cli_provider import CLAUDE_TOOLS, run_command_streaming
@@ -251,6 +272,7 @@ def _build_prompt(
     branch_prefix: str = "koan/",
     issue_number: str = "",
     project_memory: str = "",
+    base_branch: str = "main",
 ) -> str:
     """Build the fix prompt from the issue content."""
     template_vars = dict(
@@ -261,6 +283,7 @@ def _build_prompt(
         BRANCH_PREFIX=branch_prefix,
         ISSUE_NUMBER=issue_number,
         PROJECT_MEMORY=project_memory,
+        BASE_BRANCH=base_branch,
     )
 
     return load_prompt_or_skill(skill_dir, "fix", **template_vars)
@@ -279,6 +302,7 @@ def _submit_fix_pr(
     issue_url: str,
     base_branch: Optional[str] = None,
     project_name: str = "",
+    notify_fn=None,
 ) -> Optional[str]:
     """Build fix-specific PR title/body and delegate to shared submit."""
     from app.pr_submit import get_commit_subjects
@@ -320,9 +344,15 @@ def _submit_fix_pr(
             pr_body=pr_body,
             issue_url=issue_url,
             base_branch=base_branch,
+            notify_fn=notify_fn,
         )
     except Exception as e:
         logger.warning("PR submission failed: %s", e)
+        if notify_fn:
+            notify_fn(
+                f"❌ PR submission raised "
+                f"{type(e).__name__}: {str(e)[:200]}"
+            )
         return None
 
 

--- a/koan/skills/core/fix/prompts/fix.md
+++ b/koan/skills/core/fix/prompts/fix.md
@@ -29,6 +29,8 @@ You are fixing an issue from the configured issue tracker. Your job is to unders
 
 Branch naming: `{BRANCH_PREFIX}fix-issue-{ISSUE_NUMBER}`
 
+**Mandatory before any commit**: the repository's base branch for this project is `{BASE_BRANCH}`. If you are currently on `{BASE_BRANCH}`, on `main`, or on `master`, create and switch to the branch named above before making any changes. **Never commit on `{BASE_BRANCH}`, `main`, or `master` directly** — that leaves the work on a base branch where no PR can be opened and is treated as a failed mission. If you are already on a feature branch (anything other than `{BASE_BRANCH}`, `main`, or `master`), stay on it.
+
 {@include implementation-workflow}
 
 ## Rules

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -140,6 +140,14 @@ def run_implement(
     elif gate_result is not None:
         return gate_result
 
+    # Resolve the effective base branch once; both the implementation prompt
+    # and the post-implementation guard need to agree on what counts as
+    # "the base branch" for this project (e.g. `staging` on anantys-back).
+    from app.projects_config import resolve_base_branch
+    effective_base_branch = base_branch or resolve_base_branch(
+        project_name or guess_project_name(project_path), project_path,
+    )
+
     # Invoke Claude with the plan
     effective_context = (context or "Implement the full plan.") + improvement_context
     try:
@@ -153,6 +161,7 @@ def run_implement(
             issue_number=str(issue_number),
             project_name=project_name,
             instance_dir=instance_dir,
+            base_branch=effective_base_branch,
         )
     except Exception as e:
         return False, f"Implementation failed: {str(e)[:300]}"
@@ -174,13 +183,19 @@ def run_implement(
                 skill_dir=skill_dir,
                 base_branch=base_branch,
                 project_name=project_name,
+                notify_fn=notify_fn,
             )
         except (RuntimeError, OSError, ValueError,
                 subprocess.SubprocessError) as e:
             logger.warning("PR submission failed: %s", e)
+            notify_fn(
+                f"\u274c PR submission for issue {label} raised "
+                f"{type(e).__name__}: {str(e)[:200]}"
+            )
 
     # Build notification and summary
     branch = get_current_branch(project_path)
+    on_base_branch = branch in (effective_base_branch, "main", "master")
     if pr_url:
         notify_fn(
             f"\u2705 Implementation complete for issue {label}"
@@ -190,11 +205,14 @@ def run_implement(
             f"Implementation complete for {label}{context_label}"
             f"\nDraft PR: {pr_url}"
         )
-    elif branch not in ("main", "master"):
+    elif not on_base_branch:
+        skip_reason = (
+            " (PR creation skipped)" if provider != "github"
+            else " (PR creation failed \u2014 see prior message for details)"
+        )
         notify_fn(
             f"\u2705 Implementation complete for issue {label}"
-            f"{context_label}\nBranch: {branch}"
-            f"{'' if pr_url else ' (PR creation skipped)' if provider != 'github' else ' (PR creation failed)'}"
+            f"{context_label}\nBranch: {branch}{skip_reason}"
         )
         summary = (
             f"Implementation complete for {label}{context_label}"
@@ -203,11 +221,14 @@ def run_implement(
     else:
         notify_fn(
             f"\u26a0\ufe0f Implementation complete for issue {label}"
-            f"{context_label} \u2014 changes landed on {branch}, no PR created"
+            f"{context_label} \u2014 changes landed on the base branch "
+            f"`{branch}`, no PR created. The skill failed to create a "
+            "feature branch; move the commits onto a feature branch "
+            "manually before pushing."
         )
         summary = (
             f"Implementation complete for {label}{context_label}"
-            f" (on {branch}, no PR)"
+            f" (on base branch {branch}, no PR)"
         )
 
     return True, summary
@@ -421,6 +442,7 @@ def _build_prompt(
     branch_prefix: str = "koan/",
     issue_number: str = "",
     project_memory: str = "",
+    base_branch: str = "main",
 ) -> str:
     """Build the implementation prompt from the issue and plan."""
     template_vars = dict(
@@ -431,6 +453,7 @@ def _build_prompt(
         BRANCH_PREFIX=branch_prefix,
         ISSUE_NUMBER=issue_number,
         PROJECT_MEMORY=project_memory,
+        BASE_BRANCH=base_branch,
     )
 
     return load_prompt_or_skill(skill_dir, "implement", **template_vars)
@@ -484,12 +507,17 @@ def _execute_implementation(
     issue_number: str = "",
     project_name: str = "",
     instance_dir: str = "",
+    base_branch: Optional[str] = None,
 ) -> str:
     """Execute the implementation via Claude CLI."""
     from app.config import get_branch_prefix
+    from app.projects_config import resolve_base_branch
     from app.skill_memory import build_memory_block_for_skill
 
     branch_prefix = get_branch_prefix()
+    effective_base = base_branch or resolve_base_branch(
+        project_name or guess_project_name(project_path), project_path,
+    )
     project_memory = build_memory_block_for_skill(
         project_path,
         f"{issue_title}\n{plan}",
@@ -502,6 +530,7 @@ def _execute_implementation(
         branch_prefix=branch_prefix,
         issue_number=issue_number,
         project_memory=project_memory,
+        base_branch=effective_base,
     )
 
     from app.cli_provider import CLAUDE_TOOLS, run_command_streaming
@@ -527,6 +556,7 @@ def _submit_implement_pr(
     skill_dir: Optional[Path] = None,
     base_branch: Optional[str] = None,
     project_name: str = "",
+    notify_fn=None,
 ) -> Optional[str]:
     """Build implement-specific PR title/body and delegate to shared submit."""
     from app.pr_submit import get_commit_subjects
@@ -570,9 +600,15 @@ def _submit_implement_pr(
             pr_body=pr_body,
             issue_url=issue_url,
             base_branch=base_branch,
+            notify_fn=notify_fn,
         )
     except Exception as e:
         logger.warning("PR submission failed: %s", e)
+        if notify_fn:
+            notify_fn(
+                f"❌ PR submission raised "
+                f"{type(e).__name__}: {str(e)[:200]}"
+            )
         return None
 
 

--- a/koan/skills/core/implement/prompts/implement.md
+++ b/koan/skills/core/implement/prompts/implement.md
@@ -17,7 +17,7 @@ You are implementing a plan from the configured issue tracker. Your job is to re
 
 1. **Read the plan carefully**: Understand the overall goal, the phases, and the acceptance criteria for each phase.
 
-2. **Create a dedicated branch**: If you are currently on `main` or `master`, create a new branch before making any changes: `{BRANCH_PREFIX}implement-{ISSUE_NUMBER}`. If you are already on a feature branch, stay on it.
+2. **Create a dedicated branch — mandatory before any commit**: The repository's base branch for this project is `{BASE_BRANCH}`. If you are currently on `{BASE_BRANCH}`, on `main`, or on `master`, you MUST create a new branch named `{BRANCH_PREFIX}implement-{ISSUE_NUMBER}` before making any changes. **Never commit on `{BASE_BRANCH}`, `main`, or `master` directly** — that leaves the work on a base branch where no PR can be opened and is treated as a failed mission. If you are already on a feature branch (anything other than `{BASE_BRANCH}`, `main`, or `master`), stay on it.
 
 3. **Explore the codebase first**: Use Read, Glob, and Grep to understand the current state of the code. Verify that assumptions in the plan still hold — the codebase may have changed since the plan was written.
 

--- a/koan/system-prompts/_partials/implementation-workflow.md
+++ b/koan/system-prompts/_partials/implementation-workflow.md
@@ -8,7 +8,7 @@
 
 For each phase in your plan:
 
-9. **Create a branch** (first phase only) following the branch naming specified above. If already on a feature branch, stay on it.
+9. **Create a feature branch — mandatory** (first phase only). If you are currently on the base branch `{BASE_BRANCH}` (or on `main` / `master`), create the feature branch now using the naming specified earlier in this prompt and switch to it before the first edit. **Never commit on the base branch.** If you are already on a feature branch (anything other than `{BASE_BRANCH}`, `main`, or `master`), stay on it.
 10. **Implement the change.** Edit the minimal set of files needed. Follow project conventions strictly.
 11. **Run tests** to verify. Fix any failures before proceeding.
 12. **Commit** with a clear message describing what this phase does.

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -618,6 +618,7 @@ class TestBuildPrompt:
                 BRANCH_PREFIX="koan/",
                 ISSUE_NUMBER="",
                 PROJECT_MEMORY="",
+                BASE_BRANCH="main",
             )
             assert result == "prompt"
 
@@ -635,8 +636,21 @@ class TestBuildPrompt:
                 BRANCH_PREFIX="koan/",
                 ISSUE_NUMBER="",
                 PROJECT_MEMORY="",
+                BASE_BRANCH="main",
             )
             assert result == "prompt"
+
+    def test_base_branch_propagates_into_prompt_template_vars(self):
+        """BASE_BRANCH must reach load_prompt_or_skill so the rendered prompt
+        names the project's actual base (e.g. `staging`) — otherwise Claude
+        falls back to the hardcoded main/master branch-creation rule and
+        commits onto the base branch (regression seen on aback)."""
+        with patch(f"{_IMPL_MODULE}.load_prompt_or_skill", return_value="p") as mock_load:
+            _build_prompt(
+                "http://url", "Title", "Plan", "Context",
+                base_branch="staging",
+            )
+            assert mock_load.call_args.kwargs["BASE_BRANCH"] == "staging"
 
     def test_prompt_includes_pr_creation_step(self):
         """implement.md must instruct Claude to push and create a draft PR."""
@@ -651,12 +665,34 @@ class TestBuildPrompt:
             CONTEXT="ctx",
             BRANCH_PREFIX="koan/",
             ISSUE_NUMBER="42",
+            BASE_BRANCH="main",
         )
         assert "gh pr create --draft" in prompt
         assert "git push" in prompt
         assert "Closes https://github.com/o/r/issues/42" in prompt
         assert "{KOAN_PYTHON}" not in prompt
         assert " -m app.issue_cli" in prompt
+
+    def test_prompt_mentions_resolved_base_branch_so_claude_branches_off_it(self):
+        """When the project's base branch is not main/master (e.g. staging),
+        the rendered prompt MUST tell Claude that committing on that branch
+        is forbidden. Otherwise the branch-creation rule never triggers and
+        Claude commits straight onto staging."""
+        skill_dir = Path(__file__).resolve().parent.parent / "skills" / "core" / "implement"
+        from app.prompts import load_skill_prompt
+
+        prompt = load_skill_prompt(
+            skill_dir, "implement",
+            ISSUE_URL="https://github.com/o/r/issues/42",
+            ISSUE_TITLE="Test",
+            PLAN="Plan text",
+            CONTEXT="ctx",
+            BRANCH_PREFIX="koan/",
+            ISSUE_NUMBER="42",
+            BASE_BRANCH="staging",
+        )
+        assert "staging" in prompt
+        assert "Never commit on `staging`" in prompt
 
 
 class TestExecuteImplementation:
@@ -831,18 +867,21 @@ class TestRunImplement:
                     return_value=_github_issue(title="Title", body=body)), \
              patch(f"{_IMPL_MODULE}._run_plan_review_gate", return_value=None), \
              patch(f"{_IMPL_MODULE}._execute_implementation",
-                    return_value="Done"):
+                    return_value="Done"), \
+             patch(f"{_IMPL_MODULE}._submit_implement_pr", return_value=None):
             run_implement(
                 "/project",
                 "https://github.com/o/r/issues/42",
                 context="Phase 1",
                 notify_fn=notify,
             )
-            first_msg = notify.call_args_list[0][0][0]
-            assert "#42" in first_msg
-            assert "Phase 1" in first_msg
-            second_msg = notify.call_args_list[1][0][0]
-            assert "#42" in second_msg
+            messages = [c.args[0] for c in notify.call_args_list]
+            # First message: the "Implementing #42..." kickoff.
+            assert "#42" in messages[0]
+            assert "Phase 1" in messages[0]
+            # Last message: the final implementation summary, also tagged #42.
+            assert "#42" in messages[-1]
+            assert "Phase 1" in messages[-1]
 
     def test_explicit_project_name_reaches_tracker_and_memory(self):
         notify = MagicMock()

--- a/koan/tests/test_pr_submit.py
+++ b/koan/tests/test_pr_submit.py
@@ -152,33 +152,85 @@ class TestResolveSubmitTarget:
 
 class TestSubmitDraftPr:
     def test_skips_on_main(self):
-        with patch(f"{_M}.get_current_branch", return_value="main"):
+        with patch(f"{_M}.get_current_branch", return_value="main"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"):
             assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") is None
 
     def test_skips_on_master(self):
-        with patch(f"{_M}.get_current_branch", return_value="master"):
+        with patch(f"{_M}.get_current_branch", return_value="master"), \
+             patch(f"{_M}.resolve_base_branch", return_value="master"):
             assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") is None
+
+    def test_skips_when_head_is_resolved_base_branch_staging(self):
+        """Regression for the staging-commit bug: when the project's base
+        branch resolves to `staging` and Claude landed there without
+        creating a feature branch, submit_draft_pr must abort the push (no
+        diff exists) and notify the caller — it must not just log+silent."""
+        notify = MagicMock()
+        with patch(f"{_M}.get_current_branch", return_value="staging"), \
+             patch(f"{_M}.resolve_base_branch", return_value="staging"):
+            result = submit_draft_pr(
+                "/p", "proj", "o", "r", "1", "T", "B", notify_fn=notify,
+            )
+        assert result is None
+        notify.assert_called_once()
+        msg = notify.call_args.args[0]
+        assert "staging" in msg
+        assert "feature branch" in msg.lower() or "base branch" in msg.lower()
+
+    def test_explicit_base_branch_arg_used_in_guard(self):
+        """If the caller passes an explicit base_branch, it overrides the
+        resolved one and the guard fires against that. Confirms the guard
+        is not bypassable through a misconfigured projects.yaml."""
+        notify = MagicMock()
+        with patch(f"{_M}.get_current_branch", return_value="release-11"), \
+             patch(f"{_M}.resolve_base_branch", return_value="staging") as resolved:
+            result = submit_draft_pr(
+                "/p", "proj", "o", "r", "1", "T", "B",
+                base_branch="release-11", notify_fn=notify,
+            )
+        assert result is None
+        # resolve_base_branch must NOT be consulted when an explicit value
+        # is supplied — that's a fork in the resolution path.
+        resolved.assert_not_called()
+        notify.assert_called_once()
 
     def test_returns_existing_pr(self):
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value="https://pr/1"):
             assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") == "https://pr/1"
 
-    def test_no_commits_returns_none(self):
+    def test_no_commits_returns_none_and_notifies(self):
+        notify = MagicMock()
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value=""), \
              patch(f"{_M}.get_commit_subjects", return_value=[]):
-            assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") is None
+            assert submit_draft_pr(
+                "/p", "proj", "o", "r", "1", "T", "B", notify_fn=notify,
+            ) is None
+        notify.assert_called_once()
+        assert "No commits" in notify.call_args.args[0]
 
-    def test_push_failure_returns_none(self):
+    def test_push_failure_returns_none_and_notifies(self):
+        notify = MagicMock()
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value=""), \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
-             patch(f"{_M}.run_git_strict", side_effect=RuntimeError("push")):
-            assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") is None
+             patch(f"{_M}.run_git_strict", side_effect=RuntimeError("auth denied")):
+            assert submit_draft_pr(
+                "/p", "proj", "o", "r", "1", "T", "B", notify_fn=notify,
+            ) is None
+        notify.assert_called_once()
+        msg = notify.call_args.args[0]
+        assert "git push failed" in msg
+        assert "auth denied" in msg
 
     def test_creates_pr_with_correct_kwargs(self):
         with patch(f"{_M}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", side_effect=["", ""]), \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \
@@ -199,6 +251,7 @@ class TestSubmitDraftPr:
 
     def test_fork_workflow_sets_repo_and_head(self):
         with patch(f"{_M}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", side_effect=["", ""]), \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \
@@ -212,18 +265,27 @@ class TestSubmitDraftPr:
             assert kw["repo"] == "upstream/r"
             assert kw["head"] == "myfork:koan/feat"
 
-    def test_pr_create_failure_returns_none(self):
+    def test_pr_create_failure_returns_none_and_notifies(self):
+        notify = MagicMock()
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value=""), \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \
              patch(f"{_M}.resolve_submit_target",
                     return_value={"repo": "o/r", "is_fork": False}), \
-             patch(f"{_M}.pr_create", side_effect=RuntimeError("auth")):
-            assert submit_draft_pr("/p", "proj", "o", "r", "1", "T", "B") is None
+             patch(f"{_M}.pr_create", side_effect=RuntimeError("403 forbidden")):
+            assert submit_draft_pr(
+                "/p", "proj", "o", "r", "1", "T", "B", notify_fn=notify,
+            ) is None
+        notify.assert_called_once()
+        msg = notify.call_args.args[0]
+        assert "gh pr create failed" in msg
+        assert "403 forbidden" in msg
 
     def test_issue_comment_posted_when_url_given(self):
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value=""), \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \
@@ -242,6 +304,7 @@ class TestSubmitDraftPr:
 
     def test_no_issue_comment_when_no_url(self):
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value="") as mock_gh, \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \
@@ -256,6 +319,7 @@ class TestSubmitDraftPr:
 
     def test_issue_comment_for_non_github_url_uses_tracker_service(self):
         with patch(f"{_M}.get_current_branch", return_value="feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
              patch(f"{_M}.run_gh", return_value="") as mock_gh, \
              patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
              patch(f"{_M}.run_git_strict"), \


### PR DESCRIPTION
## Summary

Fixes the regression from #1588 — `/implement` and `/fix` silently committed straight onto the project's base branch (e.g. `staging`) instead of creating a feature branch, then reported `(PR creation failed)` with no usable explanation.

Three coupled bugs lined up only when the project's `base_branch` is not `main`/`master`:

1. **`implement.md` step 2** only triggered branch creation on `main`/`master`.
2. **`implementation-workflow.md` Phase 4 step 9** referenced "the branch naming specified above" — which only applies to the same main/master case. On `staging`, Claude read *"if already on a feature branch, stay on it"* and committed onto the base branch.
3. **`pr_submit.submit_draft_pr`** guarded only `("main", "master")`. With branch == "staging" the guard missed, `get_commit_subjects(base="staging")` came back empty, and the function returned `None` while only logging `logger.warning` (no Telegram surface).

The regression was masked at v0.70 by the monolithic implement prompt that ended with explicit *"push the branch + `gh pr create --draft`"* steps — Claude reliably created a feature branch even on `staging` because Phase 7 wasn't satisfiable otherwise. Commit `82707d5` (v0.74→v0.75) moved those steps into the `implementation-workflow` partial and rewrote the branch step to the ambiguous "create a branch (first phase only) following the branch naming specified above", turning a latent bug into a live one.

## Changes

- `koan/app/pr_submit.py` — `submit_draft_pr` now resolves `effective_base` up-front and aborts when HEAD is on it (or on `main`/`master`). New optional `notify_fn` parameter is invoked on every failure path (push fail, `gh pr create` fail, no commits, base-branch landing) with the actual reason.
- `koan/skills/core/implement/prompts/implement.md` — passes `{BASE_BRANCH}`. Step 2 is rewritten to be explicit: committing on the base branch is forbidden, no matter what it's called.
- `koan/system-prompts/_partials/implementation-workflow.md` — Phase 4 step 9 names the base branch inline instead of referencing "above".
- `koan/skills/core/implement/implement_runner.py` + `koan/skills/core/fix/fix_runner.py` — resolve effective base branch once at the top of `run_*`, thread it into the prompt and the post-implementation guard, forward `notify_fn` into `submit_draft_pr`, and replace the hardcoded `("main", "master")` display guard with a base-branch-aware comparison.
- `koan/skills/core/fix/prompts/fix.md` — mirrors the `implement.md` branch-creation rule.

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 13276 pass (the one pre-existing failure is `test_no_orphaned_skill_directories` for unrelated `__pycache__` leftovers in `scaffold-skill/` and `update/`, present on `main`)
- New regressions added:
  - `TestSubmitDraftPr::test_skips_when_head_is_resolved_base_branch_staging` — staging-as-base, asserts abort + notify
  - `TestSubmitDraftPr::test_explicit_base_branch_arg_used_in_guard` — explicit `base_branch` arg overrides resolved one
  - `TestSubmitDraftPr::test_no_commits_returns_none_and_notifies` + `test_push_failure_returns_none_and_notifies` + `test_pr_create_failure_returns_none_and_notifies` — every failure path surfaces a Telegram-shaped message
  - `TestBuildPrompt::test_base_branch_propagates_into_prompt_template_vars`
  - `TestBuildPrompt::test_prompt_mentions_resolved_base_branch_so_claude_branches_off_it` — rendered prompt must contain `staging` + `Never commit on \`staging\`` when `BASE_BRANCH=staging`
- [ ] Run `/implement` against a `base_branch: staging` project end-to-end (requires live Telegram session — owner to verify before un-drafting).

Closes #1588
