### PR TITLE
fix(robustness): FD leak, atomic webhook, YAML triple-parse, redundant exception

### DIFF
--- a/koan/app/github_webhook.py
+++ b/koan/app/github_webhook.py
@@ -36,6 +36,7 @@ from typing import Optional, Set
 
 from app.github_config import DEFAULT_WEBHOOK_HOST, DEFAULT_WEBHOOK_PORT
 from app.signals import CHECK_NOTIFICATIONS_FILE
+from app.utils import atomic_write
 
 log = logging.getLogger(__name__)
 
@@ -151,8 +152,8 @@ def write_check_signal(koan_root: str) -> bool:
     """
     signal_path = os.path.join(str(koan_root), CHECK_NOTIFICATIONS_FILE)
     try:
-        with open(signal_path, "w") as f:
-            f.write(f"github webhook at {time.strftime('%H:%M:%S')}\n")
+        from pathlib import Path
+        atomic_write(Path(signal_path), f"github webhook at {time.strftime('%H:%M:%S')}\n")
         return True
     except OSError as e:
         log.warning("Webhook: failed to write check-notifications signal: %s", e)

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -389,7 +389,7 @@ def _read_pending_content(instance_dir: str) -> str:
     pending_path = Path(instance_dir) / "journal" / "pending.md"
     try:
         return pending_path.read_text()
-    except (OSError, FileNotFoundError):
+    except OSError:
         return ""
 
 
@@ -412,7 +412,7 @@ def _read_stdout_summary(stdout_file: str, max_chars: int = 2000) -> str:
             return ""
         text = parse_claude_output(raw)
         return text[:max_chars] if text else ""
-    except (OSError, FileNotFoundError):
+    except OSError:
         return ""
 
 
@@ -663,7 +663,7 @@ def archive_pending(instance_dir: str, project_name: str, run_num: int) -> bool:
     pending_path = Path(instance_dir) / "journal" / "pending.md"
     try:
         pending_content = pending_path.read_text()
-    except (OSError, FileNotFoundError):
+    except OSError:
         return False
 
     # Append pending content to daily journal (with file locking)
@@ -1310,7 +1310,7 @@ def _read_full_stdout_text(stdout_file: str) -> str:
         if not raw.strip():
             return ""
         return parse_claude_output(raw) or ""
-    except (OSError, FileNotFoundError):
+    except OSError:
         return ""
 
 

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -163,6 +163,9 @@ def acquire_pidfile(koan_root: Path, process_name: str) -> IO:
         msg += ". Aborting."
         print(msg, file=sys.stderr)
         sys.exit(1)
+    except BaseException:
+        fh.close()
+        raise
 
     # Lock acquired — write our PID
     fh.seek(0)

--- a/koan/app/recurring.py
+++ b/koan/app/recurring.py
@@ -636,9 +636,11 @@ def force_run(
 
         if identifier is None:
             # Inject all enabled missions (ignore disabled, bypass cadence)
-            for mission in missions:
-                if mission.get("enabled", True):
-                    injected.append(_inject_one(mission, missions_path, now))
+            injected.extend(
+                _inject_one(mission, missions_path, now)
+                for mission in missions
+                if mission.get("enabled", True)
+            )
         else:
             # Inject the single matching mission (ignore enabled, bypass cadence)
             target = _resolve_target(missions, identifier)

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -685,7 +685,9 @@ def _persist_and_cache_remotes(
             print(f"[utils] Failed to cache github_url for {name}: {e}", file=sys.stderr)
 
 
-def _resolve_via_fork_parent(target: str, projects: list) -> Optional[str]:
+def _resolve_via_fork_parent(
+    target: str, projects: list, config: Optional[dict] = None
+) -> Optional[str]:
     """Resolve a GitHub repo via its fork parent.
 
     When ``target`` (owner/repo) isn't found in any local remote, ask GitHub
@@ -708,11 +710,12 @@ def _resolve_via_fork_parent(target: str, projects: list) -> Optional[str]:
     except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
         return None
 
