### PR TITLE
fix(quota): provider-aware budget gating and per-provider usage tracking

### DIFF
--- a/koan/app/provider/base.py
+++ b/koan/app/provider/base.py
@@ -332,6 +332,14 @@ class CLIProvider:
         """
         return True, ""
 
+    def has_api_quota(self) -> bool:
+        """Return True when this provider consumes metered API quota.
+
+        When False the usage tracker disables budget gating because
+        local/self-hosted providers have no API-enforced token limit.
+        """
+        return True
+
     def detect_quota_exhaustion(
         self,
         stdout_text: str = "",

--- a/koan/app/provider/local.py
+++ b/koan/app/provider/local.py
@@ -110,3 +110,7 @@ class LocalLLMProvider(CLIProvider):
         if api_key:
             cmd.extend(["--api-key", api_key])
         return cmd
+
+    def has_api_quota(self) -> bool:
+        """Local LLM runs on self-hosted infrastructure — no metered API quota."""
+        return False

--- a/koan/app/provider/ollama_launch.py
+++ b/koan/app/provider/ollama_launch.py
@@ -152,3 +152,7 @@ class OllamaLaunchProvider(ClaudeProvider):
     def check_quota_available(self, project_path: str, timeout: int = 15) -> Tuple[bool, str]:
         """Local models have no API quota — always available."""
         return True, ""
+
+    def has_api_quota(self) -> bool:
+        """Ollama launch uses local or cloud Ollama — no metered API quota."""
+        return False

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -83,6 +83,26 @@ def _load_config(koan_root: Path) -> dict:
         return {}
 
 
+def _provider_name() -> str:
+    """Return the configured CLI provider name, or 'unknown'."""
+    try:
+        from app.cli_provider import get_provider_name
+        return get_provider_name()
+    except Exception as exc:
+        _log.debug("provider_name failed: %s", exc)
+        return "unknown"
+
+
+def _provider_has_api_quota() -> bool:
+    """Return True when the active provider consumes metered API quota."""
+    try:
+        from app.cli_provider import get_provider
+        return get_provider().has_api_quota()
+    except Exception as exc:
+        _log.debug("provider_has_api_quota failed: %s", exc)
+        return True
+
+
 def _coerce(raw: str):
     """Parse a user-entered string into the closest native YAML scalar."""
     try:
@@ -873,10 +893,15 @@ class KoanDashboard(App):
         try:
             from app.usage_tracker import UsageTracker
 
-            t = UsageTracker(self.koan_root / "instance" / "usage.md")
+            usage_md = self.koan_root / "instance" / "usage.md"
+            t = UsageTracker(usage_md)
             lines.append("")
-            lines.append("  " + self._bar("session", t.session_pct, t.session_reset))
-            lines.append("  " + self._bar("weekly", t.weekly_pct, t.weekly_reset))
+            if _provider_has_api_quota():
+                lines.append("  " + self._bar("session", t.session_pct, t.session_reset))
+                lines.append("  " + self._bar("weekly", t.weekly_pct, t.weekly_reset))
+            else:
+                lines.append("  [dim]session    no API quota (provider: " + _provider_name() + ")[/]")
+                lines.append("  [dim]weekly     no API quota[/]")
         except Exception as exc:
             self.log(f"status usage failed: {exc}")
 
@@ -985,23 +1010,29 @@ class KoanDashboard(App):
             from app.usage_tracker import UsageTracker
 
             t = UsageTracker(usage_md)
-            lines.append(self._bar("Session", t.session_pct, t.session_reset))
-            lines.append(self._bar("Weekly", t.weekly_pct, t.weekly_reset))
-            lines.append("")
-            has_data = True
-            try:
-                mode = t.decide_mode()
-                lines.append(f"Mode      [{_MINT}]{mode}[/]")
-            except Exception as exc:
-                self.log(f"mode decision unavailable: {exc}")
-            try:
-                from app.burn_rate import burn_rate_pct_per_minute
+            if _provider_has_api_quota():
+                lines.append(self._bar("Session", t.session_pct, t.session_reset))
+                lines.append(self._bar("Weekly", t.weekly_pct, t.weekly_reset))
+                lines.append("")
+                has_data = True
+                try:
+                    mode = t.decide_mode()
+                    lines.append(f"Mode      [{_MINT}]{mode}[/]")
+                except Exception as exc:
+                    self.log(f"mode decision unavailable: {exc}")
+                try:
+                    from app.burn_rate import burn_rate_pct_per_minute
 
-                burn = burn_rate_pct_per_minute(usage_md.parent)
-                if burn is not None:
-                    lines.append(f"Burn      [{_MINT}]{burn:.2f}%/min[/]")
-            except Exception as exc:
-                self.log(f"burn rate unavailable: {exc}")
+                    burn = burn_rate_pct_per_minute(usage_md.parent)
+                    if burn is not None:
+                        lines.append(f"Burn      [{_MINT}]{burn:.2f}%/min[/]")
+                except Exception as exc:
+                    self.log(f"burn rate unavailable: {exc}")
+            else:
+                lines.append("[dim]Session    no API quota[/]")
+                lines.append("[dim]Weekly     no API quota[/]")
+                lines.append("")
+                lines.append(f"Mode      [{_MINT}]deep[/]  [dim](budget disabled for {_provider_name()})[/]")
         except Exception as exc:
             lines.append(f"[dim](usage unavailable: {exc})[/dim]")
         if not (usage_md.exists()):

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -1036,6 +1036,7 @@ class KoanDashboard(App):
                     mode = t.decide_mode()
                     lines.append(f"Mode      [{_MINT}]{mode}[/]  [dim](budget disabled for {_provider_name()})[/]")
                 except Exception as exc:
+                    self.log(f"mode decision unavailable: {exc}")
                     lines.append(f"Mode      [{_MINT}]deep[/]  [dim](budget disabled for {_provider_name()})[/]")
         except Exception as exc:
             lines.append(f"[dim](usage unavailable: {exc})[/dim]")

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -99,7 +99,7 @@ def _provider_has_api_quota() -> bool:
         from app.cli_provider import get_provider
         return get_provider().has_api_quota()
     except Exception as exc:
-        _log.debug("provider_has_api_quota failed: %s", exc)
+        _log.warning("provider_has_api_quota failed: %s", exc)
         return True
 
 
@@ -1032,7 +1032,11 @@ class KoanDashboard(App):
                 lines.append("[dim]Session    no API quota[/]")
                 lines.append("[dim]Weekly     no API quota[/]")
                 lines.append("")
-                lines.append(f"Mode      [{_MINT}]deep[/]  [dim](budget disabled for {_provider_name()})[/]")
+                try:
+                    mode = t.decide_mode()
+                    lines.append(f"Mode      [{_MINT}]{mode}[/]  [dim](budget disabled for {_provider_name()})[/]")
+                except Exception as exc:
+                    lines.append(f"Mode      [{_MINT}]deep[/]  [dim](budget disabled for {_provider_name()})[/]")
         except Exception as exc:
             lines.append(f"[dim](usage unavailable: {exc})[/dim]")
         if not (usage_md.exists()):

--- a/koan/app/usage_estimator.py
+++ b/koan/app/usage_estimator.py
@@ -40,9 +40,10 @@ def _load_state(state_file: Path) -> dict:
     return _fresh_state()
 
 
-def _fresh_state() -> dict:
+def _fresh_state(provider: str = "") -> dict:
     now = datetime.now().isoformat()
     return {
+        "provider": provider,
         "session_start": now,
         "session_tokens": 0,
         "weekly_start": now,
@@ -194,6 +195,32 @@ def _get_today_cache_line(instance_dir: Path) -> str:
         return ""
 
 
+def _current_provider(config: dict) -> str:
+    """Return the configured CLI provider name (default 'claude')."""
+    return config.get("cli_provider", "claude")
+
+
+def _maybe_reset_provider(state: dict, current_provider: str) -> dict:
+    """Reset counters when the CLI provider has changed.
+
+    Local providers (ollama-launch, local) do not share API quota with
+    metered providers (claude, copilot, codex), so stale usage from a
+    previous provider must not gate the current one.
+    """
+    stored = state.get("provider", "")
+    if stored and stored != current_provider:
+        now = datetime.now().isoformat()
+        state["provider"] = current_provider
+        state["session_start"] = now
+        state["session_tokens"] = 0
+        state["weekly_start"] = now
+        state["weekly_tokens"] = 0
+        state["runs"] = 0
+    elif not stored:
+        state["provider"] = current_provider
+    return state
+
+
 def cmd_update(claude_json_path: Path, state_file: Path,
                usage_md: Path) -> Optional[float]:
     """Update state with tokens from a Claude run, then refresh usage.md.
