### PR TITLE
feat(dashboard): add 90-day usage stats and raise max to 100 days

### DIFF
--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -920,7 +920,7 @@ def api_usage():
 
     try:
         days = int(days)
-        days = max(1, min(days, 90))
+        days = max(1, min(days, 100))
     except (ValueError, TypeError):
         days = 7
 
@@ -1034,7 +1034,7 @@ def api_usage_missions():
     limit_raw = request.args.get("limit", "100", type=str)
 
     try:
-        days = max(1, min(int(days), 90))
+        days = max(1, min(int(days), 100))
     except (ValueError, TypeError):
         days = 7
 

--- a/koan/templates/usage.html
+++ b/koan/templates/usage.html
@@ -144,6 +144,7 @@
         <option value="1">Today</option>
         <option value="7" selected>Last 7 days</option>
         <option value="30">Last 30 days</option>
+        <option value="90">Last 90 days</option>
     </select>
     <select id="granularity-select" style="padding:0.4rem;background:var(--bg);color:var(--text);border:1px solid var(--border);border-radius:4px;">
         <option value="day" selected>By day</option>

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -528,6 +528,52 @@ class TestUsageApi:
         assert end0 - end1 == _td(days=7)
         assert data1["offset"] == 1
 
+    def test_api_usage_accepts_90_days(self, app_client):
+        """days=90 is accepted and clamped to 100, not 90."""
+        fake_summary = {
+            "total_input": 0, "total_output": 0,
+            "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+            "cache_hit_rate": 0.0, "count": 0,
+            "by_project": {}, "by_model": {},
+            "by_mode": {}, "by_project_and_mode": {},
+        }
+        with patch("app.cost_tracker.summarize_range", return_value=fake_summary) as mock_sr, \
+             patch("app.cost_tracker.get_pricing_config", return_value=None), \
+             patch("app.cost_tracker.estimate_cache_savings", return_value=None), \
+             patch("app.cost_tracker.daily_series", return_value=[]):
+            resp = app_client.get("/api/usage?days=90")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["days"] == 90
+        # verify summarize_range was called with the correct start/end span (~90 days)
+        args, _ = mock_sr.call_args
+        start_date, end_date = args[1], args[2]
+        assert (end_date - start_date).days == 89  # 90-day inclusive window
+
+    def test_api_usage_clamps_days_to_100(self, app_client):
+        """days > 100 is clamped to 100."""
+        fake_summary = {
+            "total_input": 0, "total_output": 0,
+            "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0,
+            "cache_hit_rate": 0.0, "count": 0,
+            "by_project": {}, "by_model": {},
+            "by_mode": {}, "by_project_and_mode": {},
+        }
+        with patch("app.cost_tracker.summarize_range", return_value=fake_summary) as mock_sr, \
+             patch("app.cost_tracker.get_pricing_config", return_value=None), \
+             patch("app.cost_tracker.estimate_cache_savings", return_value=None), \
+             patch("app.cost_tracker.daily_series", return_value=[]):
+            resp = app_client.get("/api/usage?days=200")
+
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["days"] == 100
+        # verify summarize_range was called with the correct start/end span (~100 days)
+        args, _ = mock_sr.call_args
+        start_date, end_date = args[1], args[2]
+        assert (end_date - start_date).days == 99  # 100-day inclusive window
+
 
 class TestSignals:
     def test_no_signals(self, tmp_path):


### PR DESCRIPTION
## What

Extend the dashboard /usage page with a 90-day stats option and raise the API clamp to 100 days so the full window is available.

## Changes

- **Frontend** (`koan/templates/usage.html`): add `<option value="90">Last 90 days</option>` to the range selector.
- **Backend** (`koan/app/dashboard.py`): raise `days` clamp from `90` to `100` in both `/api/usage` and `/api/usage/missions` endpoints.
- **Tests** (`koan/tests/test_dashboard.py`): add `test_api_usage_accepts_90_days` and `test_api_usage_clamps_days_to_100` to verify the new clamp behavior.

## Verification

- `make lint` passes
- `make test` passes (15840 passed)
- Dashboard usage API tests pass (13/13)

---
### Quality Report

**Changes**: 3 files changed, 49 insertions(+), 2 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_