### PR TITLE
feat(config): move recovery constants into config.yaml

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1203,6 +1203,16 @@ stagnation:
   sample_lines: 50            # Trailing lines hashed each sample
   max_retry_on_stagnation: 3  # Stagnation requeues before marking Failed (0 disables retry)
 
+# Crash and error recovery — how the loop tolerates failures before pausing
+# or giving up. Backoff grows linearly (attempt * multiplier) up to the caps.
+recovery:
+  max_consecutive_errors: 10    # Pause after this many iteration errors
+  max_main_crashes: 5          # Give up after this many crashes in main()
+  backoff_multiplier: 10       # Seconds per attempt step
+  max_backoff_main: 60         # Ceiling for main() crash backoff
+  max_backoff_iteration: 300    # Ceiling for iteration error backoff
+  error_notification_interval: 5  # Notify every N errors after the first
+
 # Prompt guard (content safety)
 prompt_guard:
   enabled: true               # Enable prompt injection detection (default: true)

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -258,6 +258,19 @@ skill_timeout: 7200
 #   sample_lines: 50
 #   max_retry_on_stagnation: 3
 
+# Crash and error recovery — how the agent loop tolerates failures.
+# ``max_consecutive_errors`` is the number of iteration failures before
+# the loop enters pause mode. ``max_main_crashes`` is the number of
+# unexpected crashes in the outer ``main()`` wrapper before giving up.
+# Backoff grows linearly (attempt * multiplier) up to the caps below.
+# recovery:
+#   max_consecutive_errors: 10
+#   max_main_crashes: 5
+#   backoff_multiplier: 10
+#   max_backoff_main: 60
+#   max_backoff_iteration: 300
+#   error_notification_interval: 5
+
 # Autonomous health diagnostics — automatically inject diagnostic missions
 # (tech_debt, dead_code, or audit) when a project's success rate falls below
 # a threshold and it has accumulated consecutive non-productive sessions.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1439,6 +1439,49 @@ def get_review_concurrency_config() -> dict:
     }
 
 
+def get_recovery_config() -> dict:
+    """Get crash and error recovery configuration from config.yaml.
+
+    Controls how the agent loop handles consecutive iteration errors and
+    unexpected crashes in main().  All values have defaults so recovery
+    works out of the box even when the section is absent.
+
+    Config key: recovery
+      - max_consecutive_errors (int): Pause after this many consecutive
+            iteration errors. Default: 10.
+      - max_main_crashes (int): Give up after this many crashes in main().
+            Default: 5.
+      - backoff_multiplier (int): Linear backoff step in seconds.
+            Default: 10.
+      - max_backoff_main (int): Backoff ceiling for main() crashes.
+            Default: 60.
+      - max_backoff_iteration (int): Backoff ceiling for iteration errors.
+            Default: 300.
+      - error_notification_interval (int): Notify every N errors after the
+            first. Default: 5.
+
+    Returns:
+        Dict with all keys present and values as ints.
+    """
+    defaults = {
+        "max_consecutive_errors": 10,
+        "max_main_crashes": 5,
+        "backoff_multiplier": 10,
+        "max_backoff_main": 60,
+        "max_backoff_iteration": 300,
+        "error_notification_interval": 5,
+    }
+    config = _load_config()
+    section = config.get("recovery", {})
+    if not isinstance(section, dict):
+        section = {}
+
+    result = {}
+    for key, default in defaults.items():
+        result[key] = _safe_int(section.get(key, default), default)
+    return result
+
+
 def get_review_reply_config() -> dict:
     """Get review reply guard configuration from config.yaml.
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -63,27 +63,9 @@ from app.signals import (
     STATUS_FILE,
     STOP_FILE,
 )
+from app.config import get_recovery_config
 from app.subprocess_runner import kill_process_group
 from app.utils import atomic_write
-
-
-# ---------------------------------------------------------------------------
-# Recovery configuration
-# ---------------------------------------------------------------------------
-
-# Maximum consecutive iteration errors before entering pause mode.
-MAX_CONSECUTIVE_ERRORS = 10
-
-# Maximum crashes in main() before giving up.
-MAX_MAIN_CRASHES = 5
-
-# Backoff parameters (in seconds).
-BACKOFF_MULTIPLIER = 10
-MAX_BACKOFF_MAIN = 60
-MAX_BACKOFF_ITERATION = 300
-
-# Notification throttling: notify on first error, then every N errors.
-ERROR_NOTIFICATION_INTERVAL = 5
 
 
 # ---------------------------------------------------------------------------
@@ -93,17 +75,21 @@ ERROR_NOTIFICATION_INTERVAL = 5
 def _calculate_backoff(attempt: int, max_backoff: int) -> int:
     """Calculate linear backoff capped at max_backoff.
 
