### PR TITLE
Bump GitHub artifact actions to v7 in CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: ⬆️ Upload coverage data
         if: ${{ !inputs.group || matrix.group.name == inputs.group }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage-py${{ matrix.python-version }}-${{ matrix.group.name }}
           path: koan/.coverage
@@ -101,7 +101,7 @@ jobs:
         run: pip install coverage
 
       - name: ⬇️ Download all coverage artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           pattern: coverage-py*
           path: coverage-parts


### PR DESCRIPTION
Upgrade actions/upload-artifact and actions/download-artifact from v4
to v7 in .github/workflows/tests.yml. Both actions must share the same
major version to stay compatible, so they are bumped together.

This keeps the CI on the current supported major version and avoids
future deprecation warnings from GitHub.
