### PR TITLE
refactor(provider): inherit OllamaLaunchProvider from ClaudeProvider

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ update the relevant docs in the same change.
 - [User Manual](users/user-manual.md) - daily use, workflows, and command guide.
 - [Onboarding](users/onboarding.md) - first-run setup and configuration flow.
 - [Skills Reference](users/skills.md) - built-in command reference.
-- [Provider Setup](providers/) - Claude, Codex, Copilot, and local providers.
+- [Provider Setup](providers/) - Claude, Codex, Copilot, local, and Ollama Launch providers.
 - [Messaging Setup](messaging/) - Telegram, Slack, Matrix, Discord, GitHub, and Jira.
 - [Troubleshooting](operations/troubleshooting.md) - common issues and how to fix them.
 

--- a/docs/providers/ollama-launch.md
+++ b/docs/providers/ollama-launch.md
@@ -1,0 +1,204 @@
+# Ollama Launch Provider
+
+The `ollama-launch` provider uses Ollama v0.16.0+ ``ollama launch claude`` to run
+the Claude Code CLI through an Ollama-managed server. Ollama handles the
+``ANTHROPIC_BASE_URL`` environment variable and server lifecycle automatically,
+so no manual configuration is needed.
+
+Because everything after the ``--`` separator is forwarded to the Claude Code
+CLI verbatim, this provider supports the full Claude feature set: native tool
+calling, JSONL streaming, session resume, MCP servers, effort/thinking levels,
+and Claude-style quota detection.
+
+## Quick Setup
+
+### 1. Install Ollama
+
+```bash
+# macOS
+brew install ollama
+
+# Or download from https://ollama.com/download
+```
+
+Verify the version supports ``launch claude``:
+
+```bash
+ollama --version        # Must be v0.16.0 or later
+ollama launch claude --help
+```
+
+### 2. Pull a Model
+
+```bash
+ollama pull qwen2.5-coder:14b
+# Or any model you prefer
+ollama list
+```
+
+### 3. Configure Koan
+
+In `instance/config.yaml`:
+
+```yaml
+cli_provider: "ollama-launch"
+
+ollama_launch:
+  model: "qwen2.5-coder:14b"
+```
+
+Or via environment variable (in `.env`):
+
+```bash
+KOAN_CLI_PROVIDER=ollama-launch
+KOAN_OLLAMA_LAUNCH_MODEL=qwen2.5-coder:14b
+```
+
+Environment variables override `config.yaml` values.
+
+### 4. Start Koan
+
+```bash
+make start
+```
+
+Unlike the `local` provider, you do **not** need to run `ollama serve`
+separately. The `ollama launch claude` command starts the Ollama server
+on demand.
+
+To stop:
+
+```bash
+make stop
+```
+
+### 5. Verify
+
+Send a test mission via Telegram or check the logs:
+
+```bash
+make logs
+```
+
+You should see the CLI command built as:
+
+```
+ollama launch claude --model <model> -- -p <prompt> ...
+```
+
+## Per-Project Configuration
+
+Use `ollama-launch` for specific projects while keeping Claude for others:
+
+```yaml
+# projects.yaml
+defaults:
+  cli_provider: "claude"
+
+projects:
+  critical-app:
+    path: "/path/to/app"
+    # Uses Claude (default)
+
+  side-project:
+    path: "/path/to/side"
+    cli_provider: "ollama-launch"
+    models:
+      mission: "qwen2.5-coder:14b"
+```
+
+## Provider-Specific Model Configuration
+
+In `instance/config.yaml`:
+
+```yaml
+models:
+  ollama-launch:
+    mission: "qwen2.5-coder:14b"
+    chat: "qwen2.5-coder:14b"
+    lightweight: "qwen2.5-coder:7b"
+    fallback: ""
+    review_mode: "qwen2.5-coder:14b"
+    reflect: "qwen2.5-coder:7b"
+
+  default:
+    mission: ""
+    chat: ""
+    lightweight: "haiku"
+    fallback: "sonnet"
+```
+
+Provider names may use hyphens or underscores (`ollama-launch` or
+`ollama_launch`).
+
+## How It Works
+
+The command structure is:
+
+```bash
+ollama launch claude --model <model> -- <claude-flags>
+```
+
+- **Before `--`**: Ollama args (`launch`, `claude`, `--model`)
+- **After `--`**: Claude Code CLI args (`-p`, `--allowedTools`,
+  `--output-format stream-json --verbose`, `--resume`, `--append-system-prompt`,
+  `--effort`, `--mcp-config`, etc.)
+
+Because the Claude side is built by the same code as the native `claude`
+provider, feature parity is automatic.
+
+## Feature Comparison
+
+| Feature | `local` | `ollama-launch` |
+|---------|---------|-----------------|
+| Server management | Manual (`ollama serve`) | Automatic |
+| Tool protocol | OpenAI function calling | Claude native |
+| Streaming (`stream-json`) | ❌ Raw text | ✅ JSONL |
+| System prompt file | ❌ Prepend only | ✅ `--append-system-prompt-file` |
+| Session resume | ❌ | ✅ `--resume` |
+| MCP support | ❌ | ✅ `--mcp-config` |
+| Effort / thinking | ❌ | ✅ `--effort` |
+| Quota detection | N/A | ✅ Claude-style |
+| Cost | Free (hardware) | Free (hardware) |
+
+## Troubleshooting
+
+### "ollama launch claude: command not found"
+
+Your Ollama version is too old. Upgrade to v0.16.0+:
+
+```bash
+brew upgrade ollama   # macOS
+```
+
+### Model not found
+
+Pull the model first:
+
+```bash
+ollama pull <model-name>
+ollama list           # Verify it's available
+```
+
+### Koan still uses Claude after config change
+
+Check the env var override. `.env` takes priority over `config.yaml`:
+
+```bash
+grep KOAN_CLI_PROVIDER .env
+```
+
+### `make ollama` starts an extra server
+
+The `make ollama` target is for the `local` provider (which needs a standalone
+`ollama serve`). For `ollama-launch`, use `make start` only — the server is
+started on demand by `ollama launch claude`.
+
+### Poor quality results
+
+Local models vary in tool-use capability. If the agent ignores tools or
+produces garbled output:
+
+1. Try a larger model (14B+ recommended)
+2. Try a different model family (Qwen2.5-Coder works well)
+3. Keep a Claude project around for complex architectural work

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1481,10 +1481,11 @@ Kōan supports multiple CLI backends. Configure globally via `KOAN_CLI_PROVIDER`
 | **OpenAI Codex** | ChatGPT users who want Codex models | [codex.md](../providers/codex.md) |
 | **GitHub Copilot** | Teams with existing Copilot licenses | [copilot.md](../providers/copilot.md) |
 | **Local LLM** | Offline, privacy, zero API cost | [local.md](../providers/local.md) |
