### PR TITLE
fix(models): honor configured model role in /ai and spec generator

### DIFF
--- a/koan/app/ai_runner.py
+++ b/koan/app/ai_runner.py
@@ -240,6 +240,7 @@ def run_exploration(
         result = run_command_streaming(
             prompt, project_path,
             allowed_tools=["Read", "Glob", "Grep", "Bash"],
+            model_key="mission",
             max_turns=get_skill_max_turns(),
             timeout=get_skill_timeout(),
         )

--- a/koan/app/spec_generator.py
+++ b/koan/app/spec_generator.py
@@ -73,6 +73,7 @@ def generate_spec(
             prompt,
             project_path,
             allowed_tools=["Read", "Glob", "Grep"],
+            model_key="lightweight",
             max_turns=5,
             timeout=_get_spec_timeout(),
             max_turns_source=None,

--- a/koan/tests/test_ai_runner.py
+++ b/koan/tests/test_ai_runner.py
@@ -416,6 +416,20 @@ class TestRunExploration:
     @patch("app.ai_runner.gather_project_structure", return_value="Directories: src/")
     @patch("app.ai_runner.gather_git_activity", return_value="Recent commits: abc")
     @patch("app.ai_runner.load_skill_prompt", return_value="Explore myapp")
+    def test_uses_mission_model_key(
+        self, mock_prompt, mock_git, mock_struct, mock_missions, mock_claude,
+        tmp_path
+    ):
+        """AI exploration is mission-level reasoning (like /plan) and must use
+        the configured mission model, not silently fall back to 'chat'."""
+        run_exploration(str(tmp_path), "myapp", str(tmp_path), notify_fn=MagicMock())
+        assert mock_claude.call_args.kwargs["model_key"] == "mission"
+
+    @patch("app.cli_provider.run_command_streaming", return_value="Found 3 issues")
+    @patch("app.ai_runner.get_missions_context", return_value="No active missions.")
+    @patch("app.ai_runner.gather_project_structure", return_value="Directories: src/")
+    @patch("app.ai_runner.gather_git_activity", return_value="Recent commits: abc")
+    @patch("app.ai_runner.load_skill_prompt", return_value="Explore myapp")
     def test_success_returns_true(
         self, mock_prompt, mock_git, mock_struct, mock_missions, mock_claude,
         tmp_path

--- a/koan/tests/test_spec_generator.py
+++ b/koan/tests/test_spec_generator.py
@@ -137,3 +137,12 @@ class TestGenerateSpec:
         with patch.dict("sys.modules", {"app.cli_provider": None}):
             result = generate_spec(str(tmp_path), "test mission", str(tmp_path))
             assert result is None
+
+    def test_uses_lightweight_model_key(self, tmp_path):
+        """Spec generation must request the lightweight model role explicitly,
+        not silently fall back to the 'chat' default — so it honors the user's
+        configured lightweight model (matches the module's documented intent)."""
+        with patch("app.prompts.load_prompt", return_value="prompt"), \
+             patch("app.cli_provider.run_command", return_value="## Goal\nx") as mock_run:
+            generate_spec(str(tmp_path), "test mission", str(tmp_path))
+        assert mock_run.call_args.kwargs["model_key"] == "lightweight"


### PR DESCRIPTION
## What
Make two non-chat Claude calls honor the configured model role, instead of silently using the `chat` default — the same bug class fixed for `/plan` in #1619.

## Why
Follow-up to #1619. I audited every `run_command` / `run_command_streaming` / `build_full_command` call site for whether it honors the user's configured model role. Both helpers default `model_key="chat"`, so any non-chat action that omits it silently runs on the wrong model.

Two call sites were affected:
- **`ai_runner.py`** (`/ai` exploration) — omitted `model_key`, so creative codebase exploration ran on the `chat` model. Like `/plan`, this is mission-level reasoning and should use the configured **mission** model.
- **`spec_generator.py`** (mission-spec generator) — omitted `model_key`, so it ran on the `chat` default even though its docstring says "lightweight spec". With default config `chat=""` resolves to the CLI default (potentially Opus), making this both *wrong* and *wasteful*. Set to **lightweight** to match documented intent and honor the user's lightweight model.

## How
- `ai_runner`: `model_key="mission"`
- `spec_generator`: `model_key="lightweight"`
- Regression tests assert the `model_key` passed for each.

## Audit — other call sites (all correct, no change needed)
- `review_runner` → `mission` ✓ · `github_intent` / `suggestion_engine` / `plan_runner` review subagent → `lightweight` ✓ · `github_reply` → `chat` ✓ (conversational reply)
- `build_full_command` callers pass an explicit resolved `model=` from `get_model_config()`: `claude_step`/`rebase_pr`/`recreate_pr`/`squash_pr`/`claudemd_refresh` → mission/review; `memory_manager`/`describe_pr`/`format_outbox` → lightweight; contemplative → `lightweight` via role flags. ✓

## Noted, out of scope
- `post_mission_reflection.py`, `self_reflection.py`, `rituals.py` call `build_full_command` with **no** `model`, falling back to the CLI default rather than the `reflect`/`lightweight` role. A `reflect` model key exists in config but is only consumed by `review_runner`. Worth a follow-up but kept out of this focused fix.
- `run_command`/`run_command_streaming` resolve `get_model_config()` without a `project_name`, so per-project model overrides are ignored for these helpers (uniform, separate concern).

## Testing
`KOAN_ROOT=/tmp/test-koan pytest koan/tests/test_ai_runner.py koan/tests/test_spec_generator.py` → 100 passed. Full suite green except one pre-existing, unrelated failure (`test_no_orphaned_skill_directories`: stale `__pycache__`-only dirs `scaffold-skill`/`update` in the working tree). `make lint` passes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
### Quality Report

**Changes**: 4 files changed, 25 insertions(+)

**Code scan**: clean

**Tests**: failed (cannot import name 'get_rebase_ci_idle_timeout' from 'app.config' (/Users/alexissukrieh/Devel/koan/k)

**Branch hygiene**: clean

*Generated by Kōan post-mission quality pipeline*