### PR TITLE
fix(permissions): auto-create .claude/settings.json allowlist for instance/ files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,11 @@
 # Kōan instance data (private to each user)
 instance
 .koan*
+
+# Claude Code local directory — track settings.json (permission allowlist) but
+# ignore session data, credentials, and machine-specific overrides.
 .claude
+!.claude/settings.json
 
 # Python
 __pycache__/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 -include .env
 export
 
-.PHONY: install onboard setup start stop status restart
+.PHONY: install onboard setup permissions start stop status restart
 .PHONY: clean say migrate test test-skills test-strict coverage lint sync-instance rename-project release
 .PHONY: awake run errand-run errand-awake dashboard api api-token webhook
 .PHONY: ollama logs ssh-forward
@@ -62,12 +62,22 @@ endif
 SERVICE_INSTALLED = $(shell [ -f /etc/systemd/system/koan.service ] && echo 1)
 LAUNCHD_INSTALLED = $(shell [ -f ~/Library/LaunchAgents/com.koan.run.plist ] && echo 1)
 
-setup: $(VENV)/.installed
+setup: $(VENV)/.installed .claude/settings.json
 
 $(VENV)/.installed: koan/requirements.txt
 	$(PYTHON_BIN) -m venv $(VENV)
 	$(VENV)/bin/pip install -r koan/requirements.txt
 	@touch $@
+
+# Create .claude/settings.json with the instance/** permission allowlist so
+# autonomous agents can write to runtime state files without approval prompts.
+# Safe to re-run — idempotent.
+.claude/settings.json: koan/app/setup_claude_settings.py
+	$(KOAN_RUN) -m app.setup_claude_settings
+
+permissions:
+	$(KOAN_RUN) -m app.setup_claude_settings
+	@echo "→ Re-run 'make permissions' any time to refresh the allowlist."
 
 awake: setup
 	$(KOAN_RUN) app/awake.py

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -126,6 +126,30 @@ Messages queue in `instance/outbox.md`. The bridge flushes this to Telegram on e
 
 ## CLI Provider Issues
 
+### Agent blocked by permission prompts on instance/ files
+
+Kōan writes to `instance/` files (mission queue, outbox, journals, memory) during
+every session. If Claude Code prompts for approval on these writes, autonomous
+operation stalls.
+
+**Fix**: Run `make permissions` (or `make setup`) to create `.claude/settings.json`
+with the permission allowlist for `instance/**`:
+
+```bash
+make permissions
+```
+
+This creates `.claude/settings.json` in the project root with pre-approved rules
+for `Write(instance/**)`, `Edit(instance/**)`, git, and gh operations. The file
+persists across runs — you only need to run this once, or after a fresh clone.
+
+To verify: `/doctor` will show a `Permissions` section — `✅ .claude/settings.json present`
+or `⚠️ missing` with an auto-fix available via `/doctor --fix`.
+
+**Why not use `skip_permissions: true`?** `skip_permissions: true` passes
+`--dangerously-skip-permissions` to Claude CLI, which is rejected when Kōan runs
+as root and is broader than needed. The per-file allowlist is more surgical.
+
 ### Claude Code not found or not working
 
 1. Verify the CLI is installed: `which claude` or `claude --version`.

