### PR TITLE
Recover stalled rebase feedback and make bot-comment filtering opt-out

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -549,8 +549,14 @@ Use this before `/plan` when the idea is architecturally complex, when you want 
 By default, Telegram `/rebase` only queues PRs created by this instance
 (branch prefix match). Set `allow_rebase_foreign_prs: true` in
 `instance/config.yaml` to allow rebasing other writable PRs.
+By default, `/rebase` feedback analysis includes bot-authored comments
+(`rebase_include_bot_feedback: true`). Set it to `false` to keep noisy
+third-party CI/bot output out of the feedback prompt. Kōan's own comments
+are always kept (never treated as bot output), so review feedback it left on
+a previous iteration is available to a later rebase — important for combined
+review + rebase flows.
 
-When `/rebase` runs long, Kōan now uses activity-aware limits for review and CI-fix phases: it allows long sessions when CLI output keeps flowing, but still aborts stalled phases after inactivity or a max-duration cap. If the review-feedback step *stalls* (idle/max-duration timeout) or hits a *provider quota limit*, the rebase is stopped so you can re-run it later. Any other (transient) feedback error is treated as best-effort: the already-completed rebase is still pushed, with a note that review feedback could not be applied — so a flaky feedback step never discards a clean rebase.
+When `/rebase` runs long, Kōan uses activity-aware limits for review and CI-fix phases: it allows long sessions when CLI output keeps flowing, but still aborts stalled phases after inactivity or a max-duration cap. If the review-feedback step *stalls* (idle/max-duration timeout), Kōan now restores the clean rebased checkpoint and still pushes the rebase (without partial feedback edits), so timeout noise does not discard a valid rebase. If the feedback step hits a *provider quota limit*, the rebase still stops so you can retry after quota reset. Any other transient feedback error remains best-effort and does not block pushing the rebase.
 
 After completion, Kōan posts a structured comment on the PR with these sections:
 
@@ -1091,6 +1097,7 @@ rebase_review_idle_timeout: 1800   # /rebase review phase: kill on inactivity
 rebase_review_max_duration: 10800  # /rebase review phase: absolute cap
 rebase_ci_idle_timeout: 1800       # /rebase CI-fix phase: kill on inactivity
 rebase_ci_max_duration: 7200       # /rebase CI-fix phase: absolute cap
+rebase_include_bot_feedback: true  # Include bot-authored PR comments in feedback analysis (set false to filter them out)
 allow_rebase_foreign_prs: false    # Telegram /rebase can target non-instance PRs
 skill_max_turns: 200          # Max agentic turns for heavy skills
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -153,6 +153,13 @@ skill_timeout: 7200
 # Defaults to skill_timeout.
 # rebase_ci_max_duration: 7200
 
+# Include bot-authored review/issue comments in /rebase feedback analysis.
+# Default true uses bot comments by design; set false to keep noisy
+# third-party CI/bot comments out of the review-feedback prompt. Kōan's own
+# comments are always kept, so feedback from a previous review/rebase
+# iteration is preserved.
+# rebase_include_bot_feedback: true
+
 # Allow /rebase on PRs not created by this instance.
 # Default false keeps the branch-prefix ownership guard in Telegram /rebase.
 # Set true only when you intentionally want to rebase any writable PR.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -636,6 +636,17 @@ def get_rebase_ci_max_duration() -> int:
     return _safe_int(config.get("rebase_ci_max_duration", fallback), fallback)
 
 
