### PR TITLE
docs: update repo URLs from sukria to Anantys-oss

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,7 +10,7 @@ Kōan has two branches you can track:
 Track stable:
 
 ```bash
-git clone -b stable https://github.com/sukria/koan.git
+git clone -b stable https://github.com/Anantys-oss/koan.git
 cd koan
 # update later with:
 git pull origin stable
@@ -31,7 +31,7 @@ See [docs/maint.md](docs/maint.md) for the release procedure and cadence philoso
 The easiest way to set up Kōan is with the interactive wizard:
 
 ```bash
-git clone https://github.com/sukria/koan.git
+git clone https://github.com/Anantys-oss/koan.git
 cd koan
 make setup
 make install
@@ -78,7 +78,7 @@ per-project configuration via `projects.yaml`.
 ### 1. Clone and create your instance
 
 ```bash
-git clone https://github.com/sukria/koan.git
+git clone https://github.com/Anantys-oss/koan.git
 cd koan
 cp -r instance.example instance
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This isn't a chatbot wrapper. It's a collaborator with memory, personality, and 
 ## Quick Start
 
 ```bash
-git clone https://github.com/sukria/koan.git
+git clone https://github.com/Anantys-oss/koan.git
 cd koan
 make setup
 make install    # Interactive web wizard — sets up everything

--- a/docs/messaging/github-commands.md
+++ b/docs/messaging/github-commands.md
@@ -2,7 +2,7 @@
 
 Control Kōan directly from GitHub PR and issue comments using `@mention` commands.
 
-> **Introduced in**: [PR #251](https://github.com/sukria/koan/pull/251) — 10 commits, 6 new modules, 102 tests.
+> **Introduced in**: [PR #251](https://github.com/Anantys-oss/koan/pull/251) — 10 commits, 6 new modules, 102 tests.
 
 ## Overview
 
@@ -350,5 +350,5 @@ See [Jira Integration](jira-integration.md) for full setup instructions and the 
 - [Messaging: Telegram](telegram.md) — Alternative command interface via Telegram
 - [Messaging: Slack](slack.md) — Alternative command interface via Slack
 - [Messaging: Matrix](matrix.md) — Alternative command interface via Matrix
-- [PR #251](https://github.com/sukria/koan/pull/251) — Original implementation
-- [Issue #243](https://github.com/sukria/koan/issues/243) — Feature request and design plan
+- [PR #251](https://github.com/Anantys-oss/koan/pull/251) — Original implementation
+- [Issue #243](https://github.com/Anantys-oss/koan/issues/243) — Feature request and design plan

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -17,7 +17,7 @@
 
 ```bash
 # 1. Clone and enter the repo
-git clone https://github.com/sukria/koan.git
+git clone https://github.com/Anantys-oss/koan.git
 cd koan
 
 # 2. Create your instance directory


### PR DESCRIPTION
## Summary

- Replace all `github.com/sukria/koan` URLs with `github.com/Anantys-oss/koan` following the repo migration
- Updated 4 files: `README.md`, `INSTALL.md`, `docs/setup/docker.md`, `docs/messaging/github-commands.md`
- Left `sukria-koan0` user account link in README untouched (that's a separate GitHub user, not the org)

## Test plan

- [ ] Verify all clone commands in docs point to the correct new repo
- [ ] Confirm PR/issue links in `github-commands.md` resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)