### PR TITLE
fix(claudemd): use built-in /init skill when CLAUDE.md is missing

### DIFF
--- a/koan/app/claudemd_refresh.py
+++ b/koan/app/claudemd_refresh.py
@@ -212,7 +212,6 @@ def run_refresh(project_path: str, project_name: str) -> int:
     claude_md = Path(project_path) / "CLAUDE.md"
     claude_md_exists = claude_md.exists()
 
-    # Determine mode
     if claude_md_exists:
         mode = "UPDATE"
         mode_instructions = (
@@ -220,22 +219,16 @@ def run_refresh(project_path: str, project_name: str) -> int:
             "architecturally significant changes and update the file accordingly. "
             "Make minimal, surgical edits. If nothing significant changed, say so."
         )
+        # Gather git context (before branching, so we see main's history)
+        git_context = build_git_context(project_path, True)
+
+        # Check if there's nothing to do
+        if "No new commits since then" in git_context:
+            print("CLAUDE.md is up to date — no new commits since last update.")
+            return 0
     else:
         mode = "INIT"
-        mode_instructions = (
-            "No CLAUDE.md exists yet. Explore the project structure, build system, "
-            "and codebase to create a comprehensive but concise CLAUDE.md from scratch. "
-            "Focus on: what the project does, how to build/test/run it, key architecture, "
-            "and important conventions."
-        )
-
-    # Gather git context (before branching, so we see main's history)
-    git_context = build_git_context(project_path, claude_md_exists)
-
-    # Check if there's nothing to do
-    if claude_md_exists and "No new commits since then" in git_context:
-        print("CLAUDE.md is up to date — no new commits since last update.")
-        return 0
+        # No git context needed — the built-in /init skill explores the project itself
 
     # Remember the base branch for the PR
     base_branch = run_git_strict(
@@ -252,21 +245,24 @@ def run_refresh(project_path: str, project_name: str) -> int:
         print(f"Failed to create branch {branch_name}: {e}", file=sys.stderr)
         return 1
 
-    # Build project memory block (learnings, context, priorities)
-    task_text = f"CLAUDE.md refresh for {project_name}\n{git_context}"
-    project_memory = build_memory_block_for_skill(project_path, task_text)
+    if claude_md_exists:
+        # Build project memory block (learnings, context, priorities)
+        task_text = f"CLAUDE.md refresh for {project_name}\n{git_context}"
+        project_memory = build_memory_block_for_skill(project_path, task_text)
 
-    # Build prompt
-    skill_dir = Path(__file__).parent.parent / "skills" / "core" / "claudemd"
-    prompt = load_skill_prompt(
-        skill_dir, "refresh-claude-md",
-        MODE=mode,
-        MODE_INSTRUCTIONS=mode_instructions,
-        PROJECT_PATH=project_path,
-        PROJECT_NAME=project_name,
-        GIT_CONTEXT=git_context,
-        PROJECT_MEMORY=project_memory,
-    )
+        # Build prompt
+        skill_dir = Path(__file__).parent.parent / "skills" / "core" / "claudemd"
+        prompt = load_skill_prompt(
+            skill_dir, "refresh-claude-md",
+            MODE=mode,
+            MODE_INSTRUCTIONS=mode_instructions,
+            PROJECT_PATH=project_path,
+            PROJECT_NAME=project_name,
+            GIT_CONTEXT=git_context,
+            PROJECT_MEMORY=project_memory,
+        )
+    else:
+        prompt = "/init"
 
     # Build CLI command
     models = get_model_config()

--- a/koan/tests/test_claudemd_refresh.py
+++ b/koan/tests/test_claudemd_refresh.py
@@ -331,15 +331,20 @@ class TestRunRefresh:
         assert result == 0
         self._mock_pr_create.assert_not_called()
 
-    def test_init_mode_when_no_claudemd(self, tmp_path):
+    def test_init_mode_uses_builtin_init_skill(self, tmp_path):
+        """When no CLAUDE.md exists, use Claude's built-in /init skill."""
         project = tmp_path / "project"
         project.mkdir()
 
-        with patch("app.claudemd_refresh.build_git_context", return_value="No CLAUDE.md"):
+        with patch("app.claudemd_refresh.build_git_context") as mock_git_ctx:
             run_refresh(str(project), "test")
 
-        prompt_call = self._mock_prompt.call_args
-        assert prompt_call[1]["MODE"] == "INIT"
+        # /init explores the project itself — no need for custom git context
+        mock_git_ctx.assert_not_called()
+        # load_skill_prompt should not be called — we use the built-in /init skill
+        self._mock_prompt.assert_not_called()
+        # build_full_command should receive the /init prompt
+        assert self._mock_build_cmd.call_args[1]["prompt"] == "/init"
 
     def test_update_mode_when_claudemd_exists(self, tmp_path):
         project = tmp_path / "project"


### PR DESCRIPTION
**What:** When /claudemd runs on a repo without an existing CLAUDE.md, it now dispatches Claude Code's built-in /init skill instead of a custom prompt.

**Why:** The custom refresh prompt was failing to create a good initial CLAUDE.md from scratch. The /init skill is purpose-built for bootstrapping CLAUDE.md and explores the project structure automatically.

**How:**
- Restructured run_refresh() to detect missing CLAUDE.md early.
- In INIT mode, skip git-context gathering and skill-prompt loading.
- Pass prompt="/init" to build_full_command so the CLI runs the built-in skill.
- Commit/push/PR flow remains unchanged.

**Testing:**
- Updated test_init_mode_uses_builtin_init_skill to assert /init prompt and no custom prompt loading.
- Full test suite passes (exit 0).
- ruff clean (exit 0).

---
### Quality Report

**Changes**: 2 files changed, 35 insertions(+), 34 deletions(-)

**Code scan**: 1 issue(s) found
- `koan/app/claudemd_refresh.py:227` — debug print statement

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_