-    Returns: attempt * BACKOFF_MULTIPLIER, capped at max_backoff.
+    Reads ``backoff_multiplier`` from ``recovery`` config section.
+    Returns: attempt * multiplier, capped at max_backoff.
     """
-    return min(BACKOFF_MULTIPLIER * attempt, max_backoff)
+    cfg = get_recovery_config()
+    return min(cfg["backoff_multiplier"] * attempt, max_backoff)
 
 
 def _should_notify_error(attempt: int) -> bool:
     """Determine if error notification should be sent.
 
-    Notifies on first error and every ERROR_NOTIFICATION_INTERVAL errors.
+    Notifies on first error and every ``error_notification_interval`` errors.
     """
-    return attempt == 1 or attempt % ERROR_NOTIFICATION_INTERVAL == 0
+    cfg = get_recovery_config()
+    interval = cfg["error_notification_interval"]
+    return attempt == 1 or attempt % interval == 0
 
 
 def _provider_identity() -> Tuple[str, str]:
@@ -1314,21 +1300,23 @@ def _handle_iteration_error(
     """Handle an exception from _run_iteration.
 
     Logs the error, backs off with increasing sleep, and enters
-    pause mode after MAX_CONSECUTIVE_ERRORS to avoid thrashing.
+    pause mode after ``max_consecutive_errors`` to avoid thrashing.
     """
+    cfg = get_recovery_config()
+    max_errors = cfg["max_consecutive_errors"]
     tb = traceback.format_exc()
-    log("error", f"Iteration failed ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): {error}")
+    log("error", f"Iteration failed ({consecutive_errors}/{max_errors}): {error}")
     log("error", f"Traceback:\n{tb}")
-    set_status(koan_root, f"Error recovery ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS})")
+    set_status(koan_root, f"Error recovery ({consecutive_errors}/{max_errors})")
 
     # Notify on first error and periodically
     if _should_notify_error(consecutive_errors):
         _notify(instance, (
-            f"⚠️ Run loop error ({consecutive_errors}/{MAX_CONSECUTIVE_ERRORS}): "
+            f"⚠️ Run loop error ({consecutive_errors}/{max_errors}): "
             f"{type(error).__name__}: {error}"
         ))
 
-    if consecutive_errors >= MAX_CONSECUTIVE_ERRORS:
+    if consecutive_errors >= max_errors:
         log("error", f"Too many consecutive errors ({consecutive_errors}). Entering pause mode.")
         _notify(instance, (
             f"🛑 Kōan entering pause mode after {consecutive_errors} consecutive errors.\n"
@@ -1340,7 +1328,7 @@ def _handle_iteration_error(
         return
 
     # Backoff with increasing delay
-    backoff = _calculate_backoff(consecutive_errors, MAX_BACKOFF_ITERATION)
+    backoff = _calculate_backoff(consecutive_errors, cfg["max_backoff_iteration"])
     log("koan", f"Recovering in {backoff}s...")
     time.sleep(backoff)
 
@@ -2292,14 +2280,16 @@ def main():
         except Exception:
             crash_count += 1
             tb = traceback.format_exc()
-            print(f"[koan] Unexpected crash ({crash_count}/{MAX_MAIN_CRASHES}): {tb}", file=sys.stderr)
+            cfg = get_recovery_config()
+            max_crashes = cfg["max_main_crashes"]
+            print(f"[koan] Unexpected crash ({crash_count}/{max_crashes}): {tb}", file=sys.stderr)
 
-            if crash_count >= MAX_MAIN_CRASHES:
-                print(f"[koan] Too many crashes ({MAX_MAIN_CRASHES}). Giving up.", file=sys.stderr)
+            if crash_count >= max_crashes:
+                print(f"[koan] Too many crashes ({max_crashes}). Giving up.", file=sys.stderr)
                 _reset_terminal()
                 sys.exit(1)
 
-            backoff = _calculate_backoff(crash_count, MAX_BACKOFF_MAIN)
+            backoff = _calculate_backoff(crash_count, cfg["max_backoff_main"])
             print(f"[koan] Restarting in {backoff}s...", file=sys.stderr)
             time.sleep(backoff)
 

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -37,7 +37,17 @@ def koan_root(tmp_path):
     instance = tmp_path / "instance"
     instance.mkdir()
     (instance / "missions.md").write_text("# Missions\n\n## En attente\n\n## En cours\n\n## Terminées\n")
-    (instance / "config.yaml").write_text("max_runs: 5\ninterval: 10\n")
+    (instance / "config.yaml").write_text(
+        "max_runs: 5\n"
+        "interval: 10\n"
+        "recovery:\n"
+        "  max_consecutive_errors: 10\n"
+        "  max_main_crashes: 5\n"
+        "  backoff_multiplier: 10\n"
+        "  max_backoff_main: 60\n"
+        "  max_backoff_iteration: 300\n"
+        "  error_notification_interval: 5\n"
+    )
     (tmp_path / "koan" / "app").mkdir(parents=True)
     return tmp_path
 
@@ -2457,10 +2467,10 @@ class TestHandleIterationError:
         mock_error_handling["sleep"].assert_called_once_with(80)
 
     def test_backoff_capped_at_max_iteration_constant(self, koan_root, mock_error_handling):
-        from app.run import _handle_iteration_error, MAX_CONSECUTIVE_ERRORS
+        from app.run import _handle_iteration_error
         instance = str(koan_root / "instance")
 
-        # Use error count below MAX_CONSECUTIVE_ERRORS to avoid entering pause mode
+        # Use error count below max to avoid entering pause mode
         with patch("app.pause_manager.create_pause"):
             _handle_iteration_error(
                 ValueError("err"), 9, str(koan_root), instance,
@@ -2482,11 +2492,11 @@ class TestHandleIterationError:
 
     def test_throttles_notifications(self, koan_root):
         """Only notifies on 1st and every 5th error."""
-        from app.run import _handle_iteration_error, ERROR_NOTIFICATION_INTERVAL
+        from app.run import _handle_iteration_error
         instance = str(koan_root / "instance")
 
         # Errors 2, 3, 4 should not notify
-        for i in range(2, ERROR_NOTIFICATION_INTERVAL):
+        for i in range(2, 5):
             with patch("app.run._notify") as mock_notify, \
                  patch("app.run.time.sleep"), \
                  patch("app.run.log"):
@@ -2495,34 +2505,34 @@ class TestHandleIterationError:
                 )
             mock_notify.assert_not_called()
 
-        # ERROR_NOTIFICATION_INTERVAL-th error: should notify
+        # 5th error: should notify
         with patch("app.run._notify") as mock_notify, \
              patch("app.run.time.sleep"), \
              patch("app.run.log"):
             _handle_iteration_error(
-                ValueError("err"), ERROR_NOTIFICATION_INTERVAL, str(koan_root), instance,
+                ValueError("err"), 5, str(koan_root), instance,
             )
         mock_notify.assert_called_once()
 
     def test_enters_pause_at_max_errors(self, koan_root, mock_error_handling):
-        from app.run import _handle_iteration_error, MAX_CONSECUTIVE_ERRORS
+        from app.run import _handle_iteration_error
         instance = str(koan_root / "instance")
 
         with patch("app.pause_manager.create_pause") as mock_pause:
             _handle_iteration_error(
-                RuntimeError("fatal"), MAX_CONSECUTIVE_ERRORS,
+                RuntimeError("fatal"), 10,
                 str(koan_root), instance,
             )
 
         mock_pause.assert_called_once_with(str(koan_root), "errors")
 
     def test_no_pause_below_max_errors(self, koan_root, mock_error_handling):
-        from app.run import _handle_iteration_error, MAX_CONSECUTIVE_ERRORS
+        from app.run import _handle_iteration_error
         instance = str(koan_root / "instance")
 
         with patch("app.pause_manager.create_pause") as mock_pause:
             _handle_iteration_error(
-                RuntimeError("err"), MAX_CONSECUTIVE_ERRORS - 1,
+                RuntimeError("err"), 9,
                 str(koan_root), instance,
             )
 
@@ -2530,12 +2540,12 @@ class TestHandleIterationError:
 
     def test_no_sleep_at_max_errors(self, koan_root, mock_error_handling):
         """At max errors, enters pause — no backoff sleep."""
-        from app.run import _handle_iteration_error, MAX_CONSECUTIVE_ERRORS
+        from app.run import _handle_iteration_error
         instance = str(koan_root / "instance")
 
         with patch("app.pause_manager.create_pause"):
             _handle_iteration_error(
-                RuntimeError("fatal"), MAX_CONSECUTIVE_ERRORS,
+                RuntimeError("fatal"), 10,
                 str(koan_root), instance,
             )
 
@@ -2695,7 +2705,7 @@ class TestMainCrashRecovery:
     @patch("app.run.time.sleep")
     def test_recovers_from_unexpected_crash(self, mock_sleep, mock_loop):
         """main() restarts main_loop after an unexpected exception."""
-        from app.run import main, BACKOFF_MULTIPLIER
+        from app.run import main
 
         call_count = [0]
         def side_effect():
@@ -2707,20 +2717,20 @@ class TestMainCrashRecovery:
         mock_loop.side_effect = side_effect
         main()
         assert call_count[0] == 2
-        # First crash: BACKOFF_MULTIPLIER * 1 = 10s
-        mock_sleep.assert_called_once_with(BACKOFF_MULTIPLIER)
+        # First crash: 10s
+        mock_sleep.assert_called_once_with(10)
 
     @patch("app.run.main_loop")
     @patch("app.run.time.sleep")
     def test_gives_up_after_max_crashes(self, mock_sleep, mock_loop):
-        """main() exits with code 1 after MAX_MAIN_CRASHES consecutive crashes."""
-        from app.run import main, MAX_MAIN_CRASHES
+        """main() exits with code 1 after max consecutive crashes."""
+        from app.run import main
 
         mock_loop.side_effect = RuntimeError("always crashing")
         with pytest.raises(SystemExit) as exc_info:
             main()
         assert exc_info.value.code == 1
-        assert mock_loop.call_count == MAX_MAIN_CRASHES
+        assert mock_loop.call_count == 5
 
     @patch("app.run.main_loop")
     @patch("app.run.time.sleep")
@@ -2750,7 +2760,7 @@ class TestMainCrashRecovery:
     @patch("app.run.time.sleep")
     def test_increasing_backoff_on_crashes(self, mock_sleep, mock_loop):
         """Backoff increases: 10s, 20s, 30s, 40s."""
-        from app.run import main, BACKOFF_MULTIPLIER
+        from app.run import main
 
         call_count = [0]
         def side_effect():
@@ -2762,7 +2772,7 @@ class TestMainCrashRecovery:
         mock_loop.side_effect = side_effect
         main()
         sleeps = [c[0][0] for c in mock_sleep.call_args_list]
-        expected = [BACKOFF_MULTIPLIER * i for i in range(1, 5)]
+        expected = [10 * i for i in range(1, 5)]
         assert sleeps == expected
 
 
@@ -3542,13 +3552,19 @@ class TestClaudeExitInit:
 
 
 # ---------------------------------------------------------------------------
-# Test: MAX_CONSECUTIVE_ERRORS constant
+# Test: Recovery config defaults
 # ---------------------------------------------------------------------------
 
 class TestConstants:
-    def test_max_consecutive_errors_is_10(self):
-        from app.run import MAX_CONSECUTIVE_ERRORS
-        assert MAX_CONSECUTIVE_ERRORS == 10
+    def test_recovery_defaults(self):
+        from app.config import get_recovery_config
+        cfg = get_recovery_config()
+        assert cfg["max_consecutive_errors"] == 10
+        assert cfg["max_main_crashes"] == 5
+        assert cfg["backoff_multiplier"] == 10
+        assert cfg["max_backoff_main"] == 60
+        assert cfg["max_backoff_iteration"] == 300
+        assert cfg["error_notification_interval"] == 5
 
 
 # ---------------------------------------------------------------------------
@@ -3559,10 +3575,10 @@ class TestRecoveryHelpers:
     """Tests for _calculate_backoff and _should_notify_error."""
 
     def test_calculate_backoff_linear_growth(self):
-        from app.run import _calculate_backoff, BACKOFF_MULTIPLIER
-        assert _calculate_backoff(1, 300) == BACKOFF_MULTIPLIER
-        assert _calculate_backoff(2, 300) == BACKOFF_MULTIPLIER * 2
-        assert _calculate_backoff(3, 300) == BACKOFF_MULTIPLIER * 3
+        from app.run import _calculate_backoff
+        assert _calculate_backoff(1, 300) == 10
+        assert _calculate_backoff(2, 300) == 20
+        assert _calculate_backoff(3, 300) == 30
 
     def test_calculate_backoff_capped(self):
         from app.run import _calculate_backoff
@@ -3574,13 +3590,13 @@ class TestRecoveryHelpers:
         assert _should_notify_error(1) is True
 
     def test_should_notify_at_interval(self):
-        from app.run import _should_notify_error, ERROR_NOTIFICATION_INTERVAL
-        assert _should_notify_error(ERROR_NOTIFICATION_INTERVAL) is True
-        assert _should_notify_error(ERROR_NOTIFICATION_INTERVAL * 2) is True
+        from app.run import _should_notify_error
+        assert _should_notify_error(5) is True
+        assert _should_notify_error(10) is True
 
     def test_should_not_notify_between_intervals(self):
-        from app.run import _should_notify_error, ERROR_NOTIFICATION_INTERVAL
-        for i in range(2, ERROR_NOTIFICATION_INTERVAL):
+        from app.run import _should_notify_error
+        for i in range(2, 5):
             assert _should_notify_error(i) is False
 
 


### PR DESCRIPTION
**What:** Move 6 hardcoded crash and error recovery constants from `run.py` into the `recovery:` section of `config.yaml`.

**Why:** Operators currently have to edit source code to tune how Kōan tolerates iteration errors and unexpected crashes. Making these values configurable per-instance allows tuning resilience without branch divergence.

**How:**
- Added `get_recovery_config()` to `app.config` with safe defaults for all 6 keys.
- Replaced module-level constants in `run.py` with inline config lookups via `get_recovery_config()`.
- Updated `test_run.py` fixture to write recovery values into `config.yaml` and removed tests that asserted on the now-removed constants.
- Documented the new section in `instance.example/config.yaml` and `docs/users/user-manual.md`.

**Testing:**
- Full test suite passes (`make test`).
- Lint passes (`make lint`).
- Recovery helper tests (`_calculate_backoff`, `_should_notify_error`) verified with default values.
- Iteration error handler and main crash recovery paths verified end-to-end.

---
### Quality Report

**Changes**: 5 files changed, 139 insertions(+), 67 deletions(-)

**Code scan**: 2 issue(s) found
- `koan/app/run.py:2285` — debug print statement
- `koan/app/run.py:2288` — debug print statement

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_