### PR TITLE
docs: add contributing guide and troubleshooting reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,98 @@
+# Contributing to Kōan
+
+Thanks for contributing! This guide covers how to set up your environment, make changes, and submit them.
+
+## Development Setup
+
+```bash
+git clone https://github.com/Anantys-oss/koan.git
+cd koan
+make setup          # Create venv, install dependencies
+```
+
+Copy and customize the instance template:
+
+```bash
+cp -r instance.example instance
+# Edit instance/config.yaml, instance/soul.md, and .env as needed
+```
+
+## Running Tests
+
+```bash
+# Full test suite (KOAN_ROOT must be set)
+KOAN_ROOT=/tmp/test-koan make test
+
+# Single test file
+KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_missions.py -v
+
+# With coverage report
+KOAN_ROOT=/tmp/test-koan make coverage
+```
+
+All tests must pass before submitting. CI runs against multiple Python versions — if it doesn't run on 3.11, it doesn't ship.
+
+## Linting
+
+```bash
+make lint   # Runs ruff (PERF rules enforced; E/F/W/I/B are good hygiene)
+```
+
+Fix all lint errors before committing. Do not disable rules with `# noqa` unless there is a clear, documented reason.
+
+## Code Conventions
+
+See [CLAUDE.md](CLAUDE.md) for the full conventions. Key points:
+
+- **Python 3.11+ only** — no syntax or stdlib introduced after 3.11.
+- **No inline prompts** — LLM prompts go in `.md` files, loaded via `load_prompt()` or `load_skill_prompt()`. Reusable fragments belong in `koan/system-prompts/_partials/`.
+- **Branch isolation** — Kōan creates `koan/*` branches, never commits to `main`.
+- **Public artifacts stay generic** — no private operator identifiers in source code, comments, docstrings, tests, docs, or commit messages. Use placeholders: `my_toolkit`, `my_team`, `my_fix`, `@koan-bot`, `PROJ-NNN`.
+- **No hyphens in skill names** — Telegram treats hyphens as word boundaries. Use underscores: `dead_code`, not `dead-code`.
+- **Config via files, not env vars** — new features should use `config.yaml` / `projects.yaml` for configuration. Env vars are for secrets and deployment-specific settings.
+
+## Adding a New Core Skill
+
+Every core skill needs ALL of these. See the full checklist in [CLAUDE.md](CLAUDE.md) "Adding a new core skill" section.
+
+1. Create `koan/skills/core/<skill_name>/SKILL.md` with frontmatter including `name`, `description`, `group`, `commands`, and `audience`.
+2. Register in `skill_dispatch.py` if it runs via the agent loop.
+3. Add to `docs/users/skills.md` in the appropriate category table.
+4. Add to `docs/users/user-manual.md` in the appropriate tier section and quick-reference table.
+5. Run tests — `TestCoreSkillGroupEnforcement` enforces the `group:` field.
+
+See [koan/skills/README.md](koan/skills/README.md) for the full SKILL.md format and handler conventions.
+
+## Documentation
+
+**Before implementing**, inspect relevant docs with search tools. **After changing** user behavior, configuration, daemon flow, provider behavior, shared state, or safety boundaries, update the relevant docs in the same branch.
+
+| Change type | Docs to update |
+|---|---|
+| User command / skill | `docs/users/user-manual.md` + `docs/users/skills.md` |
+| Architecture / daemon | `docs/architecture/` |
+| Provider behavior | `docs/providers/` |
+| Messaging / tracker integration | `docs/messaging/` |
+| Config / operations | `docs/operations/` + `instance.example/config.yaml` |
+| Design decision / philosophy | `docs/design/decisions.md` |
+| Security | `docs/security/` |
+
+Prefer updating an existing page over adding a new one unless the topic is a new subsystem.
+
+## Pull Request Process
+
+1. Create a feature branch and make your changes.
+2. Run `make lint` and `make test` — both must pass.
+3. Update relevant documentation in the same branch.
+4. Submit a PR against `main`.
+5. The PR description should explain what changed and why.
+
+## Release Process
+
+Releases are cut from `main` when it's healthy and something worth shipping has landed. See [docs/operations/maint.md](docs/operations/maint.md) for the full procedure (`make release`).
+
+## Questions?
+
+- [Documentation index](docs/README.md)
+- [User manual](docs/users/user-manual.md)
+- [Architecture overview](docs/architecture/overview.md)

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@
 </p>
 
 <p align="center">
