### PR TITLE
feat(github): add TTL cache to permission checks

### DIFF
--- a/koan/app/github_notifications.py
+++ b/koan/app/github_notifications.py
@@ -20,6 +20,7 @@ from typing import Dict, List, Optional, Set, Tuple
 
 from app.bounded_set import BoundedSet
 from app.github import SSOAuthRequired, api
+from app.response_cache import TTLCache
 
 log = logging.getLogger(__name__)
 
@@ -80,6 +81,10 @@ class NotificationTracker:
         self.processed_comments: BoundedSet = BoundedSet(
             maxlen=_MAX_PROCESSED_COMMENTS,
         )
+
+        # Permission cache: avoids repeated GitHub API calls for the same
+        # user/repo combination during a notification processing cycle.
+        self.permission_cache: TTLCache = TTLCache(max_entries=200)
 
     # -- SSO failure tracking -------------------------------------------------
 
@@ -588,6 +593,11 @@ class NotificationTracker:
             return username in allowed_users
 
         # Wildcard: verify at least write access via GitHub API
+        cache_key = f"{owner}/{repo}/{username}"
+        cached = self.permission_cache.get(cache_key)
+        if cached is not None:
+            return cached == "1"
+
         try:
             raw = api(
                 f"repos/{owner}/{repo}/collaborators/{username}/permission",
@@ -595,7 +605,9 @@ class NotificationTracker:
             )
             data = json.loads(raw) if raw else {}
             permission = data.get("permission", "none")
-            return permission in ("admin", "write")
+            result = permission in ("admin", "write")
+            self.permission_cache.put(cache_key, "1" if result else "0", ttl=300)
+            return result
         except SSOAuthRequired:
             self.record_sso_failure(
                 f"check_user_permission {owner}/{repo}",

--- a/koan/tests/test_github_notifications.py
+++ b/koan/tests/test_github_notifications.py
@@ -15,6 +15,7 @@ from app.github_notifications import (
     FetchResult,
     NotificationTracker,
     _FETCH_FAILURE_THRESHOLD,
+    _default_tracker,
     _processed_comments,
     _reactions_endpoint,
     _search_comments_for_mention,
@@ -558,6 +559,9 @@ class TestAddReaction:
 
 
 class TestCheckUserPermission:
+    def setup_method(self):
+        _default_tracker.permission_cache.clear()
+
     @patch("app.github_notifications.api")
     def test_wildcard_with_write_access(self, mock_api):
         mock_api.return_value = json.dumps({"permission": "write"})
@@ -583,6 +587,48 @@ class TestCheckUserPermission:
         """Explicit user in allowlist returns True without any GitHub API call."""
         assert check_user_permission("o", "r", "bob", ["alice", "bob"]) is True
         mock_api.assert_not_called()
+
+    @patch("app.github_notifications.api")
+    def test_wildcard_caches_result(self, mock_api):
+        """Second call with same owner/repo/user hits cache and skips API."""
+        mock_api.return_value = json.dumps({"permission": "write"})
+        assert check_user_permission("o", "r", "alice", ["*"]) is True
+        assert check_user_permission("o", "r", "alice", ["*"]) is True
+        mock_api.assert_called_once()
+
+    @patch("app.github_notifications.api")
+    def test_wildcard_cache_respects_different_keys(self, mock_api):
+        """Different owner/repo/user combinations each trigger a separate API call."""
+        mock_api.side_effect = [
+            json.dumps({"permission": "write"}),
+            json.dumps({"permission": "read"}),
+        ]
+        assert check_user_permission("o1", "r1", "alice", ["*"]) is True
+        assert check_user_permission("o2", "r2", "alice", ["*"]) is False
+        assert mock_api.call_count == 2
+
+    @patch("app.github_notifications.api")
+    def test_wildcard_cache_expires_after_ttl(self, mock_api):
+        """Cached entry expires after TTL and triggers a fresh API call."""
+        mock_api.return_value = json.dumps({"permission": "write"})
+        with patch("app.response_cache.time.monotonic", return_value=0.0):
+            assert check_user_permission("o", "r", "alice", ["*"]) is True
+            assert mock_api.call_count == 1
+        # Advance past default TTL (300s) + 1s margin
+        with patch("app.response_cache.time.monotonic", return_value=301.0):
+            assert check_user_permission("o", "r", "alice", ["*"]) is True
+            assert mock_api.call_count == 2
+
+    @patch("app.github_notifications.api")
+    def test_wildcard_cache_does_not_cache_errors(self, mock_api):
+        """Failed permission checks (API errors) are not cached."""
+        mock_api.side_effect = RuntimeError("API down")
+        assert check_user_permission("o", "r", "alice", ["*"]) is False
+        # Second call should retry the API
+        mock_api.side_effect = None
+        mock_api.return_value = json.dumps({"permission": "write"})
+        assert check_user_permission("o", "r", "alice", ["*"]) is True
+        assert mock_api.call_count == 2
 
 
 class TestIsNotificationStale:


### PR DESCRIPTION
**What:** Cache GitHub permission check results for wildcard mode to avoid repeated API calls within a 5-minute window.

**Why:** Every @mention notification in wildcard mode triggers a  API call. During a burst of notifications from the same repo, this quickly exhausts the GitHub API rate limit. Caching reduces redundant calls while still respecting permission changes within a reasonable TTL.

**How:**
- Reuses the existing  from  (300s TTL, 200-entry max).
- Cache is keyed by .
- Explicit allowlists bypass the cache entirely (no API call needed).
- API errors (SSO, RuntimeError, JSON decode) are **not** cached so retries happen on the next cycle.
- Added  to clear cache between tests.

**Testing:**
- 4 new tests covering cache hit, key separation, TTL expiry, and error non-caching.
- Full test suite: 138 passed, 0 failed.
- Ruff lint clean.

---
### Quality Report

**Changes**: 2 files changed, 59 insertions(+), 1 deletion(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_