### PR TITLE
fix(usage): record skill-dispatch activity + backfill historical days

### DIFF
--- a/docs/operations/dashboard.md
+++ b/docs/operations/dashboard.md
@@ -27,14 +27,32 @@ config) and exposes a JSON/SSE API under `/api/*`.
 | `/` | Dashboard — agent status, mission counts, attention zone, health, projects |
 | `/missions` | Pending / in-progress / done missions, with drag-reorder, edit, cancel |
 | `/chat` | Chat with the agent or queue a mission |
-| `/usage` | Token usage analytics (Chart.js): spend, by project, outcomes, types |
-| `/prs` | Open pull requests across projects with CI and review status |
+| `/usage` | Token usage analytics (Chart.js): spend, by project, outcomes, types, and daily mission activity from `instance/usage/*.jsonl` |
+| `/prs` | Open pull requests across projects with CI and review status, sorted by last activity (`updatedAt`, fallback `createdAt`) |
 | `/plans` | Plan issues with phase progress |
 | `/progress` | Live stream of the current run's output (SSE) |
 | `/journal` | Journal entries grouped by date and project |
 | `/logs` | Recent log lines with source filter and search |
 | `/agent` | Read-only introspection: soul, memory, skills, config |
 | `/rules` | Automation rules CRUD |
+
+### Usage activity backfill
+
+`/usage` reads daily mission activity solely from `instance/usage/*.jsonl`. Runs whose token
+usage cannot be extracted (e.g. some skill-dispatch missions) are now recorded with a
+placeholder row so activity stays visible. To reconstruct activity for **historical** days that
+predate that fix, run the one-shot backfill from `instance/session_outcomes.json`:
+
+```bash
+# dry-run (default) — shows per-day counts that would be written
+python -m app.backfill_usage --start 2026-05-30
+# apply
+python -m app.backfill_usage --start 2026-05-30 --apply
+```
+
+Synthetic rows carry a `"backfill": true` marker (zero tokens/cost — counts only, since token
+data is unrecoverable) and the tool is idempotent: re-running writes nothing already present and
+credits any real rows so days are never over-counted.
 
 ## Layout
 

