### PR TITLE
feat(provider): add Cline CLI provider support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,6 +100,7 @@ Communication between processes happens through shared files in `instance/` with
 **CLI provider abstraction** (`koan/app/provider/`):
 - **`provider/base.py`** — `CLIProvider` base class + tool name constants + per-provider usage tracking hooks (`supports_usage_tracking()`, `record_usage()`)
 - **`provider/claude.py`** — `ClaudeProvider` (Claude Code CLI)
+- **`provider/cline.py`** — `ClineProvider` (Cline CLI)
 - **`provider/copilot.py`** — `CopilotProvider` (GitHub Copilot CLI) with tool name mapping
 - **`provider/__init__.py`** — Provider registry, resolution (env → config → default), cached singleton, and convenience functions (`run_command()`, `run_command_streaming()`, `build_full_command()`). Main entry point for the provider package.
 - **`cli_provider.py`** — Re-export facade (legacy); prefer importing from `provider` directly

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,7 @@ update the relevant docs in the same change.
 - [User Manual](users/user-manual.md) - daily use, workflows, and command guide.
 - [Onboarding](users/onboarding.md) - first-run setup and configuration flow.
 - [Skills Reference](users/skills.md) - built-in command reference.
-- [Provider Setup](providers/) - Claude, Codex, Copilot, local, and Ollama Launch providers.
+- [Provider Setup](providers/) - Claude, Cline, Codex, Copilot, local, and Ollama Launch providers.
 - [Messaging Setup](messaging/) - Telegram, Slack, Matrix, Discord, GitHub, and Jira.
 - [Troubleshooting](operations/troubleshooting.md) - common issues and how to fix them.
 

--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -31,6 +31,7 @@ prefer importing from `koan.app.provider`.
 ## Current Providers
 
 - Claude provider: Claude Code CLI integration.
+- Cline provider: Cline CLI multi-backend integration.
 - Codex provider: OpenAI Codex CLI integration.
 - Copilot provider: GitHub Copilot CLI integration with tool-name mapping.
 - Local provider: local model server integration.