+def get_rebase_include_bot_feedback() -> bool:
+    """Whether /rebase review feedback should include bot-authored comments.
+
+    When true (default), rebase feedback prompts include bot-authored
+    review/issue comments. Set false to keep noisy CI/bot output out of the
+    prompt and use only human-authored feedback.
+    """
+    config = _load_config()
+    return bool(config.get("rebase_include_bot_feedback", True))
+
+
 def is_rebase_foreign_prs_allowed() -> bool:
     """Allow Telegram /rebase to target PRs from other branch prefixes.
 

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -45,6 +45,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "rebase_review_max_duration": "int",
     "rebase_ci_idle_timeout": "int",
     "rebase_ci_max_duration": "int",
+    "rebase_include_bot_feedback": "bool",
     "allow_rebase_foreign_prs": "bool",
     "post_mission_timeout": "int",
     "contemplative_chance": "int",

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -43,6 +43,7 @@ from app.claude_step import (
     wait_for_ci,
 )
 from app.config import (
+    get_rebase_include_bot_feedback,
     get_rebase_ci_idle_timeout,
     get_rebase_ci_max_duration,
     get_rebase_review_idle_timeout,
@@ -56,10 +57,12 @@ from app.prompts import load_prompt, load_prompt_or_skill, load_skill_prompt  # 
 from app.retry import retry_with_backoff
 from app.utils import _GITHUB_REMOTE_RE, truncate_diff, truncate_text
 
-def _resolve_bot_login() -> str:
-    """Resolve the bot's GitHub login from config.
+def _resolve_own_login() -> str:
+    """Resolve our own GitHub login (the configured ``github.nickname``).
 
-    Returns empty string if not configured.
+    This identity is exempt from bot-comment filtering so feedback Kōan left
+    on a previous review/rebase iteration is preserved. Returns empty string
+    if not configured.
     """
     try:
         from app.utils import load_config
@@ -67,8 +70,71 @@ def _resolve_bot_login() -> str:
         github = config.get("github") or {}
         return str(github.get("nickname", "")).strip()
     except Exception as e:
-        print(f"[rebase_pr] could not resolve bot login: {e}", file=sys.stderr)
+        print(f"[rebase_pr] could not resolve own login: {e}", file=sys.stderr)
         return ""
