### PR TITLE
feat(sdlc): SDLC state persistence layer (#1704)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,6 +134,7 @@ Communication between processes happens through shared files in `instance/` with
 - **`usage_tracker.py`** — Budget tracking; decides autonomous mode (REVIEW/IMPLEMENT/DEEP/WAIT) based on quota percentage. Pure parser + threshold class — burn-rate-driven downgrades live in `iteration_manager._downgrade_if_burning_fast` next to the existing affordability downgrade.
 - **`burn_rate.py`** — Rolling burn-rate estimator (% session quota per minute). Maintains a 20-sample circular buffer in `instance/.burn-rate.json` with `fcntl.flock(LOCK_SH)` on reads, exposes `record_run()`, `burn_rate_pct_per_minute()` (total cost / span across all samples), `time_to_exhaustion(session_pct, mode=None)`, and the canonical `MODE_MULTIPLIERS` table shared with `usage_tracker.can_afford_run`. Also tracks the last-warning timestamp so the iteration manager fires at most one Telegram alert per quota cycle.
 - **`recover.py`** — Crash recovery for stale in-progress missions
+- **`sdlc_state.py`** — SDLC workflow state persistence: `SdlcPhase` enum, `SdlcState` dataclass, workspace helpers (`get_sdlc_workspace`, `load_sdlc_state`, `save_sdlc_state`, `get_artifact_path`, `archive_sdlc_workspace`). Stores per-run state and phase artifacts under `instance/sdlc/{issue_name}/`. Foundation for the `/sdlc` orchestrator skill.
 - **`prompts.py`** — System prompt loader; `load_prompt()` for `koan/system-prompts/*.md`, `load_skill_prompt()` for skill-bound prompts. Supports `{@include partial-name}` directive for reusable prompt fragments from `koan/system-prompts/_partials/`.
 - **`skill_manager.py`** — External skill package manager: install from Git repos, update, remove, track via `instance/skills.yaml`
 - **`claudemd_refresh.py`** — CLAUDE.md refresh pipeline: gathers git context, invokes Claude to update/create CLAUDE.md
@@ -180,6 +181,7 @@ Extensible command plugin system. Each skill lives in `skills/<scope>/<skill-nam
 - `journal/` — Daily logs organized as `YYYY-MM-DD/project.md`
 - `events/` — One-shot scheduled missions (JSON files consumed by `event_scheduler.py`)
 - `hooks/` — User-defined Python hook modules for lifecycle events (see `instance.example/hooks/README.md`)
+- `sdlc/` — Per-workflow SDLC state: `sdlc/{issue_name}/STATE.json` + phase artifact files (RESEARCH.md, ADR.md, PLAN.md, etc.). Managed by `sdlc_state.py`. Archived to `sdlc/_archived/` on terminal phase (PRODUCTION_READY or ABANDONED). Never logged verbatim — may contain sensitive project details.
 
 ## Python compatibility
 

--- a/koan/app/sdlc_state.py
+++ b/koan/app/sdlc_state.py
@@ -1,0 +1,252 @@
+"""Kōan — SDLC State Persistence Layer
+
+Manages per-workflow state for the /sdlc multi-phase orchestration skill.
+Each SDLC run for a given issue lives in its own workspace under
+``instance/sdlc/{issue_name}/`` with:
+
+- ``STATE.json``     — phase tracking, metadata, approval flag
+- ``RESEARCH.md``    — research agent output
+- ``ADR.md``         — architecture decision record
+- ``PLAN.md``        — implementation plan (human reviews this before /approve)
+- ``IMPLEMENTATION.md`` — implementation diff summary
+- ``SECURITY.md``    — security review verdict
+- ``QA.md``          — QA review verdict
+- ``SRE.md``         — SRE review verdict
+- ``REVIEW.md``      — aggregated review summary
+- ``DOCS.md``        — documentation update summary
+
+Concurrent SDLC runs for the same issue_name will race on STATE.json.
+``save_sdlc_state`` uses ``atomic_write_json`` (temp + rename + fcntl.flock)
+which serializes writers at the OS level — last writer wins.
+
+State files accumulate indefinitely; call ``archive_sdlc_workspace()`` to
+move a terminal workspace (PRODUCTION_READY or ABANDONED) to
+``instance/sdlc/_archived/``.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from app.utils import atomic_write_json
+
+
+# Artifact file names produced/consumed by each SDLC phase.
+SDLC_ARTIFACTS = [
+    "RESEARCH.md",
+    "ADR.md",
+    "PLAN.md",
+    "IMPLEMENTATION.md",
+    "SECURITY.md",
+    "QA.md",
+    "SRE.md",
+    "REVIEW.md",
+    "DOCS.md",
+]
+
+# JSON state file inside each workspace.
+_STATE_FILENAME = "STATE.json"
+
+# Max SDLC fix iterations before the orchestrator gives up.
+MAX_FIX_ITERATIONS = 3
+
+
+class SdlcPhase(str, Enum):
+    """Ordered phases of an SDLC workflow run."""
+
+    RESEARCH = "research"
+    ARCHITECTURE = "architecture"
+    PLANNING = "planning"
+    AWAITING_APPROVAL = "awaiting_approval"
+    IMPLEMENTATION = "implementation"
+    REVIEW = "review"
+    FIX_LOOP = "fix_loop"
+    DOCUMENTATION = "documentation"
+    PRODUCTION_READY = "production_ready"
+    ABANDONED = "abandoned"
+
+    @property
+    def is_terminal(self) -> bool:
+        return self in (SdlcPhase.PRODUCTION_READY, SdlcPhase.ABANDONED)
+
+
+class SdlcRiskLevel(str, Enum):
+    """Assessed risk level for an SDLC workflow."""
+
+    LOW = "Low"
+    MEDIUM = "Medium"
+    HIGH = "High"
+
+
+@dataclass
+class SdlcState:
+    """Runtime state for one SDLC workflow run.
+
+    Serialised to / deserialised from STATE.json inside the workspace.
+    """
+
+    issue_name: str
+    description: str
+    current_phase: SdlcPhase
+    risk_level: SdlcRiskLevel = SdlcRiskLevel.MEDIUM
+    fix_iteration: int = 0
+    failing_experts: List[str] = field(default_factory=list)
+    approved: bool = False
+    started_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat(timespec="seconds")
+    )
+    artifact_checksums: Dict[str, str] = field(default_factory=dict)
+
+    def to_dict(self) -> dict:
+        return {
+            "issue_name": self.issue_name,
+            "description": self.description,
+            "current_phase": self.current_phase.value,
+            "risk_level": self.risk_level.value,
+            "fix_iteration": self.fix_iteration,
+            "failing_experts": list(self.failing_experts),
+            "approved": self.approved,
+            "started_at": self.started_at,
+            "artifact_checksums": dict(self.artifact_checksums),
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "SdlcState":
+        try:
+            phase = SdlcPhase(data.get("current_phase", "research"))
+        except ValueError:
+            phase = SdlcPhase.RESEARCH
+
+        try:
+            risk = SdlcRiskLevel(data.get("risk_level", "Medium"))
+        except ValueError:
+            risk = SdlcRiskLevel.MEDIUM
+
+        return cls(
+            issue_name=data.get("issue_name", ""),
+            description=data.get("description", ""),
+            current_phase=phase,
+            risk_level=risk,
+            fix_iteration=int(data.get("fix_iteration", 0)),
+            failing_experts=list(data.get("failing_experts", [])),
+            approved=bool(data.get("approved", False)),
+            started_at=data.get(
+                "started_at",
+                datetime.now(timezone.utc).isoformat(timespec="seconds"),
+            ),
+            artifact_checksums=dict(data.get("artifact_checksums", {})),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Workspace helpers
+# ---------------------------------------------------------------------------
+
+
+def get_sdlc_workspace(instance_dir: str, issue_name: str) -> Path:
+    """Return the workspace directory for *issue_name*, creating it if absent."""
+    ws = Path(instance_dir) / "sdlc" / _sanitise_issue_name(issue_name)
+    ws.mkdir(parents=True, exist_ok=True)
+    return ws
+
+
+def load_sdlc_state(instance_dir: str, issue_name: str) -> Optional[SdlcState]:
+    """Load the SDLC state for *issue_name*.
+
+    Returns ``None`` cleanly if the workspace is absent or STATE.json is
+    missing or malformed — callers should treat ``None`` as "not started".
+    """
+    ws = Path(instance_dir) / "sdlc" / _sanitise_issue_name(issue_name)
+    state_file = ws / _STATE_FILENAME
+    if not state_file.exists():
+        return None
+    try:
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+        return SdlcState.from_dict(data)
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def save_sdlc_state(instance_dir: str, state: SdlcState) -> None:
+    """Persist *state* to STATE.json atomically.
+
+    Creates the workspace directory if absent. Uses ``atomic_write_json``
+    (temp-file + os.replace + fcntl.flock) so a crash mid-write never
+    leaves a partial file.
+    """
+    ws = get_sdlc_workspace(instance_dir, state.issue_name)
+    state_file = ws / _STATE_FILENAME
+    atomic_write_json(state_file, state.to_dict(), indent=2)
+
+
+def get_artifact_path(
+    instance_dir: str, issue_name: str, artifact_name: str
+) -> Path:
+    """Return the path to *artifact_name* inside *issue_name*'s workspace.
+
+    The artifact need not exist yet — this is a pure path computation.
+    *artifact_name* must be one of ``SDLC_ARTIFACTS`` (e.g. ``"PLAN.md"``).
+    """
+    ws = Path(instance_dir) / "sdlc" / _sanitise_issue_name(issue_name)
+    return ws / artifact_name
+
+
+def archive_sdlc_workspace(instance_dir: str, issue_name: str) -> Optional[Path]:
+    """Move a terminal workspace to ``instance/sdlc/_archived/``.
+
+    Only moves workspaces whose ``current_phase`` is PRODUCTION_READY or
+    ABANDONED.  Returns the destination path, or ``None`` if the workspace
+    was absent or not in a terminal phase.
+    """
+    ws = Path(instance_dir) / "sdlc" / _sanitise_issue_name(issue_name)
+    if not ws.exists():
+        return None
+
+    state = load_sdlc_state(instance_dir, issue_name)
+    if state is None or not state.current_phase.is_terminal:
+        return None
+
+    archived_root = Path(instance_dir) / "sdlc" / "_archived"
+    archived_root.mkdir(parents=True, exist_ok=True)
+    dest = archived_root / _sanitise_issue_name(issue_name)
+
+    # Avoid clobbering a previous archive with the same name.
+    if dest.exists():
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S")
+        dest = archived_root / f"{_sanitise_issue_name(issue_name)}-{ts}"
+
+    shutil.move(str(ws), str(dest))
+    return dest
+
+
+def list_sdlc_workspaces(instance_dir: str) -> List[str]:
+    """Return issue names for all active (non-archived) SDLC workspaces."""
+    sdlc_root = Path(instance_dir) / "sdlc"
+    if not sdlc_root.exists():
+        return []
+    return [
+        d.name
+        for d in sorted(sdlc_root.iterdir())
+        if d.is_dir() and d.name != "_archived"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _sanitise_issue_name(issue_name: str) -> str:
+    """Normalise *issue_name* for use as a directory component.
+
+    Replaces characters unsafe in file paths with underscores and strips
+    leading/trailing whitespace, dots, and underscores.
+    """
+    safe = "".join(c if c.isalnum() or c in "-_." else "_" for c in issue_name.strip())
+    return safe.strip("._") or "unnamed"

--- a/koan/tests/test_sdlc_state.py
+++ b/koan/tests/test_sdlc_state.py
@@ -1,0 +1,376 @@
+"""Tests for the SDLC state persistence layer (sdlc_state.py)."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.sdlc_state import (
+    MAX_FIX_ITERATIONS,
+    SDLC_ARTIFACTS,
+    SdlcPhase,
+    SdlcRiskLevel,
+    SdlcState,
+    archive_sdlc_workspace,
+    get_artifact_path,
+    get_sdlc_workspace,
+    list_sdlc_workspaces,
+    load_sdlc_state,
+    save_sdlc_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# SdlcPhase enum
+# ---------------------------------------------------------------------------
+
+
+class TestSdlcPhase:
+    def test_all_phases_have_string_values(self):
+        for phase in SdlcPhase:
+            assert isinstance(phase.value, str)
+
+    def test_terminal_phases(self):
+        assert SdlcPhase.PRODUCTION_READY.is_terminal
+        assert SdlcPhase.ABANDONED.is_terminal
+
+    def test_non_terminal_phases(self):
+        non_terminal = [
+            SdlcPhase.RESEARCH,
+            SdlcPhase.ARCHITECTURE,
+            SdlcPhase.PLANNING,
+            SdlcPhase.AWAITING_APPROVAL,
+            SdlcPhase.IMPLEMENTATION,
+            SdlcPhase.REVIEW,
+            SdlcPhase.FIX_LOOP,
+            SdlcPhase.DOCUMENTATION,
+        ]
+        for phase in non_terminal:
+            assert not phase.is_terminal, f"{phase} should not be terminal"
+
+    def test_phases_are_str_subclass(self):
+        assert isinstance(SdlcPhase.RESEARCH, str)
+        assert SdlcPhase.RESEARCH == "research"
+
+
+# ---------------------------------------------------------------------------
+# SdlcState serialization
+# ---------------------------------------------------------------------------
+
+
+class TestSdlcStateRoundTrip:
+    def _make_state(self, **kwargs) -> SdlcState:
+        defaults = dict(
+            issue_name="issue-42",
+            description="Add auth module",
+            current_phase=SdlcPhase.PLANNING,
+        )
+        defaults.update(kwargs)
+        return SdlcState(**defaults)
+
+    def test_basic_roundtrip(self):
+        state = self._make_state()
+        assert SdlcState.from_dict(state.to_dict()).issue_name == "issue-42"
+        assert SdlcState.from_dict(state.to_dict()).current_phase == SdlcPhase.PLANNING
+
+    def test_list_field_roundtrip(self):
+        state = self._make_state(failing_experts=["security", "qa"])
+        restored = SdlcState.from_dict(state.to_dict())
+        assert restored.failing_experts == ["security", "qa"]
+
+    def test_dict_field_roundtrip(self):
+        state = self._make_state(artifact_checksums={"RESEARCH.md": "abc123"})
+        restored = SdlcState.from_dict(state.to_dict())
+        assert restored.artifact_checksums == {"RESEARCH.md": "abc123"}
+
+    def test_bool_approved_roundtrip(self):
+        state = self._make_state(approved=True)
+        assert SdlcState.from_dict(state.to_dict()).approved is True
+        state2 = self._make_state(approved=False)
+        assert SdlcState.from_dict(state2.to_dict()).approved is False
+
+    def test_all_phases_survive_roundtrip(self):
+        for phase in SdlcPhase:
+            state = self._make_state(current_phase=phase)
+            assert SdlcState.from_dict(state.to_dict()).current_phase == phase
+
+    def test_all_risk_levels_survive_roundtrip(self):
+        for risk in SdlcRiskLevel:
+            state = self._make_state(risk_level=risk)
+            assert SdlcState.from_dict(state.to_dict()).risk_level == risk
+
+    def test_to_dict_contains_expected_keys(self):
+        state = self._make_state()
+        d = state.to_dict()
+        for key in (
+            "issue_name",
+            "description",
+            "current_phase",
+            "risk_level",
+            "fix_iteration",
+            "failing_experts",
+            "approved",
+            "started_at",
+            "artifact_checksums",
+        ):
+            assert key in d, f"Missing key: {key}"
+
+    def test_from_dict_unknown_phase_defaults_to_research(self):
+        state = SdlcState.from_dict(
+            {
+                "issue_name": "x",
+                "description": "",
+                "current_phase": "nonexistent_phase",
+            }
+        )
+        assert state.current_phase == SdlcPhase.RESEARCH
+
+    def test_from_dict_unknown_risk_defaults_to_medium(self):
+        state = SdlcState.from_dict(
+            {
+                "issue_name": "x",
+                "description": "",
+                "current_phase": "research",
+                "risk_level": "Extreme",
+            }
+        )
+        assert state.risk_level == SdlcRiskLevel.MEDIUM
+
+    def test_from_dict_missing_optional_fields(self):
+        # Minimal required keys; optional fields must have sensible defaults.
+        state = SdlcState.from_dict({"issue_name": "y", "description": ""})
+        assert state.fix_iteration == 0
+        assert state.failing_experts == []
+        assert state.approved is False
+        assert state.artifact_checksums == {}
+        assert state.started_at  # non-empty default
+
+
+# ---------------------------------------------------------------------------
+# get_sdlc_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestGetSdlcWorkspace:
+    def test_creates_directory(self, tmp_path):
+        ws = get_sdlc_workspace(str(tmp_path), "feature-auth")
+        assert ws.is_dir()
+
+    def test_idempotent(self, tmp_path):
+        ws1 = get_sdlc_workspace(str(tmp_path), "feature-auth")
+        ws2 = get_sdlc_workspace(str(tmp_path), "feature-auth")
+        assert ws1 == ws2
+
+    def test_workspace_inside_sdlc_subdir(self, tmp_path):
+        ws = get_sdlc_workspace(str(tmp_path), "my-issue")
+        assert ws.parent == tmp_path / "sdlc"
+
+    def test_different_issues_have_different_workspaces(self, tmp_path):
+        ws_a = get_sdlc_workspace(str(tmp_path), "issue-a")
+        ws_b = get_sdlc_workspace(str(tmp_path), "issue-b")
+        assert ws_a != ws_b
+
+    def test_unsafe_chars_in_issue_name(self, tmp_path):
+        ws = get_sdlc_workspace(str(tmp_path), "issue/with/../slashes")
+        assert ws.exists()
+        # The resolved path must stay inside the sdlc dir.
+        assert str(ws).startswith(str(tmp_path / "sdlc"))
+
+
+# ---------------------------------------------------------------------------
+# load_sdlc_state
+# ---------------------------------------------------------------------------
+
+
+class TestLoadSdlcState:
+    def test_returns_none_when_workspace_absent(self, tmp_path):
+        result = load_sdlc_state(str(tmp_path), "nonexistent")
+        assert result is None
+
+    def test_returns_none_when_state_file_absent(self, tmp_path):
+        get_sdlc_workspace(str(tmp_path), "issue-x")  # create dir, no STATE.json
+        result = load_sdlc_state(str(tmp_path), "issue-x")
+        assert result is None
+
+    def test_returns_none_on_corrupt_json(self, tmp_path):
+        ws = get_sdlc_workspace(str(tmp_path), "issue-corrupt")
+        (ws / "STATE.json").write_text("{ not valid json }")
+        result = load_sdlc_state(str(tmp_path), "issue-corrupt")
+        assert result is None
+
+    def test_returns_none_on_empty_file(self, tmp_path):
+        ws = get_sdlc_workspace(str(tmp_path), "issue-empty")
+        (ws / "STATE.json").write_text("")
+        result = load_sdlc_state(str(tmp_path), "issue-empty")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# save_sdlc_state + load_sdlc_state round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSaveLoadCycle:
+    def _make_state(self, issue_name: str = "issue-99", **kwargs) -> SdlcState:
+        defaults = dict(
+            description="test workflow",
+            current_phase=SdlcPhase.RESEARCH,
+        )
+        defaults.update(kwargs)
+        return SdlcState(issue_name=issue_name, **defaults)
+
+    def test_save_then_load(self, tmp_path):
+        state = self._make_state()
+        save_sdlc_state(str(tmp_path), state)
+        loaded = load_sdlc_state(str(tmp_path), state.issue_name)
+        assert loaded is not None
+        assert loaded.issue_name == state.issue_name
+        assert loaded.current_phase == SdlcPhase.RESEARCH
+
+    def test_state_file_is_valid_json(self, tmp_path):
+        state = self._make_state()
+        save_sdlc_state(str(tmp_path), state)
+        ws = get_sdlc_workspace(str(tmp_path), state.issue_name)
+        raw = (ws / "STATE.json").read_text()
+        data = json.loads(raw)
+        assert data["issue_name"] == state.issue_name
+
+    def test_save_creates_workspace_if_absent(self, tmp_path):
+        state = self._make_state(issue_name="fresh-issue")
+        ws = tmp_path / "sdlc" / "fresh-issue"
+        assert not ws.exists()
+        save_sdlc_state(str(tmp_path), state)
+        assert ws.exists()
+
+    def test_update_phase(self, tmp_path):
+        state = self._make_state()
+        save_sdlc_state(str(tmp_path), state)
+
+        state.current_phase = SdlcPhase.IMPLEMENTATION
+        save_sdlc_state(str(tmp_path), state)
+
+        loaded = load_sdlc_state(str(tmp_path), state.issue_name)
+        assert loaded.current_phase == SdlcPhase.IMPLEMENTATION
+
+    def test_update_failing_experts(self, tmp_path):
+        state = self._make_state()
+        save_sdlc_state(str(tmp_path), state)
+
+        state.failing_experts = ["security"]
+        save_sdlc_state(str(tmp_path), state)
+
+        loaded = load_sdlc_state(str(tmp_path), state.issue_name)
+        assert loaded.failing_experts == ["security"]
+
+    def test_multiple_issues_isolated(self, tmp_path):
+        a = self._make_state(issue_name="alpha", current_phase=SdlcPhase.PLANNING)
+        b = self._make_state(issue_name="beta", current_phase=SdlcPhase.REVIEW)
+        save_sdlc_state(str(tmp_path), a)
+        save_sdlc_state(str(tmp_path), b)
+
+        loaded_a = load_sdlc_state(str(tmp_path), "alpha")
+        loaded_b = load_sdlc_state(str(tmp_path), "beta")
+        assert loaded_a.current_phase == SdlcPhase.PLANNING
+        assert loaded_b.current_phase == SdlcPhase.REVIEW
+
+    def test_high_fix_iteration_survives(self, tmp_path):
+        state = self._make_state(fix_iteration=MAX_FIX_ITERATIONS)
+        save_sdlc_state(str(tmp_path), state)
+        loaded = load_sdlc_state(str(tmp_path), state.issue_name)
+        assert loaded.fix_iteration == MAX_FIX_ITERATIONS
+
+
+# ---------------------------------------------------------------------------
+# get_artifact_path
+# ---------------------------------------------------------------------------
+
+
+class TestGetArtifactPath:
+    def test_returns_path_inside_workspace(self, tmp_path):
+        p = get_artifact_path(str(tmp_path), "my-issue", "PLAN.md")
+        assert p == tmp_path / "sdlc" / "my-issue" / "PLAN.md"
+
+    def test_path_need_not_exist(self, tmp_path):
+        p = get_artifact_path(str(tmp_path), "ghost", "RESEARCH.md")
+        assert not p.exists()
+
+    def test_all_defined_artifacts_have_valid_paths(self, tmp_path):
+        for name in SDLC_ARTIFACTS:
+            p = get_artifact_path(str(tmp_path), "issue-x", name)
+            assert p.name == name
+
+
+# ---------------------------------------------------------------------------
+# archive_sdlc_workspace
+# ---------------------------------------------------------------------------
+
+
+class TestArchiveSdlcWorkspace:
+    def _make_state(self, tmp_path: Path, issue_name: str, phase: SdlcPhase) -> SdlcState:
+        state = SdlcState(
+            issue_name=issue_name,
+            description="",
+            current_phase=phase,
+        )
+        save_sdlc_state(str(tmp_path), state)
+        return state
+
+    def test_archives_production_ready(self, tmp_path):
+        self._make_state(tmp_path, "done-issue", SdlcPhase.PRODUCTION_READY)
+        dest = archive_sdlc_workspace(str(tmp_path), "done-issue")
+        assert dest is not None
+        assert dest.exists()
+        ws_original = tmp_path / "sdlc" / "done-issue"
+        assert not ws_original.exists()
+
+    def test_archives_abandoned(self, tmp_path):
+        self._make_state(tmp_path, "dead-issue", SdlcPhase.ABANDONED)
+        dest = archive_sdlc_workspace(str(tmp_path), "dead-issue")
+        assert dest is not None
+        assert str(dest).startswith(str(tmp_path / "sdlc" / "_archived"))
+
+    def test_returns_none_for_non_terminal(self, tmp_path):
+        self._make_state(tmp_path, "active-issue", SdlcPhase.IMPLEMENTATION)
+        result = archive_sdlc_workspace(str(tmp_path), "active-issue")
+        assert result is None
+        assert (tmp_path / "sdlc" / "active-issue").exists()
+
+    def test_returns_none_for_missing_workspace(self, tmp_path):
+        result = archive_sdlc_workspace(str(tmp_path), "ghost")
+        assert result is None
+
+    def test_no_clobber_existing_archive(self, tmp_path):
+        self._make_state(tmp_path, "repeated-issue", SdlcPhase.ABANDONED)
+        dest1 = archive_sdlc_workspace(str(tmp_path), "repeated-issue")
+
+        # Re-create and archive again.
+        self._make_state(tmp_path, "repeated-issue", SdlcPhase.ABANDONED)
+        dest2 = archive_sdlc_workspace(str(tmp_path), "repeated-issue")
+
+        assert dest1 != dest2
+        assert dest1.exists()
+        assert dest2.exists()
+
+
+# ---------------------------------------------------------------------------
+# list_sdlc_workspaces
+# ---------------------------------------------------------------------------
+
+
+class TestListSdlcWorkspaces:
+    def test_empty_when_no_sdlc_dir(self, tmp_path):
+        assert list_sdlc_workspaces(str(tmp_path)) == []
+
+    def test_lists_active_workspaces(self, tmp_path):
+        for name in ("alpha", "beta", "gamma"):
+            get_sdlc_workspace(str(tmp_path), name)
+        workspaces = list_sdlc_workspaces(str(tmp_path))
+        assert set(workspaces) == {"alpha", "beta", "gamma"}
+
+    def test_excludes_archived(self, tmp_path):
+        get_sdlc_workspace(str(tmp_path), "active")
+        archived = tmp_path / "sdlc" / "_archived"
+        archived.mkdir(parents=True)
+        workspaces = list_sdlc_workspaces(str(tmp_path))
+        assert "_archived" not in workspaces
+        assert "active" in workspaces


### PR DESCRIPTION
## What
Add `sdlc_state.py` — the persistence foundation for the /sdlc multi-phase orchestration skill.

## Why
Issue #1704: without durable cross-mission state, SDLC phases are isolated runs that share zero structured data. A failed mid-implementation run loses all research and architecture work, the orchestrator can't make data-driven routing decisions, and the approval checkpoint (#1706) has nowhere to persist its `approved` flag.

This is the prerequisite for #1707 (/sdlc orchestrator skill) and #1706 (human approval checkpoint).

## How
- `SdlcPhase` str-enum (RESEARCH → PRODUCTION_READY / ABANDONED) with `is_terminal` property
- `SdlcRiskLevel` enum (Low/Medium/High)
- `SdlcState` dataclass with `to_dict()`/`from_dict()` round-trip for all field types (lists, dicts, enums, bool)
- Workspace layout: `instance/sdlc/{issue_name}/STATE.json` + named artifact files (RESEARCH.md, ADR.md, PLAN.md, IMPLEMENTATION.md, SECURITY.md, QA.md, SRE.md, REVIEW.md, DOCS.md)
- `save_sdlc_state` uses `atomic_write_json` (temp + rename + `fcntl.flock`) — crash mid-write never corrupts existing state
- `archive_sdlc_workspace` moves terminal workspaces to `sdlc/_archived/` without clobbering prior archives (timestamp suffix)
- `list_sdlc_workspaces` returns active (non-archived) workspace names
- CLAUDE.md updated: instance directory section + key modules section

## Testing
55 unit tests covering: phase/risk enum round-trips, `from_dict` with unknown/missing fields, `get_sdlc_workspace` idempotency and path safety, `load_sdlc_state` resilience (missing workspace, corrupt JSON, empty file), save/load cycle with multiple isolated issues, artifact path computation, archive behaviour for terminal vs active phases, and list excluding `_archived`.

Closes #1704