### PR TITLE
refactor(provider): move prompt/auth handling into providers

### DIFF
--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -11,6 +11,9 @@ Providers are responsible for:
 - resolving the executable and authentication assumptions;
 - mapping Koan tool permissions to provider-specific flags;
 - building commands for print or streaming execution;
+- declaring how prompts can be moved from argv to stdin;
+- declaring whether invocations must be serialized to protect shared provider
+  state such as rotating auth tokens;
 - normalizing output handling enough for mission execution code;
 - exposing provider capabilities without leaking provider details into unrelated
   modules.

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -172,6 +172,24 @@ Install the CLI: `npm install -g @openai/codex`
 
 Re-authenticate: `codex login --device-auth`
 
+When debugging Kōan, test the same non-interactive path Kōan uses. A short
+plain command like `codex exec 'say hello'` can succeed while the daemon path
+fails during JSON streaming, stdin prompt passing, or final-message capture:
+
+```bash
+printf 'say hello' | codex exec --json --output-last-message /tmp/koan-codex-last-message --sandbox workspace-write -
+```
+
+If Kōan runs as a background service, also verify that the service user has the
+same `HOME`, `PATH`, `.codex/auth.json`, and `.env` values as your interactive
+shell. Restart Kōan after re-authenticating so the daemon uses the refreshed
+Codex auth state.
+
+Kōan serializes its own Codex CLI subprocesses to avoid concurrent token-refresh
+races between preflight probes, message formatting, and long-running review
+sessions. If Codex still reports `401 Unauthorized` or refresh-token reuse, Kōan
+will pause for auth and requeue the active mission instead of marking it failed.
+
 ### Rate limits
 
 Codex shares quota with your ChatGPT subscription. If you hit limits,

--- a/koan/app/cli_errors.py
+++ b/koan/app/cli_errors.py
@@ -13,8 +13,8 @@ Categories:
 """
 
 import re
+import sys
 from enum import Enum
-from typing import Optional
 
 
 class ErrorCategory(Enum):
@@ -79,6 +79,47 @@ _RETRYABLE_RE = re.compile("|".join(_RETRYABLE_PATTERNS), re.IGNORECASE)
 _TERMINAL_RE = re.compile("|".join(_TERMINAL_PATTERNS), re.IGNORECASE)
 
 
+def _detect_auth_for_provider(
+    *,
+    stdout_text: str,
+    stderr_text: str,
+    provider_name: str,
+    exit_code: int,
+) -> bool:
+    """Delegate provider-specific auth detection to the provider object.
+
+    Mirrors ``quota_handler._detect_quota_for_provider``: resolve via the public
+    ``get_provider_by_name`` API (which normalizes the name and raises a clean
+    ``KeyError`` on unknown names), and degrade conservatively to ``False`` on
+    any failure. ``classify_cli_error`` runs on some unwrapped call paths, so a
+    provider-side bug must never crash the caller — it is logged and swallowed.
+    """
+    if not provider_name:
+        return False
+    try:
+        from app.provider import get_provider_by_name
+
+        provider = get_provider_by_name(provider_name)
+        return provider.detect_auth_failure(
+            stdout_text=stdout_text,
+            stderr_text=stderr_text,
+            exit_code=exit_code,
+        )
+    except KeyError as e:
+        print(
+            f"[cli_errors] unknown provider {provider_name!r}: {e}",
+            file=sys.stderr,
+        )
+        return False
+    except Exception as e:
+        print(
+            f"[cli_errors] provider auth detector failed "
+            f"for {provider_name!r}: {e}",
+            file=sys.stderr,
+        )
+        return False
+
+
 def classify_cli_error(
     exit_code: int,
     stdout: str = "",
@@ -126,6 +167,14 @@ def classify_cli_error(
     # Checked before generic TERMINAL so "401 + OAuth expired" routes here
     # instead of falling into the generic "unauthorized" terminal bucket.
     if _AUTH_RE.search(combined):
+        return ErrorCategory.AUTH
+
+    if _detect_auth_for_provider(
+        stdout_text=stdout,
+        stderr_text=stderr,
+        provider_name=provider_name,
+        exit_code=exit_code,
+    ):
         return ErrorCategory.AUTH
 
     # Terminal errors — don't retry

--- a/koan/app/cli_exec.py
+++ b/koan/app/cli_exec.py
@@ -2,9 +2,8 @@
 
 Prevents prompts from leaking into ``ps`` process listings and avoids OS
 ``ARG_MAX`` failures by writing them to a temporary file (``0o600``) and
-redirecting that file as the subprocess stdin.  Claude-style ``-p``
-arguments become the short placeholder ``@stdin``; Codex ``exec`` prompts
-become ``-``, which Codex reads from stdin.
+redirecting that file as the subprocess stdin. Providers decide how their
+prompt argument is rewritten to consume stdin.
 
 Providers that consume stdin for the prompt (making it unavailable for
 the agent's own tool calls) skip this mechanism and pass the prompt
@@ -13,13 +12,17 @@ directly as a ``-p`` argument.
 
 import contextlib
 import os
+import re
 import subprocess
 import sys
 import tempfile
 import threading
 import time
+from pathlib import Path
+from types import TracebackType
 from typing import Callable, List, Optional, Sequence, Tuple
 
+from app.provider.base import CLIProvider
 from app.run_log import log_safe as _log_cli, suppress_logged
 
 STDIN_PLACEHOLDER = "@stdin"
@@ -28,56 +31,119 @@ STDIN_PLACEHOLDER = "@stdin"
 # explicit timeout, but this guards against future callers forgetting.
 DEFAULT_TIMEOUT = 600  # 10 minutes
 
+_PROVIDER_LOCK_DIR = "/tmp"
+_FALLBACK_PROVIDER = CLIProvider()
 
-def _uses_stdin_passing() -> bool:
-    """Check if the current provider supports stdin-based prompt passing.
 
