### PR TITLE
Fix focus trap in TUI Config tab

### DIFF
--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -289,10 +289,13 @@ class KoanDashboard(App):
         Binding("2", "show('logs')", "Logs", show=False),
         Binding("3", "show('usage')", "Usage", show=False),
         Binding("4", "show('config')", "Config", show=False),
-        Binding("s", "show('status')", "Status", show=False),
-        Binding("l", "show('logs')", "Logs", show=False),
-        Binding("u", "show('usage')", "Usage", show=False),
-        Binding("c", "show('config')", "Config", show=False),
+        Binding("s", "show('status')", "Status", show=False, priority=True),
+        Binding("l", "show('logs')", "Logs", show=False, priority=True),
+        Binding("u", "show('usage')", "Usage", show=False, priority=True),
+        Binding("c", "show('config')", "Config", show=False, priority=True),
+        Binding("up", "focus_up", "Focus up", show=False, priority=True),
+        Binding("down", "focus_pane", "Focus pane", show=False),
+        Binding("escape", "focus_tabs", "Focus tabs", show=False),
         Binding("t", "toggle", "Toggle bool", show=False),
         Binding("r", "refresh", "Refresh", show=False),
     ]
@@ -337,10 +340,12 @@ class KoanDashboard(App):
     def on_tabbed_content_tab_activated(
         self, event: "TabbedContent.TabActivated"
     ) -> None:
-        # Give keyboard focus to the config tree when its tab is shown so
-        # arrow keys browse it (otherwise focus stays on the tab bar).
-        if self.active_pane_id() == "config":
-            self._focus_config_tree()
+        # Keep focus on the tab bar after any switch so Left/Right navigate
+        # tabs and letter shortcuts are never trapped by pane widgets.
+        try:
+            self.query_one(Tabs).focus()
+        except Exception as exc:
+            self.log(f"tab focus failed: {exc}")
 
     def _focus_config_tree(self) -> None:
         try:
@@ -354,21 +359,44 @@ class KoanDashboard(App):
         self._build_config_tree()
         self.refresh_dynamic()
 
+    def action_focus_up(self) -> None:
+        """Up arrow: navigate the config tree upward, or return to tabs at root."""
+        try:
+            tree = self.query_one("#config-tree", Tree)
+            if tree.has_focus:
+                cursor = getattr(tree, "cursor_node", None)
+                if cursor is not None and cursor != tree.root:
+                    tree.action_cursor_up()
+                    return
+        except Exception as exc:
+            self.log(f"focus up tree check failed: {exc}")
+        self.action_focus_tabs()
+
+    def action_focus_tabs(self) -> None:
+        """Move keyboard focus to the tab bar (Escape)."""
+        try:
+            self.query_one(Tabs).focus()
+        except Exception as exc:
+            self.log(f"focus tabs failed: {exc}")
+
+    def action_focus_pane(self) -> None:
+        """Move focus from the tab bar into the active pane (Down)."""
+        if self.active_pane_id() == "config":
+            self._focus_config_tree()
+
     def action_show(self, pane: str) -> None:
-        """Switch tabs via 1/2/3 — works even while the config tree has focus."""
+        """Switch tabs via 1/2/3/4 or s/l/u/c."""
         try:
             self.query_one(TabbedContent).active = pane
         except Exception as exc:
             self.log(f"tab switch failed: {exc}")
             return
-        if pane == "config":
-            self._focus_config_tree()
-        else:
-            # Move focus off the (now hidden) tree so it stops eating keys.
-            try:
-                self.query_one(Tabs).focus()
-            except Exception as exc:
-                self.log(f"tab focus failed: {exc}")
+        # Always leave focus on the tab bar so Left/Right navigate tabs
+        # and letter shortcuts are never trapped by pane widgets.
+        try:
+            self.query_one(Tabs).focus()
+        except Exception as exc:
+            self.log(f"tab focus failed: {exc}")
 
     def action_pause(self) -> None:
         try:

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -106,7 +106,10 @@ def test_pilot_config_tab_focuses_tree_and_arrows_move(tmp_path):
             app.query_one(tui.TabbedContent).active = "config"
             await pilot.pause()
             tree = app.query_one("#config-tree", tui.Tree)
-            # The config tab activation should hand focus to the tree.
+            # Focus stays on the tab bar after tab activation; Down enters the tree.
+            assert app.focused is not tree
+            await pilot.press("down")
+            await pilot.pause()
             assert app.focused is tree
             tree.root.children[0].expand()
             await pilot.pause()
@@ -124,11 +127,11 @@ def test_pilot_can_leave_config_tab_via_number_keys(tmp_path):
     async def scenario():
         app = tui.KoanDashboard(tmp_path)
         async with app.run_test() as pilot:
-            await pilot.press("c")  # to config — tree takes focus
+            await pilot.press("c")  # to config — focus stays on tab bar
             await pilot.pause()
             tree = app.query_one("#config-tree", tui.Tree)
-            assert app.focused is tree
-            await pilot.press("2")  # back to logs even though tree had focus
+            assert app.focused is not tree  # tree does not auto-focus
+            await pilot.press("2")  # back to logs
             await pilot.pause()
             assert app.query_one(tui.TabbedContent).active == "logs"
             assert app.focused is not tree  # tree no longer traps keys
@@ -142,7 +145,7 @@ def test_pilot_bool_toggles_with_space_and_enter(tmp_path):
     async def scenario():
         app = tui.KoanDashboard(tmp_path)
         async with app.run_test() as pilot:
-            await pilot.press("c")  # config tab, tree focused
+            await pilot.press("c")  # config tab, focus stays on tab bar
             await pilot.pause()
             tree = app.query_one("#config-tree", tui.Tree)
             branch = tree.root.children[0]
@@ -162,11 +165,15 @@ def test_pilot_bool_toggles_with_space_and_enter(tmp_path):
                 tree.move_cursor(b.children[0])
                 await pilot.pause()
 
+            await pilot.press("down")  # move focus into the tree
+            await pilot.pause()
             await pilot.press("t")  # toggle false -> true, no modal
             await pilot.pause()
             assert yaml.safe_load(cfg.read_text())["auto_update"]["enabled"] is True
 
             await _focus_leaf()
+            await pilot.press("down")  # re-focus the tree after rebuild
+            await pilot.pause()
             await pilot.press("enter")  # enter also flips a bool, no modal
             await pilot.pause()
             assert yaml.safe_load(cfg.read_text())["auto_update"]["enabled"] is False


### PR DESCRIPTION
Prevent the Config tab's Tree widget from swallowing letter keys
(s/l/u/c) and trapping arrow-key navigation. In Textual, a focused
Tree consumes alphanumeric keystrokes for node-jump navigation, which
broke the BIOS-style tab shortcuts. Additionally, auto-focusing the
tree on tab activation trapped the cursor so Left/Right no longer
switched tabs.

Changes:
- Mark s/l/u/c bindings as priority=True so they fire before the
  focused widget can consume them.
- Add Up/Escape → focus_tabs and Down → focus_pane actions for
  explicit focus movement between the tab bar and pane content.
- Remove auto-focus of the config tree on tab activation; always
  leave focus on the tab bar after a switch so Left/Right
  naturally navigate tabs.
- Change action_show() to consistently return focus to the tab bar.

This preserves the ability to browse the config tree (Down enters it,
Up returns to tabs) while keeping keyboard navigation predictable.

Changelog: Fix focus trap in TUI Config tab; tab shortcuts and arrow
  navigation now work reliably across all tabs.
