### PR TITLE
feat(missions): add [project:all] tag for org-wide missions

### DIFF
--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -15,6 +15,26 @@ Missions are stored in Markdown sections. The canonical lifecycle is:
 French section names are also accepted for compatibility. Missions can include
 project tags such as `[project:name]`.
 
+### Org-wide missions (`[project:all]`)
+
+A mission tagged `[project:all]` (or a recurring entry with `"project": "all"`)
+is an **org-wide** mission: it targets every repository in the workspace
+instead of a single project. The engine resolves it to the workspace root
+(`<KOAN_ROOT>/workspace`) as its working directory and launches it **once** —
+the mission's own instructions are responsible for iterating over each repo
+(e.g. enumerating `workspace/*/` and operating on each, optionally via
+sub-agents). Engine-level git branch preparation and auto-merge are skipped for
+org-wide missions, because there is no single repo to branch; each repo's git
+work (branches, PRs) is handled inside the mission.
+
+`all` is a reserved sentinel resolved in
+`iteration_manager._resolve_project_path`. A real project literally named `all`
+still takes precedence over the sentinel. Missions with **no** project tag keep
+their previous behaviour (they default to the first configured project), so
+single-project setups are unaffected. To scope which repos an org-wide mission
+touches, exclude repos at the workspace-sync layer (they simply never get cloned
+into `workspace/`).
+
 ## Normal Execution
 
 1. The bridge, a command handler, a scheduler, or a GitHub/Jira notification

--- a/koan/app/constants.py
+++ b/koan/app/constants.py
@@ -83,3 +83,21 @@ BURN_RATE_WARNING_MIN_RESET_GAP_MIN = 120.0
 
 # Ring-buffer cap for the selection audit log.
 MAX_SELECTION_AUDIT_ENTRIES = 200
+
+# ---------------------------------------------------------------------------
+# Org-wide missions  (iteration_manager.py, mission_executor.py)
+# ---------------------------------------------------------------------------
+
+# Sentinel project name marking an "org-wide" mission, i.e. one meant to
+# cover every repository in the workspace rather than a single project.
+# A mission tagged ``[project:all]`` (or a recurring entry with
+# ``"project": "all"``) resolves to the workspace root as its working
+# directory and is launched ONCE; the mission's own instructions iterate
+# over every repo under the workspace. The engine skips per-project git
+# branch preparation for it — each repo's git work is handled inside the
+# mission itself. A real project literally named "all" still takes
+# precedence over this sentinel.
+ORG_WIDE_PROJECT = "all"
+
+# Name of the workspace directory under KOAN_ROOT that holds all repos.
+WORKSPACE_DIRNAME = "workspace"

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -34,6 +34,8 @@ from app.constants import (
     BURN_RATE_DOWNGRADE_THRESHOLD_MIN,
     BURN_RATE_WARNING_MIN_RESET_GAP_MIN,
     BURN_RATE_WARNING_THRESHOLD_MIN,
+    ORG_WIDE_PROJECT,
+    WORKSPACE_DIRNAME,
     MAX_SELECTION_AUDIT_ENTRIES as _MAX_SELECTION_AUDIT_ENTRIES,
 )
 from app.loop_manager import resolve_focus_area
@@ -523,10 +525,35 @@ def _projects_to_str(projects: List[Tuple[str, str]]) -> str:
     return ";".join(f"{name}:{path}" for name, path in projects)
 
 