-  <img src="https://img.shields.io/badge/python-3.10+-blue.svg" alt="Python 3.10+" />
+  <img src="https://img.shields.io/badge/python-3.11+-blue.svg" alt="Python 3.11+" />
   <img src="https://img.shields.io/badge/tests-9000+-green.svg" alt="Tests" />
-  <img src="https://img.shields.io/badge/skills-44-blueviolet.svg" alt="Skills" />
+  <img src="https://img.shields.io/badge/skills-80+-blueviolet.svg" alt="Skills" />
   <img src="https://img.shields.io/badge/license-GPL--3.0-blue.svg" alt="License" />
 </p>
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ update the relevant docs in the same change.
 - [Skills Reference](users/skills.md) - built-in command reference.
 - [Provider Setup](providers/) - Claude, Codex, Copilot, and local providers.
 - [Messaging Setup](messaging/) - Telegram, Slack, Matrix, Discord, GitHub, and Jira.
+- [Troubleshooting](operations/troubleshooting.md) - common issues and how to fix them.
 
 ## Implementation Reference
 
@@ -38,7 +39,7 @@ memory, or integration changes:
 - `setup/` - installation and host runtime setup.
 - `providers/` - CLI and local model provider setup and behavior.
 - `messaging/` - messaging and issue-tracker integration setup.
-- `operations/` - maintenance, self-update, and optional operational tools (dashboard, REST API, auto-update, RTK).
+- `operations/` - maintenance, troubleshooting, self-update, and optional operational tools (dashboard, REST API, auto-update, RTK).
 - `architecture/` - current daemon design and implementation references.
 - `security/` - security review docs and threat models.
 - `design/` - durable decisions, design notes, and larger specs.

--- a/docs/operations/dashboard.md
+++ b/docs/operations/dashboard.md
@@ -112,6 +112,6 @@ All third-party assets are **vendored** so the local-only dashboard works fully 
 
 ## Related
 
