### PR TITLE
fix(awake): don't sys.exit(1) on non-telegram messaging providers

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -83,7 +83,12 @@ def _get_last_message_id() -> int:
 
 
 def check_config():
-    if not BOT_TOKEN or not CHAT_ID:
+    # BOT_TOKEN / CHAT_ID are Telegram-specific.  Slack and Matrix users
+    # don't set them — defer the actual credential check to each
+    # provider's own ``configure()`` (called from get_messaging_provider
+    # below) so non-telegram providers don't get sys.exit(1)'d here.
+    from app.messaging import resolve_provider_name
+    if resolve_provider_name() == "telegram" and (not BOT_TOKEN or not CHAT_ID):
         log("error", "Set KOAN_TELEGRAM_TOKEN and KOAN_TELEGRAM_CHAT_ID env vars.")
         sys.exit(1)
     if not INSTANCE_DIR.exists():
@@ -727,7 +732,8 @@ def main():
 
     setup_github_auth()
 
-    provider_name = "telegram"  # about to become dynamic with provider abstraction
+    from app.messaging import resolve_provider_name
+    provider_name = resolve_provider_name()
     print_bridge_banner(f"messaging bridge — {provider_name.lower()}")
 
     # Record startup time — used to ignore stale signal files in the
@@ -743,8 +749,10 @@ def main():
     heartbeat_file = KOAN_ROOT / HEARTBEAT_FILE
     heartbeat_file.unlink(missing_ok=True)
     write_heartbeat(str(KOAN_ROOT))
-    log("init", f"Token: ...{BOT_TOKEN[-8:]}")
-    log("init", f"Chat ID: {CHAT_ID}")
+    if BOT_TOKEN:
+        log("init", f"Token: ...{BOT_TOKEN[-8:]}")
+    if CHAT_ID:
+        log("init", f"Chat ID: {CHAT_ID}")
     log("init", f"Soul: {len(SOUL)} chars loaded")
     log("init", f"Summary: {len(SUMMARY)} chars loaded")
     registry = _get_registry()
@@ -798,7 +806,16 @@ def main():
                 continue
 
             for update in updates:
-                offset = update["update_id"] + 1
+                # Telegram uses update_id for offset-based pagination.
+                # Other providers (matrix, slack, discord) manage their own
+                # cursor internally and may hand us updates that don't carry
+                # this key. Never let a missing/malformed update_id crash the
+                # bridge: a single non-conforming update would otherwise take
+                # down main(), the supervisor would restart us, the same
+                # poison message would be re-delivered, and we'd crash-loop
+                # forever (see logs/awake.log KeyError: 'update_id').
+                if "update_id" in update:
+                    offset = update["update_id"] + 1
 
                 # Handle reaction updates
                 if "message_reaction" in update:
@@ -811,7 +828,26 @@ def main():
                 msg = update.get("message", {})
                 text = msg.get("text", "")
                 chat_id = str(msg.get("chat", {}).get("id", ""))
-                if chat_id == CHAT_ID and text:
+                # Match against either: (a) the active provider's channel
+                # id (resolved at startup — covers slack/matrix where
+                # CHAT_ID is unset), or (b) CHAT_ID (telegram-only, kept
+                # for backward compat with existing tests that patch it
+                # directly).  For telegram in production the two are the
+                # same value.
+                #
+                # message_id / mention-stripping MUST be derived inside this
+                # block, not a separate `chat_id == CHAT_ID` guard: for matrix
+                # (and any provider where CHAT_ID is unset) chat_id matches
+                # channel_id but never CHAT_ID, so a CHAT_ID-only guard leaves
+                # message_id unbound and set_reply_context() below raises
+                # UnboundLocalError — crashing the bridge on every message.
+                #
+                # Empty strings are stripped from the match set and an empty
+                # chat_id is rejected: with CHAT_ID="" (normal for matrix/slack)
+                # a malformed update missing chat.id would otherwise satisfy
+                # `"" in (channel_id, "")` and slip past the channel filter.
+                valid_chat_ids = {str(channel_id), str(CHAT_ID)} - {""}
+                if text and chat_id and chat_id in valid_chat_ids:
                     message_id = msg.get("message_id", 0)
                     text = _strip_bot_mention_from_text(text, msg)
                     log("chat", f"Received: {text[:60]}")