--- a/koan/app/backfill_usage.py
+++ b/koan/app/backfill_usage.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Backfill historical usage activity from session outcomes.
+
+The dashboard ``/usage`` page reads daily mission activity exclusively from
+``instance/usage/YYYY-MM-DD.jsonl``. Skill-dispatch missions (e.g. ``/review``)
+historically failed token extraction and wrote no usage row, so those days show
+no activity even though ``instance/session_outcomes.json`` recorded the work.
+
+This one-shot maintenance tool reconstructs the missing per-day activity by
+writing synthetic, zero-cost usage rows derived from ``session_outcomes.json``.
+Token and cost values are unrecoverable, so they are recorded as 0 / "unknown":
+the goal is restoring the per-day activity *count* (and per-project / per-type
+breakdowns), not historical spend.
+
+Synthetic rows carry a ``"backfill": true`` marker. ``cost_tracker`` readers
+ignore the marker (it is not a known field), but it makes synthetic rows
+distinguishable from real ones — which is what keeps this tool idempotent and
+prevents double-counting once the forward fix starts writing real rows.
+
+Usage:
+    python -m app.backfill_usage [--apply] [--start YYYY-MM-DD] [--end YYYY-MM-DD]
+
+Without --apply, runs in dry-run mode (shows what would change).
+"""
+
+import argparse
+import fcntl
+import json
+import os
+import sys
+from datetime import date, datetime, timedelta
+from pathlib import Path
+from typing import Optional
+
+from app import cost_tracker
+
+# Marker key stamped on synthetic rows. Real usage rows never set this.
+BACKFILL_MARKER = "backfill"
+
+# Default window start — the first day the usage JSONL gap began.
+DEFAULT_START = date(2026, 5, 30)
+
+
+def get_koan_root() -> Path:
+    root = os.environ.get("KOAN_ROOT")
+    if not root:
+        print("Error: KOAN_ROOT not set", file=sys.stderr)
+        sys.exit(1)
+    return Path(root)
+
+
+def load_outcomes(outcomes_path: Path) -> list:
+    """Load the session outcomes list. Returns [] when missing or malformed."""
+    if not outcomes_path.exists():
+        return []
+    try:
+        data = json.loads(outcomes_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return []
+    return data if isinstance(data, list) else []
+
+
+def _outcome_date(outcome: dict) -> Optional[date]:
+    """Parse the calendar date from an outcome timestamp; None if unparseable."""
+    ts = outcome.get("timestamp")
+    if not isinstance(ts, str):
+        return None
+    try:
+        return date.fromisoformat(ts[:10])
+    except ValueError:
+        return None
+
+
+def group_outcomes_by_date(
+    outcomes: list, start: date, end: date
+) -> "dict[date, list]":
+    """Group outcomes by calendar date within [start, end] (inclusive).
+
+    Each day's list is ordered by timestamp for deterministic backfill.
+    """
+    grouped: "dict[date, list]" = {}
+    for o in outcomes:
+        d = _outcome_date(o)
+        if d is None or d < start or d > end:
+            continue
+        grouped.setdefault(d, []).append(o)
+    for day_outcomes in grouped.values():
+        day_outcomes.sort(key=lambda o: o.get("timestamp", ""))
+    return grouped
+
+
+def _synthetic_entry(outcome: dict) -> dict:
+    """Build a synthetic usage row from an outcome, matching the real schema.
+
+    Mirrors ``cost_tracker.record_usage``'s entry shape (omitting empty optional
+    fields), with zero tokens/cost and the backfill marker appended.
+    """
+    entry = {
+        "ts": outcome.get("timestamp"),
+        "project": outcome.get("project") or "_global",
+        "model": "unknown",
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "mode": outcome.get("mode", ""),
+        "mission": outcome.get("summary", ""),
+    }
+    mission_type = outcome.get("mission_type")
+    if mission_type:
+        entry["mission_type"] = mission_type
+    entry[BACKFILL_MARKER] = True
+    return entry
+
+
+def _serialize(entry: dict) -> str:
+    """Match cost_tracker's compact JSONL serialization exactly."""
+    return json.dumps(entry, separators=(",", ":")) + "\n"
+
+
+def plan_day(usage_dir: Path, d: date, day_outcomes: list) -> dict:
+    """Compute the backfill action for a single day.
+
+    Credits existing real rows and previously written backfill rows so the tool
+    is idempotent and never over-counts:
+
+        target_synthetic = max(0, outcomes - real_rows)
+        to_write         = target_synthetic - existing_backfill
+
+    Returns a dict with counts and the list of synthetic entries to append
+    (the outcomes already credited are skipped from the front, deterministically).
+    """
+    existing = cost_tracker._read_jsonl_for_date(usage_dir, d)
+    existing_backfill = sum(1 for e in existing if e.get(BACKFILL_MARKER) is True)
+    real_rows = len(existing) - existing_backfill
+
+    outcomes_count = len(day_outcomes)
+    target_synthetic = max(0, outcomes_count - real_rows)
+    to_write = target_synthetic - existing_backfill
+
+    entries = []
+    if to_write > 0:
+        # Skip outcomes already accounted for (real rows + prior backfill rows),
+        # then materialize the remaining ones. Deterministic across re-runs.
+        skip = real_rows + existing_backfill
+        entries = [_synthetic_entry(o) for o in day_outcomes[skip:skip + to_write]]
+
+    return {
+        "date": d,
+        "outcomes": outcomes_count,
+        "real_rows": real_rows,
+        "existing_backfill": existing_backfill,
+        "to_write": to_write,
+        "entries": entries,
+    }
+
+
+def append_rows(jsonl_path: Path, entries: list) -> bool:
+    """Append synthetic rows under an exclusive lock, matching record_usage."""
+    if not entries:
+        return True
+    jsonl_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = "".join(_serialize(e) for e in entries)
+    try:
+        with open(jsonl_path, "a", encoding="utf-8") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            f.write(payload)
+            f.flush()
+            os.fsync(f.fileno())
+        return True
+    except OSError:
+        return False
+
+
+def run_backfill(
+    instance_dir: Path,
+    start: date,
+    end: date,
+    dry_run: bool = True,
+) -> dict:
+    """Plan (and optionally apply) the usage backfill for [start, end].
+
+    Returns a summary dict: per-day plans plus totals. When dry_run is False,
+    synthetic rows are appended to the per-day JSONL files.
+    """
+    usage_dir = Path(instance_dir) / "usage"
+    outcomes = load_outcomes(Path(instance_dir) / "session_outcomes.json")
+    grouped = group_outcomes_by_date(outcomes, start, end)
+
+    plans = []
+    current = start
+    while current <= end:
+        plans.append(plan_day(usage_dir, current, grouped.get(current, [])))
+        current += timedelta(days=1)
+
+    written = 0
+    over = 0
+    for p in plans:
+        if p["to_write"] < 0:
+            over += 1
+            print(
+                f"  WARNING {p['date']}: {-p['to_write']} more backfill row(s) "
+                f"than outcomes — leaving as-is (no data removed)"
+            )
+        if not dry_run and p["entries"]:
+            jsonl_path = usage_dir / f"{p['date'].isoformat()}.jsonl"
+            if append_rows(jsonl_path, p["entries"]):
+                written += len(p["entries"])
+
+    total_to_write = sum(max(0, p["to_write"]) for p in plans)
+    return {
+        "plans": plans,
+        "total_to_write": total_to_write,
+        "written": written,
+        "over_backfilled_days": over,
+        "dry_run": dry_run,
+    }
+
+
+def _print_summary(summary: dict) -> None:
+    print(f"{'DATE':<12} {'OUTCOMES':>9} {'REAL':>5} {'BACKFILL':>9} {'WOULD WRITE':>12}")
+    print("-" * 52)
+    for p in summary["plans"]:
+        if p["outcomes"] == 0 and p["existing_backfill"] == 0 and p["real_rows"] == 0:
+            continue
+        print(
+            f"{p['date'].isoformat():<12} {p['outcomes']:>9} {p['real_rows']:>5} "
+            f"{p['existing_backfill']:>9} {max(0, p['to_write']):>12}"
+        )
+    print("-" * 52)
+    if summary["dry_run"]:
+        print(
+            f"Total synthetic rows to write: {summary['total_to_write']}\n"
+            "\nThis was a dry run. To apply, re-run with --apply"
+        )
+    else:
+        print(f"Wrote {summary['written']} synthetic row(s).")
+
+
+def _parse_date(value: str) -> date:
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid date (expected YYYY-MM-DD): {value}")
+
+
+def main(argv: Optional[list] = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Backfill historical usage activity from session outcomes."
+    )
+    parser.add_argument("--apply", action="store_true", help="Apply changes (default: dry run)")
+    parser.add_argument(
+        "--start", type=_parse_date, default=DEFAULT_START,
+        help=f"Start date YYYY-MM-DD (default: {DEFAULT_START.isoformat()})",
+    )
+    parser.add_argument(
+        "--end", type=_parse_date, default=None,
+        help="End date YYYY-MM-DD (default: today)",
+    )
+    parser.add_argument(
+        "--instance-dir", type=Path, default=None,
+        help="Instance directory (default: $KOAN_ROOT/instance)",
+    )
+    args = parser.parse_args(argv)
+
+    instance_dir = args.instance_dir or (get_koan_root() / "instance")
+    end = args.end or datetime.now().date()
+
+    if args.start > end:
+        print(f"Error: start {args.start} is after end {end}", file=sys.stderr)
+        sys.exit(1)
+
+    summary = run_backfill(instance_dir, args.start, end, dry_run=not args.apply)
+    _print_summary(summary)
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/app/backfill_usage.py
+++ b/koan/app/backfill_usage.py
@@ -55,9 +55,19 @@ def load_outcomes(outcomes_path: Path) -> list:
         return []
     try:
         data = json.loads(outcomes_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+    except (OSError, json.JSONDecodeError) as exc:
+        print(
+            f"WARNING: {outcomes_path} exists but cannot be read: {exc}",
+            file=sys.stderr,
+        )
         return []
-    return data if isinstance(data, list) else []
+    if not isinstance(data, list):
+        print(
+            f"WARNING: {outcomes_path} is not a JSON array — skipping",
+            file=sys.stderr,
+        )
+        return []
+    return data
 
 
 def _outcome_date(outcome: dict) -> Optional[date]:
@@ -204,12 +214,18 @@ def run_backfill(
             jsonl_path = usage_dir / f"{p['date'].isoformat()}.jsonl"
             if append_rows(jsonl_path, p["entries"]):
                 written += len(p["entries"])
+            else:
+                print(
+                    f"  WARNING {p['date']}: write failed for {jsonl_path}"
+                )
 
     total_to_write = sum(max(0, p["to_write"]) for p in plans)
+    failed = total_to_write - written if not dry_run else 0
     return {
         "plans": plans,
         "total_to_write": total_to_write,
         "written": written,
+        "failed_days": failed,
         "over_backfilled_days": over,
         "dry_run": dry_run,
     }
@@ -233,6 +249,11 @@ def _print_summary(summary: dict) -> None:
         )
     else:
         print(f"Wrote {summary['written']} synthetic row(s).")
+        if summary.get("failed_days"):
+            print(
+                f"WARNING: {summary['failed_days']} row(s) failed to write",
+                file=sys.stderr,
+            )
 
 
 def _parse_date(value: str) -> date:

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -544,6 +544,7 @@ def _record_cost_event(
     mission_title: str,
     mission_type: str = "",
     tokens: Optional[dict] = None,
+    allow_placeholder: bool = False,
 ) -> None:
     """Record structured usage event to JSONL cost tracker (fire-and-forget).
 
@@ -556,7 +557,18 @@ def _record_cost_event(
 
         tokens = _ensure_tokens(stdout_file, tokens)
         if tokens is None:
-            return
+            if not allow_placeholder:
+                return
+            # Keep daily/project activity visible even when token extraction
+            # is unavailable (common on skill-dispatch stream runs).
+            tokens = {
+                "model": "unknown",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+                "cost_usd": 0.0,
+            }
 
         record_usage(
             instance_dir=Path(instance_dir),
@@ -1415,6 +1427,7 @@ def run_post_mission(
             instance_dir, project_name, stdout_file,
             autonomous_mode, mission_title, mission_type=_mission_type,
             tokens=_tokens,
+            allow_placeholder=is_skill_dispatch,
         )
 
         # 2. Compute duration (needed for quota early-return, reflection, and outcome tracking)

--- a/koan/app/pr_tracker.py
+++ b/koan/app/pr_tracker.py
@@ -26,7 +26,7 @@ from app.projects_config import (
 # Fields requested from gh pr list
 _PR_FIELDS = (
     "number,title,author,headRefName,isDraft,url,"
-    "createdAt,reviewDecision,statusCheckRollup,state"
+    "createdAt,updatedAt,reviewDecision,statusCheckRollup,state"
 )
 
 # ---------------------------------------------------------------------------
@@ -155,8 +155,11 @@ def fetch_all_prs(
                 print(f"[pr_tracker] error fetching PRs: {e}", file=sys.stderr)
                 had_errors = True
 
-    # Sort by creation date descending (newest first)
-    all_prs.sort(key=lambda pr: pr.get("createdAt", ""), reverse=True)
+    # Sort by last activity descending (fallback to creation date).
+    all_prs.sort(
+        key=lambda pr: (pr.get("updatedAt") or pr.get("createdAt") or ""),
+        reverse=True,
+    )
 
     return {
         "prs": all_prs,

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -714,8 +714,10 @@ def _persist_stream_usage_snapshot(snapshot: Optional[Dict[str, Any]]) -> None:
     target = os.environ.get("KOAN_STREAM_USAGE_FILE", "").strip()
     if not target:
         return
-    with contextlib.suppress(OSError):
+    try:
         Path(target).write_text(json.dumps(snapshot, separators=(",", ":")))
+    except OSError as exc:
+        print(f"[provider] WARNING: stream usage sidecar write failed: {exc}", file=sys.stderr)
 
 
 def run_command_streaming(

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -659,6 +659,65 @@ def _is_stream_json_max_turns(event: Dict[str, Any]) -> bool:
     return subtype in _STREAM_JSON_MAX_TURNS_SUBTYPES
 
 
+def _usage_snapshot_from_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Extract token usage snapshot from a stream event when present."""
+    if not isinstance(event, dict):
+        return None
+
+    usage = event.get("usage")
+    if isinstance(usage, dict):
+        input_tokens = int(usage.get("input_tokens", 0) or 0)
+        output_tokens = int(usage.get("output_tokens", 0) or 0)
+        cached_input = int(usage.get("cached_input_tokens", 0) or 0)
+        if cached_input > 0:
+            input_tokens = max(0, input_tokens - cached_input)
+        if input_tokens or output_tokens or cached_input:
+            return {
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+                "cache_read_input_tokens": cached_input,
+                "cache_creation_input_tokens": 0,
+                "model": str(event.get("model") or "unknown"),
+            }
+
+    payload = event.get("payload")
+    if (
+        isinstance(payload, dict)
+        and event.get("type") == "event_msg"
+        and payload.get("type") == "token_count"
+    ):
+        info = payload.get("info")
+        if isinstance(info, dict):
+            total = info.get("total_token_usage")
+            if isinstance(total, dict):
+                input_tokens = int(total.get("input_tokens", 0) or 0)
+                output_tokens = int(total.get("output_tokens", 0) or 0)
+                cached_input = int(total.get("cached_input_tokens", 0) or 0)
+                if cached_input > 0:
+                    input_tokens = max(0, input_tokens - cached_input)
+                if input_tokens or output_tokens or cached_input:
+                    return {
+                        "input_tokens": input_tokens,
+                        "output_tokens": output_tokens,
+                        "cache_read_input_tokens": cached_input,
+                        "cache_creation_input_tokens": 0,
+                        "model": str(info.get("model") or event.get("model") or "unknown"),
+                    }
+
+    return None
+
+
+def _persist_stream_usage_snapshot(snapshot: Optional[Dict[str, Any]]) -> None:
+    """Persist usage snapshot for skill-dispatch post-mission accounting."""
+    if not snapshot:
+        return
+    target = os.environ.get("KOAN_STREAM_USAGE_FILE", "").strip()
+    if not target:
+        return
+    with contextlib.suppress(OSError):
+        Path(target).write_text(json.dumps(snapshot, separators=(",", ":")))
+
+
 def run_command_streaming(
     prompt: str,
     project_path: str,
@@ -723,6 +782,7 @@ def run_command_streaming(
     raw_lines: List[str] = []  # for error reporting (full transcript)
     text_lines: List[str] = []  # fallback return value when no result event
     final_result: Optional[str] = None
+    usage_snapshot: Optional[Dict[str, Any]] = None
     saw_max_turns_event = False
     stderr_text = ""
     try:
@@ -754,6 +814,9 @@ def run_command_streaming(
                         event = None
                 if event is not None:
                     print(_summarize_stream_event(event), flush=True)
+                    event_usage = _usage_snapshot_from_event(event)
+                    if event_usage is not None:
+                        usage_snapshot = event_usage
                     # Accumulate assistant text blocks so a stream that dies
                     # before the final ``result`` event (timeout, watchdog
                     # kill, SIGPIPE) still returns whatever the provider managed
@@ -804,6 +867,7 @@ def run_command_streaming(
             if hit_max_turns:
                 _warn_max_turns(max_turns, max_turns_source)
                 from app.claude_step import strip_cli_noise
+                _persist_stream_usage_snapshot(usage_snapshot)
                 return strip_cli_noise(return_text.strip())
             raise RuntimeError(
                 _format_cli_error(proc.returncode, raw_stdout, stderr_text)
@@ -813,6 +877,7 @@ def run_command_streaming(
             _warn_max_turns(max_turns, max_turns_source)
 
         from app.claude_step import strip_cli_noise
+        _persist_stream_usage_snapshot(usage_snapshot)
         return strip_cli_noise(return_text.strip())
     finally:
         if last_message_path:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -3185,7 +3185,7 @@ def _run_skill_mission(
         # Provider stream mode can persist token usage to a sidecar file.
         # Append that JSON payload to stdout capture so token_parser can
         # account for skill-dispatch sessions in run_post_mission.
-        with suppress_logged(log, "debug", "Skill stream usage read failed", OSError, json.JSONDecodeError):
+        with suppress_logged(log, "warning", "Skill stream usage read failed", OSError, json.JSONDecodeError):
             raw_usage = Path(stream_usage_file).read_text().strip()
             if raw_usage:
                 usage_payload = json.loads(raw_usage)

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -20,6 +20,7 @@ Features:
 """
 
 import os
+import json
 import signal
 import subprocess
 import sys
@@ -3078,11 +3079,6 @@ def _run_skill_mission(
     koan_pkg_dir = os.path.join(koan_root, "koan")
     pending_path = Path(instance) / "journal" / "pending.md"
 
-    # Explicitly set PYTHONPATH so the subprocess can always resolve
-    # app.* modules even if the working tree changes (e.g. skill does
-    # a git checkout on the koan repo itself).
-    skill_env = {**os.environ, "PYTHONPATH": koan_pkg_dir}
-
     # Record the koan repo's HEAD before execution.  Skills like
     # /rebase and /recreate do git checkouts on project_path which
     # may be the koan repo itself — if they crash without restoring
@@ -3105,6 +3101,16 @@ def _run_skill_mission(
     os.close(fd_out)
     fd_err, stderr_file = tempfile.mkstemp(prefix="koan-err-")
     os.close(fd_err)
+    fd_usage, stream_usage_file = tempfile.mkstemp(prefix="koan-stream-usage-")
+    os.close(fd_usage)
+    # Explicitly set PYTHONPATH so the subprocess can always resolve
+    # app.* modules even if the working tree changes (e.g. skill does
+    # a git checkout on the koan repo itself).
+    skill_env = {
+        **os.environ,
+        "PYTHONPATH": koan_pkg_dir,
+        "KOAN_STREAM_USAGE_FILE": stream_usage_file,
+    }
     stderr_fh = None
     try:
         stderr_fh = open(stderr_file, "w")
@@ -3176,6 +3182,19 @@ def _run_skill_mission(
             raise subprocess.TimeoutExpired(skill_cmd, skill_timeout)
         exit_code = proc.returncode
         skill_stdout = "\n".join(stdout_lines)
+        # Provider stream mode can persist token usage to a sidecar file.
+        # Append that JSON payload to stdout capture so token_parser can
+        # account for skill-dispatch sessions in run_post_mission.
+        with suppress_logged(log, "debug", "Skill stream usage read failed", OSError, json.JSONDecodeError):
+            raw_usage = Path(stream_usage_file).read_text().strip()
+            if raw_usage:
+                usage_payload = json.loads(raw_usage)
+                if isinstance(usage_payload, dict):
+                    usage_json = json.dumps(usage_payload, separators=(",", ":"))
+                    if skill_stdout:
+                        skill_stdout = f"{skill_stdout}\n{usage_json}"
+                    else:
+                        skill_stdout = usage_json
         # Read stderr from file after process exits.
         stderr_fh.close()
         stderr_fh = None
@@ -3283,7 +3302,7 @@ def _run_skill_mission(
     except Exception as e:
         log("error", f"Post-mission error: {e}")
     finally:
-        _cleanup_temp(stdout_file, stderr_file)
+        _cleanup_temp(stdout_file, stderr_file, stream_usage_file)
     duration = int(time.time()) - mission_start
     debug_log(f"[run] skill exec: done in {duration}s, exit_code={exit_code}")
     return skill_result

--- a/koan/templates/prs.html
+++ b/koan/templates/prs.html
@@ -56,7 +56,7 @@
                 <th style="padding:0.5rem 0;">Project</th>
                 <th style="padding:0.5rem 0;">PR</th>
                 <th style="padding:0.5rem 0;" class="hide-mobile">Branch</th>
-                <th style="padding:0.5rem 0;" class="hide-mobile">Age</th>
+                <th style="padding:0.5rem 0;" class="hide-mobile">Last activity</th>
                 <th style="padding:0.5rem 0;">Status</th>
                 <th style="padding:0.5rem 0;">CI</th>
                 <th style="padding:0.5rem 0;">Review</th>
@@ -231,7 +231,7 @@ function renderTable() {
                 'style="color:var(--accent);text-decoration:none;" onclick="event.stopPropagation();">' +
                 '#' + pr.number + '</a> ' + title + '</td>' +
             '<td style="padding:0.5rem 0;font-family:var(--mono);font-size:0.8rem;color:var(--text-muted);" class="hide-mobile">' + branch + '</td>' +
-            '<td style="padding:0.5rem 0;font-family:var(--mono);font-size:0.8rem;color:var(--text-muted);" class="hide-mobile">' + timeAgo(pr.createdAt) + '</td>' +
+            '<td style="padding:0.5rem 0;font-family:var(--mono);font-size:0.8rem;color:var(--text-muted);" class="hide-mobile">' + timeAgo(pr.updatedAt || pr.createdAt) + '</td>' +
             '<td style="padding:0.5rem 0;"><span class="badge badge-' + statusBadge + '">' + statusLabel + '</span></td>' +
             '<td style="padding:0.5rem 0;"><span class="badge badge-' + ci.badge + '">' + ci.label + '</span></td>' +
             '<td style="padding:0.5rem 0;"><span class="badge badge-' + rv.badge + '">' + rv.label + '</span></td>' +

--- a/koan/tests/test_backfill_usage.py
+++ b/koan/tests/test_backfill_usage.py
@@ -1,0 +1,191 @@
+"""Tests for backfill_usage.py — reconstruct historical usage activity."""
+
+import json
+from datetime import date
+from pathlib import Path
+
+import pytest
+
+from app import backfill_usage, cost_tracker
+from app.backfill_usage import (
+    BACKFILL_MARKER,
+    group_outcomes_by_date,
+    load_outcomes,
+    run_backfill,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def instance_dir(tmp_path: Path) -> Path:
+    (tmp_path / "usage").mkdir(parents=True)
+    return tmp_path
+
+
+def _write_outcomes(instance_dir: Path, outcomes: list) -> None:
+    (instance_dir / "session_outcomes.json").write_text(json.dumps(outcomes))
+
+
+def _outcome(ts: str, project: str = "my-toolkit", mode: str = "implement", mtype: str = "review") -> dict:
+    return {
+        "timestamp": ts,
+        "project": project,
+        "mode": mode,
+        "mission_type": mtype,
+        "outcome": "productive",
+        "summary": f"work at {ts}",
+    }
+
+
+def _write_real_row(usage_dir: Path, d: date, project: str = "my-toolkit") -> None:
+    """Append a non-backfill (real) usage row for a date."""
+    entry = {
+        "ts": f"{d.isoformat()}T10:00:00",
+        "project": project,
+        "model": "claude",
+        "input_tokens": 100,
+        "output_tokens": 50,
+        "mode": "deep",
+        "mission": "real work",
+    }
+    path = usage_dir / f"{d.isoformat()}.jsonl"
+    with open(path, "a", encoding="utf-8") as f:
+        f.write(json.dumps(entry, separators=(",", ":")) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Grouping / loading
+# ---------------------------------------------------------------------------
+
+def test_load_outcomes_missing_returns_empty(instance_dir: Path):
+    assert load_outcomes(instance_dir / "nope.json") == []
+
+
+def test_group_outcomes_respects_range_and_orders_by_timestamp(instance_dir: Path):
+    outcomes = [
+        _outcome("2026-05-31T09:00:00"),
+        _outcome("2026-06-01T15:00:00"),
+        _outcome("2026-06-01T08:00:00"),
+        _outcome("2026-06-05T08:00:00"),  # out of range
+    ]
+    grouped = group_outcomes_by_date(outcomes, date(2026, 6, 1), date(2026, 6, 2))
+    assert set(grouped.keys()) == {date(2026, 6, 1)}
+    ts = [o["timestamp"] for o in grouped[date(2026, 6, 1)]]
+    assert ts == ["2026-06-01T08:00:00", "2026-06-01T15:00:00"]
+
+
+def test_group_skips_unparseable_timestamps(instance_dir: Path):
+    outcomes = [_outcome("not-a-date"), {"project": "x"}, _outcome("2026-06-01T08:00:00")]
+    grouped = group_outcomes_by_date(outcomes, date(2026, 6, 1), date(2026, 6, 1))
+    assert len(grouped[date(2026, 6, 1)]) == 1
+
+
+# ---------------------------------------------------------------------------
+# Dry run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_writes_nothing(instance_dir: Path):
+    _write_outcomes(instance_dir, [_outcome("2026-06-01T08:00:00")])
+    summary = run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=True)
+    assert summary["total_to_write"] == 1
+    assert summary["written"] == 0
+    assert not (instance_dir / "usage" / "2026-06-01.jsonl").exists()
+
+
+# ---------------------------------------------------------------------------
+# Apply
+# ---------------------------------------------------------------------------
+
+def test_apply_creates_rows_matching_outcome_count(instance_dir: Path):
+    outcomes = [_outcome(f"2026-06-01T0{i}:00:00") for i in range(3)]
+    _write_outcomes(instance_dir, outcomes)
+    run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+
+    rows = cost_tracker._read_jsonl_for_date(instance_dir / "usage", date(2026, 6, 1))
+    assert len(rows) == 3
+    assert all(r[BACKFILL_MARKER] is True for r in rows)
+    assert all(r["input_tokens"] == 0 and r["output_tokens"] == 0 for r in rows)
+    assert all(r["model"] == "unknown" for r in rows)
+
+
+def test_apply_is_idempotent(instance_dir: Path):
+    outcomes = [_outcome(f"2026-06-01T0{i}:00:00") for i in range(4)]
+    _write_outcomes(instance_dir, outcomes)
+
+    run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+    second = run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+
+    assert second["written"] == 0
+    rows = cost_tracker._read_jsonl_for_date(instance_dir / "usage", date(2026, 6, 1))
+    assert len(rows) == 4  # no duplicates on re-run
+
+
+def test_real_rows_offset_synthetic_need(instance_dir: Path):
+    # 5 outcomes, 2 real rows already present -> exactly 3 synthetic rows.
+    outcomes = [_outcome(f"2026-06-01T0{i}:00:00") for i in range(5)]
+    _write_outcomes(instance_dir, outcomes)
+    usage_dir = instance_dir / "usage"
+    _write_real_row(usage_dir, date(2026, 6, 1))
+    _write_real_row(usage_dir, date(2026, 6, 1))
+
+    run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+
+    rows = cost_tracker._read_jsonl_for_date(usage_dir, date(2026, 6, 1))
+    synthetic = [r for r in rows if r.get(BACKFILL_MARKER) is True]
+    assert len(rows) == 5  # 2 real + 3 synthetic == outcome count
+    assert len(synthetic) == 3
+
+
+def test_over_backfilled_day_left_untouched(instance_dir: Path):
+    # More existing backfill rows than outcomes: leave as-is, write nothing.
+    outcomes = [_outcome("2026-06-01T01:00:00")]
+    _write_outcomes(instance_dir, outcomes)
+    # Simulate prior over-backfill by pre-writing 3 marked rows.
+    usage_dir = instance_dir / "usage"
+    path = usage_dir / "2026-06-01.jsonl"
+    for i in range(3):
+        backfill_usage.append_rows(path, [{"ts": f"2026-06-01T0{i}:00:00", BACKFILL_MARKER: True}])
+
+    summary = run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+    assert summary["over_backfilled_days"] == 1
+    assert summary["written"] == 0
+    rows = cost_tracker._read_jsonl_for_date(usage_dir, date(2026, 6, 1))
+    assert len(rows) == 3  # nothing removed
+
+
+# ---------------------------------------------------------------------------
+# Integration with daily_series (what the dashboard reads)
+# ---------------------------------------------------------------------------
+
+def test_daily_series_count_reflects_backfill(instance_dir: Path):
+    outcomes = (
+        [_outcome("2026-05-31T08:00:00", project="my-toolkit")]
+        + [_outcome(f"2026-06-01T0{i}:00:00", project="proj-b") for i in range(3)]
+    )
+    _write_outcomes(instance_dir, outcomes)
+    run_backfill(instance_dir, date(2026, 5, 31), date(2026, 6, 1), dry_run=False)
+
+    series = cost_tracker.daily_series(instance_dir, date(2026, 5, 31), date(2026, 6, 1))
+    by_date = {e["date"]: e for e in series}
+    assert by_date["2026-05-31"]["count"] == 1
+    assert by_date["2026-06-01"]["count"] == 3
+    # Backfilled days contribute activity but zero tokens.
+    assert by_date["2026-06-01"]["total_input"] == 0
+    assert by_date["2026-06-01"]["total_output"] == 0
+
+
+def test_synthetic_rows_preserve_project_for_breakdown(instance_dir: Path):
+    outcomes = [
+        _outcome("2026-06-01T01:00:00", project="my-toolkit"),
+        _outcome("2026-06-01T02:00:00", project="proj-b"),
+    ]
+    _write_outcomes(instance_dir, outcomes)
+    run_backfill(instance_dir, date(2026, 6, 1), date(2026, 6, 1), dry_run=False)
+
+    # One synthetic row per outcome, each carrying its originating project so
+    # per-project dashboard breakdowns stay correct.
+    rows = cost_tracker._read_jsonl_for_date(instance_dir / "usage", date(2026, 6, 1))
+    assert {r["project"] for r in rows} == {"my-toolkit", "proj-b"}

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -3187,6 +3187,25 @@ class TestMissionRunnerFireAndForgetMetrics:
         assert kwargs["mission_type"] == "fix"
         assert kwargs["cache_read_input_tokens"] == 7
 
+    def test_record_cost_event_placeholder_for_skill_dispatch(self):
+        from app.mission_runner import _record_cost_event
+
+        with (
+            patch("app.token_parser.extract_tokens", return_value=None),
+            patch("app.cost_tracker.record_usage") as mock_record,
+        ):
+            _record_cost_event(
+                "/instance", "cp", "/tmp/out.json", "implement", "/review foo",
+                mission_type="review", allow_placeholder=True,
+            )
+
+        kwargs = mock_record.call_args.kwargs
+        assert kwargs["project"] == "cp"
+        assert kwargs["model"] == "unknown"
+        assert kwargs["input_tokens"] == 0
+        assert kwargs["output_tokens"] == 0
+        assert kwargs["mission_type"] == "review"
+
     def test_log_activity_usage_uses_preparsed_tokens(self):
         from app.mission_runner import _log_activity_usage
 

--- a/koan/tests/test_pr_tracker.py
+++ b/koan/tests/test_pr_tracker.py
@@ -35,6 +35,7 @@ SAMPLE_PR = {
     "isDraft": False,
     "url": "https://github.com/owner/repo/pull/42",
     "createdAt": "2026-03-13T10:00:00Z",
+    "updatedAt": "2026-03-13T10:00:00Z",
     "reviewDecision": "APPROVED",
     "statusCheckRollup": [
         {"name": "ci", "state": "SUCCESS", "conclusion": "SUCCESS"},
@@ -106,8 +107,18 @@ class TestFetchAllPrs:
     @patch("app.pr_tracker.load_projects_config")
     def test_aggregates_projects(self, mock_config, mock_gh, mock_user):
         mock_config.return_value = SAMPLE_CONFIG
-        pr1 = {**SAMPLE_PR, "number": 1, "createdAt": "2026-03-13T10:00:00Z"}
-        pr2 = {**SAMPLE_PR, "number": 2, "createdAt": "2026-03-13T12:00:00Z"}
+        pr1 = {
+            **SAMPLE_PR,
+            "number": 1,
+            "createdAt": "2026-03-13T10:00:00Z",
+            "updatedAt": "2026-03-13T10:00:00Z",
+        }
+        pr2 = {
+            **SAMPLE_PR,
+            "number": 2,
+            "createdAt": "2026-03-13T09:00:00Z",
+            "updatedAt": "2026-03-13T12:00:00Z",
+        }
         mock_gh.side_effect = [json.dumps([pr1]), json.dumps([pr2])]
 
         result = pr_tracker.fetch_all_prs("/tmp/koan")
@@ -115,6 +126,40 @@ class TestFetchAllPrs:
         assert len(result["prs"]) == 2
         # Newest first
         assert result["prs"][0]["number"] == 2
+
+    @patch("app.pr_tracker.get_gh_username", return_value="koan-bot")
+    @patch("app.pr_tracker.run_gh")
+    @patch("app.pr_tracker.load_projects_config")
+    def test_sorts_by_updated_at_with_created_at_fallback(self, mock_config, mock_gh, mock_user):
+        mock_config.return_value = SAMPLE_CONFIG
+        # updatedAt should win over createdAt when sorting.
+        pr_old_created_new_updated = {
+            **SAMPLE_PR,
+            "number": 101,
+            "createdAt": "2026-03-10T08:00:00Z",
+            "updatedAt": "2026-03-15T08:00:00Z",
+        }
+        pr_new_created_old_updated = {
+            **SAMPLE_PR,
+            "number": 102,
+            "createdAt": "2026-03-14T09:00:00Z",
+            "updatedAt": "2026-03-14T09:00:00Z",
+        }
+        # Missing updatedAt falls back to createdAt.
+        pr_no_updated = {
+            **SAMPLE_PR,
+            "number": 103,
+            "createdAt": "2026-03-13T10:00:00Z",
+        }
+        pr_no_updated.pop("updatedAt", None)
+        mock_gh.side_effect = [
+            json.dumps([pr_old_created_new_updated, pr_no_updated]),
+            json.dumps([pr_new_created_old_updated]),
+        ]
+
+        result = pr_tracker.fetch_all_prs("/tmp/koan")
+        numbers = [pr["number"] for pr in result["prs"]]
+        assert numbers == [101, 102, 103]
 
     @patch("app.pr_tracker.load_projects_config", return_value=None)
     def test_no_config(self, mock_config):

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -1127,6 +1127,45 @@ class TestRunCommandStreaming:
         assert captured_kwargs.get("output_format") == "stream-json"
         assert out == "codex answer"
 
+    def test_stream_usage_sidecar_persists_usage_snapshot(self, tmp_path):
+        """When configured, stream usage is persisted for skill post-processing."""
+        import json
+        from app.provider import run_command_streaming
+
+        usage_file = tmp_path / "stream-usage.json"
+        events = [
+            json.dumps({
+                "type": "turn.completed",
+                "model": "claude-sonnet-4-20250514",
+                "usage": {
+                    "input_tokens": 1200,
+                    "cached_input_tokens": 900,
+                    "output_tokens": 80,
+                },
+            }) + "\n",
+            json.dumps({
+                "type": "result",
+                "subtype": "success",
+                "result": "ok",
+            }) + "\n",
+        ]
+        proc = self._make_proc(events)
+        cleanup = MagicMock()
+
+        with patch.dict(os.environ, {"KOAN_STREAM_USAGE_FILE": str(usage_file)}), \
+             patch("app.config.get_model_config", return_value={"chat": "m", "fallback": "f"}), \
+             patch("app.provider.get_provider_name", return_value="claude"), \
+             patch("app.provider.build_full_command", return_value=["fake"]), \
+             patch("app.cli_exec.popen_cli", return_value=(proc, cleanup)), \
+             patch("app.claude_step.strip_cli_noise", side_effect=lambda s: s):
+            out = run_command_streaming("hi", "/tmp", [])
+
+        assert out == "ok"
+        payload = json.loads(usage_file.read_text())
+        assert payload["input_tokens"] == 300
+        assert payload["cache_read_input_tokens"] == 900
+        assert payload["output_tokens"] == 80
+
     def test_codex_turn_complete_returns_last_agent_message(self):
         import json
         from app.provider import run_command_streaming

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -3859,6 +3859,58 @@ class TestRunSkillMissionEnv:
         assert "env" in call_kwargs
         assert call_kwargs["env"]["PYTHONPATH"] == str(tmp_path / "koan")
 
+    def test_appends_stream_usage_to_stdout_file_for_post_mission(self, tmp_path):
+        """Skill stream usage sidecar is appended to stdout file for token parsing."""
+        from app.run import _run_skill_mission
+
+        koan_root = str(tmp_path)
+        instance = str(tmp_path / "instance")
+        (tmp_path / "instance").mkdir()
+        (tmp_path / "instance" / "journal").mkdir(parents=True)
+        (tmp_path / "koan").mkdir()
+
+        mock_proc = self._make_mock_popen(stdout_lines=["step 1\n"])
+        stream_usage_paths = []
+        captured_stdout = []
+
+        def _popen_with_usage(*args, **kwargs):
+            usage_path = kwargs.get("env", {}).get("KOAN_STREAM_USAGE_FILE", "")
+            assert usage_path
+            stream_usage_paths.append(usage_path)
+            Path(usage_path).write_text(
+                '{"model":"codex-mini","input_tokens":11,'
+                '"output_tokens":7,"cache_read_input_tokens":3,'
+                '"cache_creation_input_tokens":0}'
+            )
+            return mock_proc._side_effect(*args, **kwargs)
+
+        def _capture_post_mission(**kwargs):
+            with open(kwargs["stdout_file"]) as f:
+                captured_stdout.append(f.read())
+
+        with patch("app.run.subprocess.Popen", side_effect=_popen_with_usage), \
+             patch("app.run._get_koan_branch", return_value="main"), \
+             patch("app.run._restore_koan_branch"), \
+             patch("app.run._reset_terminal"), \
+             patch("app.mission_runner.run_post_mission", side_effect=_capture_post_mission):
+            result = _run_skill_mission(
+                skill_cmd=["python3", "--help"],
+                koan_root=koan_root,
+                instance=instance,
+                project_name="test",
+                project_path=str(tmp_path),
+                run_num=1,
+                mission_title="/plan test",
+                autonomous_mode="implement",
+            )
+
+        assert result["exit_code"] == 0
+        assert len(stream_usage_paths) == 1
+        assert Path(stream_usage_paths[0]).exists() is False
+        assert len(captured_stdout) == 1
+        assert "step 1" in captured_stdout[0]
+        assert '"model":"codex-mini"' in captured_stdout[0]
+
     def test_restores_branch_after_skill_execution(self, tmp_path):
         """_run_skill_mission calls _restore_koan_branch after execution."""
         from app.run import _run_skill_mission


### PR DESCRIPTION
The dashboard /usage page reads daily mission activity solely from instance/usage/*.jsonl. Skill-dispatch missions (e.g. /review) produce runner text instead of CLI JSON, so token extraction returned None and _record_cost_event silently wrote no row — leaving recent days blank on the dashboard even though session_outcomes.json had the activity.

Forward fix (already in tree, now landed): capture token usage from provider stream events into a sidecar file (provider/__init__.py + run.py), and write a zero-token placeholder row for skill-dispatch runs when extraction still fails (mission_runner.allow_placeholder), so a row is recorded for every run. Also sort dashboard PRs by updatedAt.

Backfill: add `python -m app.backfill_usage` (dry-run by default, --apply to write) to reconstruct historical per-day activity from session_outcomes.json. Synthetic rows carry a "backfill": true marker (zero tokens/cost — counts only), and the tool is idempotent: it credits existing real and prior backfill rows so days are never over-counted.