### PR TITLE
feat(dashboard): heatmap total column + green→red warmth scale

### DIFF
--- a/koan/templates/usage.html
+++ b/koan/templates/usage.html
@@ -108,15 +108,16 @@
     justify-content: center;
     font-size: 0.65rem;
     font-weight: 600;
-    color: rgba(255,255,255,0.9);
     cursor: default;
     transition: filter 0.1s;
+    text-shadow: 0 0 2px rgba(0,0,0,0.45);
 }
-.heatmap-cell:hover { filter: brightness(1.2); }
+.heatmap-cell:hover { filter: brightness(1.15); }
 .heatmap-cell.empty-cell {
     background: var(--surface-3) !important;
     opacity: 0.25;
     color: transparent;
+    text-shadow: none;
 }
 /* Custom tooltip for heatmap */
 #heatmap-tooltip {
@@ -1096,6 +1097,34 @@ document.addEventListener('mousemove', function(e) {
     if (_heatTipVisible) _positionHeatTip(e);
 });
 
+function heatColor(intensity) {
+    // intensity 0 → green, 0.33 → yellow, 0.66 → orange, 1 → red
+    const stops = [
+        {r: 63,  g: 185, b: 80},   // green
+        {r: 210, g: 153, b: 34},   // yellow
+        {r: 240, g: 136, b: 62},   // orange
+        {r: 248, g: 81,  b: 73},   // red
+    ];
+    const scaled = Math.max(0, Math.min(1, intensity)) * 3;
+    const idx = Math.min(2, Math.floor(scaled));
+    const t = scaled - idx;
+    const a = stops[idx];
+    const b = stops[idx + 1];
+    const r = Math.round(a.r + (b.r - a.r) * t);
+    const g = Math.round(a.g + (b.g - a.g) * t);
+    const b_ = Math.round(a.b + (b.b - a.b) * t);
+    return 'rgb(' + r + ',' + g + ',' + b_ + ')';
+}
+
+function heatTextColor(intensity) {
+    const c = heatColor(intensity);
+    const m = c.match(/rgb\((\d+),(\d+),(\d+)\)/);
+    if (!m) return '#fff';
+    const r = parseInt(m[1]), g = parseInt(m[2]), b = parseInt(m[3]);
+    const lum = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+    return lum > 0.58 ? '#161b22' : '#fff';
+}
+
 function renderHeatmap(byProjectAndType, hasPricing) {
     const container = document.getElementById('heatmap-container');
     const emptyEl = document.getElementById('heatmap-empty');
@@ -1121,23 +1150,30 @@ function renderHeatmap(byProjectAndType, hasPricing) {
     }
     emptyEl.style.display = 'none';
 
-    // Find max for log scale
-    let maxTok = 1;
+    // Global max for the main grid cells (cross-project, cross-type)
+    let maxCellTok = 1;
     for (const proj of projects) {
         for (const type of types) {
             const d = (byProjectAndType[proj] || {})[type];
-            if (d) maxTok = Math.max(maxTok, d.input_tokens + d.output_tokens);
+            if (d) maxCellTok = Math.max(maxCellTok, d.input_tokens + d.output_tokens);
         }
     }
-    const logMax = Math.log(maxTok + 1);
+    const logMaxCell = Math.log(maxCellTok + 1);
 
-    // Build CSS grid: first column = row labels (fixed width), rest = type columns
-    const colDef = '90px ' + types.map(() => 'minmax(44px,1fr)').join(' ');
+    // Separate max for the total column (row totals only)
+    let maxTotalTok = 1;
+    for (const proj of projects) {
+        maxTotalTok = Math.max(maxTotalTok, projectTotals[proj]);
+    }
+    const logMaxTotal = Math.log(maxTotalTok + 1);
+
+    // Build CSS grid: row labels + type columns + total column
+    const colDef = '90px ' + types.map(() => 'minmax(44px,1fr)').join(' ') + ' minmax(56px,1fr)';
     const grid = document.createElement('div');
     grid.className = 'heatmap-grid';
     grid.style.gridTemplateColumns = colDef;
 
-    // Header row: empty corner + type labels
+    // Header row: empty corner + type labels + Total
     const corner = document.createElement('div');
     corner.className = 'heatmap-corner';
     grid.appendChild(corner);
@@ -1148,6 +1184,11 @@ function renderHeatmap(byProjectAndType, hasPricing) {
         th.title = capitalize(type);
         grid.appendChild(th);
     }
+    const totalTh = document.createElement('div');
+    totalTh.className = 'heatmap-col-label';
+    totalTh.textContent = 'Total';
+    totalTh.title = 'Total tokens per project';
+    grid.appendChild(totalTh);
 
     // Data rows
     for (const proj of projects) {
@@ -1158,6 +1199,7 @@ function renderHeatmap(byProjectAndType, hasPricing) {
         rowLabel.addEventListener('click', function() { setProjectFilter(proj); });
         grid.appendChild(rowLabel);
 
+        // Main grid cells
         for (const type of types) {
             const d = (byProjectAndType[proj] || {})[type];
             const cell = document.createElement('div');
@@ -1165,10 +1207,11 @@ function renderHeatmap(byProjectAndType, hasPricing) {
 
             if (d) {
                 const tok = d.input_tokens + d.output_tokens;
-                const intensity = logMax > 0 ? Math.log(tok + 1) / logMax : 0;
-                // Blue accent, opacity 0.12 (near-zero) → 0.85 (max)
-                const alpha = (0.12 + intensity * 0.73).toFixed(2);
-                cell.style.background = 'rgba(88,166,255,' + alpha + ')';
+                const intensity = logMaxCell > 0 ? Math.log(tok + 1) / logMaxCell : 0;
+                const bg = heatColor(intensity);
+                const fg = heatTextColor(intensity);
+                cell.style.background = bg;
+                cell.style.color = fg;
                 cell.textContent = fmtTokens(tok);
 
                 const tipLines = [
@@ -1188,6 +1231,24 @@ function renderHeatmap(byProjectAndType, hasPricing) {
             }
             grid.appendChild(cell);
         }
+
+        // Total column cell — uses its own relative scale
+        const totalCell = document.createElement('div');
+        totalCell.className = 'heatmap-cell';
+        const totalTok = projectTotals[proj];
+        const totalIntensity = logMaxTotal > 0 ? Math.log(totalTok + 1) / logMaxTotal : 0;
+        totalCell.style.background = heatColor(totalIntensity);
+        totalCell.style.color = heatTextColor(totalIntensity);
+        totalCell.style.fontWeight = '700';
+        totalCell.textContent = fmtTokens(totalTok);
+
+        const totalTip = [
+            '<strong>' + escapeHtml(proj) + ' — Total</strong>',
+            fmtTokens(totalTok) + ' tokens',
+        ];
+        totalCell.addEventListener('mouseenter', function(e) { _showHeatTip(e, totalTip.join('<br>')); });
+        totalCell.addEventListener('mouseleave', function() { _hideHeatTip(); });
+        grid.appendChild(totalCell);
     }
 
     container.appendChild(grid);

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -133,6 +133,12 @@ class TestRoutes:
         assert resp.status_code == 200
         assert b"Send" in resp.data
 
+    def test_usage_page(self, app_client):
+        resp = app_client.get("/usage")
+        assert resp.status_code == 200
+        assert b"Efficiency Heatmap" in resp.data
+        assert b"heatmap-container" in resp.data
+
     def test_api_status(self, app_client):
         resp = app_client.get("/api/status")
         assert resp.status_code == 200


### PR DESCRIPTION
- **What**: Improves the Efficiency Heatmap on the dashboard /usage page.
- **Why**: The old single-blue opacity scale made it hard to spot hotspots at a glance. Adding a total column gives an immediate per-project summary.
- **How**:
  - Added a "Total" column using its own log-relative color scale so the heaviest projects stand out.
  - Replaced blue-opacity with a green→yellow→orange→red warmth scale for both main cells and totals.
  - Main cells keep a global scale (cross-project, cross-type) so the hottest intersections are obvious.
  - Added adaptive text color (dark on light backgrounds, white on dark) plus text-shadow for readability.
- **Testing**: New  verifies the /usage route renders and includes the heatmark markup. Full suite passes, lint clean.

---
### Quality Report

**Changes**: 2 files changed, 80 insertions(+), 13 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_