+def _org_wide_workspace_root(koan_root: Optional[str]) -> Optional[str]:
+    """Resolve the workspace root directory used for org-wide missions.
+
+    Returns the absolute path to ``<KOAN_ROOT>/workspace`` if it exists as a
+    directory, otherwise ``None`` (org-wide missions require the workspace
+    layout that holds all repos). ``koan_root`` falls back to the
+    ``KOAN_ROOT`` environment variable when not provided.
+    """
+    root = koan_root
+    if not root:
+        import os
+        root = os.environ.get("KOAN_ROOT", "")
+    if not root:
+        return None
+    workspace = Path(root) / WORKSPACE_DIRNAME
+    return str(workspace) if workspace.is_dir() else None
+
+
 def _resolve_project_path(
-    project_name: str, projects: List[Tuple[str, str]],
+    project_name: str,
+    projects: List[Tuple[str, str]],
+    koan_root: Optional[str] = None,
 ) -> Optional[Tuple[str, str]]:
     """Find the canonical name and path for a project name (case-insensitive).
+
+    Recognises the org-wide sentinel ``ORG_WIDE_PROJECT`` ("all"): when no
+    real project matches that name, it resolves to the workspace root so the
+    mission is launched once with every repo visible underneath. A real
+    project literally named "all" still takes precedence.
 
     Returns:
         (canonical_name, path) tuple or None if not found
@@ -546,6 +573,13 @@ def _resolve_project_path(
         for name, path in projects:
             if name.lower() == canonical_lower:
                 return (name, path)
+
+    # Org-wide sentinel: no real project matched, so "all" means "run once at
+    # the workspace root and let the mission iterate over every repo itself".
+    if lower == ORG_WIDE_PROJECT:
+        workspace_root = _org_wide_workspace_root(koan_root)
+        if workspace_root:
+            return (ORG_WIDE_PROJECT, workspace_root)
     return None
 
 
@@ -1470,7 +1504,7 @@ def plan_iteration(
 
     # Step 5: Resolve project for the picked mission.
     if mission_project and mission_title:
-        resolved = _resolve_project_path(mission_project, projects)
+        resolved = _resolve_project_path(mission_project, projects, koan_root)
 
         if resolved is None:
             project_name = mission_project

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -723,25 +723,35 @@ def _run_iteration(
     log("project", bold_green(f">>> Current project: {project_name}") + f" ({project_path})")
 
     # --- Prepare project git state ---
-    from app.git_prep import prepare_project_branch
-    try:
-        prep = prepare_project_branch(project_path, project_name, koan_root)
-        if prep.stashed:
-            log("git", f"Stashed uncommitted changes in {project_name}")
-        if not prep.success:
-            log("error", f"Git prep failed for {project_name}: {prep.error}")
+    # Org-wide missions run at the workspace root (which is not itself a git
+    # repo) and iterate over every repo themselves, handling each repo's git
+    # branch/PR work inside the mission. Engine-level branch preparation would
+    # fail there, so skip it for the org-wide sentinel.
+    from app.constants import ORG_WIDE_PROJECT
+    is_org_wide = project_name == ORG_WIDE_PROJECT
+    if is_org_wide:
+        log("git", f"Org-wide mission — running at workspace root ({project_path}); "
+                    "skipping branch prep (mission manages git per repo)")
+    else:
+        from app.git_prep import prepare_project_branch
+        try:
+            prep = prepare_project_branch(project_path, project_name, koan_root)
+            if prep.stashed:
+                log("git", f"Stashed uncommitted changes in {project_name}")
+            if not prep.success:
+                log("error", f"Git prep failed for {project_name}: {prep.error}")
+                if mission_title:
+                    _run._update_mission_in_file(instance, mission_title, failed=True)
+                    _run._notify(instance, f"❌ [{project_name}] Git prep failed, aborting mission: {mission_title[:60]}")
+                return False  # abort — branch state is unreliable
+            else:
+                log("git", f"Ready on {prep.base_branch} from {prep.remote_used}")
+        except Exception as e:
+            log("error", f"Git prep error for {project_name}: {e}\n{traceback.format_exc()}")
             if mission_title:
                 _run._update_mission_in_file(instance, mission_title, failed=True)
-                _run._notify(instance, f"❌ [{project_name}] Git prep failed, aborting mission: {mission_title[:60]}")
+                _run._notify(instance, f"❌ [{project_name}] Git prep error, aborting mission: {mission_title[:60]}")
             return False  # abort — branch state is unreliable
-        else:
-            log("git", f"Ready on {prep.base_branch} from {prep.remote_used}")
-    except Exception as e:
-        log("error", f"Git prep error for {project_name}: {e}\n{traceback.format_exc()}")
-        if mission_title:
-            _run._update_mission_in_file(instance, mission_title, failed=True)
-            _run._notify(instance, f"❌ [{project_name}] Git prep error, aborting mission: {mission_title[:60]}")
-        return False  # abort — branch state is unreliable
 
     # --- Mark mission as In Progress ---
     # Save the original title before skill dispatch may translate it.

--- a/koan/app/pick_mission.py
+++ b/koan/app/pick_mission.py
@@ -27,13 +27,17 @@ def fallback_extract(content: str, projects_str: str) -> tuple[str | None, str |
     if not line:
         return (None, None)
 
-    # Try to extract project from inline tag
+    # Try to extract project from inline tag.
+    # The sentinel tag [project:all] passes through verbatim here; it is
+    # resolved to the workspace root downstream (iteration_manager
+    # ._resolve_project_path) so the org-wide mission runs once over all repos.
     tag = PROJECT_TAG_RE.search(line)
     if tag:
         project = tag.group(1)
         title = PROJECT_TAG_STRIP_RE.sub("", line).removeprefix("- ").strip()
     else:
-        # Default to first project
+        # No tag: default to the first project (intentional for single-project
+        # setups). Org-wide missions must carry an explicit [project:all] tag.
         parts = [p for p in projects_str.split(";") if p]
         project = parts[0].split(":")[0] if parts else "default"
         title = line.removeprefix("- ").strip()

--- a/koan/skills/core/recurring/SKILL.md
+++ b/koan/skills/core/recurring/SKILL.md
@@ -24,3 +24,8 @@ commands:
     usage: /recurring, /recurring resume <n>, /recurring run [n], /recurring pause <n>, /recurring cancel <n>, /recurring days <n> <days>
 handler: handler.py
 ---
+
+Use `project:all` to make a recurring mission **org-wide**: it runs once at the
+workspace root and its instructions iterate over every repo in the workspace
+(see `docs/architecture/mission-lifecycle.md`). Without a `project:` tag, a
+mission defaults to the first configured project.

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -120,6 +120,59 @@ class TestResolveProjectPath:
         assert _resolve_project_path("ghost", PROJECTS_LIST) is None
 
 
+class TestResolveProjectPathOrgWide:
+    """The org-wide sentinel ([project:all]) resolves to the workspace root."""
+
+    def test_all_resolves_to_workspace_root(self, tmp_path, monkeypatch):
+        """`all` with no matching project resolves to <KOAN_ROOT>/workspace."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        result = _resolve_project_path("all", PROJECTS_LIST, str(tmp_path))
+        assert result == ("all", str(workspace))
+
+    def test_all_case_insensitive(self, tmp_path, monkeypatch):
+        """The sentinel is matched case-insensitively."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        (tmp_path / "workspace").mkdir()
+        result = _resolve_project_path("ALL", PROJECTS_LIST, str(tmp_path))
+        assert result == ("all", str(tmp_path / "workspace"))
+
+    def test_all_falls_back_to_env_koan_root(self, tmp_path, monkeypatch):
+        """When koan_root is omitted, KOAN_ROOT env is used."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        (tmp_path / "workspace").mkdir()
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        result = _resolve_project_path("all", PROJECTS_LIST)
+        assert result == ("all", str(tmp_path / "workspace"))
+
+    def test_all_none_when_no_workspace_dir(self, tmp_path, monkeypatch):
+        """No workspace/ directory means the sentinel cannot resolve."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        # tmp_path has no "workspace" subdirectory
+        assert _resolve_project_path("all", PROJECTS_LIST, str(tmp_path)) is None
+
+    def test_real_project_named_all_takes_precedence(self, tmp_path, monkeypatch):
+        """A real project literally named 'all' wins over the sentinel."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        (tmp_path / "workspace").mkdir()
+        projects = [("all", "/path/to/real-all"), ("backend", "/path/to/backend")]
+        result = _resolve_project_path("all", projects, str(tmp_path))
+        assert result == ("all", "/path/to/real-all")
+
+    def test_named_project_unaffected_by_workspace(self, tmp_path, monkeypatch):
+        """A named project still resolves to its own path, not the workspace."""
+        import app.utils as utils
+        monkeypatch.setattr(utils, "resolve_project_alias", lambda n: None)
+        (tmp_path / "workspace").mkdir()
+        result = _resolve_project_path("backend", PROJECTS_LIST, str(tmp_path))
+        assert result == ("backend", "/path/to/backend")
+
 
 class TestGetKnownProjectNames:
 


