### PR TITLE
feat(tui): show CLI provider and models on Status tab

### DIFF
--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -724,6 +724,26 @@ class KoanDashboard(App):
             f"  run loop     {self._dot(run_on)}  [dim]{'running' if run_on else 'stopped'}[/]",
             f"  api          {self._dot(api_on)}  [dim]{'live' if api_on else 'off'}[/]",
         ]
+        # Provider + models (placed before usage so the operator sees *what* is
+        # driving consumption before the quota bars).
+        try:
+            from app.config import get_cli_provider_name, get_model_config
+
+            provider = get_cli_provider_name()
+            models = get_model_config()
+            if provider:
+                lines.append("")
+                lines.append(f"  provider     [{_MINT}]{provider}[/]")
+                model_parts = []
+                for role in ("mission", "chat", "lightweight", "fallback", "review_mode", "reflect"):
+                    val = models.get(role, "")
+                    if val:
+                        label = role.replace("_", " ")
+                        model_parts.append(f"{label}: {val}")
+                if model_parts:
+                    lines.append(f"  models       [dim]{' · '.join(model_parts)}[/dim]")
+        except Exception as exc:
+            self.log(f"provider/models display failed: {exc}")
         # Usage bars reuse the same renderer as the Usage tab.
         try:
             from app.usage_tracker import UsageTracker

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -422,3 +422,73 @@ def test_pilot_status_shows_run_and_api(tmp_path, monkeypatch):
             assert "live" in text     # api is up
 
     asyncio.run(scenario())
+
+
+def test_pilot_status_shows_provider_and_models(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    monkeypatch.setattr(
+        "app.config.get_cli_provider_name", lambda: "claude"
+    )
+    monkeypatch.setattr(
+        "app.config.get_model_config", lambda project_name="": {
+            "mission": "opus",
+            "chat": "haiku",
+            "lightweight": "haiku",
+            "fallback": "sonnet",
+            "review_mode": "",
+            "reflect": "",
+        }
+    )
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.refresh_dynamic()
+            await pilot.pause()
+            body = app.query_one("#status-body", tui.Static)
+            rendered = body.render()
+            text = getattr(rendered, "plain", str(rendered))
+            assert "provider" in text
+            assert "claude" in text
+            assert "mission: opus" in text
+            assert "chat: haiku" in text
+            assert "lightweight: haiku" in text
+            assert "fallback: sonnet" in text
+            # Empty roles should not appear
+            assert "review mode" not in text
+            assert "reflect" not in text
+
+    asyncio.run(scenario())
+
+
+def test_pilot_status_shows_provider_even_without_models(tmp_path, monkeypatch):
+    _write_config(tmp_path, "x: 1\n")
+    monkeypatch.setattr(
+        "app.config.get_cli_provider_name", lambda: "ollama-launch"
+    )
+    monkeypatch.setattr(
+        "app.config.get_model_config", lambda project_name="": {
+            "mission": "",
+            "chat": "",
+            "lightweight": "",
+            "fallback": "",
+            "review_mode": "",
+            "reflect": "",
+        }
+    )
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.refresh_dynamic()
+            await pilot.pause()
+            body = app.query_one("#status-body", tui.Static)
+            rendered = body.render()
+            text = getattr(rendered, "plain", str(rendered))
+            assert "provider" in text
+            assert "ollama-launch" in text
+            assert "models" not in text  # no non-empty models, line hidden
+
+    asyncio.run(scenario())


### PR DESCRIPTION
**What**: The TUI Status tab now displays the active CLI provider and configured models before the usage quota bars.

**Why**: Operators running multiple providers (Claude, Ollama, Copilot) need to see at a glance which backend is driving quota consumption and which models are assigned to each role.

**How**: 
- `_render_status()` imports `get_cli_provider_name` and `get_model_config` from `app.config`
- Provider name rendered as a mint-colored line
- Non-empty model roles (mission, chat, lightweight, fallback, review_mode, reflect) shown as `role: model` pairs joined by `·`
- Empty roles are hidden to keep the line compact
- Placed immediately before the session/weekly bars so context precedes consumption

**Testing**: 
- `test_pilot_status_shows_provider_and_models` verifies provider + all model roles appear, empty roles hidden
- `test_pilot_status_shows_provider_even_without_models` verifies graceful fallback when no models are configured
- Full suite passes (0 failures), ruff clean

---
### Quality Report

**Changes**: 2 files changed, 90 insertions(+)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_