+
+
+def _is_bot_login(login: str, own_login: str = "") -> bool:
+    """Return True when *login* is a third-party bot whose comments may be
+    filtered from rebase feedback.
+
+    Our own identity (*own_login*, the configured ``github.nickname``) is
+    never treated as a bot: comments Kōan authored on a previous review or
+    rebase iteration are preserved so a combined review+rebase flow can act
+    on its own earlier feedback — even if that identity is a GitHub App whose
+    login ends in ``[bot]``.
+    """
+    normalized = (login or "").strip().lower()
+    if not normalized:
+        return False
+    own = (own_login or "").strip().lower()
+    if own and normalized == own:
+        return False
+    return normalized.endswith("[bot]")
+
+
+def _extract_issue_comment_author(line: str) -> Optional[str]:
+    """Extract ``@author`` from issue-comment formatted lines."""
+    if not line.startswith("@") or ": " not in line:
+        return None
+    return line[1:].split(":", 1)[0].strip()
+
+
+def _extract_review_author(line: str) -> Optional[str]:
+    """Extract ``@author`` from PR review summary formatted lines."""
+    match = re.match(r"^@([^\s:(]+)\s+\([^)]*\):\s", line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _extract_inline_review_author(line: str) -> Optional[str]:
+    """Extract ``@author`` from inline review-comment formatted lines."""
+    match = re.match(r"^\[[^\]]+\]\s+@([^:\s]+):\s", line)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _filter_bot_comment_blocks(
+    raw: str,
+    author_extractor,
+) -> str:
+    """Remove bot-authored multi-line comment blocks from formatted text."""
+    if not raw:
+        return raw
+
+    own_login = _resolve_own_login()
+    lines = raw.split("\n")
+    filtered: list = []
+    skip = False
+    for line in lines:
+        author = author_extractor(line)
+        if author is not None:
+            skip = _is_bot_login(author, own_login)
+        if not skip:
+            filtered.append(line)
+    return "\n".join(filtered)
 
 
 def _filter_bot_issue_comments(raw: str) -> str:
@@ -78,21 +144,17 @@ def _filter_bot_issue_comments(raw: str) -> str:
     Bot comments (rebase summaries, review results) are verbose and push
     human feedback out of the truncation window.
     """
-    bot_login = _resolve_bot_login()
-    if not bot_login or not raw:
-        return raw
+    return _filter_bot_comment_blocks(raw, _extract_issue_comment_author)
 
-    bot_prefix = f"@{bot_login.lower()}:"
-    lines = raw.split("\n")
-    filtered: list = []
-    skip = False
-    for line in lines:
-        if line.startswith("@") and ": " in line:
-            # New comment block — check if it's from the bot
-            skip = line.lower().startswith(bot_prefix)
-        if not skip:
-            filtered.append(line)
-    return "\n".join(filtered)
+
+def _filter_bot_reviews(raw: str) -> str:
+    """Remove bot-authored PR review summaries."""
+    return _filter_bot_comment_blocks(raw, _extract_review_author)
+
+
+def _filter_bot_review_comments(raw: str) -> str:
+    """Remove bot-authored inline PR review comments."""
+    return _filter_bot_comment_blocks(raw, _extract_inline_review_author)
 
 
 def _truncate_recent(text: str, max_chars: int) -> str:
@@ -450,16 +512,22 @@ def fetch_pr_context(
     except RuntimeError:
         issue_comments = ""
 
-    # Filter out bot's own comments to preserve budget for human feedback.
-    # Bot replies (rebase summaries, review results) are verbose and push
-    # human comments out of the truncation window.
-    issue_comments = _filter_bot_issue_comments(issue_comments)
+    # Count inline comments BEFORE bot-filtering: pending-review detection
+    # compares against the API's total review-comment count (which includes
+    # bot comments), so filtering here would skew it into false positives.
+    fetched_comment_count = len(comments_json.strip().splitlines()) if comments_json.strip() else 0
+
+    # By default bot comments are included; when disabled, drop them so noisy
+    # CI/bot output does not inflate prompt size and stall the feedback phase.
+    if not get_rebase_include_bot_feedback():
+        comments_json = _filter_bot_review_comments(comments_json)
+        reviews_json = _filter_bot_reviews(reviews_json)
+        issue_comments = _filter_bot_issue_comments(issue_comments)
 
     # Detect pending (unsubmitted) reviews: GitHub counts pending review
     # comments in the PR metadata but the API doesn't return them to other
     # users.  When the count is positive but fetched comments are empty,
     # there are invisible pending reviews.
-    fetched_comment_count = len(comments_json.strip().splitlines()) if comments_json.strip() else 0
     has_pending_reviews = api_review_comment_count > 0 and fetched_comment_count == 0
 
     return {
@@ -702,6 +770,20 @@ def run_rebase(
             f"Could not resolve conflicts.\n{guidance}"
         )
 
+    # Save the clean rebased state before optional review-feedback edits.
+    # If feedback application stalls, we can safely reset to this point
+    # and still push a correct rebase.
+    rebase_checkpoint = ""
+    try:
+        rebase_checkpoint = _run_git(
+            ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=30,
+        ).strip()
+    except Exception as e:
+        print(
+            f"[rebase_pr] could not capture rebase checkpoint: {e}",
+            file=sys.stderr,
+        )
+
     # ── Step 4: Analyze review comments and apply changes ──────────────
     change_summary = ""
     if _has_review_feedback(context):
@@ -721,11 +803,42 @@ def run_rebase(
         )
         feedback_status = feedback_meta.get("status", "")
         if feedback_status == "feedback_timeout":
-            _safe_checkout(original_branch, project_path)
-            guidance = _build_rebase_recovery_guidance(project_path)
-            return False, (
-                "[feedback_timeout] Rebase stopped while applying review feedback.\n"
-                f"{guidance}"
+            timeout_error = feedback_meta.get("error", "").strip()
+            if _get_current_branch(project_path) != branch:
+                _safe_checkout(branch, project_path)
+
+            recovered = False
+            if rebase_checkpoint:
+                try:
+                    _run_git(
+                        ["git", "reset", "--hard", rebase_checkpoint],
+                        cwd=project_path, timeout=30,
+                    )
+                    recovered = True
+                except Exception as e:
+                    print(
+                        "[rebase_pr] feedback-timeout recovery reset failed: "
+                        f"{e}",
+                        file=sys.stderr,
+                    )
+
+            if not recovered:
+                _safe_checkout(original_branch, project_path)
+                guidance = _build_rebase_recovery_guidance(project_path)
+                return False, (
+                    "[feedback_timeout] Rebase feedback timed out and automatic "
+                    "recovery to the clean rebased state failed.\n"
+                    f"{guidance}"
+                )
+
+            suffix = f" ({timeout_error})" if timeout_error else ""
+            actions_log.append(
+                "Review feedback timed out; restored clean rebased state and "
+                "continuing with rebase-only push"
+            )
+            notify_fn(
+                f"Review feedback timed out on `{branch}`{suffix}; "
+                "pushing the clean rebase without feedback edits."
             )
         if feedback_status == "feedback_quota":
             # Provider quota is exhausted — no point pushing a half-applied
@@ -1917,8 +2030,8 @@ def _build_rebase_comment(
     4. Actions — pipeline steps performed
     5. CI — test / CI status
     """
-    has_feedback = _has_review_feedback(context) and any(
-        "feedback" in a.lower() for a in actions_log
+    has_feedback = bool(change_summary.strip()) or any(
+        "applied review feedback" in a.lower() for a in actions_log
     )
     has_conflicts = any("conflict" in a.lower() for a in actions_log)
 

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -609,6 +609,20 @@ class TestGetRebaseCiMaxDuration:
             assert get_rebase_ci_max_duration() == 9000
 
 
+class TestGetRebaseIncludeBotFeedback:
+    def test_default_true(self):
+        from app.config import get_rebase_include_bot_feedback
+
+        with _mock_config({}):
+            assert get_rebase_include_bot_feedback() is True
+
+    def test_uses_override(self):
+        from app.config import get_rebase_include_bot_feedback
+
+        with _mock_config({"rebase_include_bot_feedback": False}):
+            assert get_rebase_include_bot_feedback() is False
+
+
 # --- get_skill_max_turns ---
 
 

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -592,6 +592,17 @@ class TestBuildRebaseComment:
         assert "## Rebase with requested adjustments" in result
         assert "review feedback was applied" in result
 
+    def test_feedback_timeout_note_does_not_count_as_adjustments(self):
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            [
+                "Rebased onto origin/main",
+                "Review feedback timed out; restored clean rebased state and continuing with rebase-only push",
+            ],
+            {"title": "Fix bug", "review_comments": "please fix the typo"},
+        )
+        assert "## Simple rebase" in result
+
     def test_conflict_resolution_noted(self):
         result = _build_rebase_comment(
             "42", "koan/fix", "main",
@@ -833,6 +844,93 @@ class TestFetchPrContext:
         assert context["review_comments"] == ""
         assert context["reviews"] == ""
         assert context["issue_comments"] == ""
+
+    @patch("app.rebase_pr.get_rebase_include_bot_feedback", return_value=False)
+    @patch("app.github.subprocess.run")
+    def test_filters_bot_feedback_when_disabled(self, mock_run, _mock_include_bots):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "PR", "headRefName": "br", "baseRefName": "main",
+                "state": "OPEN", "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(returncode=0, stdout="+diff"),
+            MagicMock(
+                returncode=0,
+                stdout=(
+                    "[f.py:10] @github-actions[bot]: bot inline\n"
+                    "[f.py:11] @alice: human inline"
+                ),
+            ),
+            MagicMock(
+                returncode=0,
+                stdout=(
+                    "@github-actions[bot] (COMMENTED): bot review\n"
+                    "@alice (COMMENTED): human review"
+                ),
+            ),
+            MagicMock(
+                returncode=0,
+                stdout=(
+                    "@github-actions[bot]: bot issue line 1\n"
+                    "bot continuation\n"
+                    "@alice: human issue"
+                ),
+            ),
+        ]
+        context = fetch_pr_context("o", "r", "1")
+        assert "@github-actions[bot]" not in context["review_comments"]
+        assert "@github-actions[bot]" not in context["reviews"]
+        assert "@github-actions[bot]" not in context["issue_comments"]
+        assert "@alice: human issue" in context["issue_comments"]
+        assert "@alice (COMMENTED): human review" in context["reviews"]
+        assert "@alice: human inline" in context["review_comments"]
+
+    @patch("app.rebase_pr.get_rebase_include_bot_feedback", return_value=True)
+    @patch("app.github.subprocess.run")
+    def test_can_include_bot_feedback_when_enabled(self, mock_run, _mock_include_bots):
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "PR", "headRefName": "br", "baseRefName": "main",
+                "state": "OPEN", "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(returncode=0, stdout="+diff"),
+            MagicMock(returncode=0, stdout="[f.py:10] @github-actions[bot]: bot inline"),
+            MagicMock(returncode=0, stdout="@github-actions[bot] (COMMENTED): bot review"),
+            MagicMock(returncode=0, stdout="@github-actions[bot]: bot issue"),
+        ]
+        context = fetch_pr_context("o", "r", "1")
+        assert "@github-actions[bot]" in context["review_comments"]
+        assert "@github-actions[bot]" in context["reviews"]
+        assert "@github-actions[bot]" in context["issue_comments"]
+
+    @patch("app.rebase_pr.get_rebase_include_bot_feedback", return_value=False)
+    @patch("app.github.subprocess.run")
+    def test_pending_reviews_not_triggered_by_filtered_bot_comments(
+        self, mock_run, _mock_include_bots,
+    ):
+        # The API reports inline review comments (count > 0), but they are all
+        # bot-authored and get filtered out of the prompt. Pending-review
+        # detection must count the raw comments so it does not false-positive.
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "PR", "headRefName": "br", "baseRefName": "main",
+                "state": "OPEN", "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="1"),  # .review_comments count
+            MagicMock(returncode=0, stdout="+diff"),
+            MagicMock(returncode=0, stdout="[f.py:10] @github-actions[bot]: bot inline"),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        context = fetch_pr_context("o", "r", "1")
+        # Bot comment filtered from the prompt, but no false pending warning.
+        assert "@github-actions[bot]" not in context["review_comments"]
+        assert context["has_pending_reviews"] is False
 
     @patch("app.github.subprocess.run")
     def test_detects_pending_reviews(self, mock_run):
