### PR TITLE
fix(quota): add Ollama-specific quota patterns

### DIFF
--- a/koan/app/provider/ollama_launch.py
+++ b/koan/app/provider/ollama_launch.py
@@ -15,6 +15,7 @@ Claude Code CLI verbatim.
 """
 
 import os
+import re
 import shutil
 import sys
 from typing import Dict, List, Optional, Tuple
@@ -152,6 +153,30 @@ class OllamaLaunchProvider(ClaudeProvider):
     def check_quota_available(self, project_path: str, timeout: int = 15) -> Tuple[bool, str]:
         """Local models have no API quota — always available."""
         return True, ""
+
+    def detect_quota_exhaustion(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect Ollama-specific quota failures, then fall back to Claude patterns.
+
+        Ollama can rate-limit requests with a 429 when the upstream API
+        (Anthropic via Ollama) is exhausted. The error text includes phrases
+        like "Request rejected (429)" and "reached your session usage limit".
+        """
+        text = (stderr_text or "") + "\n" + (stdout_text or "")
+        ollama_patterns = [
+            r"Request rejected \(429\)",
+            r"reached your session usage limit",
+            r"ollama\.com/upgrade",
+        ]
+        for pattern in ollama_patterns:
+            if re.search(pattern, text, re.IGNORECASE):
+                return True
+        # Fall back to Claude patterns (rate_limit_event, session limit, etc.)
+        return super().detect_quota_exhaustion(stdout_text, stderr_text, exit_code)
 
     def has_api_quota(self) -> bool:
         """Ollama launch uses local or cloud Ollama — no metered API quota."""

--- a/koan/app/quota_handler.py
+++ b/koan/app/quota_handler.py
@@ -58,6 +58,10 @@ _STRICT_QUOTA_PATTERNS = [
     r"insufficient.*credits?",
     r"billing.*(?:limit|period.*exceeded)",
     r"usage.*cap.*(?:reached|exceeded|hit)",
+    # Ollama / ollama-launch provider
+    r"Request rejected \(429\)",
+    r"reached your session usage limit",
+    r"ollama\.com/upgrade",
     # Claude Code CLI: "You've hit your session limit · resets 6pm (UTC)"
     r"(?:you'?ve\s+)?hit\s+(?:your|the)\s+(?:session\s+)?limit",
 ]

--- a/koan/tests/test_ollama_launch_provider.py
+++ b/koan/tests/test_ollama_launch_provider.py
@@ -218,6 +218,42 @@ class TestOllamaLaunchFlags:
             stdout_text="", stderr_text="ok", exit_code=0,
         ) is False
 
+    def test_detects_ollama_429_rejected(self):
+        """Detect Ollama-specific 429 rejection message."""
+        stderr = (
+            "API Error: Request rejected (429) · you have reached your "
+            "session usage limit, upgrade for higher limits: https://ollama.com/upgrade"
+        )
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text=stderr, exit_code=1,
+        ) is True
+
+    def test_detects_ollama_session_usage_limit(self):
+        """Detect Ollama 'reached your session usage limit' message."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="reached your session usage limit", exit_code=1,
+        ) is True
+
+    def test_detects_ollama_upgrade_link(self):
+        """Detect Ollama upgrade link as quota signal."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="visit https://ollama.com/upgrade", exit_code=1,
+        ) is True
+
+    def test_ollama_quota_patterns_are_case_insensitive(self):
+        """Ollama quota patterns are matched case-insensitively."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="", stderr_text="REQUEST REJECTED (429)", exit_code=1,
+        ) is True
+
+    def test_no_false_positive_on_normal_ollama_output(self):
+        """Normal Ollama output should not trigger quota detection."""
+        assert self.provider.detect_quota_exhaustion(
+            stdout_text="ollama launch claude started successfully",
+            stderr_text="",
+            exit_code=0,
+        ) is False
+
     def test_get_session_data_none_when_no_project(self):
         """Session data depends on Claude CLI artifacts; missing project returns None."""
         from unittest.mock import patch

--- a/koan/tests/test_quota_handler.py
+++ b/koan/tests/test_quota_handler.py
@@ -377,6 +377,43 @@ class TestDetectQuotaExhaustionCreditMessages:
         assert detect_quota_exhaustion(error_json) is True
 
 
+class TestDetectQuotaExhaustionOllama:
+    """Test detection of Ollama / ollama-launch specific quota messages."""
+
+    def test_detects_request_rejected_429(self):
+        from app.quota_handler import detect_quota_exhaustion
+
+        assert detect_quota_exhaustion(
+            "API Error: Request rejected (429) · you have reached your limit"
+        ) is True
+
+    def test_detects_session_usage_limit(self):
+        from app.quota_handler import detect_quota_exhaustion
+
+        assert detect_quota_exhaustion(
+            "you (atoomic) have reached your session usage limit"
+        ) is True
+
+    def test_detects_ollama_upgrade_link(self):
+        from app.quota_handler import detect_quota_exhaustion
+
+        assert detect_quota_exhaustion(
+            "upgrade for higher limits: https://ollama.com/upgrade"
+        ) is True
+
+    def test_case_insensitive(self):
+        from app.quota_handler import detect_quota_exhaustion
+
+        assert detect_quota_exhaustion("REQUEST REJECTED (429)") is True
+        assert detect_quota_exhaustion("Reached Your Session Usage Limit") is True
+
+    def test_no_false_positive_on_normal_ollama_output(self):
+        from app.quota_handler import detect_quota_exhaustion
+
+        assert detect_quota_exhaustion("ollama launch claude started") is False
+        assert detect_quota_exhaustion("running ollama serve") is False
+
+
 class TestExtractResetInfo:
     """Test extract_reset_info function."""
 


### PR DESCRIPTION
**What:** Add Ollama-specific quota patterns to the global quota detector and ollama-launch provider.

**Why:** Ollama's error format ("Request rejected (429) · you have reached your session usage limit") does not match existing patterns, causing false "no exhaustion" detections and infinite looping.

**How:** Adds three strict patterns: `Request rejected (429)`, `reached your session usage limit`, `ollama.com/upgrade`. Also overrides `detect_quota_exhaustion` in `OllamaLaunchProvider`.

**Testing:** Added 3 new tests for the global detector and 3 tests for the provider override — all passing.

---
### Quality Report

**Changes**: 4 files changed, 102 insertions(+)

**Code scan**: clean

**Tests**: passed (42 
tests)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

_Generated by [Kōan](https://koan.anantys.com)_