### PR TITLE
fix: load .env before git identity setup in startup_manager

### DIFF
--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -518,6 +518,12 @@ def run_startup(koan_root: str, instance: str, projects: list):
     _safe_run("Start on pause", handle_start_on_pause, koan_root)
     _safe_run("Start passive", handle_start_passive, koan_root)
 
+    # Load .env before git identity so KOAN_EMAIL is available.
+    # run.py does not source .env itself; without this, GIT_AUTHOR_EMAIL is
+    # never set and git falls back to the global ~/.gitconfig identity.
+    from app.utils import load_dotenv
+    load_dotenv()
+
     # Git identity and GitHub auth
     _safe_run("Git identity", setup_git_identity)
     _safe_run("GitHub auth", setup_github_auth)


### PR DESCRIPTION
## Problem

`setup_git_identity()` reads `KOAN_EMAIL` from the environment to set `GIT_AUTHOR_EMAIL` and `GIT_COMMITTER_EMAIL`. However, `run.py` never sources the `.env` file before calling `run_startup()`, so `KOAN_EMAIL` is not present in the environment at the time git identity is configured. Git silently falls back to the global `~/.gitconfig` identity, causing commits to be authored under the system user rather than the configured Kōan identity.

## Fix

Add a `load_dotenv()` call in `run_startup()` after the pause/passive setup phase but before `setup_git_identity()`. `load_dotenv()` uses `os.environ.setdefault`, so it will not overwrite variables that were already set explicitly in the environment.

## Testing

- With `KOAN_EMAIL` set only in `.env` (not exported in the shell), git commits now use the configured identity.
- When `KOAN_EMAIL` is already in the environment, `setdefault` is a no-op and behavior is unchanged.