### PR TITLE
feat(tui): surface active work in quit confirmation

### DIFF
--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -655,10 +655,18 @@ class KoanDashboard(App):
                 self._detached = False
                 self.exit()
 
-        self.push_screen(ConfirmScreen(
-            "Stop Kōan?",
-            "This stops the agent + bridge. Use d to detach and keep it running."),
-            _confirmed)
+        parts = ["This stops the agent + bridge. Use d to detach and keep it running."]
+        active = self._active_processes()
+        if active:
+            parts.append(f"\nActive processes: {', '.join(active)}")
+        titles = self._in_progress_missions()
+        if titles:
+            parts.append(f"\nIn progress ({len(titles)}):")
+            parts.extend(f"  · {t}" for t in titles[:5])
+            if len(titles) > 5:
+                parts.append(f"  … +{len(titles) - 5} more")
+
+        self.push_screen(ConfirmScreen("Stop Kōan?", "\n".join(parts)), _confirmed)
 
     def action_new_mission(self) -> None:
         """Queue a new mission into missions.md from a modal input."""
@@ -811,6 +819,20 @@ class KoanDashboard(App):
         except Exception as exc:
             self.log(f"api status failed: {exc}")
             return False
+
+    def _active_processes(self) -> list:
+        """Return names of active Kōan processes (excluding the dashboard itself)."""
+        try:
+            from app.pid_manager import PROCESS_NAMES, check_pidfile
+
+            return [
+                name
+                for name in PROCESS_NAMES
+                if name != "dashboard" and check_pidfile(self.koan_root, name) is not None
+            ]
+        except Exception as exc:
+            self.log(f"process list failed: {exc}")
+            return []
 
     def _render_status(self) -> None:
         try:

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -733,3 +733,115 @@ def test_pilot_usage_hides_duration_when_none(tmp_path, monkeypatch):
             assert "Duration" not in text
 
     asyncio.run(scenario())
+
+
+# --- quit confirmation --------------------------------------------------------
+
+def test_active_processes_excludes_dashboard(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile",
+        lambda root, name: 123 if name in ("run", "awake", "api") else None,
+    )
+    app = tui.KoanDashboard(tmp_path)
+    assert app._active_processes() == ["run", "awake", "api"]
+
+
+def test_quit_confirmation_default_when_nothing_active(tmp_path, monkeypatch):
+    monkeypatch.setattr("app.pid_manager.check_pidfile", lambda root, name: None)
+    app = tui.KoanDashboard(tmp_path)
+    captured = {}
+
+    def _capture(screen, callback=None):
+        captured["screen"] = screen
+
+    app.push_screen = _capture
+    app.action_request_quit()
+    assert "agent + bridge" in captured["screen"]._message
+    assert "Active processes" not in captured["screen"]._message
+    assert "In progress" not in captured["screen"]._message
+
+
+def test_quit_confirmation_shows_active_processes(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile",
+        lambda root, name: 123 if name == "run" else None,
+    )
+    app = tui.KoanDashboard(tmp_path)
+    captured = {}
+
+    def _capture(screen, callback=None):
+        captured["screen"] = screen
+
+    app.push_screen = _capture
+    app.action_request_quit()
+    assert "Active processes: run" in captured["screen"]._message
+
+
+def test_quit_confirmation_shows_in_progress_missions(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    inst = tmp_path / "instance"
+    (inst / "missions.md").write_text(
+        "# Missions\n\n## Pending\n\n## In Progress\n\n"
+        "- mission alpha\n- mission beta\n\n## Done\n"
+    )
+    monkeypatch.setattr("app.pid_manager.check_pidfile", lambda root, name: None)
+    app = tui.KoanDashboard(tmp_path)
+    captured = {}
+
+    def _capture(screen, callback=None):
+        captured["screen"] = screen
+
+    app.push_screen = _capture
+    app.action_request_quit()
+    msg = captured["screen"]._message
+    assert "In progress (2):" in msg
+    assert "mission alpha" in msg
+    assert "mission beta" in msg
+
+
+def test_quit_confirmation_caps_missions_at_five(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    inst = tmp_path / "instance"
+    missions = "\n".join(f"- mission {i}" for i in range(7))
+    (inst / "missions.md").write_text(
+        f"# Missions\n\n## Pending\n\n## In Progress\n\n{missions}\n\n## Done\n"
+    )
+    monkeypatch.setattr("app.pid_manager.check_pidfile", lambda root, name: None)
+    app = tui.KoanDashboard(tmp_path)
+    captured = {}
+
+    def _capture(screen, callback=None):
+        captured["screen"] = screen
+
+    app.push_screen = _capture
+    app.action_request_quit()
+    msg = captured["screen"]._message
+    assert "In progress (7):" in msg
+    assert "… +2 more" in msg
+    # Only first 5 listed explicitly.
+    assert msg.count("mission ") == 5
+
+
+def test_quit_confirmation_shows_both_processes_and_missions(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    inst = tmp_path / "instance"
+    (inst / "missions.md").write_text(
+        "# Missions\n\n## Pending\n\n## In Progress\n\n"
+        "- mission one\n\n## Done\n"
+    )
+    monkeypatch.setattr(
+        "app.pid_manager.check_pidfile",
+        lambda root, name: 123 if name in ("run", "awake") else None,
+    )
+    app = tui.KoanDashboard(tmp_path)
+    captured = {}
+
+    def _capture(screen, callback=None):
+        captured["screen"] = screen
+
+    app.push_screen = _capture
+    app.action_request_quit()
+    msg = captured["screen"]._message
+    assert "Active processes: run, awake" in msg
+    assert "In progress (1):" in msg
+    assert "mission one" in msg


### PR DESCRIPTION
**What**: The TUI quit-confirmation modal now shows live context — active processes and in-progress missions — before the user stops Kōan.

**Why**: Pressing q blindly tears down the stack. Knowing there are running missions or live processes (run, awake, api, ollama) helps the operator decide whether to detach (d) instead.

**How**:
- `_active_processes()` queries `check_pidfile` for all `PROCESS_NAMES` except dashboard.
- `action_request_quit` assembles a dynamic message: base hint + optional process list + optional mission list (capped at 5 with +N more).
- 6 new tests cover empty state, processes-only, missions-only, combined, and cap behavior.

**Testing**: All 30 TUI tests pass; full suite green; ruff clean.

---
### Quality Report

**Changes**: 2 files changed, 138 insertions(+), 4 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_