### PR DESCRIPTION
## Problem

Recurring **org-wide** missions (defined with `project: null`, i.e. no project tag) are meant to cover **all** repos in the workspace. In practice they only ever processed **one** repo — always the same, the first one alphabetically.

Root cause (line numbers as of this branch):

- `pick_mission.fallback_extract` (`koan/app/pick_mission.py`) defaults an untagged mission to `projects[0]` (first project alphabetically).
- That single repo then becomes the Claude CLI working directory (`mission_executor.py`, `cwd=project_path`), so the agent only ever "sees" one repo even though the mission text says "all repos".

## Fix (minimal, surgical)

Introduce an explicit org-wide sentinel tag **`[project:all]`**:

- `iteration_manager._resolve_project_path` resolves the `all` sentinel to the **workspace root** (`<KOAN_ROOT>/workspace`) instead of a single project. The mission is launched **once** with every repo visible underneath; the mission's own instructions iterate over each repo (optionally via sub-agents). A real project literally named `all` still takes precedence.
- `mission_executor` **skips engine-level git branch preparation** for org-wide missions: the workspace root is not a git repo, and each repo's git/PR work is handled inside the mission. Auto-merge (`check_auto_merge`) and HEAD snapshots already degrade to no-ops at the workspace root.

## Before / After

| | Before | After |
|---|---|---|
| `[project:name]` (named repo) | runs in that repo | **unchanged** |
| no tag | defaults to first project | **unchanged** (single-project setups unaffected) |
| `[project:all]` / org-wide | N/A (fell back to first repo) | cwd = workspace root, single launch, branch prep skipped |

## Consistency constraint

This stays consistent with the governance config, where org-wide recurring missions **already iterate over `workspace/*` themselves** (`ls -d /data/workspace/*/` then `cd`). The engine launches the mission **once** and the mission loops — **no per-repo fan-out is introduced**, so a fan-out would not double-iterate (N×N) and the daily mission count is unaffected. Repo exclusion is handled at the workspace-sync layer (`SYNC_EXCLUDE`), so excluded repos never reach `workspace/`.

## Tests

New `TestResolveProjectPathOrgWide` covers both requested cases plus edges:
- org-wide → working dir = workspace root (incl. case-insensitive, env-`KOAN_ROOT` fallback)
- named project → working dir = that repo (unchanged)
- no `workspace/` dir → does not resolve
- real project named `all` → takes precedence over the sentinel

Run:
```bash
cd koan && KOAN_ROOT=/tmp/test-koan PYTHONPATH=. python3 -m pytest tests/test_iteration_manager.py -q
```
Full suite: 5213 passed locally, `ruff` clean on touched files.

## Docs

- `docs/architecture/mission-lifecycle.md` — new "Org-wide missions (`[project:all]`)" section.
- `koan/skills/core/recurring/SKILL.md` — note on `project:all`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)