--- a/koan/app/setup_claude_settings.py
+++ b/koan/app/setup_claude_settings.py
@@ -1,0 +1,123 @@
+"""Create or update .claude/settings.json with permission allowlists for Kōan.
+
+Kōan operates on its own ``instance/`` directory as runtime state — mission
+queue, outbox, journals, memory.  Without a permission allowlist, Claude Code
+prompts for approval on every Write/Edit/Bash operation touching those files,
+which defeats autonomous operation.
+
+This module writes ``.claude/settings.json`` at the project root with the
+minimum allowlist required for autonomous Kōan sessions.
+
+Safe to run multiple times (idempotent): existing keys outside the ``permissions``
+block are preserved; the ``permissions`` block is replaced wholesale.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import List
+
+
+# Minimum permission rules for autonomous Kōan sessions.
+#
+# Write/Edit cover the native file tools; Bash patterns cover shell operations
+# the agent uses to update journals and run git/gh workflows.
+KOAN_ALLOWLIST: List[str] = [
+    # --- instance/ runtime state (missions, outbox, journal, memory) ---
+    "Write(instance/**)",
+    "Edit(instance/**)",
+    # echo-append pattern used for journal updates (relative paths)
+    "Bash(echo * >> instance/**)",
+    "Bash(echo * >> */instance/**)",
+    # cleanup of pending.md at session end
+    "Bash(rm instance/**)",
+    "Bash(rm -f instance/**)",
+    # journal directory creation
+    "Bash(mkdir -p instance/**)",
+    # --- version control (required for code missions) ---
+    "Bash(git status*)",
+    "Bash(git log*)",
+    "Bash(git diff*)",
+    "Bash(git add *)",
+    "Bash(git commit*)",
+    "Bash(git push*)",
+    "Bash(git checkout*)",
+    "Bash(git branch*)",
+    "Bash(git stash*)",
+    "Bash(git fetch*)",
+    # --- GitHub CLI (PR creation, issue management) ---
+    "Bash(gh pr*)",
+    "Bash(gh issue*)",
+    "Bash(gh api*)",
+    "Bash(gh repo*)",
+]
+
+
+def _settings_path(project_root: Path) -> Path:
+    return project_root / ".claude" / "settings.json"
+
+
+def install(project_root: Path | str | None = None, dry_run: bool = False) -> dict:
+    """Write .claude/settings.json with the Kōan permission allowlist.
+
+    Returns a dict with keys:
+        path     – absolute path to settings.json
+        created  – True if the file was created, False if it already existed
+        updated  – True if permissions were changed
+        dry_run  – True when no files were written
+    """
+    root = Path(project_root) if project_root else Path.cwd()
+    path = _settings_path(root)
+
+    existing: dict = {}
+    created = not path.exists()
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            existing = {}
+
+    old_allow = (existing.get("permissions") or {}).get("allow", [])
+    new_allow = KOAN_ALLOWLIST
+
+    updated = sorted(old_allow) != sorted(new_allow)
+
+    if not dry_run:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        existing.setdefault("permissions", {})["allow"] = new_allow
+        path.write_text(
+            json.dumps(existing, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+
+    return {
+        "path": str(path),
+        "created": created,
+        "updated": updated,
+        "dry_run": dry_run,
+    }
+
+
+def main() -> None:
+    """CLI entry point: ``python -m app.setup_claude_settings [--dry-run]``."""
+    dry_run = "--dry-run" in sys.argv
+
+    import os
+    project_root = os.environ.get("KOAN_ROOT", str(Path.cwd()))
+    result = install(project_root=project_root, dry_run=dry_run)
+
+    path = result["path"]
+    if result["dry_run"]:
+        print(f"[dry-run] would write {path}")
+    elif result["created"]:
+        print(f"→ Created {path}")
+    elif result["updated"]:
+        print(f"→ Updated {path} (permissions changed)")
+    else:
+        print(f"✓ {path} already up-to-date")
+
+
+if __name__ == "__main__":
+    main()

--- a/koan/diagnostics/permissions_check.py
+++ b/koan/diagnostics/permissions_check.py
@@ -1,0 +1,89 @@
+"""
+Kōan diagnostic — Claude Code permission allowlist check.
+
+Verifies that .claude/settings.json exists with the instance/** allowlist
+entries required for autonomous operation without permission prompts.
+"""
+
+import json
+from pathlib import Path
+from typing import List
+
+from diagnostics import CheckResult, FixResult
+
+
+# Minimum allowlist entries that must be present.  Extra entries are fine.
+_REQUIRED_RULES = {
+    "Write(instance/**)",
+    "Edit(instance/**)",
+}
+
+
+def _settings_path(koan_root: str) -> Path:
+    return Path(koan_root) / ".claude" / "settings.json"
+
+
+def _read_allow(path: Path) -> List[str]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return (data.get("permissions") or {}).get("allow", [])
+    except (OSError, json.JSONDecodeError, AttributeError):
+        return []
+
+
+def run(koan_root: str, instance_dir: str) -> List[CheckResult]:
+    results = []
+    path = _settings_path(koan_root)
+
+    if not path.exists():
+        results.append(CheckResult(
+            name="claude_settings",
+            severity="warn",
+            message=".claude/settings.json missing — agents will see permission prompts for instance/ writes",
+            hint="Run `make permissions` (or `make setup`) to create the allowlist",
+            fixable=True,
+        ))
+        return results
+
+    allow = set(_read_allow(path))
+    missing = _REQUIRED_RULES - allow
+    if missing:
+        results.append(CheckResult(
+            name="claude_settings",
+            severity="warn",
+            message=f".claude/settings.json exists but is missing {len(missing)} required rule(s): {', '.join(sorted(missing))}",
+            hint="Run `make permissions` to refresh the allowlist",
+            fixable=True,
+        ))
+    else:
+        results.append(CheckResult(
+            name="claude_settings",
+            severity="ok",
+            message=f".claude/settings.json present with {len(allow)} permission rule(s)",
+        ))
+
+    return results
+
+
+def fix(koan_root: str, instance_dir: str) -> List[FixResult]:
+    """Auto-create or repair .claude/settings.json."""
+    path = _settings_path(koan_root)
+    allow = set(_read_allow(path)) if path.exists() else set()
+    if _REQUIRED_RULES.issubset(allow):
+        return []  # already fine — nothing to do
+
+    try:
+        from app.setup_claude_settings import install
+        result = install(project_root=koan_root)
+        verb = "Created" if result["created"] else "Updated"
+        return [FixResult(
+            name="claude_settings",
+            success=True,
+            message=f"{verb} .claude/settings.json with instance/** permission allowlist",
+        )]
+    except Exception as e:
+        return [FixResult(
+            name="claude_settings",
+            success=False,
+            message=f"Could not create .claude/settings.json: {e}. Run `make permissions` manually.",
+        )]

--- a/koan/skills/core/doctor/handler.py
+++ b/koan/skills/core/doctor/handler.py
@@ -12,6 +12,7 @@ _MODULE_NAMES = {
     "config_check": "Configuration",
     "environment_check": "Environment",
     "instance_check": "Instance",
+    "permissions_check": "Permissions",
     "process_check": "Processes",
     "project_check": "Projects",
     "connectivity_check": "Connectivity",

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -35,6 +35,7 @@ class TestDiscoverChecks:
         assert "config_check" in modules
         assert "environment_check" in modules
         assert "instance_check" in modules
+        assert "permissions_check" in modules
         assert "process_check" in modules
         assert "project_check" in modules
         assert "connectivity_check" in modules

--- a/koan/tests/test_permissions_check.py
+++ b/koan/tests/test_permissions_check.py
@@ -1,0 +1,53 @@
+"""Tests for koan/diagnostics/permissions_check.py."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from diagnostics.permissions_check import fix, run
+
+
+def _write_settings(root: Path, allow: list) -> None:
+    settings = root / ".claude" / "settings.json"
+    settings.parent.mkdir(parents=True, exist_ok=True)
+    settings.write_text(json.dumps({"permissions": {"allow": allow}}))
+
+
+class TestRun:
+    def test_warns_when_file_missing(self, tmp_path):
+        results = run(str(tmp_path), str(tmp_path / "instance"))
+        assert len(results) == 1
+        assert results[0].severity == "warn"
+        assert results[0].fixable is True
+
+    def test_ok_when_rules_present(self, tmp_path):
+        _write_settings(tmp_path, ["Write(instance/**)", "Edit(instance/**)", "Bash(git*)"])
+        results = run(str(tmp_path), str(tmp_path / "instance"))
+        assert results[0].severity == "ok"
+
+    def test_warns_when_rules_missing(self, tmp_path):
+        _write_settings(tmp_path, ["Bash(git*)"])
+        results = run(str(tmp_path), str(tmp_path / "instance"))
+        assert results[0].severity == "warn"
+        assert "Write(instance/**)" in results[0].message or "Edit(instance/**)" in results[0].message
+
+    def test_handles_broken_json(self, tmp_path):
+        settings = tmp_path / ".claude" / "settings.json"
+        settings.parent.mkdir(parents=True)
+        settings.write_text("{broken")
+        results = run(str(tmp_path), str(tmp_path / "instance"))
+        assert results[0].severity == "warn"
+
+
+class TestFix:
+    def test_creates_file_when_missing(self, tmp_path):
+        results = fix(str(tmp_path), str(tmp_path / "instance"))
+        assert len(results) == 1
+        assert results[0].success is True
+        assert (tmp_path / ".claude" / "settings.json").exists()
+
+    def test_no_op_when_already_correct(self, tmp_path):
+        _write_settings(tmp_path, ["Write(instance/**)", "Edit(instance/**)", "Bash(git*)"])
+        results = fix(str(tmp_path), str(tmp_path / "instance"))
+        assert results == []

--- a/koan/tests/test_setup_claude_settings.py
+++ b/koan/tests/test_setup_claude_settings.py
@@ -1,0 +1,72 @@
+"""Tests for app.setup_claude_settings — permission allowlist installer."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.setup_claude_settings import KOAN_ALLOWLIST, install
+
+
+class TestInstall:
+    def test_creates_file_when_missing(self, tmp_path):
+        result = install(project_root=tmp_path)
+        assert result["created"] is True
+        assert result["updated"] is True
+        assert result["dry_run"] is False
+        settings_path = tmp_path / ".claude" / "settings.json"
+        assert settings_path.exists()
+
+    def test_writes_correct_allowlist(self, tmp_path):
+        install(project_root=tmp_path)
+        data = json.loads((tmp_path / ".claude" / "settings.json").read_text())
+        assert data["permissions"]["allow"] == KOAN_ALLOWLIST
+
+    def test_idempotent(self, tmp_path):
+        install(project_root=tmp_path)
+        result2 = install(project_root=tmp_path)
+        assert result2["created"] is False
+        assert result2["updated"] is False
+
+    def test_dry_run_does_not_create_file(self, tmp_path):
+        result = install(project_root=tmp_path, dry_run=True)
+        assert result["dry_run"] is True
+        assert not (tmp_path / ".claude" / "settings.json").exists()
+
+    def test_preserves_extra_keys(self, tmp_path):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(json.dumps({"theme": "dark"}))
+        install(project_root=tmp_path)
+        data = json.loads(settings_path.read_text())
+        assert data["theme"] == "dark"
+        assert "permissions" in data
+
+    def test_updates_stale_allowlist(self, tmp_path):
+        settings_path = tmp_path / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True)
+        settings_path.write_text(json.dumps({"permissions": {"allow": ["Write(instance/*)"]}}))
+        result = install(project_root=tmp_path)
+        assert result["updated"] is True
+        data = json.loads(settings_path.read_text())
+        assert data["permissions"]["allow"] == KOAN_ALLOWLIST
+
+    def test_creates_parent_dirs(self, tmp_path):
+        deep_root = tmp_path / "a" / "b" / "c"
+        deep_root.mkdir(parents=True)
+        install(project_root=deep_root)
+        assert (deep_root / ".claude" / "settings.json").exists()
+
+
+class TestAllowlistContent:
+    def test_has_write_rule(self):
+        assert "Write(instance/**)" in KOAN_ALLOWLIST
+
+    def test_has_edit_rule(self):
+        assert "Edit(instance/**)" in KOAN_ALLOWLIST
+
+    def test_has_git_rules(self):
+        assert any("git" in rule for rule in KOAN_ALLOWLIST)
+
+    def test_has_gh_rules(self):
+        assert any("gh" in rule for rule in KOAN_ALLOWLIST)


### PR DESCRIPTION
## What

Add `make permissions` and `make setup` auto-step that creates `.claude/settings.json` with a permission allowlist for `instance/**` files, so autonomous agents don't get blocked by approval prompts when writing to runtime state.

## Why

Closes #1798. Autonomous Kōan sessions (and any Claude Code agent running in the koan directory) were blocked by permission dialogs every time they wrote to `instance/missions.md`, `instance/outbox.md`, or journal/memory files. This is a fundamental contradiction of the autonomy model — the agent should own its own runtime state without per-operation approval dialogs.

The bootstrap catch-22: you can't create `.claude/settings.json` via the agent because the agent needs permission to create it. The fix is to generate the file from `make setup` (which the human runs), not from the agent itself.

## How

Three components:

1. **`koan/app/setup_claude_settings.py`** — idempotent installer with `install(project_root)` API. Writes `Write(instance/**)`, `Edit(instance/**)`, and common `Bash(git*)` / `Bash(gh*)` rules into `.claude/settings.json`. Preserves existing keys outside the `permissions` block.

2. **`Makefile`** — `.claude/settings.json` is now a dependency of `setup` (auto-created on first `make setup`). `make permissions` is a standalone target to refresh it.

3. **`koan/diagnostics/permissions_check.py`** — `/doctor` reports the allowlist state; `/doctor --fix` calls `install()` to create it if missing.

Also: `.gitignore` unignores `.claude/settings.json` (safe to commit since it's project config, not credentials), doctor handler registers the new check, troubleshooting docs explain the fix.

## Testing

- 17 new unit tests: `test_setup_claude_settings.py` + `test_permissions_check.py`
- All pass; pre-existing `test_us_timezone` failure is unrelated (missing `zoneinfo` timezone data on this host)