### PR TITLE
Improve TUI logs keyboard scrolling

### DIFF
--- a/docs/operations/interactive-launcher.md
+++ b/docs/operations/interactive-launcher.md
@@ -49,6 +49,7 @@ signal files). Four tabs:
   Status/Logs/Usage/Config. These work even while the config tree holds focus.
 - `m` — queue a new mission into `missions.md` (modal input; supports
   `[project:name]` tags).
+- Logs tab: Up/Down scroll one line; Page Up/Page Down scroll one page.
 - Arrow keys browse the focused config tree; Enter (or click) edits the
   selected scalar; `t` toggles a boolean in place (Enter also flips booleans).
 - `w` web dashboard, `k` keep-awake, `p` pause, `r` reload.

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -406,6 +406,8 @@ class KoanDashboard(App):
         Binding("c", "show('config')", "Config", show=False, priority=True),
         Binding("up", "focus_up", "Focus up", show=False, priority=True),
         Binding("down", "focus_pane", "Focus pane", show=False),
+        Binding("pageup", "logs_page_up", "Logs page up", show=False),
+        Binding("pagedown", "logs_page_down", "Logs page down", show=False),
         Binding("escape", "focus_tabs", "Focus tabs", show=False),
         Binding("t", "toggle", "Toggle bool", show=False),
         Binding("r", "refresh", "Refresh", show=False),
@@ -426,6 +428,7 @@ class KoanDashboard(App):
         self._detached = False
         # Monotonic timestamp of last CTRL-C interrupt for double-tap quit.
         self._last_interrupt_at = 0.0
+        self._logs_follow_tail = True
 
     def compose(self) -> ComposeResult:
         yield Header(show_clock=True)
@@ -477,6 +480,9 @@ class KoanDashboard(App):
 
     def action_focus_up(self) -> None:
         """Up arrow: navigate the config tree upward, or return to tabs at root."""
+        if self.active_pane_id() == "logs":
+            self._scroll_logs("up")
+            return
         try:
             tree = self.query_one("#config-tree", Tree)
             if tree.has_focus:
@@ -497,8 +503,46 @@ class KoanDashboard(App):
 
     def action_focus_pane(self) -> None:
         """Move focus from the tab bar into the active pane (Down)."""
-        if self.active_pane_id() == "config":
+        pane = self.active_pane_id()
+        if pane == "logs":
+            self._scroll_logs("down")
+        elif pane == "config":
             self._focus_config_tree()
+
+    def action_logs_page_up(self) -> None:
+        if self.active_pane_id() == "logs":
+            self._scroll_logs("page_up")
+
+    def action_logs_page_down(self) -> None:
+        if self.active_pane_id() == "logs":
+            self._scroll_logs("page_down")
+
+    def _scroll_logs(self, direction: str) -> None:
+        try:
+            log_widget = self.query_one("#logs-body", RichLog)
+        except Exception as exc:
+            self.log(f"log scroll skipped: {exc}")
+            return
+
+        if direction in {"up", "page_up"}:
+            self._logs_follow_tail = False
+            log_widget.auto_scroll = False
+            if direction == "up":
+                log_widget.scroll_up(animate=False, immediate=True)
+            else:
+                log_widget.scroll_page_up(animate=False)
+            return
+
+        if direction == "down":
+            log_widget.scroll_down(animate=False, immediate=True)
+        elif direction == "page_down":
+            log_widget.scroll_page_down(animate=False)
+        else:
+            return
+
+        if log_widget.scroll_y >= log_widget.max_scroll_y:
+            self._logs_follow_tail = True
+            log_widget.auto_scroll = True
 
     def action_show(self, pane: str) -> None:
         """Switch tabs via 1/2/3/4 or s/l/u/c."""
@@ -993,8 +1037,16 @@ class KoanDashboard(App):
         from rich.text import Text
 
         log_widget = self.query_one("#logs-body", RichLog)
+        if log_widget.max_scroll_y > 0:
+            self._logs_follow_tail = log_widget.scroll_y >= log_widget.max_scroll_y
+        previous_scroll_y = log_widget.scroll_y
+        log_widget.auto_scroll = self._logs_follow_tail
         log_widget.clear()
         log_widget.write(Text.from_ansi(body))
+        if self._logs_follow_tail:
+            log_widget.scroll_end(animate=False, immediate=True)
+        else:
+            log_widget.set_scroll(None, previous_scroll_y)
 
     # --- config tree --------------------------------------------------------
 

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -531,16 +531,23 @@ class KoanDashboard(App):
             if direction == "up":
                 log_widget.scroll_up(animate=False, immediate=True)
             else:
-                log_widget.scroll_page_up(animate=False, immediate=True)
+                log_widget.scroll_page_up(animate=False)
             return
 
         if direction == "down":
             log_widget.scroll_down(animate=False, immediate=True)
         elif direction == "page_down":
-            log_widget.scroll_page_down(animate=False, immediate=True)
+            log_widget.scroll_page_down(animate=False)
+            self.call_after_refresh(
+                lambda: self._resume_logs_follow_tail_if_at_bottom(log_widget)
+            )
+            return
         else:
             return
 
+        self._resume_logs_follow_tail_if_at_bottom(log_widget)
+
+    def _resume_logs_follow_tail_if_at_bottom(self, log_widget: RichLog) -> None:
         if log_widget.scroll_y >= log_widget.max_scroll_y:
             self._logs_follow_tail = True
             log_widget.auto_scroll = True