-    Copilot CLI consumes stdin when reading the ``@stdin`` prompt,
-    leaving nothing for its internal agent's tool calls (e.g.
-    ``cat /dev/stdin``).  For these providers we pass the prompt
-    directly as a ``-p`` argument instead.
-    """
+def _get_cli_provider() -> CLIProvider:
     try:
-        from app.provider import get_provider_name
-        return get_provider_name() not in ("copilot",)
+        from app.provider import get_provider
+
+        return get_provider()
     except Exception as e:
         print(f"[cli_exec] Provider check failed: {e}", file=sys.stderr)
-        return True
+        return _FALLBACK_PROVIDER
 
 
-def prepare_prompt_file(cmd: List[str]) -> Tuple[List[str], Optional[str]]:
+def _uses_stdin_passing(provider: Optional[CLIProvider] = None) -> bool:
+    """Check if the current provider supports stdin-based prompt passing.
+
+    Some providers consume stdin when reading the prompt, leaving nothing for
+    their internal tool calls. Those providers opt out through their provider
+    implementation.
+    """
+    return (provider or _get_cli_provider()).supports_stdin_prompt_passing()
+
+
+def _lock_path(lock_name: str) -> str:
+    safe = re.sub(r"[^A-Za-z0-9_.-]+", "-", lock_name.strip()).strip(".-")
+    if not safe:
+        safe = "provider"
+    return os.path.join(_PROVIDER_LOCK_DIR, f"koan-{safe}.lock")
+
+
+class _ProviderInvocationLock:
+    """Optional process-wide file lock for provider CLI invocations.
+
+    Most providers can run concurrently. Providers whose CLIs mutate shared
+    auth/session state can opt into serialization by returning a lock name from
+    ``CLIProvider.invocation_lock_name()``.
+    """
+
+    def __init__(self, lock_name: str):
+        self._lock_name = lock_name.strip()
+        self._fh = None
+        # True only after the exclusive lock is actually held. When False with a
+        # non-empty lock name, the invocation runs UNSERIALIZED — callers may
+        # inspect this to detect the degraded state.
+        self.acquired = False
+
+    def __enter__(self) -> "_ProviderInvocationLock":
+        if not self._lock_name:
+            return self
+        try:
+            import fcntl
+
+            lock_path = _lock_path(self._lock_name)
+            Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
+            self._fh = open(lock_path, "a+")  # noqa: SIM115
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_EX)
+            self.acquired = True
+        except OSError as exc:
+            # Degrade loudly but do not abort the invocation: failing to lock
+            # is better surfaced than crashing every Codex run on a /tmp hiccup.
+            print(
+                f"[cli_exec] WARNING: serialization disabled for "
+                f"{self._lock_name!r} ({exc}); concurrent provider invocations "
+                "may race on shared auth/session state",
+                file=sys.stderr,
+            )
+            self._close()
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[type[BaseException]],
+        exc: Optional[BaseException],
+        tb: Optional[TracebackType],
+    ) -> None:
+        self.release()
+
+    def _close(self) -> None:
+        if self._fh:
+            with contextlib.suppress(OSError):
+                self._fh.close()
+            self._fh = None
+
+    def release(self) -> None:
+        if not self._fh:
+            return
+        try:
+            import fcntl
+
+            fcntl.flock(self._fh.fileno(), fcntl.LOCK_UN)
+        except OSError as exc:
+            print(f"[cli_exec] Provider lock release failed: {exc}", file=sys.stderr)
+        finally:
+            self._close()
+
+
+def prepare_prompt_file(
+    cmd: List[str],
+    provider: Optional[CLIProvider] = None,
+) -> Tuple[List[str], Optional[str]]:
     """Extract the prompt from *cmd* and write it to a secure temp file.
 
-    Returns ``(modified_cmd, temp_file_path)``.  Claude-style commands are
-    rewritten from ``-p <prompt>`` to ``-p @stdin``.  Codex commands are
-    rewritten from ``codex exec ... <prompt>`` to ``codex exec ... -``.
-    If no supported prompt argument is found, it already uses a stdin
-    marker, or the current provider does not support stdin-based prompt
-    passing, returns ``(cmd, None)`` unchanged.
+    Returns ``(modified_cmd, temp_file_path)``. If no supported prompt argument
+    is found, it already uses a stdin marker, or the current provider does not
+    support stdin-based prompt passing, returns ``(cmd, None)`` unchanged.
     """
-    if not _uses_stdin_passing():
+    provider = provider or _get_cli_provider()
+    if not _uses_stdin_passing(provider):
         return cmd, None
 
-    prompt_idx: Optional[int] = None
-    prompt_stdin_marker = STDIN_PLACEHOLDER
-    try:
-        prompt_idx = cmd.index("-p") + 1
-    except ValueError:
-        if (
-            len(cmd) >= 3
-            and os.path.basename(cmd[0]) == "codex"
-            and cmd[1] == "exec"
-            and cmd[-1] != "-"
-            and not cmd[-1].startswith("-")
-        ):
-            prompt_idx = len(cmd) - 1
-            prompt_stdin_marker = "-"
-
-    if prompt_idx is None or prompt_idx >= len(cmd):
-        return cmd, None
-
-    prompt = cmd[prompt_idx]
-    if prompt == prompt_stdin_marker:
+    new_cmd, prompt = provider.rewrite_prompt_for_stdin(cmd, STDIN_PLACEHOLDER)
+    if prompt is None:
         return cmd, None
 
     fd, path = tempfile.mkstemp(suffix=".md", prefix="koan-prompt-")
@@ -87,8 +153,6 @@ def prepare_prompt_file(cmd: List[str]) -> Tuple[List[str], Optional[str]]:
         os.close(fd)
     os.chmod(path, 0o600)
 
-    new_cmd = cmd.copy()
-    new_cmd[prompt_idx] = prompt_stdin_marker
     return new_cmd, path
 
 
@@ -99,7 +163,11 @@ def _cleanup_prompt_file(path: Optional[str]) -> None:
             os.unlink(path)
 
 
-def run_cli(cmd, **kwargs) -> subprocess.CompletedProcess:
+def run_cli(
+    cmd,
+    provider: Optional[CLIProvider] = None,
+    **kwargs,
+) -> subprocess.CompletedProcess:
     """Run a CLI command with the prompt passed via temp-file stdin.
 
     Drop-in replacement for ``subprocess.run(cmd, stdin=DEVNULL, ...)``.
