### PR TITLE
Add shared base-branch/context handling for URL skills

### DIFF
--- a/docs/messaging/jira-integration.md
+++ b/docs/messaging/jira-integration.md
@@ -123,7 +123,8 @@ When `jira.enabled: true`, Koan validates the configuration at startup and warns
 
 ## Available Commands
 
-Jira reuses the same `github_enabled: true` skill flag for command discovery — **both GitHub and Jira dispatch the exact same set of commands**. No separate Jira flag is needed.
+Jira reuses the same `github_enabled: true` skill flag for command discovery — **both GitHub and Jira discover the same command set**. No separate Jira flag is needed.
+Argument validation still applies per command, so PR-only or comment-URL-only skills require a matching GitHub URL in the Jira comment context.
 
 > **Custom skills under `instance/skills/<scope>/`** (e.g. a team-specific integration shipping `/my_fix` and `/my_plan`) are exposed here the same way: set `github_enabled: true` and `group: integrations` in their SKILL.md. Such skills with a `handler.py` are dispatched **in-process** by the Jira bridge — not queued as slash missions — and the handler automatically receives the originating Jira issue key in `ctx.args` when the commenter omitted one. See `koan/skills/README.md` for the full pattern.
 
@@ -145,6 +146,8 @@ Jira reuses the same `github_enabled: true` skill flag for command discovery —
 | `reviewrebase` | `rr` | Review then rebase combo | **Yes** |
 | `security_audit` | `security`, `secu` | Security-focused audit | **Yes** |
 | `squash` | `sq` | Squash all PR commits into one | **Yes** |
+
+For commands that require GitHub PR/comment URLs (for example `rebase`, `recreate`, `review`, `squash`, `ask`), include that GitHub URL explicitly in the Jira comment context.
 
 ### Context-aware commands
 

--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -45,6 +45,9 @@ Complete reference for all Koan slash commands. Use these via Telegram, Slack, o
 | `/claudemd [project]` | `/claude`, `/claude.md` | Refresh or create a project's CLAUDE.md | — |
 | `/doc <project> [cats]` | `/docs` | Extract structured documentation to docs/ | Yes |
 
+For URL-based `/plan`, `/implement`, and `/fix`, append `branch:<name>` to
+override the base branch for that mission.
+
 Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <command>` on a PR or issue. See [GitHub commands](../messaging/github-commands.md).
 
 ## Exploration & Analysis

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -428,14 +428,19 @@ The master tracking issue then synthesizes the set with three optional sections:
 - `/plan Add WebSocket support for real-time notifications` — Get a phased plan before writing any code
 - `/plan https://github.com/org/repo/issues/42` — Iterate on an existing issue's plan
 - `/plan https://myorg.atlassian.net/browse/PROJ-123` — Iterate on a Jira issue's plan
+- `/plan https://myorg.atlassian.net/browse/PROJ-123 branch:main` — Iterate with an explicit base-branch hint
 - `/plan webapp Add rate limiting to public API endpoints` — Target a specific project
 </details>
 
-For URL-based `/plan`, `/implement`, and `/fix`, Kōan resolves the project
+For URL-based `/plan`, `/deepplan`, `/implement`, and `/fix`, Kōan resolves the project
 from the issue URL and the known project registry. Known projects include both
 `projects.yaml` entries and repositories discovered under `KOAN_ROOT/workspace/`,
 so an explicit project prefix is not required when the URL maps to one of
 those projects.
+
+For URL-based `/plan`, `/deepplan`, `/implement`, and `/fix`, you can append
+`branch:<name>` to override the base branch for that mission (for `/plan` and
+`/deepplan`, this is passed as a planning hint in the generated context).
 
 **`/deepplan`** — Spec-first design with Socratic exploration of 2-3 approaches before planning. For complex missions where design matters more than speed.
 

