### PR TITLE
fix(tui): prevent keep-awake subprocess leak on exception

### DIFF
--- a/koan/app/tui_dashboard.py
+++ b/koan/app/tui_dashboard.py
@@ -19,6 +19,9 @@ Anantys mint theme, no emojis.
 
 import contextlib
 import logging
+import os
+import signal
+import weakref
 from collections import deque
 from pathlib import Path
 
@@ -402,6 +405,8 @@ class KoanDashboard(App):
         # Keep-awake subprocess handle (caffeinate / systemd-inhibit); on by default.
         self._keepawake = None
         self._keepawake_label = ""
+        # Belt-and-suspenders cleanup: kills the process even if on_unmount never runs.
+        self._keepawake_finalize = None
         # Detach flag: True when the user closed the dashboard but left Kōan up.
         self._detached = False
 
@@ -601,6 +606,21 @@ class KoanDashboard(App):
                      "--mode=block", "sleep", "infinity"], "systemd-inhibit")
         return None, ""
 
+    @staticmethod
+    def _finalize_keepawake(proc):
+        """Terminate a keep-awake process and its group (called by weakref.finalize)."""
+        import subprocess
+        if proc is None:
+            return
+        with contextlib.suppress(ProcessLookupError, OSError):
+            # start_new_session=True means proc is a process group leader.
+            os.killpg(os.getpgid(proc.pid), signal.SIGTERM)
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            with contextlib.suppress(ProcessLookupError, OSError):
+                os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+
     def _start_keepawake(self) -> None:
         """Keep the machine awake (caffeinate on macOS, systemd-inhibit on Linux)."""
         import subprocess
@@ -612,19 +632,28 @@ class KoanDashboard(App):
             return
         try:
             self._keepawake = subprocess.Popen(
-                argv, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                argv,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
             self._keepawake_label = label
-        except Exception as exc:
+            # Belt-and-suspenders: ensures cleanup even if on_unmount never runs.
+            self._keepawake_finalize = weakref.finalize(
+                self, self._finalize_keepawake, self._keepawake
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
             self.log(f"keep-awake start failed: {exc}")
             self._keepawake = None
 
     def _stop_keepawake(self) -> None:
         if self._keepawake is None:
             return
-        with contextlib.suppress(Exception):
-            self._keepawake.terminate()
-            self._keepawake.wait(timeout=2)  # reap so it does not linger
+        self._finalize_keepawake(self._keepawake)
         self._keepawake = None
+        if self._keepawake_finalize is not None:
+            self._keepawake_finalize.detach()
+            self._keepawake_finalize = None
 
     def _keepawake_on(self) -> bool:
         return self._keepawake is not None and self._keepawake.poll() is None

--- a/koan/tests/test_tui_dashboard.py
+++ b/koan/tests/test_tui_dashboard.py
@@ -1,6 +1,7 @@
 """Tests for the terminal dashboard (app.tui_dashboard)."""
 
 import asyncio
+import signal
 
 import pytest
 
@@ -288,6 +289,7 @@ def test_keepawake_toggle_lifecycle(tmp_path, monkeypatch):
     class FakeProc:
         def __init__(self):
             self._alive = True
+            self.pid = 99999
 
         def poll(self):
             return None if self._alive else 0
@@ -300,6 +302,7 @@ def test_keepawake_toggle_lifecycle(tmp_path, monkeypatch):
 
     def fake_start(self):
         self._keepawake = FakeProc()
+        self._keepawake_finalize = None
 
     monkeypatch.setattr(tui.KoanDashboard, "_start_keepawake", fake_start)
     app = tui.KoanDashboard(tmp_path)
@@ -309,6 +312,54 @@ def test_keepawake_toggle_lifecycle(tmp_path, monkeypatch):
     assert app._keepawake_on() is True
     app._stop_keepawake()
     assert app._keepawake_on() is False
+
+
+def test_finalize_keepawake_kills_process_group(monkeypatch):
+    """_finalize_keepawake sends SIGTERM to the process group."""
+    killed = []
+
+    def fake_getpgid(pid):
+        return pid * 10  # synthetic pgid
+
+    def fake_killpg(pgid, sig):
+        killed.append((pgid, sig))
+
+    monkeypatch.setattr("os.getpgid", fake_getpgid)
+    monkeypatch.setattr("os.killpg", fake_killpg)
+
+    class FakeProc:
+        pid = 7
+
+        def wait(self, timeout=None):
+            return 0
+
+    tui.KoanDashboard._finalize_keepawake(FakeProc())
+    assert killed == [(70, signal.SIGTERM)]
+
+
+def test_finalize_keepawake_falls_back_to_sigkill(monkeypatch):
+    """On timeout, _finalize_keepawake escalates to SIGKILL."""
+    import subprocess
+
+    killed = []
+
+    def fake_getpgid(pid):
+        return 123
+
+    def fake_killpg(pgid, sig):
+        killed.append((pgid, sig))
+
+    monkeypatch.setattr("os.getpgid", fake_getpgid)
+    monkeypatch.setattr("os.killpg", fake_killpg)
+
+    class FakeProc:
+        pid = 7
+
+        def wait(self, timeout=None):
+            raise subprocess.TimeoutExpired(cmd="fake", timeout=timeout)
+
+    tui.KoanDashboard._finalize_keepawake(FakeProc())
+    assert killed == [(123, signal.SIGTERM), (123, signal.SIGKILL)]
 
 
 def test_keepawake_command_prefers_caffeinate(monkeypatch):


### PR DESCRIPTION
## What
Prevent the TUI's keep-awake subprocess (caffeinate / systemd-inhibit) from leaking when an exception occurs during startup after _start_keepawake runs but before on_mount completes.

## Why
If any initialization step after _start_keepawake fails, on_unmount never runs and the subprocess lingers indefinitely. On macOS, caffeinate -s prevents sleep, draining batteries.

## How
- Use subprocess.Popen(start_new_session=True) to create a new process group
- Add weakref.finalize reaper that sends SIGTERM (and SIGKILL on timeout) to the entire group, even if on_unmount never runs
- Narrow exception handling in _start_keepawake to OSError / SubprocessError

Fixes #1853

---
### Quality Report

**Changes**: 2 files changed, 85 insertions(+), 5 deletions(-)

**Code scan**: clean

**Tests**: passed (42 
tests)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

_Generated by [Kōan](https://koan.anantys.com)_