### PR TITLE
feat(dashboard): token efficiency view — cost per productive outcome (#1732)

### DIFF
--- a/koan/app/cost_tracker.py
+++ b/koan/app/cost_tracker.py
@@ -707,6 +707,137 @@ def _format_tokens(n: int) -> str:
     return str(n)
 
 
+def compute_efficiency(
+    instance_dir: Path,
+    days: int = 30,
+    project: Optional[str] = None,
+) -> dict:
+    """Join cost data and session outcomes to compute per-project token efficiency.
+
+    Efficiency = tokens spent per productive outcome. Lower is better.
+    Waste % = fraction of sessions (by count) that were empty or blocked,
+    used as a proxy for wasted token spend (exact per-session attribution
+    is unavailable without a shared session_id across both stores).
+
+    Args:
+        instance_dir: Path to instance directory.
+        days: Number of days to look back (max 90).
+        project: Optional project name to filter to a single project.
+
+    Returns:
+        Dict with keys:
+            "days": days requested,
+            "by_project": {
+                project_name: {
+                    "total_tokens": int,
+                    "total_cost_usd": float,
+                    "productive_count": int,
+                    "empty_count": int,
+                    "blocked_count": int,
+                    "total_sessions": int,
+                    "tokens_per_productive_outcome": float | None,
+                    "waste_pct": float,  # 0-100
+                }
+            }
+    """
+    from app.session_tracker import load_outcomes
+
+    days = max(1, min(days, 90))
+    end = date.today()
+    start = end - timedelta(days=days - 1)
+
+    # --- Cost data: total tokens + cost per project ---
+    usage_dir = Path(instance_dir) / "usage"
+    entries = _read_jsonl_range(usage_dir, start, end)
+    if project:
+        entries = [e for e in entries if e.get("project") == project]
+
+    cost_by_project: dict = {}
+    for e in entries:
+        proj = e.get("project", "_global")
+        if proj not in cost_by_project:
+            cost_by_project[proj] = {"total_tokens": 0, "total_cost_usd": 0.0}
+        cost_by_project[proj]["total_tokens"] += (
+            e.get("input_tokens", 0) + e.get("output_tokens", 0)
+        )
+        cost_by_project[proj]["total_cost_usd"] += e.get("cost_usd", 0.0)
+
+    # --- Outcome data: productive/empty/blocked counts per project ---
+    outcomes_path = Path(instance_dir) / "session_outcomes.json"
+    all_outcomes = load_outcomes(outcomes_path)
+
+    # Filter by date window
+    cutoff = datetime.combine(start, datetime.min.time())
+    windowed = [
+        o for o in all_outcomes
+        if _parse_outcome_ts(o.get("timestamp", "")) >= cutoff
+    ]
+    if project:
+        windowed = [o for o in windowed if o.get("project") == project]
+
+    outcome_by_project: dict = {}
+    for o in windowed:
+        proj = o.get("project", "_global")
+        if proj not in outcome_by_project:
+            outcome_by_project[proj] = {
+                "productive_count": 0, "empty_count": 0, "blocked_count": 0,
+            }
+        outcome = o.get("outcome", "")
+        if outcome == "productive":
+            outcome_by_project[proj]["productive_count"] += 1
+        elif outcome == "empty":
+            outcome_by_project[proj]["empty_count"] += 1
+        elif outcome == "blocked":
+            outcome_by_project[proj]["blocked_count"] += 1
+
+    # --- Join on project key ---
+    all_projects = set(cost_by_project) | set(outcome_by_project)
+    by_project = {}
+    for proj in sorted(all_projects):
+        cost_data = cost_by_project.get(proj, {"total_tokens": 0, "total_cost_usd": 0.0})
+        outcome_data = outcome_by_project.get(proj, {
+            "productive_count": 0, "empty_count": 0, "blocked_count": 0,
+        })
+
+        has_cost_data = proj in cost_by_project
+        total_tokens = cost_data["total_tokens"]
+        productive = outcome_data["productive_count"]
+        empty = outcome_data["empty_count"]
+        blocked = outcome_data["blocked_count"]
+        total_sessions = productive + empty + blocked
+
+        tokens_per_productive = (
+            total_tokens / productive
+            if productive > 0 and has_cost_data
+            else None
+        )
+        waste_pct = (
+            round((empty + blocked) / total_sessions * 100, 1)
+            if total_sessions > 0 else 0.0
+        )
+
+        by_project[proj] = {
+            "total_tokens": total_tokens,
+            "total_cost_usd": round(cost_data["total_cost_usd"], 6),
+            "productive_count": productive,
+            "empty_count": empty,
+            "blocked_count": blocked,
+            "total_sessions": total_sessions,
+            "tokens_per_productive_outcome": tokens_per_productive,
+            "waste_pct": waste_pct,
+        }
+
+    return {"days": days, "by_project": by_project}
+
+
+def _parse_outcome_ts(ts_str: str) -> datetime:
+    """Parse an ISO timestamp string from session_outcomes.json, returning epoch on error."""
+    try:
+        return datetime.fromisoformat(ts_str)
+    except (ValueError, TypeError):
+        return datetime.min
+
+
 def get_pricing_config(config: Optional[dict] = None) -> Optional[dict]:
     """Get pricing table from config.yaml → usage.pricing.
 

--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -1062,6 +1062,26 @@ def api_usage_missions():
     return jsonify({"missions": missions, "start": start.isoformat(), "end": end.isoformat()})
 
 
+@app.route("/api/efficiency")
+def api_efficiency():
+    """Token efficiency: cost-per-productive-outcome joined across cost + outcome stores."""
+    from app.cost_tracker import compute_efficiency
+
+    days = request.args.get("days", "30", type=str)
+    selected_project = request.args.get("project", "")
+    try:
+        days = max(1, min(int(days), 90))
+    except (ValueError, TypeError):
+        days = 30
+
+    result = compute_efficiency(
+        INSTANCE_DIR,
+        days=days,
+        project=selected_project or None,
+    )
+    return jsonify(result)
+
+
 @app.route("/api/metrics")
 def api_metrics():
     """JSON mission metrics for the specified time range."""

--- a/koan/templates/usage.html
+++ b/koan/templates/usage.html
@@ -256,6 +256,18 @@
     <div class="empty-state" id="last-action-empty" style="display:none;width:100%;">No last-action data available.</div>
 </div>
 
+<h2>Token Efficiency <span style="font-size:var(--fs-caption);color:var(--text-muted);font-weight:normal;">tokens per productive outcome — lower is better</span></h2>
+<div class="card">
+    <div class="chart-container" style="height:240px;">
+        <canvas id="efficiency-chart"></canvas>
+    </div>
+    <div class="empty-state" id="efficiency-empty" style="display:none;">No efficiency data available for this period.</div>
+    <p style="font-size:var(--fs-caption);color:var(--text-muted);margin-top:0.75rem;margin-bottom:0;">
+        Approximation: token spend is distributed evenly across sessions for each project.
+        Projects with fewer than 3 productive sessions are shown but should be interpreted with caution.
+    </p>
+</div>
+
 <h2>By Project</h2>
 <div class="card" id="by-project-card">
     <div class="k-table-wrap">
@@ -270,6 +282,7 @@
                 <th class="text-right">Runs</th>
                 <th class="text-right">Cache Hit %</th>
                 <th class="text-right">Success</th>
+                <th class="text-right">Waste %</th>
                 <th class="text-right">Trend</th>
             </tr>
         </thead>
@@ -306,6 +319,7 @@ let outcomeChart = null;
 let typeChart = null;
 let modeChart = null;
 let lastActionChart = null;
+let efficiencyChart = null;
 let currentProject = '';
 let windowOffset = 0;
 
@@ -995,6 +1009,83 @@ function resortModeTable() {
     rows.forEach(r => tbody.appendChild(r));
 }
 
+function renderEfficiencyChart(byProject) {
+    const canvas = document.getElementById('efficiency-chart');
+    const emptyEl = document.getElementById('efficiency-empty');
+
+    // Filter to projects with token data, sort ascending (lower = better)
+    const entries = Object.entries(byProject)
+        .filter(([, p]) => p.total_tokens > 0 && p.tokens_per_productive_outcome !== null)
+        .sort((a, b) => a[1].tokens_per_productive_outcome - b[1].tokens_per_productive_outcome)
+        .slice(0, 15);
+
+    if (entries.length === 0) {
+        canvas.style.display = 'none';
+        emptyEl.style.display = '';
+        if (efficiencyChart) { efficiencyChart.destroy(); efficiencyChart = null; }
+        return;
+    }
+    canvas.style.display = '';
+    emptyEl.style.display = 'none';
+
+    const labels = entries.map(([name]) => name);
+    const values = entries.map(([, p]) => p.tokens_per_productive_outcome);
+    const productive = entries.map(([, p]) => p.productive_count);
+
+    // Color bars by productive count: green if >= 5, yellow if 2-4, orange if < 2
+    const colors = entries.map(([, p]) =>
+        p.productive_count >= 5 ? 'rgba(63,185,80,0.75)' :
+        p.productive_count >= 2 ? 'rgba(210,153,34,0.75)' :
+        'rgba(255,168,87,0.75)'
+    );
+
+    const ctx = canvas.getContext('2d');
+    if (efficiencyChart) efficiencyChart.destroy();
+    efficiencyChart = new Chart(ctx, {
+        type: 'bar',
+        data: {
+            labels,
+            datasets: [{
+                label: 'Tokens / productive outcome',
+                data: values,
+                backgroundColor: colors,
+                borderWidth: 0,
+            }]
+        },
+        options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+                legend: { display: false },
+                tooltip: {
+                    callbacks: {
+                        label(ctx) {
+                            const idx = ctx.dataIndex;
+                            const v = ctx.parsed.x;
+                            const prod = productive[idx];
+                            return [
+                                fmtTokens(Math.round(v)) + ' tokens / productive outcome',
+                                prod + ' productive session' + (prod === 1 ? '' : 's'),
+                            ];
+                        }
+                    }
+                }
+            },
+            scales: {
+                x: {
+                    ticks: { color: 'var(--text-muted)', callback: v => fmtTokens(v) },
+                    grid: { color: 'rgba(255,255,255,0.04)' },
+                },
+                y: {
+                    ticks: { color: 'var(--text-muted)', font: { size: 12 } },
+                    grid: { display: false },
+                }
+            }
+        }
+    });
+}
+
 function loadAll() {
     _lastMissionParams = null;
     const days = document.getElementById('range-select').value;
@@ -1051,7 +1142,7 @@ function loadAll() {
             const projects = Object.entries(data.by_project)
                 .sort((a, b) => (b[1].input_tokens + b[1].output_tokens) - (a[1].input_tokens + a[1].output_tokens));
             if (projects.length === 0) {
-                pTbody.innerHTML = '<tr><td colspan="9" class="empty-state">No data</td></tr>';
+                pTbody.innerHTML = '<tr><td colspan="10" class="empty-state">No data</td></tr>';
             }
             const hasPricing = data.has_pricing;
             for (const [name, p] of projects) {
@@ -1073,6 +1164,7 @@ function loadAll() {
                     '<td class="text-right">' + p.count + '</td>' +
                     '<td class="text-right">' + cacheHitPct + '</td>' +
                     '<td class="text-right">' + successCell + '</td>' +
+                    '<td class="text-right" data-waste>-</td>' +
                     '<td class="text-right">' + trendCell + '</td>' +
                     '</tr>';
             }
@@ -1120,12 +1212,35 @@ function loadAll() {
                     const pm = metrics.by_project[proj];
                     if (!pm) return;
                     const cells = row.querySelectorAll('td');
-                    if (cells.length >= 9) {
+                    if (cells.length >= 10) {
                         cells[7].textContent = (pm.success_rate * 100).toFixed(0) + '%';
-                        cells[8].innerHTML = trendBadge(pm.trend);
+                        cells[9].innerHTML = trendBadge(pm.trend);
                     }
                 });
             }
+        })
+        .catch(() => {});
+
+    fetch('/api/efficiency?days=' + days + projParam)
+        .then(r => r.json())
+        .then(eff => {
+            renderEfficiencyChart(eff.by_project || {});
+            // Populate Waste % cells in by-project table
+            document.querySelectorAll('#by-project tbody tr').forEach(row => {
+                const linkEl = row.querySelector('.project-link');
+                if (!linkEl) return;
+                const proj = linkEl.dataset.project;
+                const ep = (eff.by_project || {})[proj];
+                if (!ep) return;
+                const wasteCell = row.querySelector('[data-waste]');
+                if (wasteCell) {
+                    wasteCell.textContent = ep.waste_pct.toFixed(0) + '%';
+                    const color = ep.waste_pct >= 50
+                        ? 'var(--warning)' : ep.waste_pct >= 25
+                        ? 'var(--text-muted)' : 'var(--success)';
+                    wasteCell.style.color = color;
+                }
+            });
         })
         .catch(() => {});
 }

--- a/koan/tests/test_cost_tracker.py
+++ b/koan/tests/test_cost_tracker.py
@@ -24,6 +24,7 @@ from app.cost_tracker import (
     format_cache_summary,
     format_mission_cache_line,
     top_missions,
+    compute_efficiency,
     _read_jsonl_for_date,
     _read_jsonl_range,
     _aggregate,
@@ -1189,3 +1190,107 @@ class TestTopMissions:
                 result = top_missions(instance_dir, today, today)
         assert result[0]["cost_usd"] == 0.0
         assert len(call_count) == 0
+
+
+class TestComputeEfficiency:
+    def _write_outcomes(self, instance_dir, outcomes):
+        (instance_dir / "session_outcomes.json").write_text(json.dumps(outcomes))
+
+    def _write_usage(self, instance_dir, entries):
+        today = date.today()
+        usage_dir = instance_dir / "usage"
+        usage_dir.mkdir(parents=True, exist_ok=True)
+        jsonl_path = usage_dir / f"{today.isoformat()}.jsonl"
+        with open(jsonl_path, "a") as f:
+            for entry in entries:
+                f.write(json.dumps(entry) + "\n")
+
+    def _make_outcome(self, project, outcome):
+        return {
+            "timestamp": datetime.now().isoformat(),
+            "project": project,
+            "mode": "implement",
+            "outcome": outcome,
+            "mission_type": "implement",
+            "has_pr": False,
+            "has_branch": False,
+            "duration_minutes": 10,
+            "pipeline_timed_out": False,
+            "summary": "",
+        }
+
+    def test_basic_join(self, instance_dir):
+        self._write_usage(instance_dir, [
+            {"ts": datetime.now().isoformat(), "project": "alpha", "model": "sonnet",
+             "input_tokens": 9000, "output_tokens": 1000, "mode": "implement", "mission": "x"},
+        ])
+        self._write_outcomes(instance_dir, [
+            self._make_outcome("alpha", "productive"),
+            self._make_outcome("alpha", "empty"),
+        ])
+        result = compute_efficiency(instance_dir, days=7)
+        assert "alpha" in result["by_project"]
+        p = result["by_project"]["alpha"]
+        assert p["total_tokens"] == 10000
+        assert p["productive_count"] == 1
+        assert p["empty_count"] == 1
+        assert p["total_sessions"] == 2
+        assert p["tokens_per_productive_outcome"] == 10000.0
+        assert p["waste_pct"] == 50.0
+
+    def test_zero_productive_sessions(self, instance_dir):
+        self._write_usage(instance_dir, [
+            {"ts": datetime.now().isoformat(), "project": "beta", "model": "sonnet",
+             "input_tokens": 5000, "output_tokens": 1000, "mode": "review", "mission": "y"},
+        ])
+        self._write_outcomes(instance_dir, [
+            self._make_outcome("beta", "empty"),
+            self._make_outcome("beta", "blocked"),
+        ])
+        result = compute_efficiency(instance_dir, days=7)
+        p = result["by_project"]["beta"]
+        assert p["tokens_per_productive_outcome"] is None
+        assert p["waste_pct"] == 100.0
+
+    def test_project_only_in_cost_data(self, instance_dir):
+        self._write_usage(instance_dir, [
+            {"ts": datetime.now().isoformat(), "project": "gamma", "model": "sonnet",
+             "input_tokens": 1000, "output_tokens": 500, "mode": "implement", "mission": "z"},
+        ])
+        self._write_outcomes(instance_dir, [])
+        result = compute_efficiency(instance_dir, days=7)
+        assert "gamma" in result["by_project"]
+        p = result["by_project"]["gamma"]
+        assert p["total_tokens"] == 1500
+        assert p["tokens_per_productive_outcome"] is None
+        assert p["waste_pct"] == 0.0
+
+    def test_project_only_in_outcome_data(self, instance_dir):
+        self._write_outcomes(instance_dir, [
+            self._make_outcome("delta", "productive"),
+        ])
+        result = compute_efficiency(instance_dir, days=7)
+        assert "delta" in result["by_project"]
+        p = result["by_project"]["delta"]
+        assert p["total_tokens"] == 0
+        assert p["tokens_per_productive_outcome"] is None
+
+    def test_project_filter(self, instance_dir):
+        self._write_usage(instance_dir, [
+            {"ts": datetime.now().isoformat(), "project": "alpha", "model": "sonnet",
+             "input_tokens": 1000, "output_tokens": 500, "mode": "implement", "mission": "x"},
+            {"ts": datetime.now().isoformat(), "project": "beta", "model": "sonnet",
+             "input_tokens": 2000, "output_tokens": 1000, "mode": "deep", "mission": "y"},
+        ])
+        self._write_outcomes(instance_dir, [
+            self._make_outcome("alpha", "productive"),
+            self._make_outcome("beta", "productive"),
+        ])
+        result = compute_efficiency(instance_dir, days=7, project="alpha")
+        assert "alpha" in result["by_project"]
+        assert "beta" not in result["by_project"]
+
+    def test_no_data_returns_empty(self, instance_dir):
+        result = compute_efficiency(instance_dir, days=7)
+        assert result["by_project"] == {}
+        assert result["days"] == 7


### PR DESCRIPTION
## What
Adds a **Token Efficiency** section to the Usage dashboard showing tokens spent per productive mission outcome per project, and a **Waste %** column to the By Project table.

## Why
The cost tracker and session outcomes stores share a `project` key but were never joined. Operators could see "project A spent 50k tokens" and "project A has 60% productive rate" but not "project A costs 3× more per productive outcome than project B" — the ROI question that actually drives optimization decisions (closes #1732).

## How
- `compute_efficiency(instance_dir, days, project)` in `cost_tracker.py`: reads JSONL usage for the window, reads `session_outcomes.json`, joins on `project`, computes `tokens_per_productive_outcome = total_tokens / productive_count` and `waste_pct = (empty+blocked) / total_sessions * 100`. Returns `null` for efficiency when there's no cost data or no productive sessions to avoid misleading zeros.
- `GET /api/efficiency?days=30&project=...` in `dashboard.py`: thin wrapper, same days/project params as existing endpoints.
- `usage.html`: horizontal bar chart sorted ascending (lower = better), bars colored green/yellow/orange by productive session count. Waste % column in By Project table with color-coded text (green < 25%, muted 25–50%, warning > 50%).
- Approximation note in UI: token spend is distributed proportionally by session count, not per-session attribution (no shared session_id across stores yet).

## Testing
- 6 new unit tests in `TestComputeEfficiency`: basic join, zero productive sessions, project-only-in-cost-data, project-only-in-outcome-data, project filter, empty data
- All 6 pass, full test suite passes (exit 0)