### PR TITLE
feat(list): emoji headers + code block for in-progress

### DIFF
--- a/koan/skills/core/list/handler.py
+++ b/koan/skills/core/list/handler.py
@@ -191,20 +191,22 @@ def handle(ctx):
     now = datetime.now()
 
     if in_progress:
-        parts.append("IN PROGRESS")
-        for i, m in enumerate(in_progress, 1):
+        parts.append("🔄 In Progress")
+        parts.append("```")
+        for m in in_progress:
             prefix = mission_prefix(m)
             display = _humanize_timestamps(clean_mission_display(m), now)
             origin = _detect_origin_marker(m)
             display = _strip_origin_markers(display)
             if prefix:
-                parts.append(f"  {i}. {origin}{prefix} {display}")
+                parts.append(f"{origin}{prefix} {display}")
             else:
-                parts.append(f"  {i}. {origin}{display}")
+                parts.append(f"{origin}{display}")
+        parts.append("```")
         parts.append("")
 
     if pending:
-        parts.append("PENDING")
+        parts.append("⏳ Pending")
         for i, m in enumerate(pending, 1):
             prefix = mission_prefix(m)
             display = _humanize_timestamps(clean_mission_display(m), now)

--- a/koan/tests/test_list_skill.py
+++ b/koan/tests/test_list_skill.py
@@ -186,11 +186,11 @@ class TestListHandler:
         """)
         ctx = self._make_ctx(tmp_path, missions)
         result = handle(ctx)
-        assert "PENDING" in result
+        assert "⏳ Pending" in result
         assert "\U0001f4cb fix the login bug" in result
         assert "\U0001f4cb add dark mode" in result
         assert "\U0001f4cb refactor auth module" in result
-        assert "IN PROGRESS" not in result
+        assert "🔄 In Progress" not in result
 
     def test_in_progress_missions(self, tmp_path):
         from skills.core.list.handler import handle
@@ -208,9 +208,9 @@ class TestListHandler:
         """)
         ctx = self._make_ctx(tmp_path, missions)
         result = handle(ctx)
-        assert "IN PROGRESS" in result
+        assert "🔄 In Progress" in result
         assert "\U0001f4cb implement new feature" in result
-        assert "PENDING" not in result
+        assert "⏳ Pending" not in result
 
     def test_both_sections(self, tmp_path):
         from skills.core.list.handler import handle
@@ -233,13 +233,13 @@ class TestListHandler:
         """)
         ctx = self._make_ctx(tmp_path, missions)
         result = handle(ctx)
-        assert "IN PROGRESS" in result
+        assert "🔄 In Progress" in result
         assert "\U0001f4cb working on feature X" in result
-        assert "PENDING" in result
+        assert "⏳ Pending" in result
         assert "\U0001f4cb fix bug A" in result
         assert "\U0001f4cb fix bug B" in result
-        # IN PROGRESS should appear before PENDING
-        assert result.index("IN PROGRESS") < result.index("PENDING")
+        # In Progress should appear before Pending
+        assert result.index("🔄 In Progress") < result.index("⏳ Pending")
 
     def test_project_tags_displayed(self, tmp_path):
         from skills.core.list.handler import handle
@@ -292,8 +292,8 @@ class TestListHandler:
         """)
         ctx = self._make_ctx(tmp_path, missions)
         result = handle(ctx)
-        assert "IN PROGRESS" in result
-        assert "PENDING" in result
+        assert "🔄 In Progress" in result
+        assert "⏳ Pending" in result
 
     def test_plan_mission_gets_brain_prefix(self, tmp_path):
         from skills.core.list.handler import handle
@@ -604,7 +604,7 @@ class TestListCommandRouting:
             handle_command("/list")
         mock_send.assert_called_once()
         output = mock_send.call_args[0][0]
-        assert "PENDING" in output
+        assert "⏳ Pending" in output
         assert "test mission" in output
 
     @patch("app.command_handlers.send_telegram")


### PR DESCRIPTION
## What

Update `/list` output with friendlier section headers, code block formatting for in-progress missions, and remove the numeric prefix from active missions.

## Why

Better visual hierarchy: in-progress work is the most urgent, so it gets highlighted with a code block and no numbering clutter. Pending missions keep their numbered list for queue clarity.

## How

- `IN PROGRESS` → `🔄 In Progress`
- `PENDING` → `⏳ Pending`
- In-progress missions wrapped in triple-backtick code block
- Removed `1.`, `2.` prefix from in-progress entries (kept for pending)
- Updated tests to match new labels

## Testing

- `test_list_skill.py` passes (all 46 assertions)
- Full suite passes
- `make lint` clean

---
### Quality Report

**Changes**: 2 files changed, 18 insertions(+), 16 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_