### PR TITLE
fix(ci): use pull_request_target so fork PRs can access BOT_TOKEN

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -1,6 +1,6 @@
 name: 🔍 Request Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened]
 
 permissions:


### PR DESCRIPTION
pull_request events from forks do not receive repository secrets, so secrets.BOT_TOKEN resolved to empty and overrode github-script's default github.token, causing "Input required and not supplied: github-token". pull_request_target runs in the base-repo context with secret access and a read-write token. The job does no checkout, so it is not exposed to the usual pull_request_target code-injection risk.