### PR TITLE
feat(tui): add run loop and API status to dashboard

### DIFF
--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -647,6 +647,26 @@ class KoanDashboard(App):
             self.log(f"bridge status failed: {exc}")
         return bridge, configured
 
+    def _run_status(self) -> bool:
+        """Return whether the agent run loop is alive."""
+        try:
+            from app.pid_manager import check_pidfile
+
+            return check_pidfile(self.koan_root, "run") is not None
+        except Exception as exc:
+            self.log(f"run status failed: {exc}")
+            return False
+
+    def _api_status(self) -> bool:
+        """Return whether the REST API server is alive."""
+        try:
+            from app.pid_manager import check_pidfile
+
+            return check_pidfile(self.koan_root, "api") is not None
+        except Exception as exc:
+            self.log(f"api status failed: {exc}")
+            return False
+
     def _render_status(self) -> None:
         try:
             body = self.query_one("#status-body", Static)
@@ -679,6 +699,8 @@ class KoanDashboard(App):
         web_hint = "localhost:5001" if web_on else "start + open browser"
         awake_on = self._keepawake_on()
         awake_hint = self._keepawake_label if awake_on else "off"
+        run_on = self._run_status()
+        api_on = self._api_status()
         if bridge and tg_configured:
             tg = f"{self._dot(True)}  [dim]bridge live[/]"
         elif tg_configured:
@@ -699,6 +721,8 @@ class KoanDashboard(App):
             f"  telegram     {tg}",
             f"  web board    {self._dot(web_on)}  [dim](w · {web_hint})[/]",
             f"  keep awake   {self._dot(awake_on)}  [dim](k · {awake_hint})[/]",
+            f"  run loop     {self._dot(run_on)}  [dim]{'running' if run_on else 'stopped'}[/]",
+            f"  api          {self._dot(api_on)}  [dim]{'live' if api_on else 'off'}[/]",
         ]
         # Usage bars reuse the same renderer as the Usage tab.
         try:

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -374,3 +374,51 @@ def test_pilot_status_shows_mission_titles_and_telegram(tmp_path, monkeypatch):
             assert "telegram" in text
 
     asyncio.run(scenario())
+
+
+def test_run_status_reads_pidfile(tmp_path, monkeypatch):
+    app = tui.KoanDashboard(tmp_path)
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile", lambda root, name: 123 if name == "run" else None
+    )
+    assert app._run_status() is True
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile", lambda root, name: None
+    )
+    assert app._run_status() is False
+
+
+def test_api_status_reads_pidfile(tmp_path, monkeypatch):
+    app = tui.KoanDashboard(tmp_path)
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile", lambda root, name: 456 if name == "api" else None
+    )
+    assert app._api_status() is True
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile", lambda root, name: None
+    )
+    assert app._api_status() is False
+
+
+def test_pilot_status_shows_run_and_api(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile",
+        lambda root, name: 111 if name in ("run", "api") else None,
+    )
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.refresh_dynamic()
+            await pilot.pause()
+            body = app.query_one("#status-body", tui.Static)
+            rendered = body.render()
+            text = getattr(rendered, "plain", str(rendered))
+            assert "run loop" in text
+            assert "api" in text
+            assert "running" in text  # run loop is up
+            assert "live" in text     # api is up
+
+    asyncio.run(scenario())


### PR DESCRIPTION
**What**: Adds run-loop and API process live/dead indicators to the TUI dashboard Status tab.

**Why**: The Status tab already shows web board, keep-awake, and telegram health, but the two core background processes (agent run loop and REST API server) were invisible. Operators had to check `make status` separately.

**How**: Two small `_run_status()` / `_api_status()` helpers use the existing `check_pidfile` infrastructure (same pattern as web board and telegram). Rendered as mint/dim dots with "running/stopped" and "live/off" labels.

**Testing**: Three new tests cover both helpers and a full pilot render assertion. All 23 TUI tests pass; ruff clean.

---
### Quality Report

**Changes**: 2 files changed, 72 insertions(+)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_