@@ -107,48 +175,68 @@ def run_cli(cmd, **kwargs) -> subprocess.CompletedProcess:
     the caller does not provide one, preventing indefinite hangs.
     """
     kwargs.setdefault("timeout", DEFAULT_TIMEOUT)
-    cmd, prompt_path = prepare_prompt_file(cmd)
-    if prompt_path:
-        try:
-            with open(prompt_path) as f:
-                kwargs.pop("stdin", None)
-                kwargs["stdin"] = f
-                return subprocess.run(cmd, **kwargs)
-        finally:
-            _cleanup_prompt_file(prompt_path)
-    else:
-        kwargs.setdefault("stdin", subprocess.DEVNULL)
-        return subprocess.run(cmd, **kwargs)
+    provider = provider or _get_cli_provider()
+    cmd, prompt_path = prepare_prompt_file(cmd, provider=provider)
+    with _ProviderInvocationLock(provider.invocation_lock_name()):
+        if prompt_path:
+            try:
+                with open(prompt_path) as f:
+                    kwargs.pop("stdin", None)
+                    kwargs["stdin"] = f
+                    return subprocess.run(cmd, **kwargs)
+            finally:
+                _cleanup_prompt_file(prompt_path)
+        else:
+            kwargs.setdefault("stdin", subprocess.DEVNULL)
+            return subprocess.run(cmd, **kwargs)
 
 
 def popen_cli(
-    cmd, **kwargs
+    cmd,
+    provider: Optional[CLIProvider] = None,
+    **kwargs,
 ) -> Tuple[subprocess.Popen, Callable[[], None]]:
     """Start a :class:`~subprocess.Popen` process with the prompt via temp-file stdin.
 
     Returns ``(proc, cleanup)`` where *cleanup()* **must** be called after
     the process exits to close the file handle and delete the temp file.
     """
-    cmd, prompt_path = prepare_prompt_file(cmd)
-    if prompt_path:
-        stdin_file = open(prompt_path)  # noqa: SIM115
-        kwargs.pop("stdin", None)
-        kwargs["stdin"] = stdin_file
-        try:
-            proc = subprocess.Popen(cmd, **kwargs)
-        except Exception:
-            stdin_file.close()
-            _cleanup_prompt_file(prompt_path)
-            raise
+    provider = provider or _get_cli_provider()
+    cmd, prompt_path = prepare_prompt_file(cmd, provider=provider)
+    cli_lock = _ProviderInvocationLock(provider.invocation_lock_name())
+    cli_lock.__enter__()
+    # One outer guard so the lock is released on ANY failure after acquisition —
+    # including open(prompt_path) below, which sits before the Popen try/except.
+    # On the success path we return normally (no exception), so the lock stays
+    # held until the returned cleanup()/release runs.
+    try:
+        if prompt_path:
+            stdin_file = open(prompt_path)  # noqa: SIM115
+            kwargs.pop("stdin", None)
+            kwargs["stdin"] = stdin_file
+            try:
+                proc = subprocess.Popen(cmd, **kwargs)
+            except Exception:
+                stdin_file.close()
+                raise
 
-        def cleanup():
-            stdin_file.close()
-            _cleanup_prompt_file(prompt_path)
+            def cleanup():
+                stdin_file.close()
+                _cleanup_prompt_file(prompt_path)
+                cli_lock.release()
 
-        return proc, cleanup
-    else:
+            return proc, cleanup
+
         kwargs.setdefault("stdin", subprocess.DEVNULL)
-        return subprocess.Popen(cmd, **kwargs), lambda: None
+        proc = subprocess.Popen(cmd, **kwargs)
+        return proc, cli_lock.release
+    except Exception:
+        # Any failure after the lock was taken (open(), Popen, ...) must release
+        # the lock and remove the temp prompt file. _cleanup_prompt_file tolerates
+        # a None path (the no-prompt branch).
+        _cleanup_prompt_file(prompt_path)
+        cli_lock.release()
+        raise
 
 
 class StreamResult:

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -34,6 +34,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from app.provider.base import (  # noqa: F401
     CLIProvider,
     CLAUDE_TOOLS,
+    PROVIDER_ERROR_EVENT_TYPES,
     TOOL_NAME_MAP,
 )
 
@@ -43,6 +44,34 @@ from app.provider.codex import CodexProvider  # noqa: F401
 from app.provider.copilot import CopilotProvider  # noqa: F401
 from app.provider.local import LocalLLMProvider  # noqa: F401
 from app.provider.ollama_launch import OllamaLaunchProvider  # noqa: F401
+
+
+def _extract_provider_error_preview(stdout: str) -> str:
+    """Return the most useful direct provider error from JSONL stdout."""
+    previews: List[str] = []
+    for line in (stdout or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        try:
+            event = json.loads(stripped)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+        etype = str(event.get("type") or "")
+        if etype not in PROVIDER_ERROR_EVENT_TYPES:
+            continue
+        message = event.get("message")
+        if isinstance(message, str) and message.strip():
+            previews.append(message.strip())
+            continue
+        error = event.get("error")
+        if isinstance(error, dict):
+            err_message = error.get("message")
+            if isinstance(err_message, str) and err_message.strip():
+                previews.append(err_message.strip())
+    return previews[-1] if previews else ""
 
 
 def _format_cli_error(returncode: int, stdout: str, stderr: str) -> str:
@@ -57,7 +86,8 @@ def _format_cli_error(returncode: int, stdout: str, stderr: str) -> str:
     if err:
         parts.append(f"stderr={err[:300]}")
     if out and not err:
-        parts.append(f"stdout={out[:300]}")
+        preview = _extract_provider_error_preview(out) or out
+        parts.append(f"stdout={preview[:300]}")
     return "CLI invocation failed: " + " | ".join(parts)
 
 
@@ -772,10 +802,7 @@ def run_command_streaming(
             suffix=".txt",
         )
         os.close(fd)
-        last_message_args = provider.build_last_message_file_args(last_message_path)
-        if last_message_args and cmd:
-            # Codex requires exec flags before the final prompt argument.
-            cmd = [*cmd[:-1], *last_message_args, cmd[-1]]
+        cmd = provider.add_last_message_file_args(cmd, last_message_path)
 
     print(f"[cli] Starting {provider.name or 'provider'} CLI session", flush=True)
 
@@ -790,6 +817,7 @@ def run_command_streaming(
     try:
         proc, cleanup = popen_cli(
             cmd,
+            provider=provider,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             encoding="utf-8",

--- a/koan/app/provider/base.py
+++ b/koan/app/provider/base.py
@@ -1,7 +1,7 @@
 """Base class and constants for CLI provider abstraction."""
 
 import shutil
-from typing import List, Optional, Tuple
+from typing import List, Optional, Sequence, Tuple
 
 
 # ---------------------------------------------------------------------------
@@ -21,6 +21,16 @@ TOOL_NAME_MAP = {
     "Glob": "glob",
     "Grep": "grep",
     "Skill": "skill",
+}
+
+# JSONL ``type`` values that signal a provider-level error event in streamed
+# CLI output. Shared by error-preview extraction, runtime auth detection, and
+# the Codex provider so the recognized set stays in sync across modules.
+PROVIDER_ERROR_EVENT_TYPES = {
+    "error",
+    "turn.failed",
+    "response.failed",
+    "task.failed",
 }
 
 
@@ -57,6 +67,47 @@ class CLIProvider:
     def build_prompt_args(self, prompt: str) -> List[str]:
         """Build args for passing a prompt to the CLI."""
         raise NotImplementedError
+
+    def supports_stdin_prompt_passing(self) -> bool:
+        """Return True if Kōan may move the prompt from argv to stdin.
+
+        Providers that need stdin for their own tool calls should return False.
+        """
+        return True
+
+    def rewrite_prompt_for_stdin(
+        self,
+        cmd: Sequence[str],
+        stdin_marker: str,
+    ) -> Tuple[List[str], Optional[str]]:
+        """Rewrite *cmd* to read the prompt from stdin.
+
+        Returns ``(rewritten_cmd, prompt_text)``.  ``prompt_text`` is ``None``
+        when no rewrite is possible or needed.
+
+        The default supports Claude-style commands where ``-p`` is followed by
+        the prompt argument.
+        """
+        cmd_list = list(cmd)
+        try:
+            prompt_idx = cmd_list.index("-p") + 1
+        except ValueError:
+            return cmd_list, None
+        if prompt_idx >= len(cmd_list):
+            return cmd_list, None
+        prompt = cmd_list[prompt_idx]
+        if prompt == stdin_marker:
+            return cmd_list, None
+        rewritten = cmd_list.copy()
+        rewritten[prompt_idx] = stdin_marker
+        return rewritten, prompt
+
+    def invocation_lock_name(self) -> str:
+        """Return a process-wide lock name for serialized CLI invocations.
+
+        Empty string means invocations can run concurrently.
+        """
+        return ""
 
     def build_system_prompt_args(self, system_prompt: str) -> List[str]:
         """Build args for passing a system prompt to the CLI.