-- Design system: `docs/design-system/` (and its `docs/developer-handoff.md`)
+- Design system: vendored in `koan/static/css/koan.css` and `koan/static/js/koan.js` (see the Design system section above)
 - Shared state files: see `docs/architecture/`
 - REST API: [`docs/operations/rest-api.md`](rest-api.md) — programmatic HTTP control layer

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -1,0 +1,158 @@
+# Troubleshooting
+
+Common operational issues and how to resolve them.
+
+## Quick Diagnostic
+
+Run `/doctor` first — it catches many common problems and can auto-repair with `/doctor --fix`. Use `/doctor --full` to include connectivity checks (Telegram, GitHub, CLI provider).
+
+## Agent Loop Issues
+
+### Agent not picking up missions
+
+1. **Check if paused** — `/pause` or quota exhaustion pauses the agent. Run `/status` to see the current state. Use `/resume` to unpause.
+2. **Check quota** — `/quota` shows remaining budget. If below `stop_at_percent` (default 5%), the agent waits for quota reset. Override with `/quota 50` if the estimate is wrong.
+3. **Check focus mode** — `/focus` locks the agent to a specific project. If a mission is queued for a different project, it won't be picked up. Use `/unfocus` to release.
+4. **Check passive mode** — `/passive` blocks all execution. Use `/active` to resume.
+5. **Check schedule** — if `schedule.active_hours` is configured, the agent only works during those hours.
+6. **Check `missions.md`** — missions stuck under a non-canonical section header won't be picked up. Run `/doctor --fix` to reconcile malformed sections.
+
+### Agent stuck on a mission (looping / not making progress)
+
+1. **Stagnation detection** — if enabled, the agent auto-kills sessions stuck in a loop. Check the stagnation config in `config.yaml`: `stagnation.check_interval_seconds`, `abort_after_cycles`, and `max_retry_on_stagnation`.
+2. **Manual abort** — `/abort` kills the current mission and marks it Failed. The next mission in the queue picks up.
+3. **Check `/live`** — see if the agent is producing output or silently hung.
+
+### "Quota exhausted" when quota is actually available
+
+The internal usage estimate can drift from reality. Use `/quota <N>` to override (e.g., `/quota 50` tells the agent it has 50% remaining). This clears any quota-related pause.
+
+### Agent loop process not running
+
+1. Check `make status` to see which processes are alive.
+2. Check log files: `make logs` or `tail -100 instance/logs/run.log`.
+3. If the process crashed, check for a stale PID file — `/doctor --fix` removes orphaned PID files.
+
+## Git & Worktree Issues
+
+### Orphaned or stale worktrees
+
+Parallel sessions create worktrees under `.worktrees/`. If a session crashes, worktrees can linger:
+
+```bash
+# From the project directory
+git worktree list          # See all worktrees
+git worktree prune         # Remove stale references
+```
+
+Kōan cleans up worktrees on startup during crash recovery. If you see stale worktrees, restarting the agent loop should clear them.
+
+### Branch conflicts (can't checkout, can't push)
+
+1. **Force-push protection** — Kōan uses `koan/*` branches (configurable via `branch_prefix`). If the branch already exists on remote from another instance, the agent may fail to push.
+2. **Shared project repos** — if multiple Kōan instances target the same repo, ensure each uses a distinct `branch_prefix` in `config.yaml`.
+
+### SSH authentication failures
+
+See the [SSH Setup Guide](../setup/ssh-setup.md) for detailed scenarios. Quick checks:
+
+```bash
+ssh -T git@github.com          # Test basic SSH connectivity
+ssh-add -l                      # Are keys loaded in the agent?
+make ssh-forward                # Refresh agent socket (systemd deployments)
+```
+
+## Memory & Journal Issues
+
+### Memory files growing too large
+
+Memory compaction runs automatically every 24 hours (configurable). To force compaction immediately:
+
+```bash
+python3 koan/app/memory_manager.py <instance_dir> compact-learnings [project-name]
+```
+
+Configure thresholds in `config.yaml`:
+```yaml
+memory:
+  learnings_max_lines: 100      # Target after semantic compaction
+  learnings_hard_cap: 200       # Absolute max (safety net)
+  compaction_interval_hours: 24
+```
+
+### Missing memory or journal directories
+
+Run `/doctor --fix` — it recreates missing `memory/` and `journal/` directories.
+
+## Bridge (Telegram/Slack) Issues
+
+### Bot not responding to Telegram messages
+
+1. **Check bridge is running** — `make status` shows if the awake/bridge process is alive.
+2. **Check Telegram token** — verify `KOAN_TELEGRAM_TOKEN` is set in `.env`.
+3. **Check logs** — `/logs awake` or `tail -100 instance/logs/awake.log`.
+4. **Polling interval** — the bridge polls Telegram every 3 seconds. Messages should appear within 3s.
+
+### Outbox messages not being delivered
+
+Messages queue in `instance/outbox.md`. The bridge flushes this to Telegram on each poll cycle. If messages are stuck:
+
+1. Check the bridge is running (`make status`).
+2. Check for Telegram API rate limiting in `awake.log`.
+3. If the outbox has grown large, restart the bridge (`make stop && make start`).
+
+## GitHub Integration Issues
+
+### GitHub @mentions not triggering missions
+
+1. **Bot nickname** — verify `github_nickname` in `config.yaml` matches the bot's GitHub username.
+2. **Authorized users** — check `authorized_users` in `projects.yaml` for the project.
+3. **Notification polling** — by default polls every 60-300s. Use `/check_notifications` to force an immediate check.
+4. **Permissions** — the bot's GitHub token must have read access to the repository.
+
+### GitHub webhook not receiving events
+
+1. Verify the webhook secret matches `KOAN_GITHUB_WEBHOOK_SECRET`.
+2. Check the webhook endpoint is reachable from GitHub's servers.
+3. See [GitHub Webhooks](../messaging/github-webhooks.md) for setup details.
+
+## CLI Provider Issues
+
+### Claude Code not found or not working
+
+1. Verify the CLI is installed: `which claude` or `claude --version`.
+2. Check `KOAN_CLI_PROVIDER` in `.env` (default: `claude`).
+3. See [Provider Setup](../providers/) for provider-specific configuration.
+
+### Provider quota / rate limit errors
+
+Kōan detects quota-limit messages from CLI output and auto-pauses. The pause lifts 10 minutes after the reported reset time. If the reset time can't be parsed, Kōan pauses for 5 hours. Use `/quota <N>` to override the estimate and `/resume` to unpause early.
+
+## Parallel Session Issues
+
+### Sessions not running in parallel
+
+1. Check `max_parallel_sessions` in `config.yaml` (default: 2).
+2. Only one mission can target the same project at once (per-project serialization).
+3. GitHub operations (`gh` CLI) may rate-limit parallel requests.
+
+### Shared deps causing conflicts
+
+If a mission's build step modifies dependencies (e.g., `npm install`), it can affect other sessions sharing the same directory via `shared_deps`. Consider removing the dependency directory from `shared_deps` if this is a recurring issue.
+
+## Configuration Issues
+
+### Config drift after update
+
+Run `/config_check` to detect keys missing from or extra to the template. The same check runs as part of `/doctor`. Review the reported diff and update your `config.yaml` accordingly.
+
+### Config changes not taking effect
+
+Most config is read on each iteration. A few settings (process-level: API bind, ports) require a restart. Use `/restart` if a config change doesn't seem to take effect.
+
+## When Nothing Else Works
+
+1. **Collect diagnostics**: `/doctor --full` output, recent logs (`/logs all`), and `make status`.
+2. **Restart the stack**: `make stop && make start`.
+3. **Check upstream issues**: review the [GitHub repository](https://github.com/Anantys-oss/koan) for known issues.
+4. **Export a snapshot**: `/snapshot` before making destructive changes — it backs up memory state.

--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -17,6 +17,7 @@ Complete reference for all Koan slash commands. Use these via Telegram, Slack, o
 | `/list` | `/queue`, `/ls` | List pending and in-progress missions |
 | `/priority <n> <pos>` | — | Reorder a pending mission in the queue |
 | `/cancel <n or keyword>` | `/remove`, `/clear` | Cancel a pending mission |
+| `/abort` | — | Abort the current in-progress mission |
 | `/idea <text>` | `/ideas`, `/buffer` | Add to the ideas backlog (promote to mission later) |
 
 ## Recurring Missions
@@ -34,34 +35,57 @@ Complete reference for all Koan slash commands. Use these via Telegram, Slack, o
 | Command | Aliases | Description | GitHub @mention |
 |---------|---------|-------------|:-:|
 | `/plan <desc>` | — | Deep-think an idea, create a tracker issue with structured plan | — |
+| `/deepplan <desc>` | `/deeplan` | Spec-first design: explore approaches, post spec, queue /plan | — |
 | `/implement <issue>` | `/impl` | Queue implementation for a GitHub or Jira issue; never bails — resolves ambiguity with simplest viable solution, retries once before surfacing a problem | Yes |
 | `/fix <issue>` | — | Understand → plan → test → implement → submit PR | Yes |
 | `/review <PR>` | `/rv` | Review a pull request | Yes |
 | `/explain <PR>` | `/xp` | Explain a PR's changes in plain language with examples and alternative approaches | Yes |
 | `/rebase <PR>` | `/rb` | Rebase a PR onto its base branch | Yes |
-| `/planimplement <issue>` | `/planimp`, `/planimpl`, `/planit`, `/plandoit` | Plan then implement an issue (combo: /plan → /implement) | Yes |
+| `/squash <PR>` | `/sq` | Squash all PR commits into one clean commit | Yes |
 | `/recreate <PR>` | `/rc` | Re-implement a PR from scratch on a fresh branch | Yes |
 | `/refactor <desc>` | `/rf` | Targeted refactoring mission | Yes |
-| `/check <project>` | `/inspect` | Run project health checks (rebase, review, plan) | — |
+| `/check <url>` | `/inspect` | Run project health checks on a PR or issue (rebase, review, plan) | — |
+| `/check_need <url>` | `/need`, `/needs` | Analyze if a PR or issue is still needed vs. current main | — |
+| `/ci_check <PR>` | — | Check and fix CI failures on a PR | — |
 | `/pr <PR>` | — | Review and update a GitHub pull request | — |
 | `/claudemd [project]` | `/claude`, `/claude.md` | Refresh or create a project's CLAUDE.md | — |
 | `/doc <project> [cats]` | `/docs` | Extract structured documentation to docs/ | Yes |
+| `/profile <project>` | `/perf`, `/benchmark` | Performance profiling mission | Yes |
 
-For URL-based `/plan`, `/implement`, and `/fix`, append `branch:<name>` to
+For URL-based `/plan`, `/deepplan`, `/implement`, and `/fix`, append `branch:<name>` to
 override the base branch for that mission.
 
 Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <command>` on a PR or issue. See [GitHub commands](../messaging/github-commands.md).
 
+## PR Management
+
+| Command | Aliases | Description | GitHub @mention |
+|---------|---------|-------------|:-:|
+| `/ask <comment-url>` | — | Ask a question about a PR/issue — posts AI reply to GitHub | Yes |
+| `/reviewrebase <PR>` | `/rr` | Review then rebase a PR (combo: /review → /rebase) | Yes |
+| `/planimplement <issue>` | `/planimp`, `/planimpl`, `/planit`, `/plandoit` | Plan then implement an issue (combo: /plan → /implement) | Yes |
+| `/branches [project]` | `/br`, `/prs` | List koan branches + open PRs with merge order | — |
+| `/done [project]` | `/merged` | List PRs merged in the last 24 hours | — |
+| `/diagnose [project]` | `/dx` | Find the last failed mission and queue a fix attempt | — |
+| `/gh_request <url> <text>` | — | Route a natural-language GitHub request to the right skill | Yes |
+
 ## Exploration & Analysis
 
-| Command | Aliases | Description |
-|---------|---------|-------------|
-| `/ai <topic>` | `/ia` | Queue an AI exploration mission (deep, with codebase access) |
-| `/magic <topic>` | — | Instant creative exploration (quick, no mission queue) |
-| `/sparring` | — | Strategic challenge session — thinking, not code |
-| `/gha_audit [project]` | `/gha` | Scan GitHub Actions workflows for security vulnerabilities |
-| `/changelog [project]` | `/changes` | Generate changelog from recent commits and journal entries |
-| `/stats` | — | Show session outcome statistics per project |
+| Command | Aliases | Description | GitHub @mention |
+|---------|---------|-------------|:-:|
+| `/brainstorm <topic>` | — | Decompose topic into linked sub-issues + master tracking issue | Yes |
+| `/ai <topic>` | `/ia` | Queue an AI exploration mission (deep, with codebase access) | — |
+| `/magic <topic>` | — | Instant creative exploration (quick, no mission queue) | — |
+| `/sparring` | — | Strategic challenge session — thinking, not code | — |
+| `/audit <project>` | — | Audit project, create tracker issues for each finding (top 5) | Yes |
+| `/security_audit <project>` | `/security`, `/secu` | Security audit, find critical vulnerabilities (top 5) | Yes |
+| `/private_security_audit <project>` | `/private_security`, `/psecu` | Security audit, findings to journal only (no GitHub) | — |
+| `/tech_debt [project]` | `/td`, `/debt` | Scan for duplicated code, complex functions, testing gaps | — |
+| `/dead_code [project]` | `/dc` | Scan for unused imports, functions, classes, dead branches | — |
+| `/spec_audit [project]` | `/sa`, `/drift` | Audit docs/code alignment, queue fix missions | — |
+| `/gha_audit [project]` | `/gha` | Scan GitHub Actions workflows for security vulnerabilities | — |
+| `/changelog [project]` | `/changes` | Generate changelog from recent commits and journal entries | — |
+| `/stats [project]` | — | Show session outcome statistics per project | — |
 
 ## Communication & Reflection
 
@@ -76,10 +100,21 @@ Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <com
 
 | Command | Aliases | Description |
 |---------|---------|-------------|
-| `/status` | `/st`, `/ping`, `/usage`, `/metrics` | Show agent status, missions, and loop health |
+| `/status` | `/st` | Show agent state, missions, and loop health |
+| `/ping` | — | Check if the agent loop is alive |
 | `/live` | `/progress` | Show live progress from the current run |
-| `/quota` | `/q` | Check LLM quota (live, no cache) |
-| `/doctor` | `/diag` | Diagnostic self-checks; `--fix` auto-repairs, `--full` adds connectivity |
+| `/logs [run\|awake\|all]` | — | Show last 20 lines from logs (default: run) |
+| `/quota [N]` | `/q` | Check LLM quota (live), or override remaining % |
+| `/usage` | — | Detailed quota and progress |
+| `/metrics` | — | Mission success rates and reliability stats |
+| `/doctor` | — | Diagnostic self-checks; `--fix` auto-repairs, `--full` adds connectivity |
+| `/models` | `/model` | Show resolved model config for the active CLI provider |
+| `/config_check` | `/cfgcheck`, `/configcheck` | Detect drift between instance/config.yaml and the template |
+| `/check_notifications` | `/read` | Force immediate GitHub + Jira notification check |
+| `/inbox` | — | Force GitHub notification check + show queued mail count |
+| `/rescan` | `/rescan_heads` | Re-check all projects for remote HEAD branch changes |
+| `/verbose` | — | Enable real-time progress updates |
+| `/silent` | — | Disable real-time progress updates |
 
 ## Configuration
 
@@ -87,23 +122,43 @@ Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <com
 |---------|---------|-------------|
 | `/projects` | `/proj` | List configured projects |
 | `/tracker` | — | Show or set per-project issue tracker routing |
-| `/add_project <url>` | — | Clone a GitHub repo and add it to the workspace |
-| `/focus <project>` | — | Lock the agent to one project (suppress exploration) |
+| `/alias <proj> <short>` | — | Create project shortcut (e.g. `/alias Template2 tt`) |
+| `/unalias <short>` | — | Remove a project alias |
+| `/focus [duration]` | — | Lock the agent to one project (suppress exploration) |
 | `/unfocus` | — | Exit focus mode |
+| `/passive [duration]` | — | Enter read-only passive mode |
+| `/active` | — | Exit passive mode, resume execution |
 | `/explore [project]` | `/exploration`, `/noexplore` | Toggle per-project exploration mode |
 | `/autoreview [project]` | `/auto_review`, `/noautoreview` | Toggle automatic review+rebase after PR creation per project |
 | `/language <lang>` | `/lng`, `/fr`, `/en` | Set reply language preference |
-| `/verbose` | — | Enable real-time progress updates |
-| `/silent` | — | Disable real-time progress updates |
-| `/config_check` | `/cfgcheck`, `/configcheck` | Detect drift between instance/config.yaml and the template |
 
 ## System
 
 | Command | Aliases | Description |
 |---------|---------|-------------|
+| `/pause` | `/sleep` | Pause mission processing |
+| `/resume` | `/work`, `/awake`, `/run`, `/start` | Resume mission processing |
 | `/shutdown` | — | Shutdown both agent loop and messaging bridge |
-| `/update` | `/upgrade`, `/restart` | Update Koan to latest upstream and restart |
-| `/start` | — | Start the agent loop |
+| `/update` | `/upgrade` | Finish current mission, pull updates, and restart |
+| `/restart` | — | Restart processes (no code pull) |
+| `/snapshot` | — | Export memory state to a portable file |
+
+## Project Management
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| `/add_project <url>` | — | Clone a GitHub repo and add it to the workspace |
+| `/delete_project <name>` | `/delete`, `/del` | Remove a project from workspace |
+| `/rename <old> <new>` | `/rename_project` | Rename a project everywhere (config, memory, journals) |
+
+## Power Tools
+
+| Command | Aliases | Description |
+|---------|---------|-------------|
+| `/incident <error>` | — | Triage a production error from a stack trace or log snippet |
+| `/scaffold_skill <scope> <name> <desc>` | `/scaffold`, `/new_skill` | Generate SKILL.md + handler.py for a new custom skill |
+| `/rtk [setup\|uninstall\|gain\|on\|off]` | — | Manage optional rtk integration for compressed tool output |
+| `/ideas` | — | List all ideas in the backlog |
 
 ---
 

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1969,4 +1969,4 @@ Skills marked with GitHub @mention support: `/audit`, `/doc`, `/security_audit`,
 
 ---
 
-*This manual covers all 45 core skills. For the full command reference with tabular format, see [docs/users/skills.md](skills.md). For skill authoring, see [koan/skills/README.md](../../koan/skills/README.md).*
+*For the full command reference with tabular format, see [docs/users/skills.md](skills.md). For skill authoring, see [koan/skills/README.md](../../koan/skills/README.md).*


### PR DESCRIPTION
Add CONTRIBUTING.md covering dev setup, test/lint commands, code conventions, skill authoring checklist, doc update table, and PR process.

Add docs/operations/troubleshooting.md covering common operational issues: agent loop, git/worktree, memory, Telegram bridge, GitHub integration, CLI provider, parallel sessions, and config drift.

Fix Python badge (3.10+ → 3.11+) and skills count (44 → 80+) in README.md. Fix stale design-system path in dashboard.md. Expand skills.md with missing commands, new PR Management and Power Tools sections, and GitHub @mention markers. Fix incorrect clone URL and repo link pointing to the wrong GitHub account.