--- a/koan/app/jira_command_handler.py
+++ b/koan/app/jira_command_handler.py
@@ -353,6 +353,22 @@ def process_jira_mention(
         _notify_mission_from_jira(mention, command_name)
         return True, None
 
+    # Validate arguments before queueing. This catches command/url mismatches
+    # early (for example Jira issue URLs on PR-only commands) and avoids
+    # inserting missions that are guaranteed to fail in run.py.
+    from app.skill_dispatch import validate_skill_args
+    validation_parts = []
+    if issue_url:
+        validation_parts.append(issue_url)
+    if target_branch:
+        validation_parts.append(f"branch:{target_branch}")
+    if context and skill.github_context_aware:
+        validation_parts.append(context)
+    arg_error = validate_skill_args(command_name, " ".join(validation_parts))
+    if arg_error:
+        mark_jira_comment_processed(comment_id, processed_set)
+        return False, arg_error
+
     # Build mission entry
     mission_entry = build_jira_mission(
         skill, command_name, context, issue_key, issue_url, project_name,

--- a/koan/app/plan_runner.py
+++ b/koan/app/plan_runner.py
@@ -13,6 +13,7 @@ Issue-centric workflow:
 CLI:
     python3 -m app.plan_runner --project-path <path> --idea "Add dark mode"
     python3 -m app.plan_runner --project-path <path> --issue-url <url>
+    python3 -m app.plan_runner --project-path <path> --issue-url <url> --base-branch main
 """
 
 import re
@@ -32,6 +33,7 @@ from app.issue_tracker import (
     tracker_supports_labels,
 )
 from app.prompts import load_prompt_or_skill
+from app.url_skill_args import merge_context_with_base_branch
 
 # Label used to tag plan issues for searchability
 _PLAN_LABEL = "plan"
@@ -44,6 +46,7 @@ def run_plan(
     notify_fn=None,
     skill_dir: Optional[Path] = None,
     context: Optional[str] = None,
+    base_branch: Optional[str] = None,
     project_name: str = "",
     instance_dir: str = "",
 ) -> Tuple[bool, str]:
@@ -70,11 +73,13 @@ def run_plan(
     if issue_url:
         return _run_issue_plan(
             project_path, issue_url, notify_fn, skill_dir, context=context,
+            base_branch=base_branch,
             project_name=project_name, instance_dir=instance_dir,
         )
     elif idea:
         return _run_new_plan(
             project_path, idea, notify_fn, skill_dir, context=context,
+            base_branch=base_branch,
             project_name=project_name, instance_dir=instance_dir,
         )
     else:
@@ -87,6 +92,7 @@ def _run_new_plan(
     notify_fn,
     skill_dir: Optional[Path],
     context: Optional[str] = None,
+    base_branch: Optional[str] = None,
     project_name: str = "",
     instance_dir: str = "",
 ) -> Tuple[bool, str]:
@@ -104,13 +110,16 @@ def _run_new_plan(
         )
         return _run_issue_plan(
             project_path, existing.url, notify_fn, skill_dir, context=context,
+            base_branch=base_branch,
             project_name=project_name, instance_dir=instance_dir,
         )
+
+    effective_context = merge_context_with_base_branch(context, base_branch)
 
     print("[plan] Invoking Claude for plan generation", flush=True)
     try:
         plan = _generate_plan(
-            project_path, idea, context=context or "", skill_dir=skill_dir,
+            project_path, idea, context=effective_context, skill_dir=skill_dir,
             project_name=project_name, instance_dir=instance_dir,
         )
     except Exception as e:
@@ -153,6 +162,7 @@ def _run_issue_plan(
     notify_fn,
     skill_dir: Optional[Path],
     context: Optional[str] = None,
+    base_branch: Optional[str] = None,
     project_name: str = "",
     instance_dir: str = "",
 ) -> Tuple[bool, str]:
@@ -198,8 +208,9 @@ def _run_issue_plan(
         context_parts.append(f"\n\n## Discussion Comments\n\n{comments_text}")
     else:
         context_parts.append("\n\n*No comments yet on this issue.*")
-    if context:
-        context_parts.append(f"\n\n## User Instructions\n\n{context}")
+    effective_context = merge_context_with_base_branch(context, base_branch)
+    if effective_context:
+        context_parts.append(f"\n\n## User Instructions\n\n{effective_context}")
     issue_context = "\n".join(context_parts)
 
     print("[plan] Invoking Claude for plan generation", flush=True)
@@ -739,7 +750,7 @@ def main(argv=None):
     Returns exit code (0 = success, 1 = failure).
     """
     import argparse
-    import sys
+    from app.url_skill_args import add_url_skill_common_args
 
     parser = argparse.ArgumentParser(
         description="Generate a structured plan and post as GitHub issue/comment."
@@ -757,20 +768,7 @@ def main(argv=None):
         "--issue-url",
         help="GitHub issue URL to iterate on",
     )
-    parser.add_argument(
-        "--context",
-        help="Additional user context (e.g. 'Focus on phase 2')",
-    )
-    parser.add_argument(
-        "--project-name",
-        default="",
-        help="Koan project name for memory and tracker configuration",
-    )
-    parser.add_argument(
-        "--instance-dir",
-        default="",
-        help="Koan instance directory for project memory",
-    )
+    add_url_skill_common_args(parser)
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent.parent / "skills" / "core" / "plan"
@@ -781,6 +779,7 @@ def main(argv=None):
         issue_url=cli_args.issue_url,
         skill_dir=skill_dir,
         context=cli_args.context,
+        base_branch=cli_args.base_branch,
         project_name=cli_args.project_name,
         instance_dir=cli_args.instance_dir,
     )

--- a/koan/app/skill_dispatch.py
+++ b/koan/app/skill_dispatch.py
@@ -361,7 +361,9 @@ def build_skill_command(
     # Dispatch to command-specific builder (canonical names only).
     _COMMAND_BUILDERS = {
         "brainstorm": lambda: _build_brainstorm_cmd(base_cmd, args, project_path),
-        "deepplan": lambda: _build_deepplan_cmd(base_cmd, args, project_path),
+        "deepplan": lambda: _build_deepplan_cmd(
+            base_cmd, args, project_name, project_path, instance_dir,
+        ),
         "plan": lambda: _build_plan_cmd(
             base_cmd, args, project_name, project_path, instance_dir,
         ),
@@ -470,18 +472,28 @@ def _build_brainstorm_cmd(
 
 
 def _build_deepplan_cmd(
-    base_cmd: List[str], args: str, project_path: str,
+    base_cmd: List[str],
+    args: str,
+    project_name: str,
+    project_path: str,
+    instance_dir: str,
 ) -> List[str]:
     """Build deepplan_runner command.
 
-    Detects GitHub issue URLs in args and passes them as --issue-url.
-    Falls back to --idea for free-text input.
+    Reuses shared URL/context/branch parsing:
+    - URL mode: --issue-url [--base-branch] [--context]
+    - Idea mode: --idea
     """
-    url_and_context = _extract_pr_or_issue_url_and_context(args)
-    if url_and_context:
-        issue_url, _context = url_and_context
-        return base_cmd + ["--project-path", project_path, "--issue-url", issue_url]
-    return base_cmd + ["--project-path", project_path, "--idea", args.strip()]
+    # idea_fallback=True guarantees a non-None command: when no URL is found,
+    # _build_url_context_cmd falls back to --idea internally.
+    return _build_url_context_cmd(
+        base_cmd,
+        args,
+        project_name,
+        project_path,
+        instance_dir,
+        idea_fallback=True,
+    )
 
 
 def _build_url_context_cmd(
@@ -974,9 +986,8 @@ def validate_skill_args(command: str, args: str) -> Optional[str]:
                 f"https://org.atlassian.net/browse/PROJ-123)"
             )
     elif canonical == "check":
-        if not (_PR_URL_RE.search(args) or _ISSUE_URL_RE.search(args)
-                or _JIRA_URL_RE.search(args)):
-            return "/check requires a GitHub URL (PR or issue) or Jira URL"
+        if not (_PR_URL_RE.search(args) or _ISSUE_URL_RE.search(args)):
+            return "/check requires a GitHub URL (PR or issue)"
     elif canonical == "check_need":
         if not (_PR_URL_RE.search(args) or _ISSUE_URL_RE.search(args)):
             return (

--- a/koan/app/url_skill_args.py
+++ b/koan/app/url_skill_args.py
@@ -1,0 +1,61 @@
+"""Shared helpers for URL-oriented skill runners.
+
+The argparse flags here are used by /plan, /deepplan, /fix, and /implement
+to keep CLI behavior consistent with skill_dispatch command construction.
+merge_context_with_base_branch() is the single source of truth for folding a
+base-branch hint into planning context, shared by /plan and /deepplan.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Optional
+
+
+def merge_context_with_base_branch(
+    context: Optional[str], base_branch: Optional[str],
+) -> str:
+    """Merge user context with an optional base-branch hint for planning.
+
+    Returns the trimmed context when no branch is given, the branch hint
+    alone when there is no context, or both joined by a blank line.
+    """
+    context_text = (context or "").strip()
+    branch_text = (base_branch or "").strip()
+    if not branch_text:
+        return context_text
+    branch_hint = f"Target base branch: `{branch_text}`."
+    if context_text:
+        return f"{context_text}\n\n{branch_hint}"
+    return branch_hint
+
+
+def add_url_skill_common_args(parser: argparse.ArgumentParser) -> None:
+    """Add common URL-skill flags to a parser.
+
+    Adds:
+      - --context
+      - --base-branch
+      - --project-name
+      - --instance-dir
+    """
+    parser.add_argument(
+        "--context",
+        help="Additional context for the skill run",
+        default=None,
+    )
+    parser.add_argument(
+        "--base-branch",
+        help="Target base branch override (e.g. 'main' or '11.126')",
+        default=None,
+    )
+    parser.add_argument(
+        "--project-name",
+        help="Koan project name for memory and tracker configuration",
+        default="",
+    )
+    parser.add_argument(
+        "--instance-dir",
+        help="Koan instance directory for project memory",
+        default="",
+    )

--- a/koan/skills/core/deepplan/deepplan_runner.py
+++ b/koan/skills/core/deepplan/deepplan_runner.py
@@ -22,6 +22,7 @@ from app.issue_tracker import (
     tracker_supports_labels,
 )
 from app.prompts import load_prompt_or_skill
+from app.url_skill_args import merge_context_with_base_branch
 
 # Maximum spec review iterations before posting best-effort result
 _MAX_REVIEW_ROUNDS = 5
@@ -36,6 +37,9 @@ def run_deepplan(
     notify_fn=None,
     skill_dir: Optional[Path] = None,
     issue_url: Optional[str] = None,
+    context: Optional[str] = None,
+    base_branch: Optional[str] = None,
+    project_name: str = "",
 ) -> Tuple[bool, str]:
     """Execute the deep plan pipeline.
 
@@ -53,6 +57,9 @@ def run_deepplan(
         issue_url: Optional issue URL to fetch context from.
             When provided, the issue title/body/comments are fetched
             and used to enrich the idea context for exploration.
+        context: Optional additional user instructions.
+        base_branch: Optional base-branch hint for downstream planning.
+        project_name: Optional resolved project name from dispatcher.
 
     Returns:
         (success, summary) tuple.
@@ -61,14 +68,30 @@ def run_deepplan(
         from app.notify import send_telegram
         notify_fn = send_telegram
 
+    project_name = project_name or project_name_for_path(project_path)
+    user_context = merge_context_with_base_branch(context, base_branch)
+
     # When issue_url is provided, fetch issue context and enrich the idea
     issue_context = ""
     if issue_url:
-        idea, issue_context = _enrich_idea_from_issue(idea, issue_url, notify_fn)
+        idea, issue_context = _enrich_idea_from_issue(
+            idea,
+            issue_url,
+            notify_fn,
+            project_name=project_name,
+            project_path=project_path,
+        )
+        if user_context:
+            issue_context = (
+                f"{issue_context}\n\n## User Instructions\n\n{user_context}"
+                if issue_context
+                else f"## User Instructions\n\n{user_context}"
+            )
+    elif user_context:
+        issue_context = f"## User Instructions\n\n{user_context}"
 
     notify_fn(f"\U0001f9e0 Deep planning: {idea[:100]}{'...' if len(idea) > 100 else ''}")
 
-    project_name = project_name_for_path(project_path)
     if not tracker_is_configured(project_name, project_path):
         return False, "No issue tracker configured for this project."
 
@@ -115,7 +138,14 @@ def run_deepplan(
     return True, summary
 
 
-def _enrich_idea_from_issue(idea, issue_url, notify_fn):
+def _enrich_idea_from_issue(
+    idea,
+    issue_url,
+    notify_fn,
+    *,
+    project_name: str = "",
+    project_path: str = "",
+):
     """Fetch issue context from the configured tracker and enrich the idea.
 
     Args:
@@ -129,7 +159,11 @@ def _enrich_idea_from_issue(idea, issue_url, notify_fn):
     notify_fn("\U0001f50d Fetching issue context from tracker...")
 
     try:
-        issue = fetch_issue(issue_url)
+        issue = fetch_issue(
+            issue_url,
+            project_name=project_name or None,
+            project_path=project_path or None,
+        )
         title = issue.title
         body = issue.body
         comments = issue.comments
@@ -350,6 +384,7 @@ def _strip_title_line(spec_text):
 def main(argv=None):
     """CLI entry point for deepplan_runner."""
     import argparse
+    from app.url_skill_args import add_url_skill_common_args
 
     parser = argparse.ArgumentParser(
         description="Spec-first design: explore approaches, review, post spec as tracker issue."
@@ -367,6 +402,11 @@ def main(argv=None):
         "--issue-url",
         help="Issue URL to use as context for the design exploration",
     )
+    # --project-path, --idea, and --issue-url are declared above; the shared
+    # helper adds --context, --base-branch, --project-name, and --instance-dir.
+    # Keep these sets disjoint — adding an overlapping flag here would make
+    # argparse raise a conflict at runtime.
+    add_url_skill_common_args(parser)
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent
@@ -376,6 +416,9 @@ def main(argv=None):
         project_path=cli_args.project_path,
         idea=idea,
         issue_url=cli_args.issue_url,
+        context=cli_args.context,
+        base_branch=cli_args.base_branch,
+        project_name=cli_args.project_name,
         skill_dir=skill_dir,
     )
     print(summary)

--- a/koan/skills/core/fix/fix_runner.py
+++ b/koan/skills/core/fix/fix_runner.py
@@ -363,6 +363,7 @@ def _submit_fix_pr(
 def main(argv=None):
     """CLI entry point for fix_runner."""
     import argparse
+    from app.url_skill_args import add_url_skill_common_args
 
     parser = argparse.ArgumentParser(
         description="Fix a GitHub or Jira issue end-to-end."
@@ -375,26 +376,7 @@ def main(argv=None):
         "--issue-url", required=True,
         help="GitHub or Jira issue URL to fix",
     )
-    parser.add_argument(
-        "--context",
-        help="Additional context (e.g. 'backend only')",
-        default=None,
-    )
-    parser.add_argument(
-        "--base-branch",
-        help="Target branch for the PR (e.g. '11.126')",
-        default=None,
-    )
-    parser.add_argument(
-        "--project-name",
-        help="Koan project name for memory and tracker configuration",
-        default="",
-    )
-    parser.add_argument(
-        "--instance-dir",
-        help="Koan instance directory for project memory",
-        default="",
-    )
+    add_url_skill_common_args(parser)
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -619,6 +619,7 @@ def _submit_implement_pr(
 def main(argv=None):
     """CLI entry point for implement_runner."""
     import argparse
+    from app.url_skill_args import add_url_skill_common_args
 
     parser = argparse.ArgumentParser(
         description="Implement a plan from a GitHub issue."
@@ -631,26 +632,7 @@ def main(argv=None):
         "--issue-url", required=True,
         help="GitHub issue URL containing the plan",
     )
-    parser.add_argument(
-        "--context",
-        help="Additional context (e.g. 'Phase 1 to 3')",
-        default=None,
-    )
-    parser.add_argument(
-        "--base-branch",
-        help="Target branch for the PR (e.g. '11.126')",
-        default=None,
-    )
-    parser.add_argument(
-        "--project-name",
-        help="Koan project name for memory and tracker configuration",
-        default="",
-    )
-    parser.add_argument(
-        "--instance-dir",
-        help="Koan instance directory for project memory",
-        default="",
-    )
+    add_url_skill_common_args(parser)
     cli_args = parser.parse_args(argv)
 
     skill_dir = Path(__file__).resolve().parent

--- a/koan/tests/test_deepplan_skill.py
+++ b/koan/tests/test_deepplan_skill.py
@@ -439,6 +439,28 @@ class TestSkillDispatch:
         assert "https://github.com/owner/repo/issues/42" in cmd
         assert "--idea" not in cmd
 
+    def test_build_deepplan_cmd_with_issue_url_branch_and_context(self, tmp_path):
+        from app.skill_dispatch import build_skill_command
+        cmd = build_skill_command(
+            command="deepplan",
+            args=(
+                "https://github.com/owner/repo/issues/42 "
+                "branch:main focus on rollout"
+            ),
+            project_name="koan",
+            project_path=str(tmp_path),
+            koan_root=str(tmp_path),
+            instance_dir=str(tmp_path),
+        )
+        assert cmd is not None
+        assert "--issue-url" in cmd
+        assert "--base-branch" in cmd
+        base_idx = cmd.index("--base-branch")
+        assert cmd[base_idx + 1] == "main"
+        assert "--context" in cmd
+        ctx_idx = cmd.index("--context")
+        assert cmd[ctx_idx + 1] == "focus on rollout"
+
     def test_build_deepplan_cmd_free_text_no_issue_url(self, tmp_path):
         from app.skill_dispatch import build_skill_command
         cmd = build_skill_command(
@@ -582,6 +604,43 @@ class TestRunnerWithIssueUrl:
         assert "bob" in context
         assert "Memcached" in context
 
+    def test_issue_url_includes_user_context_and_branch_hint(self, runner, tmp_path):
+        valid_spec = (
+            "Design spec title\n\n"
+            "### Summary\n\nSpec body\n\n"
+            "### Alternatives Considered\n\nA\n\n"
+            "### Recommended Approach\n\nB\n\n"
+            "### Scope\n\nC\n\n"
+            "### Out of Scope\n\nD\n\n"
+            "### Open Questions\n\nNone."
+        )
+
+        with patch.object(runner, "tracker_is_configured", return_value=True), \
+             patch.object(runner, "tracker_supports_labels", return_value=True), \
+             patch.object(runner, "create_issue",
+                          return_value="https://github.com/o/r/issues/1"), \
+             patch.object(runner, "fetch_issue",
+                          return_value=_issue_content(
+                              title="Fix caching bug", body="The cache is broken")), \
+             patch.object(runner, "_explore_design", return_value=valid_spec) as mock_explore, \
+             patch.object(runner, "_review_spec", return_value=(True, "")), \
+             patch.object(runner, "_queue_plan_mission"), \
+             patch("app.notify.send_telegram"):
+            success, _summary = runner.run_deepplan(
+                project_path=str(tmp_path),
+                idea="https://github.com/owner/repo/issues/99",
+                issue_url="https://github.com/owner/repo/issues/99",
+                context="Focus phase 1",
+                base_branch="11.126",
+                project_name="koan",
+                skill_dir=RUNNER_PATH.parent,
+            )
+
+        assert success is True
+        issue_context = mock_explore.call_args.kwargs["issue_context"]
+        assert "Focus phase 1" in issue_context
+        assert "Target base branch: `11.126`." in issue_context
+
     def test_issue_fetch_failure_falls_back(self, runner, tmp_path):
         """Runner falls back gracefully when issue fetch fails."""
         with patch.object(runner, "fetch_issue",
@@ -612,3 +671,21 @@ class TestExploreDesignMaxTurns:
             result = runner._explore_design("/tmp/proj", "idea")
 
         assert mock_run.call_args[1]["max_turns"] == 42
+
+
+class TestDeepplanMainCli:
+    def test_main_passes_context_and_base_branch(self, runner):
+        with patch.object(runner, "run_deepplan", return_value=(True, "ok")) as mock_run:
+            code = runner.main([
+                "--project-path", "/project",
+                "--issue-url", "https://github.com/o/r/issues/1",
+                "--context", "Focus phase 1",
+                "--base-branch", "main",
+                "--project-name", "koan",
+            ])
+
+        assert code == 0
+        _, kwargs = mock_run.call_args
+        assert kwargs["context"] == "Focus phase 1"
+        assert kwargs["base_branch"] == "main"
+        assert kwargs["project_name"] == "koan"

--- a/koan/tests/test_fix_runner.py
+++ b/koan/tests/test_fix_runner.py
@@ -397,3 +397,13 @@ class TestMain:
         _, kwargs = mock_run.call_args
         assert kwargs["project_name"] == "webpros-shield"
         assert kwargs["instance_dir"] == "/koan/instance"
+
+    @patch(f"{_FIX_MODULE}.run_fix", return_value=(True, "Done"))
+    def test_base_branch_passed(self, mock_run):
+        main([
+            "--project-path", "/path",
+            "--issue-url", "https://github.com/o/r/issues/1",
+            "--base-branch", "main",
+        ])
+        _, kwargs = mock_run.call_args
+        assert kwargs["base_branch"] == "main"

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -1399,3 +1399,14 @@ class TestMain:
             _, kwargs = mock.call_args
             assert kwargs["project_name"] == "webpros-shield"
             assert kwargs["instance_dir"] == "/koan/instance"
+
+    def test_base_branch_arg_passed(self):
+        with patch(f"{_IMPL_MODULE}.run_implement",
+                    return_value=(True, "ok")) as mock:
+            main([
+                "--project-path", "/project",
+                "--issue-url", "https://github.com/o/r/issues/1",
+                "--base-branch", "main",
+            ])
+            _, kwargs = mock.call_args
+            assert kwargs["base_branch"] == "main"

--- a/koan/tests/test_jira_command_handler.py
+++ b/koan/tests/test_jira_command_handler.py
@@ -379,6 +379,32 @@ class TestProcessJiraMention:
         assert error is not None
         assert "denied" in error.lower()
 
+    def test_pr_only_command_rejected_for_jira_issue_url(
+        self, tmp_path, monkeypatch, mention, skill_registry, basic_config,
+    ):
+        """Jira issue URLs should not queue PR-only commands like /rebase."""
+        instance_dir = tmp_path / "instance"
+        instance_dir.mkdir()
+        missions_path = instance_dir / "missions.md"
+        missions_path.write_text("# Pending\n\n# In Progress\n\n# Done\n")
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+
+        rebase_mention = dict(mention, body_text="@koan-bot rebase")
+
+        with patch("app.jira_command_handler.get_jira_nickname", return_value="koan-bot"), \
+             patch("app.jira_command_handler.get_jira_authorized_users", return_value=["*"]), \
+             patch("app.jira_config.get_jira_max_age_hours", return_value=24):
+            processed_set = set()
+            success, error = process_jira_mention(
+                rebase_mention, skill_registry, basic_config, processed_set,
+            )
+
+        assert success is False
+        assert error is not None
+        assert "/rebase requires a PR URL" in error
+        assert rebase_mention["comment_id"] in processed_set
+        assert "🎫" not in missions_path.read_text()
+
     def test_missing_comment_id_skipped(
         self, skill_registry, basic_config
     ):

--- a/koan/tests/test_plan_runner.py
+++ b/koan/tests/test_plan_runner.py
@@ -24,6 +24,7 @@ from app.plan_runner import (
     _review_loop,
     is_simple_plan,
 )
+from app.url_skill_args import merge_context_with_base_branch
 from app.issue_tracker.types import IssueContent, IssueRef
 from app.issue_tracker import UnresolvedJiraProjectError
 
@@ -1037,6 +1038,31 @@ class TestMainCLI:
             _, kwargs = mock.call_args
             assert kwargs["project_name"] == "webpros-shield"
             assert kwargs["instance_dir"] == "/koan/instance"
+
+    def test_base_branch_flag_passed_to_run_plan(self):
+        with patch("app.plan_runner.run_plan", return_value=(True, "ok")) as mock:
+            main([
+                "--project-path", "/project",
+                "--issue-url", "https://github.com/o/r/issues/1",
+                "--base-branch", "main",
+            ])
+            _, kwargs = mock.call_args
+            assert kwargs["base_branch"] == "main"
+
+
+class TestMergeContextWithBaseBranch:
+    def test_returns_context_when_no_branch(self):
+        result = merge_context_with_base_branch("Focus on API", None)
+        assert result == "Focus on API"
+
+    def test_returns_branch_hint_when_context_empty(self):
+        result = merge_context_with_base_branch("", "main")
+        assert result == "Target base branch: `main`."
+
+    def test_combines_context_and_branch_hint(self):
+        result = merge_context_with_base_branch("Phase 1 only", "11.126")
+        assert "Phase 1 only" in result
+        assert "Target base branch: `11.126`." in result
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_skill_dispatch.py
+++ b/koan/tests/test_skill_dispatch.py
@@ -205,6 +205,17 @@ class TestBuildSkillCommand:
         ctx_idx = cmd.index("--context")
         assert cmd[ctx_idx + 1] == "Focus on phase 2"
 
+    def test_plan_with_issue_url_and_branch_override(self):
+        args = "https://github.com/sukria/koan/issues/42 branch:main Focus on phase 2"
+        cmd = self._build("plan", args)
+        assert cmd is not None
+        assert "--base-branch" in cmd
+        base_idx = cmd.index("--base-branch")
+        assert cmd[base_idx + 1] == "main"
+        assert "--context" in cmd
+        ctx_idx = cmd.index("--context")
+        assert cmd[ctx_idx + 1] == "Focus on phase 2"
+
     def test_plan_with_issue_url_no_context(self):
         """Issue URL with no trailing text should not include --context."""
         url = "https://github.com/sukria/koan/issues/42"
@@ -238,6 +249,26 @@ class TestBuildSkillCommand:
         assert "--context" in cmd
         ctx_idx = cmd.index("--context")
         assert cmd[ctx_idx + 1] == "focus on security"
+
+    def test_deepplan_with_issue_url_and_branch_override(self):
+        args = "https://github.com/sukria/koan/issues/42 branch:main focus phase 1"
+        cmd = self._build("deepplan", args)
+        assert cmd is not None
+        assert "skills.core.deepplan.deepplan_runner" in cmd
+        assert "--issue-url" in cmd
+        assert "--base-branch" in cmd
+        base_idx = cmd.index("--base-branch")
+        assert cmd[base_idx + 1] == "main"
+        assert "--context" in cmd
+        ctx_idx = cmd.index("--context")
+        assert cmd[ctx_idx + 1] == "focus phase 1"
+
+    def test_deepplan_with_idea_falls_back_to_idea_flag(self):
+        cmd = self._build("deepplan", "Refactor auth middleware")
+        assert cmd is not None
+        assert "skills.core.deepplan.deepplan_runner" in cmd
+        assert "--idea" in cmd
+        assert "Refactor auth middleware" in cmd
 
     def test_rebase(self):
         url = "https://github.com/sukria/koan/pull/42"
@@ -353,6 +384,17 @@ class TestBuildSkillCommand:
         assert "--context" in cmd
         assert "Phase 1 to 3" in cmd
 
+    def test_implement_with_branch_override(self):
+        url = "https://github.com/sukria/koan/issues/42"
+        cmd = self._build("implement", f"{url} branch:11.126 Phase 1 to 3")
+        assert cmd is not None
+        assert "--base-branch" in cmd
+        base_idx = cmd.index("--base-branch")
+        assert cmd[base_idx + 1] == "11.126"
+        assert "--context" in cmd
+        ctx_idx = cmd.index("--context")
+        assert cmd[ctx_idx + 1] == "Phase 1 to 3"
+
     def test_implement_with_pr_url(self):
         """PR URLs accepted — GitHub issues API works for PRs."""
         url = "https://github.com/sukria/koan/pull/61"
@@ -410,6 +452,17 @@ class TestBuildSkillCommand:
         assert url in cmd
         assert "--context" in cmd
         assert "backend only" in cmd
+
+    def test_fix_with_branch_override(self):
+        url = "https://github.com/Anantys/investmindr/issues/42"
+        cmd = self._build("fix", f"{url} branch:main backend only")
+        assert cmd is not None
+        assert "--base-branch" in cmd
+        base_idx = cmd.index("--base-branch")
+        assert cmd[base_idx + 1] == "main"
+        assert "--context" in cmd
+        ctx_idx = cmd.index("--context")
+        assert cmd[ctx_idx + 1] == "backend only"
 
     def test_fix_no_url(self):
         cmd = self._build("fix", "just fix the login bug")
@@ -1189,6 +1242,11 @@ class TestValidateSkillArgs:
 
     def test_check_no_url(self):
         err = validate_skill_args("check", "no url here")
+        assert err is not None
+        assert "/check requires a GitHub URL" in err
+
+    def test_check_jira_url_rejected(self):
+        err = validate_skill_args("check", "https://org.atlassian.net/browse/PROJ-123")
         assert err is not None
         assert "/check requires a GitHub URL" in err
 


### PR DESCRIPTION
Introduce koan/app/url_skill_args.py providing add_url_skill_common_args(), a single source of truth for the --context, --base-branch, --project-name, and --instance-dir CLI flags shared by the /plan, /deepplan, /fix, and /implement runners. This removes the duplicated argparse boilerplate that had drifted between fix_runner, implement_runner, plan_runner, and deepplan_runner.

Wire base-branch support through plan_runner and deepplan_runner: the new _merge_context_with_base_branch() helper folds a "Target base branch" hint into the user context so the generated plan respects the requested base branch. deepplan_runner now also accepts context and project_name, and forwards the resolved project to fetch_issue() for correct tracker configuration.

Validate skill arguments in jira_command_handler before queueing a mission, reusing validate_skill_args(). This rejects command/URL mismatches (for example a Jira issue URL on a PR-only command) at mention time instead of inserting a mission guaranteed to fail in run.py.

Tighten /check validation to require a GitHub PR or issue URL, dropping the previously accepted Jira URL form that the runner does not support.

Update the Jira integration, skills, and user-manual docs to describe the branch:<name> override and the per-command argument validation.