@@ -172,6 +223,13 @@ class CLIProvider:
         """Build args that ask the provider to write its final assistant text."""
         return []
 
+    def add_last_message_file_args(self, cmd: List[str], path: str) -> List[str]:
+        """Insert final-message-file args into an already-built command."""
+        args = self.build_last_message_file_args(path)
+        if not args:
+            return cmd
+        return [*cmd, *args]
+
     def build_thinking_args(
         self, enabled: bool = False, budget_tokens: int = 0,
     ) -> List[str]:
@@ -277,6 +335,20 @@ class CLIProvider:
         Providers own this because quota wording and output structure differ:
         Claude emits CLI/provider text, Codex emits JSONL events, Copilot emits
         GitHub-style 429 messages. The base provider has no quota concept.
+        """
+        return False
+
+    def detect_auth_failure(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Return True when provider output is an auth/session failure.
+
+        Providers own this because auth wording and output structure differ.
+        Generic classifier code handles shared auth text; providers can add
+        structured or provider-specific cases without leaking patterns upward.
         """
         return False
 

--- a/koan/app/provider/codex.py
+++ b/koan/app/provider/codex.py
@@ -1,13 +1,14 @@
 """OpenAI Codex CLI provider implementation."""
 
 import json
+import os
 import re
 import shutil
 import subprocess
 import sys
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional, Sequence, Tuple
 