--- a/docs/providers/cline.md
+++ b/docs/providers/cline.md
@@ -1,0 +1,208 @@
+# Cline CLI Provider
+
+The Cline provider lets Kōan use Cline CLI as the underlying AI agent.
+Cline is a multi-backend AI coding assistant that supports OpenRouter,
+Anthropic, OpenAI, and other providers through a unified interface.
+
+## Quick Setup
+
+### 1. Install Cline CLI
+
+```bash
+# npm (all platforms)
+npm install -g cline
+
+# Verify
+cline --version
+```
+
+### 2. Authenticate
+
+Cline authenticates with your chosen provider. Configure your API key
+via environment variables or Cline's settings:
+
+```bash
+# For Anthropic (Claude models)
+export ANTHROPIC_API_KEY=your-key
+
+# For OpenAI
+export OPENAI_API_KEY=your-key
+
+# For OpenRouter (multi-model access)
+export OPENROUTER_API_KEY=your-key
+```
+
+Or run Cline interactively once to configure:
+
+```bash
+cline
+```
+
+### 3. Configure Kōan
+
+**Option A: config.yaml** (persistent)
+
+```yaml
+cli_provider: "cline"
+```
+
+**Option B: Environment variable** (per-session)
+
+```bash
+export KOAN_CLI_PROVIDER=cline
+```
+
+The env var overrides config.yaml if both are set.
+
+### 4. Model Selection
+
+Set the model in your config.yaml `models:` section. Cline uses model
+identifiers from your chosen backend:
+
+```yaml
+models:
+  mission: "claude-sonnet-4-20250514"    # Main mission execution
+  chat: "claude-3-5-haiku-20241022"      # Chat responses
+  lightweight: "claude-3-5-haiku-20241022"  # Low-cost calls
+  fallback: ""                            # Not supported by Cline
+  review_mode: "claude-sonnet-4-20250514"   # Review mode
+```
+
+When using OpenRouter, you can access many models:
+
+```yaml
+models:
+  mission: "anthropic/claude-sonnet-4"   # OpenRouter model ID
+  chat: "anthropic/claude-3.5-haiku"
+```
+
+## How It Works
+
+Kōan invokes Cline with the `--json` flag for JSONL output and
+`--auto-approve` for unattended execution:
+
+```
+cline --auto-approve true --json --model claude-sonnet-4-20250514 "Your prompt"
+```
+
+The `--auto-approve` flag prevents Cline from blocking on interactive
+tool-approval prompts during headless execution.
+
+### Execution Modes
+
+| Kōan Setting             | Cline Flag                 | Behavior                           |
+|--------------------------|----------------------------|------------------------------------|
+| `skip_permissions: false`| `--auto-approve false`     | Explicit disable (prevents deadlock) |
+| `skip_permissions: true` | `--auto-approve true`      | Auto-approve all tool calls        |
+
+### Feature Mapping
+
+| Kōan Feature           | Cline Support | Notes                                   |
+|------------------------|---------------|-----------------------------------------|
+| Model selection        | ✅            | `--model` flag                          |
+| Fallback model         | ❌            | Silently ignored                        |
+| System prompt          | ⚠️            | Prepended to user prompt (no native flag) |
+| Per-tool allow/disallow| ❌            | Use `CLINE_COMMAND_PERMISSIONS` env var  |
+| Max turns              | ❌            | Cline runs to completion                |
+| MCP servers            | ⚠️            | Configure in Cline's own config         |
+| Plugin directories     | ❌            | Not supported                           |
+| Output format (JSON)   | ✅            | `--json` for JSONL events               |
+| Extended thinking      | ✅            | `--thinking` flag                       |
+| Quota check            | ✅            | Minimal probe via `cline --json "ok"`   |
+
+### Extended Thinking
+
+Cline supports extended thinking mode via the `--thinking` flag. Enable
+it in Kōan by passing thinking-related parameters through the provider
+interface. This activates Claude-style extended reasoning when using
+Claude models through Cline.
+
+## Per-Project Override
+
+You can use Cline for specific projects while keeping another provider
+as the default. In `projects.yaml`:
+
+```yaml
+projects:
+  my-cline-project:
+    path: "/path/to/project"
+    cli_provider: "cline"
+    models:
+      mission: "claude-sonnet-4-20250514"
+      chat: "claude-3-5-haiku-20241022"
+```
+
+## Tool Permissions
+
+Cline does not support per-tool allow/disallow flags on the command line.
+Instead, control tool access via the `CLINE_COMMAND_PERMISSIONS` environment
+variable. Refer to Cline documentation for the permission schema.
+
+## MCP Configuration
+
+Cline configures MCP servers through its own configuration system, not
+CLI flags. Kōan's `--mcp-config` flags are silently ignored when using
+the Cline provider. Configure MCP servers directly in Cline's config.
+
+## Quota Detection
+
+Cline is a multi-backend client, so quota detection uses generic patterns
+that work across Anthropic, OpenAI, OpenRouter, and other providers:
+
+- Rate limit / too many requests messages
+- HTTP 429 status codes
+- Quota exceeded / insufficient quota errors
+
+Kōan's quota detector scans stderr and structured error events for these
+patterns and will pause + requeue missions when quota exhaustion is detected.
+
+## Troubleshooting
+
+### "cline: command not found"
+
+Install the CLI: `npm install -g cline`
+
+### Authentication errors
+
+Verify your API keys are set correctly:
+
+```bash
+# Check environment variables
+echo $ANTHROPIC_API_KEY
+echo $OPENAI_API_KEY
+echo $OPENROUTER_API_KEY
+```
+
+Test Cline directly:
+
+```bash
+cline --auto-approve true --json "hello"
+```
+
+### Rate limits
+
+Cline shares quota with your backend provider. If you hit limits,
+Kōan's quota detection will pause and notify you. Use `/quota` from
+Telegram to check current usage status.
+
+### System prompt not taking effect
+
+Cline does not have a native system prompt flag. System prompts are
+prepended to the user prompt as a workaround. This means they don't
+benefit from separate instruction caching that some providers offer.
+
+### Headless execution hangs
+
+If Cline appears to hang during headless execution, ensure the
+`--auto-approve` flag is being passed. Kōan always passes this flag
+explicitly (true or false) to prevent interactive approval prompts
+from blocking the daemon.
+
+### Provider selection issues
+
+To verify which backend Cline is using, check Cline's configuration
+or pass the `--provider` flag explicitly:
+
+```bash
+cline --provider anthropic --json "test"
+```

--- a/docs/users/model-configuration.md
+++ b/docs/users/model-configuration.md
@@ -21,6 +21,10 @@ models:
     mission: "opus"
     review_mode: "opus"
 
+  cline:                    # Provider-specific overrides for the Cline harness
+    mission: "claude-sonnet-4-20250514"
+    chat: "claude-3-5-haiku-20241022"
+
   codex:                    # Provider-specific overrides for the Codex harness
     mission: "gpt-5.3-codex"
     chat: "gpt-5.5"
@@ -52,6 +56,7 @@ keys. Both still work, but emit a one-time `DEPRECATED` warning at startup.
 | ------------------------------ | -------------------------------- |
 | `models.mission`, `models.chat`| `models.default.mission`, …      |
 | `models_for_claude:`           | `models.claude:`                 |
+| `models_for_cline:`            | `models.cline:`                  |
 | `models_for_codex:`            | `models.codex:`                  |
 | `models_for_ollama_launch:`    | `models.ollama-launch:`          |
 

--- a/docs/users/onboarding.md
+++ b/docs/users/onboarding.md
@@ -27,7 +27,7 @@ The wizard runs through 12 steps:
 |------|-------------|----------------|
 | 1. Prerequisites | Checks Python 3.11+, git, supported CLI providers, gh | — |
 | 2. Instance init | Creates `instance/` from template and `.env` | `instance/`, `.env` |
