### PR TITLE
fix(robustness): CI fingerprint dedup + paginated gh retry amplification (#1669, #1670)

### DIFF
--- a/koan/app/ci_dispatch.py
+++ b/koan/app/ci_dispatch.py
@@ -210,9 +210,10 @@ def compute_ci_fingerprint(
     pr_number: int,
     head_sha: str,
     job_name: str,
+    run_id: str = "",
 ) -> str:
     """Deterministic dedup key for a CI failure."""
-    key = f"{pr_number}:{head_sha}:{job_name}"
+    key = f"{pr_number}:{head_sha}:{job_name}:{run_id}"
     return hashlib.sha256(key.encode()).hexdigest()[:16]
 
 
@@ -278,7 +279,8 @@ def check_and_dispatch_ci_fixes(
 
             for fail in failures:
                 job_name = fail.get("name", "unknown")
-                fingerprint = compute_ci_fingerprint(pr_number, head_sha, job_name)
+                run_id = str(fail.get("id", ""))
+                fingerprint = compute_ci_fingerprint(pr_number, head_sha, job_name, run_id)
                 fp_key = f"{full_repo}#{fingerprint}"
 
                 if fp_key in tracker:

--- a/koan/app/review_comment_dispatch.py
+++ b/koan/app/review_comment_dispatch.py
@@ -112,7 +112,7 @@ def fetch_unresolved_review_comments(
     try:
         raw = run_gh(
             "api", f"repos/{full_repo}/pulls/{pr_number}/comments",
-            "--paginate", "--jq",
+            "--limit", "100", "--jq",
             r'.[] | {id: .id, user: .user.login, body: .body, path: .path, user_type: .user.type}',
             timeout=15,
         )
@@ -156,7 +156,7 @@ def fetch_review_body_comments(
     try:
         raw = run_gh(
             "api", f"repos/{full_repo}/pulls/{pr_number}/reviews",
-            "--paginate", "--jq",
+            "--limit", "100", "--jq",
             r'.[] | {id: .id, user: .user.login, body: .body, state: .state, user_type: .user.type}',
             timeout=15,
         )

--- a/koan/tests/test_ci_dispatch.py
+++ b/koan/tests/test_ci_dispatch.py
@@ -52,6 +52,16 @@ class TestComputeCiFingerprint:
         fp = compute_ci_fingerprint(1, "sha", "job")
         assert len(fp) == 16
 
+    def test_unnamed_jobs_differ_by_run_id(self):
+        fp1 = compute_ci_fingerprint(42, "abc123", "unknown", "111")
+        fp2 = compute_ci_fingerprint(42, "abc123", "unknown", "222")
+        assert fp1 != fp2
+
+    def test_run_id_defaults_to_empty(self):
+        fp1 = compute_ci_fingerprint(42, "abc123", "job")
+        fp2 = compute_ci_fingerprint(42, "abc123", "job", "")
+        assert fp1 == fp2
+
 
 class TestFetchKoanOpenPrs:
     @patch("app.ci_dispatch.run_gh")
@@ -217,7 +227,7 @@ class TestCheckAndDispatchCiFixes:
             {"id": 1, "name": "test-suite", "conclusion": "failure", "html_url": "u"},
         ]
 
-        fingerprint = compute_ci_fingerprint(42, "sha123", "test-suite")
+        fingerprint = compute_ci_fingerprint(42, "sha123", "test-suite", "1")
         mock_load.return_value = {f"owner/repo#{fingerprint}": fingerprint}
 
         with patch("app.projects_config.load_projects_config") as mock_pc, \


### PR DESCRIPTION
## What
Two independent robustness fixes batched together.

## Why

**#1669** — Multiple unnamed CI check runs (job name falls back to `"unknown"`) all produced the same dedup fingerprint (`pr:sha:unknown`), so only the first unnamed failure triggered a fix mission. The rest were silently dropped until a new commit was pushed.

**#1670** — `fetch_unresolved_review_comments()` and `fetch_review_body_comments()` used `--paginate` with `timeout=15`. Combined with `retry_with_backoff` (3 retries × 15s), a single slow GitHub API call could block the notification loop for ~45s per call, per PR, per project.

## How

**#1669** — Added `run_id: str = ""` parameter to `compute_ci_fingerprint()`. The call site now passes `str(fail.get("id", ""))`, making each check run's fingerprint unique even when names collide.

**#1670** — Replaced `--paginate` with `--limit 100` (GitHub's max-per-page). One API page eliminates retry amplification with no practical data loss — PRs with 100+ review comments are essentially nonexistent.

## Testing
- Added `test_unnamed_jobs_differ_by_run_id` and `test_run_id_defaults_to_empty` to `TestComputeCiFingerprint`
- Updated `test_dedup_prevents_double_dispatch` to generate the correct fingerprint (now includes `run_id="1"`)
- All 56 tests in `test_ci_dispatch.py` + `test_review_comment_dispatch.py` pass
- Full test suite passes

Closes #1669, #1670