--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -28,6 +28,7 @@ _log = logging.getLogger(__name__)
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Container, Vertical
+from textual.css.query import NoMatches, TooManyMatches
 from textual.screen import ModalScreen
 from textual.widgets import (
     Button,
@@ -520,7 +521,7 @@ class KoanDashboard(App):
     def _scroll_logs(self, direction: str) -> None:
         try:
             log_widget = self.query_one("#logs-body", RichLog)
-        except Exception as exc:
+        except (NoMatches, TooManyMatches) as exc:
             self.log(f"log scroll skipped: {exc}")
             return
 
@@ -530,13 +531,13 @@ class KoanDashboard(App):
             if direction == "up":
                 log_widget.scroll_up(animate=False, immediate=True)
             else:
-                log_widget.scroll_page_up(animate=False)
+                log_widget.scroll_page_up(animate=False, immediate=True)
             return
 
         if direction == "down":
             log_widget.scroll_down(animate=False, immediate=True)
         elif direction == "page_down":
-            log_widget.scroll_page_down(animate=False)
+            log_widget.scroll_page_down(animate=False, immediate=True)
         else:
             return
 

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -221,6 +221,92 @@ def test_pilot_logs_with_ansi_and_brackets_do_not_crash(tmp_path):
     asyncio.run(scenario())
 
 
+def test_pilot_logs_tab_arrows_scroll_without_focus_trap(tmp_path):
+    _write_config(tmp_path, "x: 1\n")
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "run.log").write_text("\n".join(f"run line {i}" for i in range(220)))
+    (logs / "awake.log").write_text("\n".join(f"awake line {i}" for i in range(220)))
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test(size=(80, 12)) as pilot:
+            await pilot.press("l")
+            await pilot.pause()
+            log_widget = app.query_one("#logs-body", tui.RichLog)
+            log_widget.action_scroll_end()
+            await pilot.pause()
+            bottom = log_widget.scroll_y
+
+            await pilot.press("up")
+            await pilot.pause()
+            assert log_widget.scroll_y < bottom
+            one_line_up = log_widget.scroll_y
+
+            await pilot.press("down")
+            await pilot.pause()
+            assert log_widget.scroll_y > one_line_up
+
+    asyncio.run(scenario())
+
+
+def test_pilot_logs_tab_pages_scroll(tmp_path):
+    _write_config(tmp_path, "x: 1\n")
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    (logs / "run.log").write_text("\n".join(f"run line {i}" for i in range(220)))
+    (logs / "awake.log").write_text("\n".join(f"awake line {i}" for i in range(220)))
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test(size=(80, 12)) as pilot:
+            await pilot.press("l")
+            await pilot.pause()
+            log_widget = app.query_one("#logs-body", tui.RichLog)
+            log_widget.action_scroll_end()
+            await pilot.pause()
+            bottom = log_widget.scroll_y
+
+            await pilot.press("pageup")
+            await pilot.pause()
+            assert log_widget.scroll_y < bottom
+            page_up = log_widget.scroll_y
+
+            await pilot.press("pagedown")
+            await pilot.pause()
+            assert log_widget.scroll_y > page_up
+
+    asyncio.run(scenario())
+
+
+def test_pilot_logs_manual_scroll_survives_refresh(tmp_path):
+    _write_config(tmp_path, "x: 1\n")
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    run_log = logs / "run.log"
+    run_log.write_text("\n".join(f"run line {i}" for i in range(220)))
+    (logs / "awake.log").write_text("")
+
+    async def scenario():
+        app = tui.KoanDashboard(tmp_path)
+        async with app.run_test(size=(80, 12)) as pilot:
+            await pilot.press("l")
+            await pilot.pause()
+            log_widget = app.query_one("#logs-body", tui.RichLog)
+            log_widget.action_scroll_end()
+            await pilot.pause()
+
+            await pilot.press("pageup")
+            await pilot.pause()
+            scrolled_position = log_widget.scroll_y
+            run_log.write_text(run_log.read_text() + "\nnew line after manual scroll")
+            app._render_logs()
+            await pilot.pause()
+            assert log_widget.scroll_y == scrolled_position
+
+    asyncio.run(scenario())
+
+
 def test_pilot_letter_aliases_switch_tabs(tmp_path):
     _write_config(tmp_path, "x: 1\n")
 


### PR DESCRIPTION
## Summary

Adds keyboard scrolling to the terminal dashboard Logs tab while preserving live tail behavior unless the operator scrolls away from the bottom.

Closes https://github.com/Anantys-oss/koan/issues/1860

## Changes

- Routes Up/Down and Page Up/Page Down to the Logs RichLog when the Logs tab is active.
- Preserves manual log scroll position across refreshes and resumes tailing at the bottom.
- Adds focused Textual pilot coverage and updates interactive launcher docs.

## Test plan

- KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_tui_dashboard.py -v
- make lint

---
### Quality Report

**Changes**: 3 files changed, 140 insertions(+), 1 deletion(-)

**Code scan**: clean

**Tests**: passed (42 
tests)

**Branch hygiene**: 2 issue(s)
- Branch is not pushed to remote
- Non-conventional commit: Add keyboard scrolling for TUI logs

_Generated by [Kōan](https://koan.anantys.com)_