-| 3. Provider | Chooses Claude, Codex, Copilot, or local provider | `.env` |
+| 3. Provider | Chooses Claude, Cline, Codex, Copilot, or local provider | `.env` |
 | 4. Models | Sets provider-specific model defaults (accept or customize per role) | `instance/config.yaml` |
 | 5. Virtual env | Runs `make setup` to install dependencies | `.venv/` |
 | 6. Messaging | Configures Telegram, Slack, or Matrix credentials | `.env` |

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1361,7 +1361,7 @@ projects:
 ```
 
 Key per-project settings:
-- **`cli_provider`** — `claude`, `codex`, `copilot`, `local`, or `ollama-launch`
+- **`cli_provider`** — `claude`, `cline`, `codex`, `copilot`, `local`, or `ollama-launch`
 - **`models`** — Override model selection per role
 - **`tools`** — Restrict available tools
 - **`git_auto_merge`** — Auto-merge completed PRs (strategy: squash/merge/rebase)
@@ -1493,6 +1493,7 @@ Kōan supports multiple CLI backends. Configure globally via `KOAN_CLI_PROVIDER`
 | Provider | Best for | Docs |
 |----------|----------|------|
 | **Claude Code** (default) | Full-featured agent, best reasoning | [claude.md](../providers/claude.md) |
+| **Cline** | Multi-backend (OpenRouter, Anthropic, OpenAI) | [cline.md](../providers/cline.md) |
 | **OpenAI Codex** | ChatGPT users who want Codex models | [codex.md](../providers/codex.md) |
 | **GitHub Copilot** | Teams with existing Copilot licenses | [copilot.md](../providers/copilot.md) |
 | **Local LLM** | Offline, privacy, zero API cost | [local.md](../providers/local.md) |

--- a/koan/app/onboarding.py
+++ b/koan/app/onboarding.py
@@ -526,6 +526,7 @@ def step_prerequisites(state: OnboardingState) -> OnboardingState:
     installed_providers = _detect_installed_providers()
     provider_tools = {
         "claude": "claude",
+        "cline": "cline",
         "codex": "codex",
         "copilot": "gh",
         "local": None,
@@ -572,6 +573,7 @@ def step_prerequisites(state: OnboardingState) -> OnboardingState:
 
 PROVIDERS = [
     ("claude", "Claude Code CLI"),
+    ("cline", "Cline CLI"),
     ("codex", "OpenAI Codex CLI"),
     ("copilot", "GitHub Copilot CLI"),
     ("local", "Local provider"),
@@ -581,6 +583,7 @@ PROVIDERS = [
 def _provider_ready(provider: str) -> tuple[bool, str]:
     tool_by_provider = {
         "claude": "claude",
+        "cline": "cline",
         "codex": "codex",
         "copilot": "gh",
         "local": None,
@@ -599,6 +602,7 @@ def _detect_installed_providers() -> list[str]:
     """Return the list of CLI providers whose binaries are on PATH."""
     provider_tools = {
         "claude": "claude",
+        "cline": "cline",
         "codex": "codex",
         "copilot": "gh",
         "local": None,
@@ -656,6 +660,14 @@ _PROVIDER_MODEL_DEFAULTS: dict[str, dict[str, str]] = {
         "chat": "",
         "lightweight": "haiku",
         "fallback": "sonnet",
+        "review_mode": "",
+        "reflect": "",
+    },
+    "cline": {
+        "mission": "",
+        "chat": "",
+        "lightweight": "",
+        "fallback": "",
         "review_mode": "",
         "reflect": "",
     },

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -563,7 +563,7 @@ def _detect_provider(koan_root: Path) -> str:
     """Detect the configured CLI provider.
 
     Uses the provider package resolution (env var > config.yaml > default).
-    Returns provider name: "claude", "copilot", "local", "ollama",
+    Returns provider name: "claude", "cline", "copilot", "local", "ollama",
     or "ollama-launch".
     """
     try:

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -2,7 +2,7 @@
 CLI provider abstraction for Kōan.
 
 Allows switching between Claude Code CLI, GitHub Copilot CLI,
-OpenAI Codex CLI, or a local LLM server as the underlying AI agent
+OpenAI Codex CLI, Cline CLI, or a local LLM server as the underlying AI agent
 binary. Each provider knows how to translate Kōan's generic command
 spec into provider-specific flags.
 
@@ -13,6 +13,7 @@ Configuration:
 Package structure:
     provider/base.py         — CLIProvider base class + tool constants
     provider/claude.py       — ClaudeProvider implementation
+    provider/cline.py        — ClineProvider implementation
     provider/codex.py        — CodexProvider implementation
     provider/copilot.py      — CopilotProvider implementation
     provider/local.py        — LocalLLMProvider implementation
@@ -40,6 +41,7 @@ from app.provider.base import (  # noqa: F401
 
 # Import concrete providers
 from app.provider.claude import ClaudeProvider  # noqa: F401
+from app.provider.cline import ClineProvider  # noqa: F401
 from app.provider.codex import CodexProvider  # noqa: F401
 from app.provider.copilot import CopilotProvider  # noqa: F401
 from app.provider.local import LocalLLMProvider  # noqa: F401
@@ -97,6 +99,7 @@ def _format_cli_error(returncode: int, stdout: str, stderr: str) -> str:
 
 _PROVIDERS = {
     "claude": ClaudeProvider,
+    "cline": ClineProvider,
     "codex": CodexProvider,
     "copilot": CopilotProvider,
     "local": LocalLLMProvider,

--- a/koan/app/provider/cline.py
+++ b/koan/app/provider/cline.py
@@ -237,7 +237,7 @@ class ClineProvider(CLIProvider):
             return True, ""
         except Exception as e:
             log_safe("error", f"[{self.name}] quota probe error: {e}")
-            return False, str(e)
+            return True, ""
 
     def detect_quota_exhaustion(
         self,

--- a/koan/app/provider/cline.py
+++ b/koan/app/provider/cline.py
@@ -3,10 +3,10 @@
 import re
 import shutil
 import subprocess
-import sys
 from typing import List, Optional, Tuple
 
 from app.provider.base import CLIProvider
+from app.run_log import log_safe
 
 
 # Generic quota/auth patterns - Cline is multi-backend (OpenRouter, Anthropic, OpenAI, etc.)
@@ -98,7 +98,8 @@ class ClineProvider(CLIProvider):
         flags: List[str] = []
         if model:
             flags.extend(["--model", model])
-        # Cline has no --fallback-model; ignored silently
+        if fallback:
+            log_safe("warning", f"[{self.name}] fallback model is not supported by Cline; ignored")
         return flags
 
     def supports_stream_json(self) -> bool:
@@ -117,14 +118,20 @@ class ClineProvider(CLIProvider):
 
     def build_mcp_args(self, configs: Optional[List[str]] = None) -> List[str]:
         # Cline configures MCP servers via its own config, not CLI flags.
+        if configs:
+            log_safe("warning", f"[{self.name}] MCP config is not supported via CLI flags; configure in Cline's own config instead")
         return []
 
     def build_plugin_args(self, plugin_dirs: Optional[List[str]] = None) -> List[str]:
         # Cline does not have plugin directories.
+        if plugin_dirs:
+            log_safe("warning", f"[{self.name}] plugin directories are not supported; ignored")
         return []
 
     def build_effort_args(self, effort: str = "") -> List[str]:
         # Cline does not have reasoning effort controls.
+        if effort:
+            log_safe("warning", f"[{self.name}] reasoning effort control is not supported; ignored")
         return []
 
     def build_thinking_args(
@@ -168,8 +175,9 @@ class ClineProvider(CLIProvider):
         """
         # Handle system prompt: Cline has no --append-system-prompt or
         # file-mode equivalent, so prepend to user prompt (base class
-        # fallback behavior). system_prompt_file is silently ignored —
-        # supports_system_prompt_file() returns False on this provider.
+        # fallback behavior).
+        if system_prompt_file:
+            log_safe("warning", f"[{self.name}] system prompt file is not supported; falling back to inline system prompt")
         if system_prompt:
             prompt = system_prompt + "\n\n" + prompt
 
@@ -228,8 +236,8 @@ class ClineProvider(CLIProvider):
         except subprocess.TimeoutExpired:
             return True, ""
         except Exception as e:
-            print(f"[cline] quota probe error: {e}", file=sys.stderr)
-            return True, ""
+            log_safe("error", f"[{self.name}] quota probe error: {e}")
+            return False, str(e)
 
     def detect_quota_exhaustion(
         self,

--- a/koan/app/provider/cline.py
+++ b/koan/app/provider/cline.py
@@ -1,0 +1,301 @@
+"""Cline CLI provider implementation."""
+
+import re
+import shutil
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+from app.provider.base import CLIProvider
+
+
+# Generic quota/auth patterns - Cline is multi-backend (OpenRouter, Anthropic, OpenAI, etc.)
+_CLINE_QUOTA_PATTERNS = [
+    r"rate[_\s-]?limit(?:ed|_error| exceeded)?",
+    r"insufficient[_\s-]?quota",
+    r"\bquota\b.*(?:exceeded|reached|exhausted|insufficient)",
+    r"(?:exceeded|reached|exhausted|insufficient).*\bquota\b",
+    r"usage.*(?:limit|cap).*(?:reached|exceeded|hit)",
+    r"billing.*(?:limit|quota|credit)",
+    r"HTTP\s*429",
+    r"status[\s:]+429",
+    r"too many requests",
+    r"retry[\s-]+after",
+]
+
+_CLINE_QUOTA_RE = re.compile("|".join(_CLINE_QUOTA_PATTERNS), re.IGNORECASE)
+
+_CLINE_AUTH_PATTERNS = [
+    r"\b401\s+Unauthorized\b",
+    r"unexpected\s+status\s+401",
+    r"access\s+token",
+    r"authentication\s+failed",
+    r"invalid\s+api\s+key",
+    r"api\s+key.*(?:invalid|missing|expired)",
+]
+
+_CLINE_AUTH_RE = re.compile("|".join(_CLINE_AUTH_PATTERNS), re.IGNORECASE)
+
+
+class ClineProvider(CLIProvider):
+    """Cline CLI provider.
+
+    Translates Kōan's generic command spec into Cline CLI equivalents.
+    Uses `--json` for JSONL headless output and `--auto-approve` for
+    unattended tool execution.
+
+    Key differences from Claude CLI:
+    - Binary: 'cline'
+    - Prompt: positional argument (final argument)
+    - Tool control: No per-tool allow/disallow flags; uses CLINE_COMMAND_PERMISSIONS env
+    - Model: -m/--model flag
+    - No --fallback-model equivalent
+    - No --append-system-prompt (falls back to prepend via base class)
+    - No --max-turns (runs to completion)
+    - Output: --json flag for JSONL events (not --output-format)
+    - Permissions: --auto-approve true/false for unattended execution
+    - Thinking: --thinking flag for extended thinking mode
+
+    Configuration (config.yaml):
+        cli_provider: "cline"
+
+    Environment:
+        KOAN_CLI_PROVIDER=cline
+    """
+
+    name = "cline"
+
+    def binary(self) -> str:
+        return "cline"
+
+    def is_available(self) -> bool:
+        return shutil.which("cline") is not None
+
+    def build_permission_args(self, skip_permissions: bool = False) -> List[str]:
+        # Cline uses --auto-approve for unattended execution.
+        # When skip_permissions=True, pass --auto-approve true.
+        # When False, pass --auto-approve false to prevent headless deadlock
+        # (interactive approval prompts would block forever in non-interactive mode).
+        if skip_permissions:
+            return ["--auto-approve", "true"]
+        return ["--auto-approve", "false"]
+
+    def build_prompt_args(self, prompt: str) -> List[str]:
+        # Cline takes the prompt as a positional argument at the end.
+        # This is handled in build_command() override.
+        return [prompt]
+
+    def build_tool_args(
+        self,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+    ):
+        # Cline CLI does not support per-tool allow/disallow flags.
+        # Tool access is controlled via CLINE_COMMAND_PERMISSIONS environment variable.
+        return []
+
+    def build_model_args(self, model: str = "", fallback: str = "") -> List[str]:
+        flags: List[str] = []
+        if model:
+            flags.extend(["--model", model])
+        # Cline has no --fallback-model; ignored silently
+        return flags
+
+    def supports_stream_json(self) -> bool:
+        # Cline --json produces newline-delimited JSON messages in headless mode.
+        return True
+
+    def build_output_args(self, fmt: str = "") -> List[str]:
+        # Cline uses --json for JSONL output.
+        if fmt in {"json", "stream-json"}:
+            return ["--json"]
+        return []
+
+    def build_max_turns_args(self, max_turns: int = 0) -> List[str]:
+        # Cline CLI does not support --max-turns.
+        return []
+
+    def build_mcp_args(self, configs: Optional[List[str]] = None) -> List[str]:
+        # Cline configures MCP servers via its own config, not CLI flags.
+        return []
+
+    def build_plugin_args(self, plugin_dirs: Optional[List[str]] = None) -> List[str]:
+        # Cline does not have plugin directories.
+        return []
+
+    def build_effort_args(self, effort: str = "") -> List[str]:
+        # Cline does not have reasoning effort controls.
+        return []
+
+    def build_thinking_args(
+        self, enabled: bool = False, budget_tokens: int = 0
+    ) -> List[str]:
+        # Cline supports --thinking for extended thinking mode.
+        # budget_tokens is ignored (Cline doesn't support token budgets).
+        if enabled:
+            return ["--thinking"]
+        return []
+
+    def invocation_lock_name(self) -> str:
+        return "cline-cli"
+
+    def build_command(
+        self,
+        prompt: str,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+        model: str = "",
+        fallback: str = "",
+        output_format: str = "",
+        max_turns: int = 0,
+        mcp_configs: Optional[List[str]] = None,
+        plugin_dirs: Optional[List[str]] = None,
+        skip_permissions: bool = False,
+        system_prompt: str = "",
+        system_prompt_file: str = "",
+        effort: str = "",
+        resume_session_id: str = "",
+    ) -> List[str]:
+        """Build a complete Cline CLI command.
+
+        Cline command structure::
+
+            cline [global-flags] "prompt"
+
+        The prompt must be the final positional argument.
+        Permission flags (--auto-approve), model (--model), and output
+        (--json) are global flags that come before the prompt.
+        """
+        # Handle system prompt: Cline has no --append-system-prompt or
+        # file-mode equivalent, so prepend to user prompt (base class
+        # fallback behavior). system_prompt_file is silently ignored —
+        # supports_system_prompt_file() returns False on this provider.
+        if system_prompt:
+            prompt = system_prompt + "\n\n" + prompt
+
+        cmd = [self.binary()]
+
+        # Global flags come before the positional prompt
+        cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(self.build_model_args(model, fallback))
+        cmd.extend(self.build_output_args(output_format))
+        cmd.extend(self.build_max_turns_args(max_turns))
+        cmd.extend(self.build_mcp_args(mcp_configs))
+        cmd.extend(self.build_plugin_args(plugin_dirs))
+        cmd.extend(self.build_effort_args(effort))
+        cmd.extend(self.build_thinking_args())
+
+        # Prompt is the final positional argument
+        cmd.append(prompt)
+
+        return cmd
+
+    def check_quota_available(self, project_path: str, timeout: int = 15) -> Tuple[bool, str]:
+        """Check Cline API quota via a minimal prompt probe.
+
+        Sends a tiny prompt ("ok") to surface rate-limit or subscription
+        errors before a full mission is attempted. Cline is multi-backend
+        (OpenRouter, Anthropic, OpenAI, etc.), so we use generic patterns.
+
+        NOTE: This probe consumes a small number of tokens on each call.
+        """
+        cmd = [self.binary(), "--auto-approve", "true", "--json", "ok"]
+
+        try:
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=project_path,
+            )
+            if self.detect_quota_exhaustion(
+                stdout_text=result.stdout or "",
+                stderr_text=result.stderr or "",
+                exit_code=result.returncode,
+            ):
+                combined = (result.stderr or "") + "\n" + (result.stdout or "")
+                return False, combined
+            if self.detect_auth_failure(
+                stdout_text=result.stdout or "",
+                stderr_text=result.stderr or "",
+                exit_code=result.returncode,
+            ):
+                combined = (result.stderr or "") + "\n" + (result.stdout or "")
+                return False, combined
+
+            return True, ""
+        except subprocess.TimeoutExpired:
+            return True, ""
+        except Exception as e:
+            print(f"[cline] quota probe error: {e}", file=sys.stderr)
+            return True, ""
+
+    def detect_quota_exhaustion(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect Cline quota/rate-limit failures.
+
+        Cline is multi-backend, so we use generic patterns that work across
+        OpenRouter, Anthropic, OpenAI, etc. Stderr is trusted for the full
+        pattern set. Stdout is only scanned when the CLI failed AND the
+        matched line looks like a provider error message.
+        """
+        stderr_text = stderr_text or ""
+        stdout_text = stdout_text or ""
+
+        if _CLINE_QUOTA_RE.search(stderr_text):
+            return True
+
+        if exit_code == 0:
+            return False
+
+        for line in stdout_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if not self._plain_stdout_quota_line(stripped):
+                continue
+            return True
+
+        return False
+
+    _STDOUT_ERROR_MARKERS = ("error", "rate", "limit", "quota", "http", "status", "api")
+
+    def _plain_stdout_quota_line(self, line: str) -> bool:
+        """Check stdout only when the line resembles a provider error."""
+        if not self._line_has_error_marker(line, self._STDOUT_ERROR_MARKERS):
+            return False
+        return bool(_CLINE_QUOTA_RE.search(line))
+
+    def detect_auth_failure(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect Cline authentication failures.
+
+        Cline auth failures may appear in stderr or stdout depending on
+        the backend provider. We scan both with generic auth patterns.
+        """
+        if exit_code == 0:
+            return False
+
+        stderr_text = stderr_text or ""
+        stdout_text = stdout_text or ""
+
+        if _CLINE_AUTH_RE.search(stderr_text):
+            return True
+
+        for line in stdout_text.splitlines():
+            stripped = line.strip()
+            if not stripped:
+                continue
+            if _CLINE_AUTH_RE.search(stripped):
+                return True
+
+        return False

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -1570,6 +1570,143 @@ class TestCodexProvider:
 
 
 # ---------------------------------------------------------------------------
+# ClineProvider
+# ---------------------------------------------------------------------------
+
+
+class TestClineProvider:
+    def test_all_build_methods(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        assert p.binary() == "cline"
+        with patch("app.provider.cline.shutil.which", return_value="/usr/bin/cline"):
+            assert p.is_available() is True
+        with patch("app.provider.cline.shutil.which", return_value=None):
+            assert p.is_available() is False
+        assert p.build_permission_args(True) == ["--auto-approve", "true"]
+        assert p.build_permission_args(False) == ["--auto-approve", "false"]
+        assert p.build_prompt_args("hi") == ["hi"]
+        assert p.build_tool_args(allowed_tools=["Bash"]) == []
+        assert p.build_model_args(model="m") == ["--model", "m"]
+        assert p.build_model_args(model="", fallback="fb") == []
+        assert p.supports_stream_json() is True
+        assert p.build_output_args("json") == ["--json"]
+        assert p.build_output_args("stream-json") == ["--json"]
+        assert p.build_max_turns_args(10) == []
+        assert p.build_mcp_args(configs=["x"]) == []
+        assert p.build_plugin_args(plugin_dirs=["/x"]) == []
+        assert p.build_effort_args(effort="high") == []
+        assert p.build_thinking_args(enabled=True) == ["--thinking"]
+        assert p.build_thinking_args(enabled=False) == []
+        assert p.invocation_lock_name() == "cline-cli"
+
+    def test_build_command_structure(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        cmd = p.build_command(prompt="hello", model="claude-sonnet-4", skip_permissions=True)
+        assert cmd[0] == "cline"
+        assert "--auto-approve" in cmd
+        assert "true" in cmd
+        assert "--model" in cmd
+        assert "claude-sonnet-4" in cmd
+        assert cmd[-1] == "hello"
+
+    def test_build_command_ordering(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        cmd = p.build_command(
+            prompt="test prompt",
+            model="claude-sonnet-4",
+            output_format="json",
+            skip_permissions=True,
+        )
+        # Verify order: binary -> permissions -> model -> output -> prompt
+        assert cmd[0] == "cline"
+        perm_idx = cmd.index("--auto-approve")
+        model_idx = cmd.index("--model")
+        assert perm_idx < model_idx
+        assert cmd[-1] == "test prompt"
+
+    def test_build_command_prepends_system_prompt(self):
+        from app.provider.cline import ClineProvider
+        cmd = ClineProvider().build_command(prompt="user", system_prompt="system")
+        assert cmd[-1].startswith("system")
+        assert "user" in cmd[-1]
+
+    def test_check_quota_success(self):
+        from app.provider.cline import ClineProvider
+        r = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, msg = ClineProvider().check_quota_available("/tmp")
+        assert ok is True
+        assert msg == ""
+
+    def test_check_quota_exhausted(self):
+        from app.provider.cline import ClineProvider
+        r = MagicMock(stdout="", stderr="rate limit exceeded", returncode=1)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, msg = ClineProvider().check_quota_available("/tmp")
+        assert ok is False
+        assert "rate limit" in msg
+
+    def test_check_quota_auth_failure(self):
+        from app.provider.cline import ClineProvider
+        r = MagicMock(stdout="401 Unauthorized", stderr="", returncode=1)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, msg = ClineProvider().check_quota_available("/tmp")
+        assert ok is False
+        assert "401" in msg
+
+    def test_check_quota_timeout_optimistic(self):
+        import subprocess as sp
+        from app.provider.cline import ClineProvider
+        with patch("app.provider.cline.subprocess.run",
+                   side_effect=sp.TimeoutExpired("cline", 1)):
+            ok, _ = ClineProvider().check_quota_available("/tmp")
+        assert ok is True
+
+    def test_check_quota_generic_error_optimistic(self):
+        from app.provider.cline import ClineProvider
+        with patch("app.provider.cline.subprocess.run",
+                   side_effect=OSError("no binary")):
+            ok, _ = ClineProvider().check_quota_available("/tmp")
+        assert ok is True
+
+    def test_detect_quota_exhaustion_stderr(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        assert p.detect_quota_exhaustion(stderr_text="rate limit exceeded") is True
+        assert p.detect_quota_exhaustion(stderr_text="quota exceeded") is True
+        assert p.detect_quota_exhaustion(stderr_text="HTTP 429") is True
+
+    def test_detect_quota_exhaustion_stdout_with_exit_code(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        assert p.detect_quota_exhaustion(
+            stdout_text="error: rate limit", exit_code=1
+        ) is True
+        # Should NOT detect quota on exit_code=0 (normal output)
+        assert p.detect_quota_exhaustion(
+            stdout_text="rate limit discussion", exit_code=0
+        ) is False
+
+    def test_detect_auth_failure(self):
+        from app.provider.cline import ClineProvider
+        p = ClineProvider()
+        assert p.detect_auth_failure(stderr_text="401 Unauthorized", exit_code=1) is True
+        assert p.detect_auth_failure(
+            stdout_text="invalid api key", exit_code=1
+        ) is True
+        assert p.detect_auth_failure(
+            stderr_text="authentication failed", exit_code=1
+        ) is True
+        # Should NOT detect auth on exit_code=0
+        assert p.detect_auth_failure(
+            stdout_text="401 Unauthorized", exit_code=0
+        ) is False
+
+
+# ---------------------------------------------------------------------------
 # _format_cli_error
 # ---------------------------------------------------------------------------
 

--- a/koan/tests/test_provider_quota.py
+++ b/koan/tests/test_provider_quota.py
@@ -336,3 +336,116 @@ class TestCopilotDetectQuotaExhaustion:
             stderr_text="",
             exit_code=1,
         ) is True
+
+
+class TestClineProviderQuota:
+    """Tests for ClineProvider.check_quota_available()."""
+
+    def setup_method(self):
+        from app.provider.cline import ClineProvider
+        self.provider = ClineProvider()
+
+    def test_quota_available(self):
+        """When probe succeeds, returns (True, '')."""
+        r = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, detail = self.provider.check_quota_available("/tmp")
+        assert ok is True
+        assert detail == ""
+
+    def test_quota_exhausted(self):
+        """When probe detects quota exhaustion, returns (False, detail)."""
+        r = MagicMock(stdout="", stderr="rate limit exceeded", returncode=1)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, detail = self.provider.check_quota_available("/tmp")
+        assert ok is False
+        assert "rate limit" in detail
+
+    def test_auth_failure(self):
+        """When probe detects auth failure, returns (False, detail)."""
+        r = MagicMock(stdout="401 Unauthorized", stderr="", returncode=1)
+        with patch("app.provider.cline.subprocess.run", return_value=r):
+            ok, detail = self.provider.check_quota_available("/tmp")
+        assert ok is False
+        assert "401" in detail
+
+    def test_timeout_returns_optimistic(self):
+        """Timeout should return (True, '') to avoid blocking the agent."""
+        with patch("app.provider.cline.subprocess.run",
+                   side_effect=subprocess.TimeoutExpired("cline", 1)):
+            ok, detail = self.provider.check_quota_available("/tmp")
+        assert ok is True
+        assert detail == ""
+
+    def test_os_error_returns_optimistic(self):
+        """OS errors should return (True, '') to avoid blocking the agent."""
+        with patch("app.provider.cline.subprocess.run",
+                   side_effect=OSError("no binary")):
+            ok, detail = self.provider.check_quota_available("/tmp")
+        assert ok is True
+        assert detail == ""
+
+    def test_probe_command_structure(self):
+        """Verify the probe uses the correct command structure."""
+        r = MagicMock(stdout="ok", stderr="", returncode=0)
+        with patch("app.provider.cline.subprocess.run", return_value=r) as mock_run:
+            self.provider.check_quota_available("/tmp/test")
+            call_args = mock_run.call_args
+            cmd = call_args[0][0]
+            assert cmd[0] == "cline"
+            assert "--auto-approve" in cmd
+            assert "true" in cmd
+            assert "--json" in cmd
+            assert "ok" in cmd
+
+
+class TestClineDetectQuotaExhaustion:
+    """Tests for ClineProvider.detect_quota_exhaustion()."""
+
+    def setup_method(self):
+        from app.provider.cline import ClineProvider
+        self.provider = ClineProvider()
+
+    def test_stderr_pattern_triggers(self):
+        """Stderr patterns always trigger quota detection."""
+        assert self.provider.detect_quota_exhaustion(
+            stderr_text="rate limit exceeded"
+        ) is True
+        assert self.provider.detect_quota_exhaustion(
+            stderr_text="quota exceeded"
+        ) is True
+        assert self.provider.detect_quota_exhaustion(
+            stderr_text="HTTP 429"
+        ) is True
+        assert self.provider.detect_quota_exhaustion(
+            stderr_text="too many requests"
+        ) is True
+
+    def test_stderr_empty_stdout_ok(self):
+        """Empty output with exit_code=0 does not trigger."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="", exit_code=0
+        ) is False
+
+    def test_stdout_quota_text_ignored_on_success(self):
+        """Rate limit text in stdout is ignored when exit_code=0."""
+        stdout = "Let's discuss rate limit handling in APIs."
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text=stdout, stderr_text="", exit_code=0
+        ) is False
+
+    def test_stdout_error_line_triggers_on_failure(self):
+        """When a stdout line looks like an error with quota text, triggers."""
+        stdout = "error: rate limit exceeded"
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text=stdout, stderr_text="", exit_code=1
+        ) is True
+
+    def test_stdout_quota_without_error_marker_ignored(self):
+        """Stdout without error marker is ignored even with quota text."""
+        # Note: This string does NOT contain error markers like "error", "api", "http", etc.
+        # but "limit" is in the error markers, so we use a string without any markers
+        stdout = "Your billing credit has run out for this billing period."
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text=stdout, stderr_text="", exit_code=1
+        ) is False

--- a/koan/tests/test_provider_system_prompt_file.py
+++ b/koan/tests/test_provider_system_prompt_file.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 from app.provider import (
     ClaudeProvider,
+    ClineProvider,
     CodexProvider,
     LocalLLMProvider,
     OllamaLaunchProvider,
@@ -25,6 +26,9 @@ class TestProviderCapabilityFlag:
 
     def test_claude_supports_file_mode(self):
         assert ClaudeProvider().supports_system_prompt_file() is True
+
+    def test_cline_does_not_support_file_mode(self):
+        assert ClineProvider().supports_system_prompt_file() is False
 
     def test_codex_does_not_support_file_mode(self):
         assert CodexProvider().supports_system_prompt_file() is False


### PR DESCRIPTION
## Summary

Adds Cline CLI as a fully supported CLI provider in Kōan, alongside Claude, Codex, Copilot, Local, and Ollama Launch. Users can now use Cline (`npm i -g cline`) with Kōan by setting `KOAN_CLI_PROVIDER=cline` or selecting it during onboarding.

Cline is a multi-backend AI coding assistant that supports OpenRouter, Anthropic, OpenAI, and other providers through a unified interface.

Closes https://github.com/Anantys-oss/koan/issues/1840

## Changes

### Core Implementation
- **koan/app/provider/cline.py**: New `ClineProvider` class implementing the CLIProvider interface
  - `--auto-approve true/false` for unattended execution (prevents headless deadlock)
  - `--json` for JSONL streaming output
  - `--thinking` for extended thinking mode
  - `--model` for model selection
  - Generic quota/auth detection patterns for multi-backend support

### Registry & Onboarding
- **koan/app/provider/__init__.py**: Import and register ClineProvider
- **koan/app/onboarding.py**: Add Cline to provider selection, model defaults, and detection
- **koan/app/pid_manager.py**: Update docstring to include "cline"

### Test Coverage
- **koan/tests/test_provider_modules.py**: 12 new tests for ClineProvider
- **koan/tests/test_provider_quota.py**: 11 new tests for quota/auth detection
- **koan/tests/test_provider_system_prompt_file.py**: 1 new test for file-mode capability

### Documentation
- **docs/providers/cline.md**: New comprehensive provider guide
- **docs/architecture/providers.md**: Add Cline to current providers list
- **docs/users/user-manual.md**: Add Cline to CLI providers table
- **docs/users/model-configuration.md**: Add `models.cline:` example
- **docs/users/onboarding.md**: Update step 3 to include Cline
- **docs/README.md**: Update Provider Setup line
- **CLAUDE.md**: Add cline.py to architecture section

## Test plan

- [x] `make lint` passes (no PERF violations)
- [x] 261 provider tests pass (including 24 new Cline tests)
- [x] `ClineProvider` builds correct CLI command structure
- [x] `--auto-approve` is always passed explicitly (true or false)
- [x] Quota detection works with generic multi-backend patterns
- [x] Auth failure detection works for 401, invalid API key, etc.
- [x] Onboarding lists Cline as selectable provider
- [x] Registry resolves `get_provider_by_name("cline")` correctly

---
### Quality Report

**Changes**: 14 files changed, 791 insertions(+), 5 deletions(-)

**Code scan**: 1 issue(s) found
- `koan/app/provider/cline.py:231` — debug print statement

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_