### PR TITLE
fix: use exclusive locking for ci_dispatch and review_comment_dispatch trackers

### DIFF
--- a/koan/app/api/mission_index.py
+++ b/koan/app/api/mission_index.py
@@ -62,11 +62,11 @@ def record_mission(instance_dir: Path, text: str, project: Optional[str]) -> str
     Returns the existing id if a pending record with the same text already
     exists (dedup guard against double-calls from dashboard + REST API).
     """
-    needle = text.lstrip("- ").strip()
+    needle = _normalize_for_match(text)
     records = _load_index(instance_dir)
     for rec in records:
         if rec.get("status") == "pending":
-            stored = rec.get("text", "").lstrip("- ").strip()
+            stored = _normalize_for_match(rec.get("text", ""))
             if stored == needle and rec.get("project") == project:
                 return rec["id"]
     mission_id = str(uuid.uuid4())

--- a/koan/app/ci_dispatch.py
+++ b/koan/app/ci_dispatch.py
@@ -76,19 +76,16 @@ def _tracker_path(instance_dir: str) -> Path:
     return Path(instance_dir) / ".ci-dispatch-tracker.json"
 
 
-def _load_tracker(instance_dir: str) -> dict:
-    path = _tracker_path(instance_dir)
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return {}
+def _read_tracker(instance_dir: str) -> dict:
+    """Read tracker state under a shared lock (snapshot for cooldown checks)."""
+    from app.locked_file import locked_json_read
+    return locked_json_read(_tracker_path(instance_dir), default={}) or {}
 
 
-def _save_tracker(instance_dir: str, data: dict) -> None:
-    from app.utils import atomic_write_json
-    atomic_write_json(_tracker_path(instance_dir), data)
+def _mutate_tracker(instance_dir: str, fn) -> None:
+    """Apply fn(data) → data under exclusive lock (atomic read-modify-write)."""
+    from app.locked_file import locked_json_modify
+    locked_json_modify(_tracker_path(instance_dir), fn)
 
 
 def fetch_koan_open_prs(project_path: str) -> List[dict]:
@@ -244,27 +241,28 @@ def check_and_dispatch_ci_fixes(
     if not projects:
         return 0
 
-    tracker = _load_tracker(instance_dir)
+    # Read snapshot for cooldown checks (no lock needed — stale reads are fine here).
+    snapshot = _read_tracker(instance_dir)
     cooldown_secs = config["cooldown_minutes"] * 60
     max_log_bytes = config["log_snippet_bytes"]
     now = time.time()
     dispatched = 0
-    tracker_changed = False
 
     for project_name, project_path in projects:
         project_key = f"cooldown:{project_name}"
-        last_check = tracker.get(project_key, 0)
+        last_check = snapshot.get(project_key, 0)
         if now - last_check < cooldown_secs:
             continue
 
         full_repo = _resolve_full_repo(project_path)
         if not full_repo:
+            # Still update the cooldown so we don't hammer gh on every cycle.
+            _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
             continue
 
         prs = fetch_koan_open_prs(project_path)
         if not prs:
-            tracker[project_key] = now
-            tracker_changed = True
+            _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
             continue
 
         for pr in prs:
@@ -283,7 +281,8 @@ def check_and_dispatch_ci_fixes(
                 fingerprint = compute_ci_fingerprint(pr_number, head_sha, job_name, run_id)
                 fp_key = f"{full_repo}#{fingerprint}"
 
-                if fp_key in tracker:
+                # Fast path: snapshot check avoids locking for already-seen failures.
+                if fp_key in snapshot:
                     continue
 
                 log_snippet = fetch_check_run_log_snippet(
@@ -299,12 +298,29 @@ def check_and_dispatch_ci_fixes(
                     f"{job_name} on PR #{pr_number} — {context}"
                 )
 
+                # Re-check under exclusive lock before inserting to prevent
+                # concurrent dispatchers from queuing the same mission twice.
+                inserted = False
+
+                def _record_and_insert(data, _fp_key=fp_key, _now=now, _mission=mission):
+                    nonlocal inserted
+                    if _fp_key in data:
+                        return data  # lost the race — already dispatched
+                    try:
+                        from app.utils import insert_pending_mission
+                        missions_path = Path(instance_dir) / "missions.md"
+                        inserted = insert_pending_mission(missions_path, f"- {_mission}")
+                    except (ImportError, OSError) as e:
+                        log.warning("Failed to insert CI fix mission: %s", e)
+                        return data
+                    # Store timestamp (not fingerprint) to enable future TTL pruning.
+                    data[_fp_key] = _now
+                    return data
+
                 try:
-                    from app.utils import insert_pending_mission
-                    missions_path = Path(instance_dir) / "missions.md"
-                    inserted = insert_pending_mission(missions_path, f"- {mission}")
-                except (ImportError, OSError) as e:
-                    log.warning("Failed to insert CI fix mission: %s", e)
+                    _mutate_tracker(instance_dir, _record_and_insert)
+                except OSError as e:
+                    log.warning("Failed to update CI dispatch tracker: %s", e)
                     continue
 
                 if inserted:
@@ -313,14 +329,9 @@ def check_and_dispatch_ci_fixes(
                         job_name, full_repo, pr_number, head_sha[:8],
                     )
                     dispatched += 1
+                    # Update snapshot so subsequent loop iterations see this fp.
+                    snapshot[fp_key] = now
 
-                tracker[fp_key] = fingerprint
-                tracker_changed = True
-
-        tracker[project_key] = now
-        tracker_changed = True
-
-    if tracker_changed:
-        _save_tracker(instance_dir, tracker)
+        _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
 
     return dispatched

--- a/koan/app/review_comment_dispatch.py
+++ b/koan/app/review_comment_dispatch.py
@@ -210,19 +210,16 @@ def _tracker_path(instance_dir: str) -> Path:
     return Path(instance_dir) / ".review-dispatch-tracker.json"
 
 
-def _load_tracker(instance_dir: str) -> dict:
-    path = _tracker_path(instance_dir)
-    if not path.exists():
-        return {}
-    try:
-        return json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return {}
+def _read_tracker(instance_dir: str) -> dict:
+    """Read tracker state under a shared lock (snapshot for cooldown checks)."""
+    from app.locked_file import locked_json_read
+    return locked_json_read(_tracker_path(instance_dir), default={}) or {}
 
 
-def _save_tracker(instance_dir: str, data: dict) -> None:
-    from app.utils import atomic_write_json
-    atomic_write_json(_tracker_path(instance_dir), data)
+def _mutate_tracker(instance_dir: str, fn) -> None:
+    """Apply fn(data) → data under exclusive lock (atomic read-modify-write)."""
+    from app.locked_file import locked_json_modify
+    locked_json_modify(_tracker_path(instance_dir), fn)
 
 
 # ---------------------------------------------------------------------------
@@ -292,27 +289,27 @@ def check_and_dispatch_review_comments(
     if not projects:
         return 0
 
-    tracker = _load_tracker(instance_dir)
+    # Read snapshot for cooldown checks (no lock needed — stale reads are fine here).
+    snapshot = _read_tracker(instance_dir)
     bot_username = _get_bot_username()
     cooldown_secs = config["cooldown_minutes"] * 60
     now = time.time()
     dispatched = 0
-    tracker_changed = False
 
     for project_name, project_path in projects:
         project_key = f"cooldown:{project_name}"
-        last_check = tracker.get(project_key, 0)
+        last_check = snapshot.get(project_key, 0)
         if now - last_check < cooldown_secs:
             continue
 
         full_repo = _resolve_full_repo(project_path)
         if not full_repo:
+            _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
             continue
 
         prs = fetch_koan_open_prs(project_path)
         if not prs:
-            tracker[project_key] = now
-            tracker_changed = True
+            _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
             continue
 
         for pr in prs:
@@ -328,14 +325,17 @@ def check_and_dispatch_review_comments(
             all_comments = inline + reviews
 
             if not all_comments:
-                if pr_key in tracker:
-                    del tracker[pr_key]
-                    tracker_changed = True
+                # Clear stored fingerprint under lock when comments are resolved.
+                def _clear_pr(data, _pr_key=pr_key):
+                    data.pop(_pr_key, None)
+                _mutate_tracker(instance_dir, _clear_pr)
+                snapshot.pop(pr_key, None)
                 continue
 
             fingerprint = compute_comment_fingerprint(all_comments)
-            stored = tracker.get(pr_key)
+            stored = snapshot.get(pr_key)
 
+            # Fast path: skip if snapshot shows no change.
             if stored == fingerprint:
                 continue
 
@@ -345,12 +345,36 @@ def check_and_dispatch_review_comments(
                 f"#{pr_number} ({summary})"
             )
 
+            # Re-check under exclusive lock before inserting to prevent concurrent
+            # dispatchers from queuing the same mission twice.
+            inserted = False
+
+            def _record_and_insert(
+                data,
+                _pr_key=pr_key,
+                _fingerprint=fingerprint,
+                _stored=stored,
+                _mission=mission,
+                _full_repo=full_repo,
+                _pr_number=pr_number,
+            ):
+                nonlocal inserted
+                if data.get(_pr_key) == _fingerprint:
+                    return data  # lost the race — already dispatched
+                try:
+                    from app.utils import insert_pending_mission
+                    missions_path = Path(instance_dir) / "missions.md"
+                    inserted = insert_pending_mission(missions_path, f"- {_mission}")
+                except (ImportError, OSError) as e:
+                    log.warning("Failed to insert review dispatch mission: %s", e)
+                    return data
+                data[_pr_key] = _fingerprint
+                return data
+
             try:
-                from app.utils import insert_pending_mission
-                missions_path = Path(instance_dir) / "missions.md"
-                inserted = insert_pending_mission(missions_path, f"- {mission}")
-            except (ImportError, OSError) as e:
-                log.warning("Failed to insert review dispatch mission: %s", e)
+                _mutate_tracker(instance_dir, _record_and_insert)
+            except OSError as e:
+                log.warning("Failed to update review dispatch tracker: %s", e)
                 continue
 
             if inserted:
@@ -360,13 +384,8 @@ def check_and_dispatch_review_comments(
                     (stored or "none")[:8], fingerprint[:8],
                 )
                 dispatched += 1
-                tracker[pr_key] = fingerprint
-                tracker_changed = True
+                snapshot[pr_key] = fingerprint
 
-        tracker[project_key] = now
-        tracker_changed = True
-
-    if tracker_changed:
-        _save_tracker(instance_dir, tracker)
+        _mutate_tracker(instance_dir, lambda d: d.update({project_key: now}) or d)
 
     return dispatched

--- a/koan/tests/test_ci_dispatch.py
+++ b/koan/tests/test_ci_dispatch.py
@@ -149,11 +149,10 @@ class TestCheckAndDispatchCiFixes:
     @patch("app.ci_dispatch.fetch_failing_check_runs")
     @patch("app.ci_dispatch.fetch_koan_open_prs")
     @patch("app.ci_dispatch._resolve_full_repo", return_value="owner/repo")
-    @patch("app.ci_dispatch._save_tracker")
-    @patch("app.ci_dispatch._load_tracker", return_value={})
+    @patch("app.ci_dispatch._read_tracker", return_value={})
     @patch("app.ci_dispatch._get_ci_dispatch_config")
     def test_dispatches_mission_on_failure(
-        self, mock_config, mock_load, mock_save, mock_repo,
+        self, mock_config, mock_read, mock_repo,
         mock_prs, mock_fails, mock_log, instance_dir, koan_root,
     ):
         mock_config.return_value = {
@@ -183,11 +182,10 @@ class TestCheckAndDispatchCiFixes:
     @patch("app.ci_dispatch.fetch_failing_check_runs", return_value=[])
     @patch("app.ci_dispatch.fetch_koan_open_prs")
     @patch("app.ci_dispatch._resolve_full_repo", return_value="owner/repo")
-    @patch("app.ci_dispatch._save_tracker")
-    @patch("app.ci_dispatch._load_tracker", return_value={})
+    @patch("app.ci_dispatch._read_tracker", return_value={})
     @patch("app.ci_dispatch._get_ci_dispatch_config")
     def test_no_dispatch_when_ci_passes(
-        self, mock_config, mock_load, mock_save, mock_repo,
+        self, mock_config, mock_read, mock_repo,
         mock_prs, mock_fails, instance_dir, koan_root,
     ):
         mock_config.return_value = {
@@ -210,11 +208,10 @@ class TestCheckAndDispatchCiFixes:
     @patch("app.ci_dispatch.fetch_failing_check_runs")
     @patch("app.ci_dispatch.fetch_koan_open_prs")
     @patch("app.ci_dispatch._resolve_full_repo", return_value="owner/repo")
-    @patch("app.ci_dispatch._save_tracker")
-    @patch("app.ci_dispatch._load_tracker")
+    @patch("app.ci_dispatch._read_tracker")
     @patch("app.ci_dispatch._get_ci_dispatch_config")
     def test_dedup_prevents_double_dispatch(
-        self, mock_config, mock_load, mock_save, mock_repo,
+        self, mock_config, mock_read, mock_repo,
         mock_prs, mock_fails, mock_log, instance_dir, koan_root,
     ):
         mock_config.return_value = {
@@ -228,7 +225,7 @@ class TestCheckAndDispatchCiFixes:
         ]
 
         fingerprint = compute_ci_fingerprint(42, "sha123", "test-suite", "1")
-        mock_load.return_value = {f"owner/repo#{fingerprint}": fingerprint}
+        mock_read.return_value = {f"owner/repo#{fingerprint}": 1234567890.0}
 
         with patch("app.projects_config.load_projects_config") as mock_pc, \
              patch("app.projects_config.get_projects_from_config") as mock_gp:
@@ -241,18 +238,17 @@ class TestCheckAndDispatchCiFixes:
 
     @patch("app.ci_dispatch.fetch_koan_open_prs")
     @patch("app.ci_dispatch._resolve_full_repo", return_value="owner/repo")
-    @patch("app.ci_dispatch._save_tracker")
-    @patch("app.ci_dispatch._load_tracker")
+    @patch("app.ci_dispatch._read_tracker")
     @patch("app.ci_dispatch._get_ci_dispatch_config")
     def test_cooldown_skips_project(
-        self, mock_config, mock_load, mock_save, mock_repo,
+        self, mock_config, mock_read, mock_repo,
         mock_prs, instance_dir, koan_root,
     ):
         import time
         mock_config.return_value = {
             "enabled": True, "cooldown_minutes": 60, "log_snippet_bytes": 4096,
         }
-        mock_load.return_value = {"cooldown:myproject": time.time()}
+        mock_read.return_value = {"cooldown:myproject": time.time()}
 
         with patch("app.projects_config.load_projects_config") as mock_pc, \
              patch("app.projects_config.get_projects_from_config") as mock_gp:

--- a/koan/tests/test_review_comment_dispatch.py
+++ b/koan/tests/test_review_comment_dispatch.py
@@ -105,22 +105,22 @@ class TestTrackerPersistence:
     """Tracker file read/write/roundtrip."""
 
     def test_load_missing_file(self, tmp_path):
-        from app.review_comment_dispatch import _load_tracker
+        from app.review_comment_dispatch import _read_tracker
 
-        assert _load_tracker(str(tmp_path)) == {}
+        assert _read_tracker(str(tmp_path)) == {}
 
     def test_load_corrupt_file(self, tmp_path):
-        from app.review_comment_dispatch import _load_tracker
+        from app.review_comment_dispatch import _read_tracker
 
         (tmp_path / ".review-dispatch-tracker.json").write_text("not json")
-        assert _load_tracker(str(tmp_path)) == {}
+        assert _read_tracker(str(tmp_path)) == {}
 
     def test_roundtrip(self, tmp_path):
-        from app.review_comment_dispatch import _load_tracker, _save_tracker
+        from app.review_comment_dispatch import _read_tracker, _mutate_tracker
 
         data = {"key": "value", "num": 42}
-        _save_tracker(str(tmp_path), data)
-        loaded = _load_tracker(str(tmp_path))
+        _mutate_tracker(str(tmp_path), lambda d: d.update(data) or d)
+        loaded = _read_tracker(str(tmp_path))
         assert loaded == data
 
 
@@ -270,6 +270,12 @@ class TestReviewDispatchConfigHelpers:
         assert _resolve_full_repo("/project") is None
 
 
+def _write_tracker(instance_dir, data: dict) -> None:
+    """Write tracker state directly to disk (test setup helper)."""
+    path = Path(instance_dir) / ".review-dispatch-tracker.json"
+    path.write_text(json.dumps(data))
+
+
 class TestCheckAndDispatch:
     """Integration test for the main dispatch orchestrator."""
 
@@ -334,7 +340,6 @@ class TestCheckAndDispatch:
         from app.review_comment_dispatch import (
             check_and_dispatch_review_comments,
             compute_comment_fingerprint,
-            _save_tracker,
         )
 
         mock_config.return_value = {"enabled": True, "cooldown_minutes": 0}
@@ -349,7 +354,7 @@ class TestCheckAndDispatch:
         mock_review_body.return_value = []
 
         fp = compute_comment_fingerprint(comments)
-        _save_tracker(instance_dir, {"owner/myproject#42": fp})
+        _write_tracker(instance_dir, {"owner/myproject#42": fp})
 
         result = check_and_dispatch_review_comments(instance_dir, "/koan")
         assert result == 0
@@ -366,10 +371,7 @@ class TestCheckAndDispatch:
         self, _, mock_review_body, mock_inline, mock_prs, mock_repo,
         mock_projects, mock_projects_config, mock_config, instance_dir,
     ):
-        from app.review_comment_dispatch import (
-            check_and_dispatch_review_comments,
-            _save_tracker,
-        )
+        from app.review_comment_dispatch import check_and_dispatch_review_comments
 
         mock_config.return_value = {"enabled": True, "cooldown_minutes": 0}
         mock_projects_config.return_value = {}
@@ -384,7 +386,7 @@ class TestCheckAndDispatch:
         ]
         mock_review_body.return_value = []
 
-        _save_tracker(instance_dir, {"owner/myproject#42": "old-fingerprint"})
+        _write_tracker(instance_dir, {"owner/myproject#42": "old-fingerprint"})
 
         result = check_and_dispatch_review_comments(instance_dir, "/koan")
         assert result == 1
@@ -399,17 +401,14 @@ class TestCheckAndDispatch:
         self, _, mock_prs, mock_repo, mock_projects,
         mock_projects_config, mock_config, instance_dir,
     ):
-        from app.review_comment_dispatch import (
-            check_and_dispatch_review_comments,
-            _save_tracker,
-        )
+        from app.review_comment_dispatch import check_and_dispatch_review_comments
         import time
 
         mock_config.return_value = {"enabled": True, "cooldown_minutes": 60}
         mock_projects_config.return_value = {}
         mock_projects.return_value = [("myproject", "/projects/myproject")]
 
-        _save_tracker(instance_dir, {"cooldown:myproject": time.time()})
+        _write_tracker(instance_dir, {"cooldown:myproject": time.time()})
 
         result = check_and_dispatch_review_comments(instance_dir, "/koan")
         assert result == 0
@@ -429,8 +428,7 @@ class TestCheckAndDispatch:
     ):
         from app.review_comment_dispatch import (
             check_and_dispatch_review_comments,
-            _save_tracker,
-            _load_tracker,
+            _read_tracker,
         )
 
         mock_config.return_value = {"enabled": True, "cooldown_minutes": 0}
@@ -443,10 +441,10 @@ class TestCheckAndDispatch:
         mock_inline.return_value = []
         mock_review_body.return_value = []
 
-        _save_tracker(instance_dir, {"owner/myproject#42": "old-fingerprint"})
+        _write_tracker(instance_dir, {"owner/myproject#42": "old-fingerprint"})
 
         check_and_dispatch_review_comments(instance_dir, "/koan")
-        tracker = _load_tracker(instance_dir)
+        tracker = _read_tracker(instance_dir)
         assert "owner/myproject#42" not in tracker
 
     @patch("app.review_comment_dispatch._get_review_dispatch_config")
@@ -461,7 +459,7 @@ class TestCheckAndDispatch:
     ):
         from app.review_comment_dispatch import (
             check_and_dispatch_review_comments,
-            _load_tracker,
+            _read_tracker,
         )
 
         mock_config.return_value = {"enabled": True, "cooldown_minutes": 0}
@@ -471,5 +469,5 @@ class TestCheckAndDispatch:
         mock_prs.return_value = []
 
         check_and_dispatch_review_comments(instance_dir, "/koan")
-        tracker = _load_tracker(instance_dir)
+        tracker = _read_tracker(instance_dir)
         assert "cooldown:myproject" in tracker


### PR DESCRIPTION
## What
Replace unlocked read-then-write tracker pattern in `ci_dispatch.py` and `review_comment_dispatch.py` with atomic locked read-modify-write using the existing `locked_file.py` abstraction. Also fix `record_mission()` dedup normalization in `api/mission_index.py`.

## Why
Both modules used `json.loads(path.read_text())` for reads and `atomic_write_json()` for writes as **separate operations** with no lock held between them. In a concurrent environment (run loop + bridge both active), two processes could:
1. Both read the tracker snapshot showing no entry for a fingerprint/PR
2. Both decide to dispatch the same mission
3. Both write their separate updates, with one silently overwriting the other

The `locked_json_modify` pattern from `locked_file.py` was already available and used correctly elsewhere (burn_rate.py, suggestion_engine.py, ci_queue.py) — this was an incomplete adoption.

A secondary bug in `record_mission()`: it used `.lstrip("- ").strip()` for dedup, while `reconcile()` and `cancel_by_text()` both use `_normalize_for_match()` (which also strips lifecycle timestamps like `▶(2026-06-10T15:10)`). This caused false misses when a stored mission text had a lifecycle marker.

## How
- `_read_tracker` (replaces `_load_tracker`): uses `locked_json_read` with shared lock for cheap snapshot reads (cooldown checks don't need exclusive access)
- `_mutate_tracker` (replaces `_load_tracker` + `_save_tracker`): uses `locked_json_modify` for atomic read-modify-write
- Double-checked locking: re-verify dedup key inside the exclusive lock before inserting mission, preventing the race even if two processes reach the dispatch point with stale snapshots
- Also: tracker now stores `time.time()` instead of fingerprint as value in CI dispatch, enabling future TTL-based pruning
- Tests updated to patch `_read_tracker` instead of `_load_tracker`, use direct JSON writes for setup state, and `_read_tracker`/`_mutate_tracker` for verification

## Testing
All 84 tests in `test_ci_dispatch.py`, `test_review_comment_dispatch.py`, and `test_api_missions.py` pass. Full test suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)