### PR TITLE
Fix plan skill to use mission model (issue #1614)

### DIFF
--- a/koan/app/plan_runner.py
+++ b/koan/app/plan_runner.py
@@ -324,7 +324,8 @@ def improve_plan(
 
     The improver explores the codebase to resolve ambiguities identified by
     the reviewer (missing file paths, vague descriptions, etc.) and returns
-    a corrected plan.
+    a corrected plan. Uses mission model (not lightweight) because it needs
+    full reasoning to fix structural plan issues, not just spot-check reviews.
 
     Args:
         plan_text: The plan that failed review.
@@ -349,7 +350,7 @@ def improve_plan(
         output = run_command(
             prompt, project_path,
             allowed_tools=["Read", "Glob", "Grep"],
-            model_key="chat",
+            model_key="mission",
             max_turns=5,
             timeout=180,
             max_turns_source=None,
@@ -635,6 +636,7 @@ def _run_claude_plan(prompt, project_path):
     output = run_command_streaming(
         prompt, project_path,
         allowed_tools=["Read", "Glob", "Grep", "WebFetch"],
+        model_key="mission",
         max_turns=get_skill_max_turns(), timeout=get_skill_timeout(),
     )
     if _is_error_output(output):

--- a/koan/tests/test_plan_runner.py
+++ b/koan/tests/test_plan_runner.py
@@ -550,8 +550,19 @@ class TestRunClaudePlan:
         mock_cmd.assert_called_once_with(
             "test prompt", "/project",
             allowed_tools=["Read", "Glob", "Grep", "WebFetch"],
+            model_key="mission",
             max_turns=50, timeout=3600,
         )
+
+    @patch("app.config.get_skill_max_turns", return_value=10)
+    @patch("app.config.get_skill_timeout", return_value=300)
+    @patch("app.cli_provider.run_command_streaming", return_value="plan output")
+    def test_uses_mission_model_key(self, mock_cmd, mock_timeout, mock_turns):
+        """Regression test for issue #1614: plan should use mission model, not haiku."""
+        _run_claude_plan("plan prompt", "/project")
+        # Verify that model_key="mission" is passed, not default "chat" (haiku)
+        call_kwargs = mock_cmd.call_args[1]
+        assert call_kwargs["model_key"] == "mission"
 
     @patch("app.cli_provider.run_command_streaming",
            side_effect=RuntimeError("CLI invocation failed: error msg"))


### PR DESCRIPTION
## Summary

Fixed `/plan` skill using wrong model (haiku via chat model_key instead of configured mission/opus). Root cause: `_run_claude_plan()` didn't specify `model_key` parameter when calling `run_command_streaming()`.

Closes https://github.com/Anantys-oss/koan/issues/1614

## Changes

- `_run_claude_plan()`: Add `model_key="mission"` to respect user's configured model
- `improve_plan()`: Change from `model_key="chat"` to `model_key="mission"` for full reasoning capability
- Tests: Updated assertions and added regression test `test_uses_mission_model_key()`
- Docstring: Clarified model selection rationale in `improve_plan()`

## Test plan

- All 136 existing tests pass: `KOAN_ROOT=/tmp/test-koan pytest koan/tests/test_plan_runner.py`
- New regression test added: `test_uses_mission_model_key()` verifies model_key="mission" is passed
- Linting passes: `make lint`

---
*Generated by Kōan*