### PR TITLE
ci: request Koanex review as fallback

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -4,7 +4,6 @@ on:
     types: [opened]
 
 permissions:
-  issues: write
   pull-requests: write
 
 jobs:
@@ -16,6 +15,7 @@ jobs:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |
             const bot = 'Koan-Bot';
+            const fallbackBot = 'Koanex';
             const author = context.payload.pull_request.user.login;
             let commented = false;
 
@@ -32,10 +32,12 @@ jobs:
             }
 
             if (!commented) {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                body: '@Koan-Bot review'
-              });
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: context.issue.number,
+                  reviewers: [fallbackBot]
+                });
+              } catch (e) {}
             }


### PR DESCRIPTION
**What**: Route request-review fallback assignment to Koanex instead of posting a review comment.

**Why**: The mission spec asked to keep review routing inside GitHub reviewer assignment when the primary Koan-Bot request is skipped or fails.

**How**: Kept the pull_request_target trigger, author check, and primary Koan-Bot request unchanged; replaced the `if (!commented)` comment fallback with a best-effort `pulls.requestReviewers` call for `Koanex`; removed the now-unused `issues: write` permission.

**Testing**: `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/request-review.yml"); puts "YAML parse: ok"'`; extracted github-script passed `node --check`; `git diff --check` passed. `KOAN_ROOT=/tmp/test-koan make test` completed with 9 existing Codex provider quota failures and 15892 passing tests.

---
### Quality Report

**Changes**: 1 file changed, 9 insertions(+), 7 deletions(-)

**Code scan**: clean

**Tests**: passed (42 
tests)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

_Generated by [Kōan](https://koan.anantys.com)_