-    from app.projects_config import load_projects_config
-    try:
-        config = load_projects_config(str(KOAN_ROOT))
-    except (OSError, ValueError):
-        return None
+    if config is None:
+        from app.projects_config import load_projects_config
+        try:
+            config = load_projects_config(str(KOAN_ROOT))
+        except (OSError, ValueError):
+            return None
     if not config:
         return None
 
@@ -771,13 +774,17 @@ def resolve_project_path(repo_name: str, owner: Optional[str] = None) -> Optiona
     projects = get_known_projects()
     target = f"{owner}/{repo_name}".lower() if owner else None
 
+    # Config loaded once at step 1 and reused at steps 6 and 7 to avoid
+    # triple-parsing projects.yaml on the same call.
+    _projects_config: Optional[dict] = None
+
     # 1. GitHub URL match via projects.yaml and in-memory cache
     if target:
         try:
             from app.projects_config import load_projects_config
-            config = load_projects_config(str(KOAN_ROOT))
-            if config:
-                for project in config.get("projects", {}).values():
+            _projects_config = load_projects_config(str(KOAN_ROOT))
+            if _projects_config:
+                for project in _projects_config.get("projects", {}).values():
                     if isinstance(project, dict):
                         # Check primary github_url
                         gh_url = project.get("github_url", "")
@@ -860,8 +867,7 @@ def resolve_project_path(repo_name: str, owner: Optional[str] = None) -> Optiona
     if target:
         repo_lower = repo_name.lower()
         try:
-            from app.projects_config import load_projects_config
-            config = load_projects_config(str(KOAN_ROOT))
+            config = _projects_config
             if config:
                 candidates = []
                 for project in config.get("projects", {}).values():
@@ -886,7 +892,7 @@ def resolve_project_path(repo_name: str, owner: Optional[str] = None) -> Optiona
     # 7. Fork resolution via GitHub API: when the URL points to a fork not
     #    in any local remote, ask GitHub for the parent repo and try matching.
     if target:
-        resolved = _resolve_via_fork_parent(target, projects)
+        resolved = _resolve_via_fork_parent(target, projects, config=_projects_config)
         if resolved:
             return resolved
 


### PR DESCRIPTION
## What

Four targeted robustness/cleanup fixes across four files: FD leak, non-atomic file write, YAML over-parsing, and misleading exception tuple.

## Why

- **#1668** (`pid_manager.py`): `acquire_pidfile()` opened the PID file before the try block. A `KeyboardInterrupt` or other `BaseException` during startup would silently leak the fd, accumulating across crash-loop restarts.
- **#1671** (`github_webhook.py`): The check-notifications signal file was written with plain `open().write()`. A crash between open (which truncates) and write completes leaves an empty file. Every other shared-file write in the codebase uses `atomic_write()` — this was the only exception.
- **#1700** (`utils.py`): `resolve_project_path()` parsed `projects.yaml` up to 3× per call (step 1, step 6, `_resolve_via_fork_parent()`). On a 50-project config, the notification pipeline was doing triple disk+YAML work per mention. Now loaded once at step 1 and reused.
- **#1672** (`mission_runner.py`): `except (OSError, FileNotFoundError)` appeared 4× in the file. `FileNotFoundError` is a subclass of `OSError` — listing it explicitly implies they're distinct exception types, which confuses future contributors narrowing the catch.

Also fixes a pre-existing PERF401 lint violation in `recurring.py` (append loop → extend).

## How

- `pid_manager.py`: added `except BaseException: fh.close(); raise` after the existing `except (OSError, BlockingIOError)` clause.
- `github_webhook.py`: replaced plain `open().write()` with `atomic_write()` from `app.utils`.
- `utils.py`: `_projects_config` local variable captures the load at step 1; step 6 reads it directly; `_resolve_via_fork_parent()` gains an optional `config=` parameter so callers can pass it.
- `mission_runner.py`: `replace_all` edit to drop `FileNotFoundError` from all 4 tuples.

## Testing

Full suite: 15769 passed, 1 pre-existing failure (`test_us_timezone` — missing `tzdata` on this system, unrelated). Lint: clean.