### PR TITLE
fix: resolve launcher issues from PR #1815

### DIFF
--- a/koan/app/koan_cli.py
+++ b/koan/app/koan_cli.py
@@ -223,10 +223,13 @@ def _launch_web(koan_root: Path) -> int:
 
 
 def _launch_terminal(koan_root: Path) -> int:
-    _start_stack(koan_root)
+    results = _start_stack(koan_root)
+    failed = [name for name, (ok, _) in results.items() if not ok]
+    if failed:
+        print(f"  {amber('some components did not start:')} {text(', '.join(failed))}")
     try:
         from app.tui_dashboard import run as run_tui
-    except Exception:
+    except (ImportError, ModuleNotFoundError):
         print(f"  {amber('terminal dashboard unavailable')} "
               f"{muted('(install textual: pip install textual) — falling back to logs')}")
         print(f"  {muted('run')} {text('make logs')} {muted('to follow output')}")

--- a/koan/app/koan_cli.py
+++ b/koan/app/koan_cli.py
@@ -205,7 +205,10 @@ def _wait_until_interrupt(koan_root: Path) -> None:
 def _launch_web(koan_root: Path) -> int:
     from app.pid_manager import start_dashboard
 
-    _start_stack(koan_root)
+    results = _start_stack(koan_root)
+    failed = [name for name, (ok, _) in results.items() if not ok]
+    if failed:
+        print(f"  {amber('some components did not start:')} {text(', '.join(failed))}")
     ok, msg = start_dashboard(koan_root)
     print(f"  {mint('dashboard') if ok else amber('dashboard')} {muted(msg)}")
     try:

--- a/koan/app/koan_cli.py
+++ b/koan/app/koan_cli.py
@@ -13,9 +13,6 @@ config), then lets the human choose how to supervise the agent:
 (services, CI, scripts). When stdin is not a TTY this launcher delegates to
 the existing headless ``start_all`` path with no prompt, so it is safe to
 call from non-interactive contexts too.
-
-The chosen mode is remembered in ``instance/.koan.prefs`` and reused on the
-next run unless ``--menu`` is passed.
 """
 
 import argparse

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -32,6 +32,7 @@ from textual.widgets import (
     Header,
     Input,
     Label,
+    RichLog,
     Static,
     TabbedContent,
     TabPane,
@@ -224,7 +225,7 @@ class KoanDashboard(App):
         yield Header(show_clock=True)
         with TabbedContent(initial="logs"):
             with TabPane("Logs", id="logs"):
-                yield Container(Static(id="logs-body", classes="pane"))
+                yield RichLog(id="logs-body", classes="pane", markup=False, auto_scroll=True)
             with TabPane("Config", id="config"):
                 yield Tree("config.yaml", id="config-tree")
                 yield Static(id="config-status", classes="pane")
@@ -373,7 +374,9 @@ class KoanDashboard(App):
         # content as literal text and converts ANSI escapes into real styling.
         from rich.text import Text
 
-        self.query_one("#logs-body", Static).update(Text.from_ansi(body))
+        log_widget = self.query_one("#logs-body", RichLog)
+        log_widget.clear()
+        log_widget.write(Text.from_ansi(body))
 
     # --- config tree --------------------------------------------------------
 

--- a/koan/tests/test_koan_cli.py
+++ b/koan/tests/test_koan_cli.py
@@ -87,6 +87,48 @@ def test_launch_terminal_stops_after_session(tmp_path, monkeypatch):
     assert stopped["called"] is True  # quitting the dashboard tears down
 
 
+def test_launch_web_checks_start_all_results(tmp_path, monkeypatch, capsys):
+    # Simulate stack start failure (run component down)
+    failed_results = {"run": (False, "failed"), "awake": (True, "ok")}
+    monkeypatch.setattr("app.pid_manager.start_all", lambda root, **kw: failed_results)
+    monkeypatch.setattr("app.pid_manager.start_dashboard", lambda root: (True, "ok"))
+    monkeypatch.setattr("app.koan_cli._wait_until_interrupt", lambda root: None)
+    monkeypatch.setattr("app.koan_cli._stop_stack", lambda root: None)
+
+    koan_cli._launch_web(tmp_path)
+    captured = capsys.readouterr()
+    # Should report the failure before proceeding
+    assert "run" in captured.out or "failed" in captured.out
+
+
+def test_launch_terminal_warns_on_failed_stack(tmp_path, monkeypatch, capsys):
+    # Simulate stack start failure
+    failed_results = {"run": (False, "failed"), "awake": (True, "ok")}
+    monkeypatch.setattr("app.pid_manager.start_all", lambda root, **kw: failed_results)
+    monkeypatch.setattr("app.tui_dashboard.run", lambda root: 0)
+    monkeypatch.setattr("app.koan_cli._wait_until_interrupt", lambda root: None)
+    monkeypatch.setattr("app.koan_cli._stop_stack", lambda root: None)
+
+    koan_cli._launch_terminal(tmp_path)
+    captured = capsys.readouterr()
+    # Should warn about failed component before launching TUI
+    assert "run" in captured.out or "failed" in captured.out
+
+
+def test_launch_terminal_narrows_import_error(tmp_path, monkeypatch, capsys):
+    # Test that non-import errors are not silently swallowed
+    monkeypatch.setattr("app.pid_manager.start_all", lambda root, **kw: {})
+
+    def bad_import(root):
+        # Simulate a real bug in tui_dashboard, not missing textual
+        raise AttributeError("some real bug in tui_dashboard")
+
+    monkeypatch.setattr("app.tui_dashboard.run", bad_import)
+
+    with pytest.raises(AttributeError):
+        koan_cli._launch_terminal(tmp_path)
+
+
 # --- theme ------------------------------------------------------------------
 
 def test_pixel_gradient_line_count():


### PR DESCRIPTION
## Summary

Fixes 5 issues from interactive launcher PR #1815:
1. Stale docstring references `.koan.prefs` and `--menu` (dropped features)
2. Web launcher doesn't check/report failed components from `start_all()`
3. Terminal launcher doesn't check/report failed components from `start_all()`
4. Terminal launcher's broad `except Exception` masks real bugs in tui_dashboard
5. Log scrolling bug — logs stop updating after 2+ minutes

## Changes

- **koan_cli.py**: Remove stale `.koan.prefs`/`--menu` docstring
- **koan_cli.py**: Check `start_all()` results and warn before opening web dashboard
- **koan_cli.py**: Check `start_all()` results and warn before launching terminal TUI
- **koan_cli.py**: Narrow exception from `Exception` to `ImportError | ModuleNotFoundError` so real bugs propagate
- **tui_dashboard.py**: Replace `Static` widget with `RichLog` (has `auto_scroll=True`)
- **test_koan_cli.py**: Add tests for error handling in both launchers and exception narrowing

Closes https://github.com/Anantys-oss/koan/pull/1816

## Test plan

- All 17 koan_cli tests pass (including 3 new tests for error handling)
- All 14 tui_dashboard tests pass
- Manual verification: logs now auto-scroll continuously in terminal dashboard

---
_Generated by [Kōan](https://koan.anantys.com)_