### PR TITLE
feat: add /v alias for /version

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -119,7 +119,7 @@ Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <com
 | `/check_notifications` | `/read` | Force immediate GitHub + Jira notification check |
 | `/inbox` | — | Force GitHub notification check + show queued mail count (works while paused) |
 | `/rescan` | `/rescan_heads` | Re-check all projects for remote HEAD branch changes |
-| `/version` | `/ver` | Show Kōan version (tag, commit, commits ahead) |
+| `/version` | `/ver`, `/v` | Show Kōan version (tag, commit, commits ahead) |
 | `/verbose` | — | Enable real-time progress updates |
 | `/silent` | — | Disable real-time progress updates |
 

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -162,7 +162,7 @@ If Kōan misclassifies your message, use `/chat` to force chat mode:
 **`/status`** — Get a quick overview of Kōan's state: what's running, what's queued, loop health.
 
 - **Aliases:** `/st`
-- **Related:** `/ping` (is the loop alive?), `/usage` (detailed quota), `/metrics` (success rates), `/version` (version only)
+- **Related:** `/ping` (is the loop alive?), `/usage` (detailed quota), `/metrics` (success rates), `/version` or `/v` (version only)
 
 <details>
 <summary>Use cases</summary>
@@ -1981,7 +1981,7 @@ All commands at a glance. **Tier:** B = Beginner, I = Intermediate, P = Power Us
 | `/inbox` | — | B | Force GitHub notification check + show queued mail count (works while paused) |
 | `/quota [N]` | `/q` | B | Check LLM quota (live), or override remaining % |
 | `/chat <msg>` | — | B | Force chat mode (bypass mission detection) |
-| `/version` | `/ver` | B | Show Kōan version |
+| `/version` | `/ver`, `/v` | B | Show Kōan version |
 | `/verbose` | — | B | Enable real-time progress updates |
 | `/silent` | — | B | Disable real-time progress updates |
 | `/projects` | `/proj` | B | List configured projects |

--- a/koan/skills/core/version/SKILL.md
+++ b/koan/skills/core/version/SKILL.md
@@ -9,6 +9,6 @@ audience: bridge
 commands:
   - name: version
     description: Show current Kōan version
-    aliases: [ver]
+    aliases: [ver, v]
 handler: handler.py
 ---

--- a/koan/tests/test_skills.py
+++ b/koan/tests/test_skills.py
@@ -2147,6 +2147,18 @@ class TestClaudemdSkillListSync:
         )
 
 
+class TestShippedSkillAliases:
+    """Behavior checks for aliases exposed by shipped core skills."""
+
+    def test_version_short_alias_resolves_to_version_skill(self):
+        registry = build_registry()
+
+        skill = registry.find_by_command("v")
+
+        assert skill is not None
+        assert skill.qualified_name == "core.version"
+
+
 class TestHyphenValidation:
     """Ensure skills with hyphens in command names or aliases are rejected."""
 


### PR DESCRIPTION
**What**: Adds `/v` as a short alias for the existing `/version` command.

**Why**: `/version` already has `/ver`; `/v` gives the status command set a faster one-letter version check.

**How**: Updated the version skill frontmatter aliases, synced user docs, and added a registry behavior test proving `v` resolves to `core.version`.

**Testing**:
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_skills.py -k version_short_alias_resolves_to_version_skill -v` — passed
- `make lint` — passed
- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_skills.py -v` — 194 passed
- `KOAN_ROOT=/tmp/test-koan make test` — failed in 9 Codex provider quota tests because this active Codex session holds `/tmp/koan-codex-cli.lock`; failures were timeouts acquiring that lock, unrelated to this alias change.

---
### Quality Report

**Changes**: 4 files changed, 16 insertions(+), 4 deletions(-)

**Code scan**: clean

**Tests**: passed (42 
tests)

**Branch hygiene**: 1 issue(s)
- Branch is not pushed to remote

_Generated by [Kōan](https://koan.anantys.com)_