+| **Ollama Launch** | Claude CLI via Ollama-managed server | [ollama-launch.md](../providers/ollama-launch.md) |
 
 #### Provider-specific model config
 
-When switching between providers, model names are not interchangeable. Use `models.claude:` / `models.codex:` sections in `instance/config.yaml` to configure provider-specific defaults without touching the global `models.default:` fallback:
+When switching between providers, model names are not interchangeable. Use `models.{provider}:` sections in `instance/config.yaml` to configure provider-specific defaults without touching the global `models.default:` fallback:
 
 ```yaml
 cli_provider: "codex"
@@ -1501,6 +1502,11 @@ models:
 
   claude:
     review_mode: "haiku"      # use haiku for cheaper REVIEW mode audits
+
+  ollama-launch:
+    mission: "qwen2.5-coder:14b"
+    chat: "qwen2.5-coder:14b"
+    lightweight: "qwen2.5-coder:7b"
 
   # Global fallback for providers without a specific section
   default:

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -360,7 +360,8 @@ tools:
     - Shell: Bash (run git, gh, make, and other commands)
 
 # CLI provider — which AI CLI to use as the backend
-# Options: "claude" (default), "codex" (OpenAI Codex CLI), "copilot" (GitHub Copilot CLI), "local" (local LLM)
+# Options: "claude" (default), "codex" (OpenAI Codex CLI), "copilot" (GitHub Copilot CLI),
+#          "local" (local LLM via OpenAI-compatible API), "ollama-launch" (Ollama-managed Claude CLI)
 # Can also be set via KOAN_CLI_PROVIDER env var (overrides this)
 cli_provider: "claude"
 
@@ -391,6 +392,20 @@ cli_provider: "claude"
 #   base_url: "http://localhost:11434/v1"
 #   model: "glm4"
 #   api_key: ""   # Usually empty for local servers
+
+# Ollama Launch configuration (used when cli_provider: "ollama-launch")
+# Uses Ollama v0.16.0+ ``ollama launch claude`` to run the Claude Code CLI
+# through an Ollama-managed server. Ollama handles ``ANTHROPIC_BASE_URL`` and
+# server lifecycle automatically — no manual env vars needed.
+#
+# The model is passed to Ollama's --model flag (before the -- separator).
+# Everything after -- is forwarded to the Claude Code CLI verbatim, so
+# all Claude features (tools, streaming, session resume, MCP, effort)
+# work exactly as with the native claude provider.
+#
+# Can also be set via KOAN_OLLAMA_LAUNCH_MODEL env var (overrides this).
+# ollama_launch:
+#   model: "qwen2.5-coder:14b"   # Model name as known to Ollama
 
 # Model configuration — controls which models are used for different types of calls.
 # Resolution order per key:
@@ -438,6 +453,15 @@ models:
   #   fallback: ""                   # empty = use provider default
   #   review_mode: "gpt-5.3-codex"  # serious code review
   #   reflect: "gpt-5.5"            # summarize / reason about result
+
+  # Ollama Launch provider overrides (uncomment to customize):
+  # ollama-launch:
+  #   mission: "qwen2.5-coder:14b"   # main mission execution
+  #   chat: "qwen2.5-coder:14b"      # chat responses
+  #   lightweight: "qwen2.5-coder:7b" # low-cost calls
+  #   fallback: ""                    # empty = use provider default
+  #   review_mode: "qwen2.5-coder:14b"
+  #   reflect: "qwen2.5-coder:7b"
 
 # Branch cleanup — automatic deletion of merged branches during git sync
 # Every git_sync_interval iterations, Kōan detects merged branches (both

--- a/koan/app/provider/ollama_launch.py
+++ b/koan/app/provider/ollama_launch.py
@@ -19,10 +19,10 @@ import shutil
 import sys
 from typing import Dict, List, Optional, Tuple
 
-from app.provider.base import CLIProvider
+from app.provider.claude import ClaudeProvider
 
 
-class OllamaLaunchProvider(CLIProvider):
+class OllamaLaunchProvider(ClaudeProvider):
     """Provider that uses ``ollama launch claude`` to run Claude Code.
 
     Advantages over manual OllamaClaudeProvider:
@@ -30,6 +30,11 @@ class OllamaLaunchProvider(CLIProvider):
     - Ollama auto-starts the server if needed
     - Native integration maintained by Ollama upstream
     - Model validated by Ollama before launch
+
+    Because everything after ``--`` is forwarded to the Claude Code CLI,
+    this provider inherits from :class:`ClaudeProvider` and reuses all
+    Claude-specific flag builders (permissions, system prompts, session
+    resume, streaming, effort, thinking, quota detection, etc.).
 
     Configuration (config.yaml)::
 
@@ -77,50 +82,9 @@ class OllamaLaunchProvider(CLIProvider):
         """Check that ollama binary exists and is v0.16.0+."""
         return shutil.which("ollama") is not None
 
-    def build_prompt_args(self, prompt: str) -> List[str]:
-        return ["-p", prompt]
-
-    def build_tool_args(
-        self,
-        allowed_tools: Optional[List[str]] = None,
-        disallowed_tools: Optional[List[str]] = None,
-    ) -> List[str]:
-        flags: List[str] = []
-        if allowed_tools:
-            flags.extend(["--allowedTools", ",".join(allowed_tools)])
-        if disallowed_tools:
-            flags.extend(["--disallowedTools", ",".join(disallowed_tools)])
-        return flags
-
     def build_model_args(self, model: str = "", fallback: str = "") -> List[str]:
-        # Model is handled by ollama --model flag, not Claude --model
-        # So we don't add anything here — it's injected in build_command()
+        # Model is handled by ollama --model flag (before --), not Claude --model.
         return []
-
-    def build_output_args(self, fmt: str = "") -> List[str]:
-        if fmt:
-            return ["--output-format", fmt]
-        return []
-
-    def build_max_turns_args(self, max_turns: int = 0) -> List[str]:
-        if max_turns > 0:
-            return ["--max-turns", str(max_turns)]
-        return []
-
-    def build_mcp_args(self, configs: Optional[List[str]] = None) -> List[str]:
-        if not configs:
-            return []
-        flags = ["--mcp-config"]
-        flags.extend(configs)
-        return flags
-
-    def build_plugin_args(self, plugin_dirs: Optional[List[str]] = None) -> List[str]:
-        if not plugin_dirs:
-            return []
-        flags: List[str] = []
-        for d in plugin_dirs:
-            flags.extend(["--plugin-dir", d])
-        return flags
 
     def build_command(
         self,
@@ -142,13 +106,11 @@ class OllamaLaunchProvider(CLIProvider):
         """Build: ollama launch claude --model X -- <claude-flags>.
 
         The ``--`` separator divides Ollama args from Claude Code args.
+        Everything after ``--`` uses the same flag builders as
+        :class:`ClaudeProvider` so feature parity is maintained
+        (permissions, system prompts, resume, output format, max turns,
+        MCP, plugins, effort).
         """
-        # Handle system prompt: prepend to user prompt (no dedicated flag).
-        # system_prompt_file is silently ignored — supports_system_prompt_file()
-        # returns False on this provider.
-        if system_prompt:
-            prompt = system_prompt + "\n\n" + prompt
-
         # Ollama part: binary + launch subcommand + model
         cmd = ["ollama", "launch", "claude"]
         effective_model = model or self._get_default_model()
@@ -158,9 +120,24 @@ class OllamaLaunchProvider(CLIProvider):
         # Separator between ollama args and Claude Code args
         cmd.append("--")
 
-        # Claude Code part: all flags passed through verbatim
+        # Claude Code part — same ordering as base CLIProvider.build_command()
+        if resume_session_id and self.supports_session_resume():
+            cmd.extend(self.build_resume_args(resume_session_id))
+        cmd.extend(self.build_permission_args(skip_permissions))
+
+        # System prompt: file mode takes precedence over inline content.
+        if system_prompt_file and self.supports_system_prompt_file():
+            cmd.extend(self.build_system_prompt_file_args(system_prompt_file))
+        elif system_prompt:
+            sys_args = self.build_system_prompt_args(system_prompt)
+            if sys_args:
+                cmd.extend(sys_args)
+            else:
+                prompt = system_prompt + "\n\n" + prompt
+
         cmd.extend(self.build_prompt_args(prompt))
         cmd.extend(self.build_tool_args(allowed_tools, disallowed_tools))
+        cmd.extend(self.build_model_args(model, fallback))
         cmd.extend(self.build_output_args(output_format))
         cmd.extend(self.build_max_turns_args(max_turns))
         cmd.extend(self.build_mcp_args(mcp_configs))

--- a/koan/tests/test_ollama_launch_provider.py
+++ b/koan/tests/test_ollama_launch_provider.py
@@ -156,10 +156,72 @@ class TestOllamaLaunchFlags:
         assert self.provider.build_plugin_args() == []
         assert self.provider.build_plugin_args([]) == []
 
+    def test_supports_system_prompt_file(self):
+        assert self.provider.supports_system_prompt_file() is True
 
-# ---------------------------------------------------------------------------
-# Full command building
-# ---------------------------------------------------------------------------
+    def test_build_system_prompt_args(self):
+        assert self.provider.build_system_prompt_args("sys") == [
+            "--append-system-prompt", "sys",
+        ]
+        assert self.provider.build_system_prompt_args("") == []
+
+    def test_build_system_prompt_file_args(self):
+        assert self.provider.build_system_prompt_file_args("/tmp/sp.txt") == [
+            "--append-system-prompt-file", "/tmp/sp.txt",
+        ]
+        assert self.provider.build_system_prompt_file_args("") == []
+
+    def test_supports_session_resume(self):
+        assert self.provider.supports_session_resume() is True
+
+    def test_build_resume_args(self):
+        assert self.provider.build_resume_args("sess-123") == [
+            "--resume", "sess-123",
+        ]
+        assert self.provider.build_resume_args("") == []
+
+    def test_supports_stream_json(self):
+        assert self.provider.supports_stream_json() is True
+
+    def test_build_permission_args(self):
+        assert self.provider.build_permission_args(True) == [
+            "--dangerously-skip-permissions",
+        ]
+        assert self.provider.build_permission_args(False) == []
+
+    def test_build_effort_args(self):
+        assert self.provider.build_effort_args("high") == ["--effort", "high"]
+        assert self.provider.build_effort_args("") == []
+        assert self.provider.build_effort_args("bogus") == []
+
+    def test_build_thinking_args(self):
+        assert self.provider.build_thinking_args(enabled=True) == [
+            "--effort", "max",
+        ]
+        assert self.provider.build_thinking_args(enabled=False) == []
+
+    def test_output_args_stream_json_includes_verbose(self):
+        """Claude CLI requires --verbose alongside stream-json in print mode."""
+        result = self.provider.build_output_args("stream-json")
+        assert result == ["--output-format", "stream-json", "--verbose"]
+
+    def test_detect_quota_exhaustion_delegates_to_claude(self):
+        """Quota patterns match the underlying Claude CLI output."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="rate limit exceeded", exit_code=1,
+        ) is True
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="ok", exit_code=0,
+        ) is False
+
+    def test_get_session_data_none_when_no_project(self):
+        """Session data depends on Claude CLI artifacts; missing project returns None."""
+        from unittest.mock import patch
+        with patch(
+            "app.provider.claude_session.collect_jsonl_tokens",
+            return_value=None,
+        ):
+            assert self.provider.get_session_data("/nonexistent") is None
 
 class TestOllamaLaunchBuildCommand:
     """Test complete command construction with -- separator."""
@@ -267,6 +329,57 @@ class TestOllamaLaunchBuildCommand:
             with patch("app.utils.load_config", return_value={}):
                 cmd = self.provider.build_command(prompt="hello")
         assert "--" in cmd
+
+    def test_build_command_with_skip_permissions(self):
+        cmd = self.provider.build_command(
+            prompt="hi", skip_permissions=True,
+        )
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--dangerously-skip-permissions" in after_sep
+
+    def test_build_command_with_system_prompt(self):
+        cmd = self.provider.build_command(
+            prompt="hi", system_prompt="Be helpful.",
+        )
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--append-system-prompt" in after_sep
+        assert "Be helpful." in after_sep
+        # User prompt should NOT have the system prompt prepended
+        prompt_idx = after_sep.index("-p") + 1
+        assert after_sep[prompt_idx] == "hi"
+
+    def test_build_command_with_system_prompt_file(self):
+        cmd = self.provider.build_command(
+            prompt="hi",
+            system_prompt="should not appear",
+            system_prompt_file="/tmp/sp.txt",
+        )
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--append-system-prompt-file" in after_sep
+        assert "/tmp/sp.txt" in after_sep
+        assert "should not appear" not in after_sep
+        assert "--append-system-prompt" not in after_sep
+
+    def test_build_command_with_resume(self):
+        cmd = self.provider.build_command(
+            prompt="hi", resume_session_id="sess-abc",
+        )
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--resume" in after_sep
+        assert "sess-abc" in after_sep
+
+    def test_build_command_with_effort(self):
+        cmd = self.provider.build_command(
+            prompt="hi", effort="high",
+        )
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--effort" in after_sep
+        assert "high" in after_sep
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -618,6 +618,62 @@ class TestOllamaLaunchProvider:
         model_idx = cmd.index("--model")
         assert cmd[model_idx + 1] == "override-model"
 
+    def test_build_command_with_permissions(self):
+        p = OllamaLaunchProvider()
+        cmd = p.build_command(prompt="hi", skip_permissions=True)
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--dangerously-skip-permissions" in after_sep
+
+    def test_build_command_with_system_prompt(self):
+        p = OllamaLaunchProvider()
+        cmd = p.build_command(prompt="hi", system_prompt="Be helpful.")
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--append-system-prompt" in after_sep
+        assert "Be helpful." in after_sep
+
+    def test_build_command_with_resume(self):
+        p = OllamaLaunchProvider()
+        cmd = p.build_command(prompt="hi", resume_session_id="sess-123")
+        sep_idx = cmd.index("--")
+        after_sep = cmd[sep_idx + 1:]
+        assert "--resume" in after_sep
+        assert "sess-123" in after_sep
+
+    def test_supports_stream_json(self):
+        assert OllamaLaunchProvider().supports_stream_json() is True
+
+    def test_supports_system_prompt_file(self):
+        assert OllamaLaunchProvider().supports_system_prompt_file() is True
+
+    def test_supports_session_resume(self):
+        assert OllamaLaunchProvider().supports_session_resume() is True
+
+    def test_output_args_stream_json(self):
+        p = OllamaLaunchProvider()
+        args = p.build_output_args("stream-json")
+        assert args == ["--output-format", "stream-json", "--verbose"]
+
+    def test_build_effort_args(self):
+        p = OllamaLaunchProvider()
+        assert p.build_effort_args("high") == ["--effort", "high"]
+        assert p.build_effort_args("") == []
+
+    def test_build_thinking_args(self):
+        p = OllamaLaunchProvider()
+        assert p.build_thinking_args(enabled=True) == ["--effort", "max"]
+        assert p.build_thinking_args(enabled=False) == []
+
+    def test_detect_quota_exhaustion(self):
+        p = OllamaLaunchProvider()
+        assert p.detect_quota_exhaustion(
+            stdout_text="", stderr_text="rate limit exceeded", exit_code=1,
+        ) is True
+        assert p.detect_quota_exhaustion(
+            stdout_text="", stderr_text="ok", exit_code=0,
+        ) is False
+
     def test_check_quota_always_available(self):
         p = OllamaLaunchProvider()
         available, detail = p.check_quota_available("/tmp")

--- a/koan/tests/test_provider_system_prompt_file.py
+++ b/koan/tests/test_provider_system_prompt_file.py
@@ -13,6 +13,7 @@ from app.provider import (
     ClaudeProvider,
     CodexProvider,
     LocalLLMProvider,
+    OllamaLaunchProvider,
     build_full_command,
     build_full_command_managed,
     cleanup_managed_paths,
@@ -30,6 +31,24 @@ class TestProviderCapabilityFlag:
 
     def test_local_does_not_support_file_mode(self):
         assert LocalLLMProvider().supports_system_prompt_file() is False
+
+    def test_ollama_launch_supports_file_mode(self):
+        assert OllamaLaunchProvider().supports_system_prompt_file() is True
+
+
+class TestOllamaLaunchFileModeArgs:
+    """OllamaLaunchProvider inherits file-mode support from ClaudeProvider."""
+
+    def test_file_flag_with_path(self):
+        p = OllamaLaunchProvider()
+        assert p.build_system_prompt_file_args("/tmp/x.txt") == [
+            "--append-system-prompt-file",
+            "/tmp/x.txt",
+        ]
+
+    def test_file_flag_empty_path_yields_empty(self):
+        p = OllamaLaunchProvider()
+        assert p.build_system_prompt_file_args("") == []
 
 
 class TestClaudeFileModeArgs:


### PR DESCRIPTION
OllamaLaunchProvider previously inherited from CLIProvider and
manually reimplemented a subset of Claude CLI flags. This meant
several features were silently broken:

- skip_permissions from config.yaml was ignored
- system_prompt only got prepended to the user prompt (no
  --append-system-prompt or --append-system-prompt-file)
- resume_session_id was ignored (no --resume)
- stream-json was not supported, so streaming fell back to raw
  text with no real-time progress (watchdog hang risk)
- effort and thinking controls were no-ops
- Quota/auth detection always returned False

Now OllamaLaunchProvider inherits from ClaudeProvider, reusing all
Claude-specific flag builders. build_command() only overrides the
Ollama-specific parts (binary, shell_command, model before --).
Everything after -- is built exactly like a native Claude CLI
command.

Adds 20+ tests covering inherited capabilities. All 114 ollama
tests and 336 broader provider tests pass.