@@ -203,8 +230,10 @@ def cmd_update(claude_json_path: Path, state_file: Path,
         (0-100), or ``None`` when no usable token count was extracted.
     """
     config = load_config()
+    current_provider = _current_provider(config)
     state = _load_state(state_file)
     state = _maybe_reset(state)
+    state = _maybe_reset_provider(state, current_provider)
 
     tokens = _extract_tokens(claude_json_path)
     cost_pct: Optional[float] = None
@@ -224,8 +253,10 @@ def cmd_update(claude_json_path: Path, state_file: Path,
 def cmd_refresh(state_file: Path, usage_md: Path):
     """Refresh usage.md from current state (handles resets)."""
     config = load_config()
+    current_provider = _current_provider(config)
     state = _load_state(state_file)
     state = _maybe_reset(state)
+    state = _maybe_reset_provider(state, current_provider)
     _save_state(state_file, state)
     _write_usage_md(state, usage_md, config)
 
@@ -238,7 +269,9 @@ def cmd_reset_session(state_file: Path, usage_md: Path):
     not block the next iteration with a stale high percentage.
     """
     config = load_config()
+    current_provider = _current_provider(config)
     state = _load_state(state_file)
+    state = _maybe_reset_provider(state, current_provider)
 
     # Force session reset regardless of elapsed time
     state["session_start"] = datetime.now().isoformat()

--- a/koan/app/usage_tracker.py
+++ b/koan/app/usage_tracker.py
@@ -288,7 +288,7 @@ def _get_budget_mode() -> str:
                     if not get_provider().has_api_quota():
                         return "disabled"
                 except Exception as exc:
-                    logger.debug("Provider quota check failed: %s", exc)
+                    logger.warning("Provider quota check failed: %s", exc)
             return mode
     except (ImportError, OSError, ValueError):
         pass

--- a/koan/app/usage_tracker.py
+++ b/koan/app/usage_tracker.py
@@ -273,12 +273,22 @@ def _get_budget_mode() -> str:
     """Read budget_mode from config.yaml → usage.budget_mode.
 
     Valid values: "full" (default), "session_only", "disabled".
+    Automatically returns "disabled" for providers that have no metered
+    API quota (ollama-launch, local) so stale usage.md never gates them.
     """
     try:
         from app.utils import load_config
         config = load_config()
         mode = config.get("usage", {}).get("budget_mode", "session_only")
         if mode in ("full", "session_only", "disabled"):
+            # Override to disabled for no-quota providers
+            if mode != "disabled":
+                try:
+                    from app.cli_provider import get_provider
+                    if not get_provider().has_api_quota():
+                        return "disabled"
+                except Exception as exc:
+                    logger.debug("Provider quota check failed: %s", exc)
             return mode
     except (ImportError, OSError, ValueError):
         pass

--- a/koan/tests/test_ollama_launch_provider.py
+++ b/koan/tests/test_ollama_launch_provider.py
@@ -43,6 +43,10 @@ class TestOllamaLaunchBasics:
         assert available is True
         assert detail == ""
 
+    def test_has_api_quota_false(self):
+        """OllamaLaunchProvider has no metered API quota."""
+        assert self.provider.has_api_quota() is False
+
 
 # ---------------------------------------------------------------------------
 # Configuration resolution

--- a/koan/tests/test_provider_base.py
+++ b/koan/tests/test_provider_base.py
@@ -122,6 +122,10 @@ class TestDefaults:
         assert available is True
         assert detail == ""
 
+    def test_has_api_quota_true_by_default(self):
+        """Base provider assumes metered API quota."""
+        assert self.base.has_api_quota() is True
+
     def test_shell_command_delegates_to_binary(self):
         """shell_command() calls binary() — which raises on the bare base class."""
         with pytest.raises(NotImplementedError):

--- a/koan/tests/test_provider_quota.py
+++ b/koan/tests/test_provider_quota.py
@@ -72,6 +72,10 @@ class TestClaudeProviderQuota:
         assert ok is True
         assert detail == ""
 
+    def test_has_api_quota_true(self):
+        """ClaudeProvider uses metered Anthropic API."""
+        assert self.provider.has_api_quota() is True
+
     def test_combines_stderr_and_stdout(self):
         """No subprocess — nothing to combine."""
         ok, detail = self.provider.check_quota_available("/tmp")
@@ -113,6 +117,20 @@ class TestLocalProviderQuota:
         ok, detail = provider.check_quota_available("/tmp")
         assert ok is True
         assert detail == ""
+
+    def test_local_has_api_quota_false(self):
+        """LocalLLMProvider runs on self-hosted infra — no metered quota."""
+        provider = LocalLLMProvider()
+        assert provider.has_api_quota() is False
+
+
+class TestOllamaLaunchProviderQuota:
+    """OllamaLaunchProvider has no metered API quota."""
+
+    def test_ollama_launch_has_api_quota_false(self):
+        from app.provider.ollama_launch import OllamaLaunchProvider
+        provider = OllamaLaunchProvider()
+        assert provider.has_api_quota() is False
 
 
 class TestCopilotProviderQuota:

--- a/koan/tests/test_usage_estimator.py
+++ b/koan/tests/test_usage_estimator.py
@@ -317,6 +317,57 @@ class TestCmdUpdate:
         state = json.loads(state_file.read_text())
         assert state["session_tokens"] == 0
 
+    @patch("app.usage_estimator.load_config", return_value={
+        "cli_provider": "ollama-launch",
+        "usage": {"session_token_limit": 500000, "weekly_token_limit": 5000000}
+    })
+    def test_resets_counters_on_provider_change(self, mock_config, claude_json, state_file, usage_md):
+        # Seed state with tokens from a previous provider
+        old_state = {
+            "provider": "claude",
+            "session_start": datetime.now().isoformat(),
+            "session_tokens": 500000,
+            "weekly_start": datetime.now().isoformat(),
+            "weekly_tokens": 5000000,
+            "runs": 100,
+        }
+        state_file.write_text(json.dumps(old_state))
+
+        # Run cmd_update with ollama-launch provider
+        cmd_update(claude_json, state_file, usage_md)
+
+        # State should be reset because provider changed
+        state = json.loads(state_file.read_text())
+        assert state["provider"] == "ollama-launch"
+        assert state["session_tokens"] == 2000  # tokens from claude_json
+        assert state["weekly_tokens"] == 2000
+        assert state["runs"] == 1
+
+    @patch("app.usage_estimator.load_config", return_value={
+        "cli_provider": "claude",
+        "usage": {"session_token_limit": 500000, "weekly_token_limit": 5000000}
+    })
+    def test_preserves_counters_when_provider_unchanged(self, mock_config, claude_json, state_file, usage_md):
+        # Seed state with tokens from the same provider
+        old_state = {
+            "provider": "claude",
+            "session_start": datetime.now().isoformat(),
+            "session_tokens": 10000,
+            "weekly_start": datetime.now().isoformat(),
+            "weekly_tokens": 50000,
+            "runs": 5,
+        }
+        state_file.write_text(json.dumps(old_state))
+
+        cmd_update(claude_json, state_file, usage_md)
+
+        # State should accumulate because provider is unchanged
+        state = json.loads(state_file.read_text())
+        assert state["provider"] == "claude"
+        assert state["session_tokens"] == 12000
+        assert state["weekly_tokens"] == 52000
+        assert state["runs"] == 6
+
 
 class TestCmdRefresh:
     @patch("app.usage_estimator.load_config", return_value={

--- a/koan/tests/test_usage_tracker.py
+++ b/koan/tests/test_usage_tracker.py
@@ -5,7 +5,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from app import burn_rate
 from app.usage_tracker import UsageTracker, _get_budget_mode, MALFORMED_DEFAULT_PCT
 
@@ -573,3 +573,43 @@ class TestGetBudgetMode:
         """Config load failure falls back to session_only."""
         with patch("app.utils.load_config", side_effect=OSError("nope")):
             assert _get_budget_mode() == "session_only"
+
+    def test_no_quota_provider_returns_disabled(self):
+        """When provider has no API quota, budget_mode is forced to disabled."""
+        with patch("app.utils.load_config", return_value={
+            "usage": {"budget_mode": "full"}
+        }):
+            with patch("app.cli_provider.get_provider") as mock_get_provider:
+                mock_provider = MagicMock()
+                mock_provider.has_api_quota.return_value = False
+                mock_get_provider.return_value = mock_provider
+                assert _get_budget_mode() == "disabled"
+
+    def test_quota_provider_respects_config(self):
+        """When provider has API quota, config budget_mode is respected."""
+        with patch("app.utils.load_config", return_value={
+            "usage": {"budget_mode": "full"}
+        }):
+            with patch("app.cli_provider.get_provider") as mock_get_provider:
+                mock_provider = MagicMock()
+                mock_provider.has_api_quota.return_value = True
+                mock_get_provider.return_value = mock_provider
+                assert _get_budget_mode() == "full"
+
+    def test_disabled_in_config_skips_provider_check(self):
+        """When config explicitly disables, provider check is skipped."""
+        with patch("app.utils.load_config", return_value={
+            "usage": {"budget_mode": "disabled"}
+        }):
+            # get_provider should not be called when mode is already disabled
+            with patch("app.cli_provider.get_provider") as mock_get_provider:
+                assert _get_budget_mode() == "disabled"
+                mock_get_provider.assert_not_called()
+
+    def test_provider_check_failure_uses_config(self):
+        """When provider check fails, falls back to config value."""
+        with patch("app.utils.load_config", return_value={
+            "usage": {"budget_mode": "session_only"}
+        }):
+            with patch("app.cli_provider.get_provider", side_effect=ImportError("nope")):
+                assert _get_budget_mode() == "session_only"


### PR DESCRIPTION
## Problem

When using ollama-launch provider, Kōan displayed incorrect 100%/100% quota numbers from previous regular Claude API usage. The usage_state.json accumulated tokens across provider switches without resetting, causing stale data to persist.

## Root Cause

- usage_estimator.py tracked tokens in a single shared state file regardless of which CLI provider was active.
- UsageTracker had no awareness of whether the current provider had metered API quota, so it gated on stale usage.md even for local/self-hosted providers.

## Fix

1. **Add CLIProvider.has_api_quota()** — returns False for ollama-launch and LocalLLMProvider (no metered API quota). Base class defaults to True.

2. **Make _get_budget_mode() provider-aware** — when the active provider has no API quota, budget_mode is forced to 'disabled' so stale usage.md never gates the agent into wait/review mode.

3. **Add per-provider tracking to usage_estimator.py** — stores  name in  and resets session/weekly counters when the provider changes. This prevents stale Claude numbers from polluting ollama-launch display.

4. **Update TUI dashboard** — shows 'no API quota' messages for no-quota providers instead of misleading usage bars.

## Verification

- Full test suite: 15877 passed, 1 warning
- New tests added for:
  - OllamaLaunchProvider.has_api_quota() returns False
  - LocalLLMProvider.has_api_quota() returns False
  - ClaudeProvider.has_api_quota() returns True
  - Provider-aware budget mode override
  - Usage counter reset on provider change
  - Usage counter preservation when provider unchanged

## Related

- Fixes #319

---
### Quality Report

**Changes**: 11 files changed, 228 insertions(+), 21 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_