--- a/koan/app/messaging/__init__.py
+++ b/koan/app/messaging/__init__.py
@@ -116,7 +116,7 @@ def get_messaging_provider(provider_name_override: Optional[str] = None) -> Mess
         if _instance is not None and provider_name_override is None:
             return _instance
 
-        name = provider_name_override or _resolve_provider_name()
+        name = provider_name_override or resolve_provider_name()
         instance = _create_provider(name)
 
         if provider_name_override is None:
@@ -132,7 +132,7 @@ def reset_provider():
         _instance = None
 
 
-def _resolve_provider_name() -> str:
+def resolve_provider_name() -> str:
     """Resolve provider name from env var or config."""
     name = os.environ.get("KOAN_MESSAGING_PROVIDER", "")
     if name:
@@ -177,6 +177,12 @@ def _ensure_providers_loaded():
         _modules_loaded = True
 
 
+# Backward-compatible private alias. ``resolve_provider_name`` is the public
+# API (used by awake.py); the underscore-prefixed name is retained so existing
+# callers/tests that imported it keep working.
+_resolve_provider_name = resolve_provider_name
+
+
 __all__ = [
     "DEFAULT_MAX_MESSAGE_SIZE",
     "MessagingProvider",
@@ -186,4 +192,5 @@ __all__ = [
     "get_messaging_provider",
     "register_provider",
     "reset_provider",
+    "resolve_provider_name",
 ]

--- a/koan/app/messaging/matrix.py
+++ b/koan/app/messaging/matrix.py
@@ -210,16 +210,38 @@ class MatrixProvider(MessagingProvider):
             if not body:
                 continue
 
+            # awake.py's main loop expects Telegram-Bot-API-shaped dicts
+            # (update["update_id"], update["message"]["chat"]["id"], …).
+            # Mint that wrapper here so the polling loop doesn't care which
+            # provider it's draining.
+            ts = event.get("origin_server_ts", "")
+            update_id = next(self._update_counter)
+            raw = {
+                "update_id": update_id,
+                "message": {
+                    "message_id": event.get("event_id", ""),
+                    "text": body,
+                    "date": ts,
+                    "chat": {"id": self._room_id, "type": "supergroup"},
+                    "from": {"id": sender, "username": sender},
+                },
+                "_matrix": {
+                    "sender": sender,
+                    "event_id": event.get("event_id", ""),
+                    "room_id": self._room_id,
+                    "origin_server_ts": ts,
+                },
+            }
             updates.append(
                 Update(
-                    update_id=next(self._update_counter),
+                    update_id=update_id,
                     message=Message(
                         text=body,
                         role="user",
-                        timestamp=str(event.get("origin_server_ts", "")),
-                        raw_data=event,
+                        timestamp=str(ts),
+                        raw_data=raw,
                     ),
-                    raw_data=event,
+                    raw_data=raw,
                 )
             )
         return updates

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -1428,6 +1428,30 @@ class TestCheckConfig:
              patch("app.awake.INSTANCE_DIR", inst):
             check_config()  # Should not raise
 
+    def test_does_not_exit_for_non_telegram_without_telegram_creds(self, tmp_path):
+        """Non-telegram providers (matrix/slack) leave BOT_TOKEN/CHAT_ID unset.
+        check_config() must not sys.exit on them — the credential check is
+        deferred to each provider's own configure()."""
+        inst = tmp_path / "instance"
+        inst.mkdir()
+        with patch("app.messaging.resolve_provider_name", return_value="matrix"), \
+             patch("app.awake.BOT_TOKEN", ""), \
+             patch("app.awake.CHAT_ID", ""), \
+             patch("app.awake.INSTANCE_DIR", inst):
+            check_config()  # Should not raise
+
+    def test_still_exits_for_telegram_without_creds(self, tmp_path):
+        """The telegram credential gate still fires when the provider is
+        telegram and creds are missing."""
+        inst = tmp_path / "instance"
+        inst.mkdir()
+        with patch("app.messaging.resolve_provider_name", return_value="telegram"), \
+             patch("app.awake.BOT_TOKEN", ""), \
+             patch("app.awake.CHAT_ID", ""), \
+             patch("app.awake.INSTANCE_DIR", inst), \
+             pytest.raises(SystemExit):
+            check_config()
+
 
 # ---------------------------------------------------------------------------
 # main() loop
@@ -1539,6 +1563,129 @@ class TestMainLoop:
         from app.awake import main
         mock_updates.return_value = [
             {"update_id": 100, "message": {"chat": {"id": int(self.TEST_CHAT_ID)}}}  # no text
+        ]
+        with pytest.raises(StopIteration):
+            main()
+        mock_handle.assert_not_called()
+
+    # -- Non-Telegram provider regressions (matrix/slack/discord) ------------
+    #
+    # These providers leave CHAT_ID unset and match on the resolved
+    # channel_id (e.g. a matrix room id). The main loop must not assume the
+    # Telegram update shape, or it crash-loops the bridge on every message.
+
+    MATRIX_ROOM_ID = "!VakERumPJhkcdQphyO:example.org"
+
+    def _matrix_provider_mock(self):
+        """A messaging provider whose channel_id is a matrix room id."""
+        provider = MagicMock()
+        provider.get_provider_name.return_value = "matrix"
+        provider.get_channel_id.return_value = self.MATRIX_ROOM_ID
+        return provider
+
+    @patch("app.awake._check_group_chat_mode")
+    @patch("app.messaging.get_messaging_provider")
+    @patch("app.awake.write_heartbeat")
+    @patch("app.awake._flush_outbox_async")
+    @patch("app.awake.handle_message")
+    @patch("app.awake.get_updates")
+    @patch("app.awake.check_config")
+    @patch("app.awake.CHAT_ID", "")  # matrix leaves CHAT_ID unset
+    @patch("app.awake.time.sleep", side_effect=StopIteration)
+    def test_main_matrix_message_binds_message_id(
+        self, mock_sleep, mock_config, mock_updates, mock_handle, mock_flush,
+        mock_heartbeat, mock_provider, mock_group_check,
+    ):
+        """A matrix message (chat_id matches channel_id but not CHAT_ID) must
+        dispatch without raising UnboundLocalError on message_id. The buggy
+        version bound message_id only inside a `chat_id == CHAT_ID` guard,
+        crashing the bridge on every matrix message → restart → crash-loop."""
+        from app.awake import main
+        mock_provider.return_value = self._matrix_provider_mock()
+        mock_updates.return_value = [
+            {"update_id": 1, "message": {
+                "message_id": "$evt", "text": "/resume",
+                "chat": {"id": self.MATRIX_ROOM_ID}}}
+        ]
+        # Must reach sleep() (StopIteration), not raise UnboundLocalError.
+        with pytest.raises(StopIteration):
+            main()
+        mock_handle.assert_called_once_with("/resume")
+
+    @patch("app.awake._check_group_chat_mode")
+    @patch("app.messaging.get_messaging_provider")
+    @patch("app.awake.write_heartbeat")
+    @patch("app.awake._flush_outbox_async")
+    @patch("app.awake.handle_message")
+    @patch("app.awake.get_updates")
+    @patch("app.awake.check_config")
+    @patch("app.awake.CHAT_ID", "")
+    @patch("app.awake.time.sleep", side_effect=StopIteration)
+    def test_main_update_without_update_id_does_not_crash(
+        self, mock_sleep, mock_config, mock_updates, mock_handle, mock_flush,
+        mock_heartbeat, mock_provider, mock_group_check,
+    ):
+        """An update lacking update_id must not crash the loop. A KeyError here
+        would take down main(), the supervisor would restart the bridge, the
+        same poison message would be re-delivered, and we'd crash-loop forever."""
+        from app.awake import main
+        mock_provider.return_value = self._matrix_provider_mock()
+        mock_updates.return_value = [
+            {"message": {"message_id": "$evt", "text": "hi from matrix",
+                         "chat": {"id": self.MATRIX_ROOM_ID}}}
+        ]
+        with pytest.raises(StopIteration):
+            main()
+        mock_handle.assert_called_once_with("hi from matrix")
+        mock_flush.assert_called_once()
+        mock_heartbeat.assert_called()
+
+    @patch("app.awake._check_group_chat_mode")
+    @patch("app.messaging.get_messaging_provider")
+    @patch("app.awake.write_heartbeat")
+    @patch("app.awake._flush_outbox_async")
+    @patch("app.awake.handle_message")
+    @patch("app.awake.get_updates")
+    @patch("app.awake.check_config")
+    @patch("app.awake.CHAT_ID", "")
+    @patch("app.awake.time.sleep", side_effect=StopIteration)
+    def test_main_drops_message_from_other_channel(
+        self, mock_sleep, mock_config, mock_updates, mock_handle, mock_flush,
+        mock_heartbeat, mock_provider, mock_group_check,
+    ):
+        """A message whose chat.id matches neither channel_id nor CHAT_ID is
+        dropped (not dispatched)."""
+        from app.awake import main
+        mock_provider.return_value = self._matrix_provider_mock()
+        mock_updates.return_value = [
+            {"update_id": 1, "message": {
+                "message_id": "$evt", "text": "intruder",
+                "chat": {"id": "!someOtherRoom:example.org"}}}
+        ]
+        with pytest.raises(StopIteration):
+            main()
+        mock_handle.assert_not_called()
+
+    @patch("app.awake._check_group_chat_mode")
+    @patch("app.messaging.get_messaging_provider")
+    @patch("app.awake.write_heartbeat")
+    @patch("app.awake._flush_outbox_async")
+    @patch("app.awake.handle_message")
+    @patch("app.awake.get_updates")
+    @patch("app.awake.check_config")
+    @patch("app.awake.CHAT_ID", "")
+    @patch("app.awake.time.sleep", side_effect=StopIteration)
+    def test_main_drops_malformed_update_missing_chat_id(
+        self, mock_sleep, mock_config, mock_updates, mock_handle, mock_flush,
+        mock_heartbeat, mock_provider, mock_group_check,
+    ):
+        """With CHAT_ID="" (normal for matrix/slack), a malformed update with no
+        chat.id (chat_id == "") must NOT pass the channel filter. Guards against
+        the empty-string match `"" in (channel_id, "")` slipping through."""
+        from app.awake import main
+        mock_provider.return_value = self._matrix_provider_mock()
+        mock_updates.return_value = [
+            {"update_id": 1, "message": {"message_id": "$evt", "text": "no chat id"}}
         ]
         with pytest.raises(StopIteration):
             main()


### PR DESCRIPTION
## Summary

Makes the `awake` bridge work for non-Telegram messaging providers (Slack/Matrix, and any provider where `CHAT_ID` is unset) instead of crash-looping on the first message. The bridge's main loop and config check had baked in several Telegram-Bot-API assumptions that broke other providers.

## Changes

**Startup / config**
- `check_config()` no longer hardcodes a `KOAN_TELEGRAM_TOKEN`/`CHAT_ID` presence check that exited non-telegram setups. The telegram-only credential check is gated to `resolve_provider_name() == "telegram"`; each provider's own `configure()` does its real credential check.
- Guard the `BOT_TOKEN` / `CHAT_ID` startup log lines against empty values (no more slicing an empty token or logging an empty chat).
- Unhardcode the bridge banner provider name (was stuck on `"telegram"` regardless of the active provider).

**Main-loop crash fixes** (Matrix crash-looped on every message)
- Matrix HTTP fallback now mints a Telegram-shaped wrapper (`update_id`, `message.chat.id`, …) in `_parse_room_events` instead of returning raw Matrix events, which raised `KeyError: 'update_id'`.
- Bind `message_id` / mention-stripping inside the channel-matching block so it's set whenever `chat_id` matches the active channel (previously only inside a `CHAT_ID` guard → `UnboundLocalError` on Matrix).
- Guard the `offset = update["update_id"] + 1` access; non-telegram providers may omit `update_id`.

**Review follow-ups**
- Chat-id filter no longer treats an empty `CHAT_ID` as a wildcard: strip `""` from the match set and require a non-empty `chat_id`, so a malformed update missing `chat.id` can't slip past the channel filter.
- Promote `_resolve_provider_name` to a public `resolve_provider_name()` (private alias kept for backward compat) and use it in `check_config()` and `main()`.

## Tests

Added regression coverage in `koan/tests/test_awake.py`:
- non-telegram `check_config()` does not exit (telegram without creds still does)
- Matrix-shaped `main()` loop drives through without crashing
- chat-id filter positive/negative + malformed-update regression

## Files

- `koan/app/awake.py`
- `koan/app/messaging/__init__.py`
- `koan/app/messaging/matrix.py`
- `koan/tests/test_awake.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