@@ -1899,13 +1997,9 @@ class TestRunRebaseClaude:
 
     @patch("app.rebase_pr._safe_checkout")
     @patch("app.rebase_pr._apply_review_feedback")
-    @patch(
-        "app.rebase_pr._build_rebase_recovery_guidance",
-        return_value="Recovery hints:\n- next: git rebase --continue",
-    )
     @patch("app.rebase_pr.fetch_pr_context")
-    def test_feedback_timeout_returns_classified_failure(
-        self, mock_ctx, mock_guidance, mock_apply, mock_safe,
+    def test_feedback_timeout_pushes_rebase_without_feedback(
+        self, mock_ctx, mock_apply, mock_safe,
     ):
         mock_ctx.return_value = {
             "title": "Fix auth", "body": "", "branch": "feat",
@@ -1924,13 +2018,66 @@ class TestRunRebaseClaude:
         with patch("app.rebase_pr._check_if_already_solved", return_value=(False, None)), \
              patch("app.rebase_pr._get_current_branch", return_value="main"), \
              patch("app.rebase_pr._checkout_pr_branch"), \
-             patch("app.rebase_pr._rebase_with_conflict_resolution", return_value="origin"):
+             patch("app.rebase_pr._rebase_with_conflict_resolution", return_value="origin"), \
+             patch("app.rebase_pr._run_git", side_effect=["abc123\n", ""]), \
+             patch("app.rebase_pr._fix_existing_ci_failures", return_value=False), \
+             patch("app.rebase_pr._enqueue_ci_check", return_value="CI queued"), \
+             patch("app.rebase_pr._push_with_fallback", return_value={
+                 "success": True, "actions": ["Force-pushed"], "error": "",
+             }) as mock_push, \
+             patch("app.rebase_pr.run_gh"):
+            success, summary = run_rebase(
+                "o", "r", "1", "/p", notify_fn=notify, skill_dir=REBASE_SKILL_DIR,
+            )
+
+        assert success is True
+        assert "Review feedback timed out" in summary
+        assert "rebase-only push" in summary
+        mock_push.assert_called_once()
+
+    @patch("app.rebase_pr._safe_checkout")
+    @patch("app.rebase_pr._apply_review_feedback")
+    @patch(
+        "app.rebase_pr._build_rebase_recovery_guidance",
+        return_value="Recovery hints:\n- next: git status",
+    )
+    @patch("app.rebase_pr.fetch_pr_context")
+    def test_feedback_timeout_recovery_failure_returns_error(
+        self, mock_ctx, _mock_guidance, mock_apply, mock_safe,
+    ):
+        mock_ctx.return_value = {
+            "title": "Fix auth", "body": "", "branch": "feat",
+            "base": "main", "state": "", "author": "", "url": "",
+            "diff": "+code", "review_comments": "@reviewer: fix this",
+            "reviews": "", "issue_comments": "",
+        }
+
+        def _apply_side_effect(*args, **kwargs):
+            kwargs["result_meta"]["status"] = "feedback_timeout"
+            kwargs["result_meta"]["error"] = "Timeout (600s)"
+            return ""
+
+        mock_apply.side_effect = _apply_side_effect
+        notify = MagicMock()
+
+        def _run_git_side_effect(cmd, **kwargs):
+            if cmd[:2] == ["git", "rev-parse"]:
+                return "abc123\n"
+            if cmd[:3] == ["git", "reset", "--hard"]:
+                raise RuntimeError("reset failed")
+            return ""
+
+        with patch("app.rebase_pr._check_if_already_solved", return_value=(False, None)), \
+             patch("app.rebase_pr._get_current_branch", return_value="main"), \
+             patch("app.rebase_pr._checkout_pr_branch"), \
+             patch("app.rebase_pr._rebase_with_conflict_resolution", return_value="origin"), \
+             patch("app.rebase_pr._run_git", side_effect=_run_git_side_effect):
             success, summary = run_rebase(
                 "o", "r", "1", "/p", notify_fn=notify, skill_dir=REBASE_SKILL_DIR,
             )
 
         assert success is False
-        assert "[feedback_timeout]" in summary
+        assert "automatic recovery" in summary
         assert "Recovery hints" in summary
 
     @patch("app.rebase_pr._safe_checkout")
@@ -3508,31 +3655,55 @@ class TestMainMinSeverity:
 class TestFilterBotIssueComments:
     """Tests for _filter_bot_issue_comments."""
 
-    def test_removes_bot_comments(self):
+    def test_removes_third_party_bot_comments(self):
         raw = (
             "@human: Please fix this bug\n"
-            "@koan-bot: ## Rebase with requested adjustments\n"
-            "Branch was rebased onto main.\n"
+            "@github-actions[bot]: ## CI run results\n"
+            "All checks passed.\n"
             "### Stats\n"
             "7 files changed\n"
             "@human: Now add config option\n"
             "@human: @koan-bot rebase"
         )
-        with patch("app.rebase_pr._resolve_bot_login", return_value="koan-bot"):
+        with patch("app.rebase_pr._resolve_own_login", return_value="koan-bot"):
             result = _filter_bot_issue_comments(raw)
         assert "@human: Please fix this bug" in result
         assert "@human: Now add config option" in result
-        assert "@koan-bot:" not in result
-        assert "Branch was rebased" not in result
+        assert "@github-actions[bot]:" not in result
+        assert "All checks passed" not in result
 
-    def test_no_bot_login_returns_original(self):
+    def test_keeps_own_identity_comments(self):
+        # Our own prior review/rebase feedback must survive filtering so a
+        # later rebase can act on it (review + rebase flow).
+        raw = (
+            "@human: Please fix this bug\n"
+            "@koan-bot: ## Review feedback from last iteration\n"
+            "Consider renaming the helper.\n"
+            "@github-actions[bot]: CI noise"
+        )
+        with patch("app.rebase_pr._resolve_own_login", return_value="koan-bot"):
+            result = _filter_bot_issue_comments(raw)
+        assert "@koan-bot: ## Review feedback from last iteration" in result
+        assert "Consider renaming the helper." in result
+        assert "@github-actions[bot]: CI noise" not in result
+
+    def test_keeps_own_identity_even_with_bot_suffix(self):
+        # If our configured identity is a GitHub App (login ends in [bot]),
+        # it is still exempt from filtering; other [bot] authors are removed.
+        raw = "@koan-app[bot]: our prior feedback\n@other[bot]: third-party noise"
+        with patch("app.rebase_pr._resolve_own_login", return_value="koan-app[bot]"):
+            result = _filter_bot_issue_comments(raw)
+        assert "@koan-app[bot]: our prior feedback" in result
+        assert "@other[bot]: third-party noise" not in result
+
+    def test_no_own_login_keeps_non_bot_authors(self):
         raw = "@bot: some text\n@human: other text"
-        with patch("app.rebase_pr._resolve_bot_login", return_value=""):
+        with patch("app.rebase_pr._resolve_own_login", return_value=""):
             result = _filter_bot_issue_comments(raw)
         assert result == raw
 
     def test_empty_input(self):
-        with patch("app.rebase_pr._resolve_bot_login", return_value="bot"):
+        with patch("app.rebase_pr._resolve_own_login", return_value="koan-bot"):
             assert _filter_bot_issue_comments("") == ""
 
 


### PR DESCRIPTION
Add a rebase_include_bot_feedback config option (default true) controlling whether the /rebase review-feedback prompt considers third-party bot-authored comments. Bot feedback is included by design; setting it false filters third-party bot comments across all three comment streams (inline review comments, review summaries, and issue comments) so verbose CI/bot output cannot inflate the prompt and stall the feedback phase.

Bot detection is centralized in _is_bot_login: a login is a bot when it ends in [bot]. Kōan's own identity (the configured github.nickname) is explicitly exempt and never filtered — even if it is a GitHub App whose login ends in [bot] — so review feedback Kōan left on a previous iteration survives into a later rebase. This is important for combined review + rebase flows.

Count inline comments before bot-filtering so pending-review detection is not skewed: it compares against the API's total review-comment count (which includes bot comments), so filtering before counting would false-positive the "pending unsubmitted review comments" warning whenever a bot left inline comments.

Recover gracefully when review-feedback application times out: capture a clean rebase checkpoint before applying feedback, and on feedback_timeout reset --hard to that checkpoint and push the rebase without partial feedback edits, rather than discarding a valid rebase. If recovery itself fails, fall back to the previous classified-failure behavior. Provider quota limits still stop the rebase for later retry.

Fix _build_rebase_comment so a feedback-timeout note in the actions log no longer counts as "requested adjustments"; the comment now keys off an actual change_summary or an "applied review feedback" action.

Update the user manual and instance.example config to document the new option, the own-identity exemption, and the timeout-recovery behavior.