-from app.provider.base import CLIProvider
+from app.provider.base import CLIProvider, PROVIDER_ERROR_EVENT_TYPES
 
 
 _CODEX_QUOTA_PATTERNS = [
@@ -25,13 +26,6 @@ _CODEX_QUOTA_PATTERNS = [
 
 _CODEX_QUOTA_RE = re.compile("|".join(_CODEX_QUOTA_PATTERNS), re.IGNORECASE)
 
-_CODEX_ERROR_EVENT_TYPES = {
-    "error",
-    "turn.failed",
-    "response.failed",
-    "task.failed",
-}
-
 _CODEX_ERROR_KEYS = {
     "code",
     "error",
@@ -42,6 +36,15 @@ _CODEX_ERROR_KEYS = {
     "status_code",
     "type",
 }
+
+_CODEX_AUTH_PATTERNS = [
+    r"\b401\s+Unauthorized\b",
+    r"unexpected\s+status\s+401",
+    r"access\s+token\s+could\s+not\s+be\s+refreshed",
+    r"refresh\s+token\s+was\s+already\s+used",
+]
+
+_CODEX_AUTH_RE = re.compile("|".join(_CODEX_AUTH_PATTERNS), re.IGNORECASE)
 
 
 class CodexProvider(CLIProvider):
@@ -96,6 +99,28 @@ class CodexProvider(CLIProvider):
         # Codex non-interactive mode: codex exec "prompt"
         return ["exec", prompt]
 
+    def rewrite_prompt_for_stdin(
+        self,
+        cmd: Sequence[str],
+        stdin_marker: str,
+    ) -> Tuple[List[str], Optional[str]]:
+        cmd_list = list(cmd)
+        if not (
+            len(cmd_list) >= 3
+            and os.path.basename(cmd_list[0]) == self.binary()
+            and cmd_list[1] == "exec"
+            and cmd_list[-1] != "-"
+            and not cmd_list[-1].startswith("-")
+        ):
+            return cmd_list, None
+        prompt = cmd_list[-1]
+        rewritten = cmd_list.copy()
+        rewritten[-1] = "-"
+        return rewritten, prompt
+
+    def invocation_lock_name(self) -> str:
+        return "codex-cli"
+
     def build_tool_args(
         self,
         allowed_tools: Optional[List[str]] = None,
@@ -134,6 +159,12 @@ class CodexProvider(CLIProvider):
 
     def build_last_message_file_args(self, path: str) -> List[str]:
         return ["--output-last-message", path]
+
+    def add_last_message_file_args(self, cmd: List[str], path: str) -> List[str]:
+        args = self.build_last_message_file_args(path)
+        if not args or not cmd:
+            return cmd
+        return [*cmd[:-1], *args, cmd[-1]]
 
     def build_max_turns_args(self, max_turns: int = 0) -> List[str]:
         # Codex CLI does not support --max-turns.
@@ -197,7 +228,7 @@ class CodexProvider(CLIProvider):
 
     def _event_has_quota_error(self, event: dict[str, Any]) -> bool:
         event_type = str(event.get("type") or "").lower()
-        if event_type not in _CODEX_ERROR_EVENT_TYPES:
+        if event_type not in PROVIDER_ERROR_EVENT_TYPES:
             return False
         return _CODEX_QUOTA_RE.search(self._error_event_text(event)) is not None
 
@@ -223,6 +254,56 @@ class CodexProvider(CLIProvider):
             parts.append(str(value))
 
         return "\n".join(p for p in parts if p)
+
+    def detect_auth_failure(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect Codex authentication/session failures.
+
+        Codex may emit auth failures as JSONL stdout events during stream
+        reconnects rather than plain stderr. For JSON events only direct
+        provider error fields are inspected, so command output cannot create
+        false positives.
+
+        Non-JSON stdout lines, however, are scanned raw with ``_CODEX_AUTH_RE``.
+        Callers must pre-filter stdout to trusted runtime lines before passing
+        it here — ``run._cli_runtime_auth_signal`` does this (only ``[cli]``
+        summaries, ``CLI invocation failed:`` lines, and structured error
+        events reach us). The exit-code path in ``cli_errors`` passes unfiltered
+        stdout, but that runs only after ``classify_cli_error``'s generic
+        ``_AUTH_RE`` check, so the marginal false-positive surface is limited to
+        Codex-specific phrases (e.g. refresh-token reuse) that benign logs are
+        very unlikely to contain.
+        """
+        if exit_code == 0:
+            return False
+
+        stderr_text = stderr_text or ""
+        stdout_text = stdout_text or ""
+
+        if _CODEX_AUTH_RE.search(stderr_text):
+            return True
+
+        for line in stdout_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            try:
+                event = json.loads(stripped)
+            except json.JSONDecodeError:
+                if _CODEX_AUTH_RE.search(stripped):
+                    return True
+                continue
+
+            if isinstance(event, dict) and _CODEX_AUTH_RE.search(
+                self._error_event_text(event)
+            ):
+                return True
+
+        return False
 
     def build_command(
         self,
@@ -286,14 +367,24 @@ class CodexProvider(CLIProvider):
         cmd = [self.binary(), "exec", "--sandbox", "workspace-write", "ok"]
 
         try:
-            result = subprocess.run(
+            from app.cli_exec import run_cli
+
+            result = run_cli(
                 cmd,
+                provider=self,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
                 cwd=project_path,
             )
             if self.detect_quota_exhaustion(
+                stdout_text=result.stdout or "",
+                stderr_text=result.stderr or "",
+                exit_code=result.returncode,
+            ):
+                combined = (result.stderr or "") + "\n" + (result.stdout or "")
+                return False, combined
+            if self.detect_auth_failure(
                 stdout_text=result.stdout or "",
                 stderr_text=result.stderr or "",
                 exit_code=result.returncode,

--- a/koan/app/provider/copilot.py
+++ b/koan/app/provider/copilot.py
@@ -65,6 +65,11 @@ class CopilotProvider(CLIProvider):
         prefix = ["copilot"] if self._is_gh_mode else []
         return prefix + ["-p", prompt]
 
+    def supports_stdin_prompt_passing(self) -> bool:
+        # Copilot consumes stdin for the prompt, which prevents its own tool
+        # calls from using stdin later in the session.
+        return False
+
     def build_tool_args(
         self,
         allowed_tools: Optional[List[str]] = None,

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -19,6 +19,7 @@ Features:
 - Colored log output with TTY detection
 """
 
+import contextlib
 import os
 import json
 import signal
@@ -2670,6 +2671,13 @@ def _classify_and_handle_cli_error(
 
         if cli_runtime_quota_signal(stdout_text):
             category = ErrorCategory.QUOTA
+    if category != ErrorCategory.AUTH and not trust_stdout:
+        if _cli_runtime_auth_signal(
+            stdout_text=stdout_text,
+            provider_name=provider_name,
+            exit_code=exit_code,
+        ):
+            category = ErrorCategory.AUTH
     if category == ErrorCategory.AUTH:
         _handle_auth_error(
             provider_label=provider_label,
@@ -2691,6 +2699,65 @@ def _classify_and_handle_cli_error(
         )
         return True
     return False
+
+
+def _cli_runtime_auth_signal(
+    *,
+    stdout_text: str,
+    provider_name: str,
+    exit_code: int,
+) -> bool:
+    """Detect provider auth failures from stdout-safe runtime lines.
+
+    Skill stdout is normally DATA, so broad stdout auth scans can false-positive
+    on quoted CI logs or source text. Codex, however, reports real stream auth
+    failures on stdout. Keep the trusted surface narrow: raw provider JSON
+    events, Koan's ``[cli]`` stream summaries, and CLI failure summaries.
+    """
+    if exit_code == 0 or not stdout_text or not provider_name:
+        return False
+
+    from app.provider.base import PROVIDER_ERROR_EVENT_TYPES
+
+    runtime_lines: list[str] = []
+    for line in stdout_text.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("[cli]") or "CLI invocation failed:" in stripped:
+            runtime_lines.append(stripped)
+            continue
+        if not stripped.startswith("{"):
+            continue
+        with contextlib.suppress(json.JSONDecodeError):
+            event = json.loads(stripped)
+            if (
+                isinstance(event, dict)
+                and str(event.get("type") or "") in PROVIDER_ERROR_EVENT_TYPES
+            ):
+                runtime_lines.append(stripped)
+
+    if not runtime_lines:
+        return False
+
+    try:
+        from app.provider import get_provider_by_name
+
+        provider = get_provider_by_name(provider_name)
+        return provider.detect_auth_failure(
+            stdout_text="\n".join(runtime_lines),
+            stderr_text="",
+            exit_code=exit_code,
+        )
+    except KeyError as e:
+        print(f"[run] unknown provider {provider_name!r}: {e}", file=sys.stderr)
+        return False
+    except Exception as e:
+        print(
+            f"[run] runtime auth detector failed for {provider_name!r}: {e}",
+            file=sys.stderr,
+        )
+        return False
 
 
 def _probe_exit0_quota(

--- a/koan/tests/test_cli_errors.py
+++ b/koan/tests/test_cli_errors.py
@@ -227,6 +227,60 @@ class TestClassifyCliError:
         result = classify_cli_error(1, stderr=stderr)
         assert result == ErrorCategory.AUTH
 
+    def test_codex_jsonl_unauthorized_is_auth(self):
+        stdout = "\n".join([
+            json.dumps({"type": "thread.started", "thread_id": "t1"}),
+            json.dumps({"type": "turn.started"}),
+            json.dumps({
+                "type": "error",
+                "message": (
+                    'unexpected status 401 Unauthorized: {"detail":"Unauthorized"}'
+                ),
+            }),
+            json.dumps({"type": "turn.failed"}),
+        ])
+        result = classify_cli_error(1, stdout=stdout, provider_name="codex")
+        assert result == ErrorCategory.AUTH
+
+    def test_codex_refresh_token_reuse_is_auth(self):
+        stderr = (
+            "Error: Your access token could not be refreshed because your "
+            "refresh token was already used. Please log out and sign in again."
+        )
+        result = classify_cli_error(1, stderr=stderr, provider_name="codex")
+        assert result == ErrorCategory.AUTH
+
+    # -- Provider auth detector resilience ---------------------------------------
+
+    def test_unknown_provider_name_does_not_raise(self):
+        """An unknown provider name must classify without crashing.
+
+        _detect_auth_for_provider resolves via get_provider_by_name, which
+        raises KeyError on unknown names; that must degrade to a normal
+        classification, not propagate.
+        """
+        result = classify_cli_error(
+            1, stderr="Error: something generic", provider_name="does-not-exist"
+        )
+        assert isinstance(result, ErrorCategory)
+        assert result != ErrorCategory.AUTH
+
+    def test_provider_auth_detector_exception_is_swallowed(self):
+        """A bug in a provider's detect_auth_failure must not crash the caller."""
+        from unittest.mock import patch
+
+        class _Boom:
+            def detect_auth_failure(self, **_kwargs):
+                raise RuntimeError("detector bug")
+
+        with patch("app.provider.get_provider_by_name", return_value=_Boom()):
+            result = classify_cli_error(
+                1, stderr="Error: generic failure", provider_name="codex"
+            )
+        # Detector blew up → no AUTH from it, and no exception propagated.
+        assert isinstance(result, ErrorCategory)
+        assert result != ErrorCategory.AUTH
+
     # -- False positive: loose quota patterns in stdout --------------------------
 
     def test_no_false_positive_rate_limit_in_stdout(self):

--- a/koan/tests/test_cli_exec.py
+++ b/koan/tests/test_cli_exec.py
@@ -15,6 +15,10 @@ from app.cli_exec import (
     stream_with_timeout,
     _cleanup_prompt_file,
 )
+from app.provider.claude import ClaudeProvider
+from app.provider.codex import CodexProvider
+from app.provider.copilot import CopilotProvider
+from app.provider.local import LocalLLMProvider
 
 
 # ---------------------------------------------------------------------------
@@ -24,23 +28,23 @@ from app.cli_exec import (
 class TestUsesStdinPassing:
     """Tests for _uses_stdin_passing() provider detection."""
 
-    @patch("app.provider.get_provider_name", return_value="claude")
+    @patch("app.provider.get_provider", return_value=ClaudeProvider())
     def test_claude_provider_uses_stdin(self, _mock):
         assert _uses_stdin_passing() is True
 
-    @patch("app.provider.get_provider_name", return_value="copilot")
+    @patch("app.provider.get_provider", return_value=CopilotProvider())
     def test_copilot_provider_skips_stdin(self, _mock):
         assert _uses_stdin_passing() is False
 
-    @patch("app.provider.get_provider_name", return_value="local")
+    @patch("app.provider.get_provider", return_value=LocalLLMProvider())
     def test_local_provider_uses_stdin(self, _mock):
         assert _uses_stdin_passing() is True
 
-    @patch("app.provider.get_provider_name", side_effect=ImportError("no provider"))
+    @patch("app.provider.get_provider", side_effect=ImportError("no provider"))
     def test_import_error_defaults_to_true(self, _mock):
         assert _uses_stdin_passing() is True
 
-    @patch("app.provider.get_provider_name", side_effect=RuntimeError("broken"))
+    @patch("app.provider.get_provider", side_effect=RuntimeError("broken"))
     def test_runtime_error_defaults_to_true(self, _mock):
         assert _uses_stdin_passing() is True
 
@@ -125,7 +129,7 @@ class TestPreparePromptFile:
         finally:
             _cleanup_prompt_file(path)
 
-    @patch("app.provider.get_provider_name", return_value="copilot")
+    @patch("app.provider.get_provider", return_value=CopilotProvider())
     def test_copilot_provider_skips_stdin_passing(self, _mock):
         """Copilot provider should skip @stdin mechanism entirely."""
         cmd = ["copilot", "-p", "my prompt", "--allow-all-tools"]
@@ -133,7 +137,7 @@ class TestPreparePromptFile:
         assert new_cmd is cmd
         assert path is None
 
-    @patch("app.provider.get_provider_name", return_value="codex")
+    @patch("app.provider.get_provider", return_value=CodexProvider())
     def test_codex_exec_prompt_uses_stdin_dash(self, _mock):
         """Codex exec reads '-' from stdin, so the prompt stays out of argv."""
         cmd = ["codex", "exec", "--sandbox", "workspace-write", "my prompt"]
@@ -148,7 +152,7 @@ class TestPreparePromptFile:
         finally:
             _cleanup_prompt_file(path)
 
-    @patch("app.provider.get_provider_name", return_value="codex")
+    @patch("app.provider.get_provider", return_value=CodexProvider())
     def test_codex_large_prompt_removed_from_argv(self, _mock):
         """Regression for OSError: Argument list too long when using Codex."""
         prompt = "x" * 200_000
@@ -162,14 +166,14 @@ class TestPreparePromptFile:
         finally:
             _cleanup_prompt_file(path)
 
-    @patch("app.provider.get_provider_name", return_value="codex")
+    @patch("app.provider.get_provider", return_value=CodexProvider())
     def test_codex_existing_stdin_dash_returns_unchanged(self, _mock):
         cmd = ["codex", "exec", "--json", "-"]
         new_cmd, path = prepare_prompt_file(cmd)
         assert new_cmd is cmd
         assert path is None
 
-    @patch("app.provider.get_provider_name", return_value="codex")
+    @patch("app.provider.get_provider", return_value=CodexProvider())
     def test_codex_without_prompt_returns_unchanged(self, _mock):
         cmd = ["codex", "exec", "--json"]
         new_cmd, path = prepare_prompt_file(cmd)
@@ -259,7 +263,7 @@ class TestRunCli:
         call_args = mock_run.call_args
         assert call_args[1]["stdin"] != subprocess.DEVNULL
 
-    @patch("app.provider.get_provider_name", return_value="copilot")
+    @patch("app.provider.get_provider", return_value=CopilotProvider())
     @patch("app.cli_exec.subprocess.run")
     def test_copilot_keeps_prompt_in_args(self, mock_run, _mock_provider):
         """Copilot provider: prompt stays in -p, stdin is DEVNULL."""
@@ -294,6 +298,20 @@ class TestRunCli:
 
         call_args = mock_run.call_args
         assert call_args[1]["timeout"] == 42
+
+    @patch("app.provider.get_provider", return_value=CodexProvider())
+    @patch("fcntl.flock")
+    @patch("app.cli_exec.subprocess.run")
+    def test_codex_run_cli_uses_file_lock(self, mock_run, mock_flock, _mock_provider):
+        import fcntl
+
+        mock_run.return_value = subprocess.CompletedProcess([], 0, "ok", "")
+        cmd = ["codex", "exec", "prompt"]
+
+        run_cli(cmd, capture_output=True, text=True)
+
+        assert mock_flock.call_args_list[0][0][1] == fcntl.LOCK_EX
+        assert mock_flock.call_args_list[-1][0][1] == fcntl.LOCK_UN
 
 
 # ---------------------------------------------------------------------------
@@ -344,7 +362,7 @@ class TestPopenCli:
         assert hasattr(stdin_arg, "read")  # it's a file object
         cleanup()
 
-    @patch("app.provider.get_provider_name", return_value="copilot")
+    @patch("app.provider.get_provider", return_value=CopilotProvider())
     @patch("app.cli_exec.subprocess.Popen")
     def test_copilot_keeps_prompt_in_args(self, mock_popen, _mock_provider):
         """Copilot provider: popen keeps prompt in -p, stdin is DEVNULL."""
@@ -357,6 +375,73 @@ class TestPopenCli:
         assert actual_cmd == ["copilot", "-p", "my prompt"]
         assert mock_popen.call_args[1]["stdin"] == subprocess.DEVNULL
         cleanup()
+
+    @patch("app.provider.get_provider", return_value=CodexProvider())
+    @patch("fcntl.flock")
+    @patch("app.cli_exec.subprocess.Popen")
+    def test_codex_popen_lock_released_on_cleanup(
+        self, mock_popen, mock_flock, _mock_provider
+    ):
+        import fcntl
+
+        mock_popen.return_value = MagicMock()
+        cmd = ["codex", "exec", "prompt"]
+
+        _proc, cleanup = popen_cli(cmd)
+
+        assert mock_flock.call_args_list[0][0][1] == fcntl.LOCK_EX
+        cleanup()
+        assert mock_flock.call_args_list[-1][0][1] == fcntl.LOCK_UN
+
+    @patch("app.provider.get_provider", return_value=CodexProvider())
+    @patch("fcntl.flock")
+    def test_codex_popen_releases_lock_when_prompt_open_fails(
+        self, mock_flock, _mock_provider
+    ):
+        """If open(prompt_path) fails after the lock is taken, it must release."""
+        import fcntl
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            # Fail only on the temp prompt file; let the lock file open normally.
+            if str(path).endswith(".md"):
+                raise OSError("simulated prompt-file open failure")
+            return real_open(path, *args, **kwargs)
+
+        cmd = ["codex", "exec", "prompt"]
+        with patch("app.cli_exec.open", side_effect=fake_open):
+            with pytest.raises(OSError):
+                popen_cli(cmd)
+
+        assert mock_flock.call_args_list[0][0][1] == fcntl.LOCK_EX
+        assert mock_flock.call_args_list[-1][0][1] == fcntl.LOCK_UN
+
+
+class TestProviderInvocationLock:
+    """Degraded-state behaviour of _ProviderInvocationLock."""
+
+    def test_no_lock_name_is_noop(self):
+        from app.cli_exec import _ProviderInvocationLock
+
+        lock = _ProviderInvocationLock("")
+        with lock as entered:
+            assert entered is lock
+            assert lock.acquired is False
+        # release() on an unacquired lock must not raise.
+        lock.release()
+
+    @patch("fcntl.flock", side_effect=OSError("flock unsupported"))
+    def test_flock_failure_degrades_without_raising(self, _mock_flock):
+        from app.cli_exec import _ProviderInvocationLock
+
+        lock = _ProviderInvocationLock("codex-cli")
+        # Acquisition failure must degrade loudly, not raise.
+        with lock as entered:
+            assert entered is lock
+            assert lock.acquired is False
+        # Behaves as a no-op context; release stays safe.
+        lock.release()
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_codex_provider.py
+++ b/koan/tests/test_codex_provider.py
@@ -125,6 +125,33 @@ class TestCodexProvider:
             "/tmp/out.txt",
         ]
 
+    def test_add_last_message_file_args_before_prompt(self):
+        cmd = ["codex", "exec", "--json", "prompt"]
+        result = self.provider.add_last_message_file_args(cmd, "/tmp/out.txt")
+        assert result == [
+            "codex",
+            "exec",
+            "--json",
+            "--output-last-message",
+            "/tmp/out.txt",
+            "prompt",
+        ]
+
+    def test_rewrite_prompt_for_stdin_uses_dash(self):
+        cmd = ["codex", "exec", "--json", "prompt"]
+        rewritten, prompt = self.provider.rewrite_prompt_for_stdin(cmd, "@stdin")
+        assert rewritten == ["codex", "exec", "--json", "-"]
+        assert prompt == "prompt"
+
+    def test_rewrite_prompt_for_stdin_existing_dash_unchanged(self):
+        cmd = ["codex", "exec", "--json", "-"]
+        rewritten, prompt = self.provider.rewrite_prompt_for_stdin(cmd, "@stdin")
+        assert rewritten == cmd
+        assert prompt is None
+
+    def test_invocation_lock_name(self):
+        assert self.provider.invocation_lock_name() == "codex-cli"
+
     # -- Max turns (no-op) --
 
     def test_max_turns_args(self):
@@ -367,6 +394,36 @@ class TestCodexQuotaCheck:
         mock_run.side_effect = OSError("codex not found")
         available, detail = self.provider.check_quota_available("/tmp/project")
         assert available is True
+
+    @patch("subprocess.run")
+    def test_auth_failure_blocks_preflight(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout=json.dumps({
+                "type": "error",
+                "message": (
+                    'unexpected status 401 Unauthorized: {"detail":"Unauthorized"}'
+                ),
+            }),
+            stderr="",
+        )
+        available, detail = self.provider.check_quota_available("/tmp/project")
+        assert available is False
+        assert "401 Unauthorized" in detail
+
+    @patch("subprocess.run")
+    def test_refresh_token_reuse_blocks_preflight(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "Error: Your access token could not be refreshed because "
+                "your refresh token was already used."
+            ),
+        )
+        available, detail = self.provider.check_quota_available("/tmp/project")
+        assert available is False
+        assert "refresh token was already used" in detail
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -4,6 +4,7 @@ Covers: base.py, claude.py, copilot.py, local.py, ollama_launch.py, __init__.py
 These modules had zero test coverage despite being used throughout the codebase.
 """
 
+import json
 import os
 import sys
 from unittest.mock import MagicMock, patch
@@ -58,6 +59,23 @@ class TestCLIProviderBase:
     def test_build_permission_args_default_empty(self):
         p = CLIProvider()
         assert p.build_permission_args(skip_permissions=True) == []
+
+    def test_stdin_prompt_passing_default_enabled(self):
+        p = CLIProvider()
+        assert p.supports_stdin_prompt_passing() is True
+
+    def test_default_rewrite_prompt_for_stdin(self):
+        p = CLIProvider()
+        rewritten, prompt = p.rewrite_prompt_for_stdin(
+            ["provider", "-p", "hello", "--model", "m"],
+            "@stdin",
+        )
+        assert rewritten == ["provider", "-p", "@stdin", "--model", "m"]
+        assert prompt == "hello"
+
+    def test_default_invocation_lock_empty(self):
+        p = CLIProvider()
+        assert p.invocation_lock_name() == ""
 
     def test_check_quota_default_always_available(self):
         p = CLIProvider()
@@ -303,6 +321,11 @@ class TestCopilotProvider:
     def test_prompt_args_standalone(self, mock_which):
         p = CopilotProvider()
         assert p.build_prompt_args("hello") == ["-p", "hello"]
+
+    @patch("shutil.which", side_effect=lambda x: "/usr/bin/copilot" if x == "copilot" else None)
+    def test_stdin_prompt_passing_disabled(self, mock_which):
+        p = CopilotProvider()
+        assert p.supports_stdin_prompt_passing() is False
 
     @patch("shutil.which", side_effect=lambda x: "/usr/bin/gh" if x == "gh" else None)
     def test_prompt_args_gh_mode(self, mock_which):
@@ -1528,6 +1551,26 @@ class TestFormatCliError:
         long_out = "y" * 500
         msg = _format_cli_error(1, long_out, "")
         assert f"stdout={'y' * 300}" in msg
+
+    def test_jsonl_error_preview_prefers_last_provider_error(self):
+        from app.provider import _format_cli_error
+        stdout = "\n".join([
+            json.dumps({"type": "thread.started"}),
+            json.dumps({
+                "type": "error",
+                "message": "Reconnecting... 2/5",
+            }),
+            json.dumps({
+                "type": "error",
+                "message": (
+                    'unexpected status 401 Unauthorized: {"detail":"Unauthorized"}'
+                ),
+            }),
+            json.dumps({"type": "turn.failed"}),
+        ])
+        msg = _format_cli_error(1, stdout, "")
+        assert "unexpected status 401 Unauthorized" in msg
+        assert "thread.started" not in msg
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -5200,6 +5200,65 @@ class TestSkillDispatchAuthQuota(TestRunSkillMissionEnv):
         mock_finalize.assert_not_called()
         mock_pause.assert_called_once_with(koan_root, "auth")
 
+    def test_codex_unauthorized_requeues_and_pauses(self, tmp_path):
+        """Codex bare 401 stream failures should be auth, not normal failure."""
+        from app.run import _handle_skill_dispatch
+
+        koan_root = str(tmp_path)
+        instance = str(tmp_path / "instance")
+        (tmp_path / "instance").mkdir()
+        (tmp_path / "instance" / "journal").mkdir(parents=True)
+        (tmp_path / "koan").mkdir()
+
+        mock_proc = self._make_mock_popen(
+            returncode=1,
+            stdout_lines=["[cli] event: turn.failed\n"],
+            stderr_content=(
+                "[review_runner] Provider review failed: CLI invocation failed: "
+                'exit=1 | stdout=unexpected status 401 Unauthorized: '
+                '{"detail":"Unauthorized"}\n'
+            ),
+        )
+
+        with patch("app.run.subprocess.Popen", side_effect=mock_proc._side_effect), \
+             patch("app.run._get_koan_branch", return_value="main"), \
+             patch("app.run._restore_koan_branch"), \
+             patch("app.run._reset_terminal"), \
+             patch("app.run.protected_phase", return_value=MagicMock(
+                 __enter__=MagicMock(), __exit__=MagicMock(return_value=False)
+             )), \
+             patch("app.run._notify") as mock_notify, \
+             patch("app.run._notify_mission_end"), \
+             patch("app.run._finalize_mission") as mock_finalize, \
+             patch("app.run._requeue_mission_in_file") as mock_requeue, \
+             patch("app.run._commit_instance"), \
+             patch("app.run._sleep_between_runs"), \
+             patch("app.run.set_status"), \
+             patch("app.run.log"), \
+             patch("app.provider.get_provider_name", return_value="codex"), \
+             patch("app.skill_dispatch.dispatch_skill_mission",
+                   return_value=["python3", "-m", "app.review_runner"]), \
+             patch("app.mission_runner.run_post_mission"), \
+             patch("app.pause_manager.create_pause") as mock_pause:
+            handled, _ = _handle_skill_dispatch(
+                mission_title="/review https://github.com/example/repo/pull/1",
+                project_name="test",
+                project_path=str(tmp_path),
+                koan_root=koan_root,
+                instance=instance,
+                run_num=1,
+                max_runs=20,
+                autonomous_mode="implement",
+                interval=30,
+            )
+
+        assert handled is True
+        mock_requeue.assert_called_once()
+        mock_finalize.assert_not_called()
+        mock_pause.assert_called_once_with(koan_root, "auth")
+        notify_text = mock_notify.call_args_list[-1][0][1]
+        assert "logged out" in notify_text.lower()
+
     def test_post_mission_quota_requeues_and_pauses(self, tmp_path):
         """Quota detected in post-mission pipeline should requeue.
 
@@ -7154,3 +7213,77 @@ class TestClassifyTrustStdout:
             )
         assert handled is True
         quota.assert_called_once()
+
+    def test_codex_runtime_auth_stdout_still_honored(self):
+        from app import run
+
+        transcript = (
+            "[cli] event: thread.started\n"
+            '[cli] error: unexpected status 401 Unauthorized: {"detail":"Unauthorized"}\n'
+            "[cli] event: turn.failed\n"
+        )
+        common = {**self._COMMON, "provider_name": "codex", "provider_label": "Codex"}
+        with patch.object(run, "_handle_quota_error") as quota, \
+             patch.object(run, "_handle_auth_error") as auth:
+            handled = run._classify_and_handle_cli_error(
+                1, transcript, "", trust_stdout=False, **common
+            )
+        assert handled is True
+        auth.assert_called_once()
+        quota.assert_not_called()
+
+    def test_plain_skill_stdout_unauthorized_still_ignored(self):
+        from app import run
+
+        transcript = "Test fixture includes text: HTTP 401 Unauthorized\n"
+        common = {**self._COMMON, "provider_name": "codex", "provider_label": "Codex"}
+        with patch.object(run, "_handle_quota_error") as quota, \
+             patch.object(run, "_handle_auth_error") as auth:
+            handled = run._classify_and_handle_cli_error(
+                1, transcript, "", trust_stdout=False, **common
+            )
+        assert handled is False
+        auth.assert_not_called()
+        quota.assert_not_called()
+
+    def test_codex_runtime_auth_json_event_still_honored(self):
+        """Raw provider JSON error events on stdout must classify as auth.
+
+        Regression: the JSON-event branch of the runtime auth scan must run
+        without raising (previously crashed on a missing ``contextlib``).
+        """
+        from app import run
+
+        transcript = (
+            '{"type": "thread.started", "thread_id": "t1"}\n'
+            '{"type": "error", "message": "unexpected status 401 Unauthorized: '
+            '{\\"detail\\":\\"Unauthorized\\"}"}\n'
+            '{"type": "turn.failed"}\n'
+        )
+        common = {**self._COMMON, "provider_name": "codex", "provider_label": "Codex"}
+        with patch.object(run, "_handle_quota_error") as quota, \
+             patch.object(run, "_handle_auth_error") as auth:
+            handled = run._classify_and_handle_cli_error(
+                1, transcript, "", trust_stdout=False, **common
+            )
+        assert handled is True
+        auth.assert_called_once()
+        quota.assert_not_called()
+
+    def test_benign_json_event_quoting_unauthorized_ignored(self):
+        """A non-error JSON event that merely quotes '401' is not an auth failure."""
+        from app import run
+
+        transcript = (
+            '{"type": "item.completed", "message": "test output: HTTP 401 '
+            'Unauthorized appears in this CI log"}\n'
+        )
+        common = {**self._COMMON, "provider_name": "codex", "provider_label": "Codex"}
+        with patch.object(run, "_handle_quota_error") as quota, \
+             patch.object(run, "_handle_auth_error") as auth:
+            handled = run._classify_and_handle_cli_error(
+                1, transcript, "", trust_stdout=False, **common
+            )
+        assert handled is False
+        auth.assert_not_called()
+        quota.assert_not_called()


### PR DESCRIPTION
Move provider-specific behavior out of shared CLI code and into the provider objects so cli_exec no longer special-cases provider names:

- Providers declare stdin prompt-passing support and own the argv->stdin rewrite (Claude "-p" placeholder, Codex "exec -").
- Providers can opt into serialized CLI invocations via a process-wide file lock. Codex uses it to avoid token-refresh races between preflight probes, message formatting, and long review sessions.
- Providers own final-message-file arg placement (Codex inserts the flag before the prompt) and auth-failure detection. Codex recognizes 401 and refresh-token-reuse errors in both stderr and streamed JSONL events.

Detect Codex auth failures from stdout-safe runtime lines so a bare 401 stream failure pauses for auth and requeues the active mission instead of marking it failed. Keep the trusted stdout surface narrow ([cli] summaries, CLI failure lines, and structured JSON error events) to avoid false positives from quoted CI logs or source text.

Fix a missing contextlib import that crashed the JSON-event branch of the runtime auth scan with NameError, and add regression coverage for both the JSON-event auth case and a benign event that merely quotes a 401 string.

Consolidate the triplicated provider error-event-type set into a single PROVIDER_ERROR_EVENT_TYPES constant in provider/base.py.