### PR TITLE
fix(devcontainer): stop container after each mission

### DIFF
--- a/koan/app/devcontainer.py
+++ b/koan/app/devcontainer.py
@@ -4,6 +4,7 @@ Handles container lifecycle and command wrapping for projects configured
 with devcontainer: true.
 """
 
+import contextlib
 import json
 import shutil
 import subprocess
@@ -207,18 +208,37 @@ def wrap_command(
     return exec_cmd
 
 
+def stop_container(container_id: str, graceful_timeout: int = 5) -> None:
+    """Stop a devcontainer, giving processes graceful_timeout seconds to flush writes.
+
+    Uses ``docker stop --time N`` which sends SIGTERM then escalates to SIGKILL,
+    matching the graceful_timeout used by kill_process_group on the host side.
+    Errors are swallowed — the container may already be stopped or Docker may be
+    unavailable; either way the mission is already aborting.
+    """
+    if not container_id:
+        return
+    with contextlib.suppress(OSError, subprocess.SubprocessError):
+        subprocess.run(
+            ["docker", "stop", "--time", str(graceful_timeout), container_id],
+            capture_output=True,
+            timeout=graceful_timeout + 10,
+        )
+
+
 def prepare_devcontainer(
     project_path: str,
     provider_name: str = "claude",
     instance_path: str = "",
     koan_tmp_path: str = "",
-) -> None:
+) -> str:
     """Orchestrate devcontainer setup before mission execution.
 
     1. Verifies devcontainer CLI is installed.
     2. Brings the container up with appropriate mounts and features.
     3. For the "claude" provider, runs post-start git credential setup.
 
+    Returns the container ID string (empty if unavailable).
     Raises RuntimeError if the devcontainer CLI is not found.
     """
     if not shutil.which("devcontainer"):
@@ -227,7 +247,7 @@ def prepare_devcontainer(
             "npm install -g @devcontainers/cli"
         )
 
-    ensure_container_up(
+    container_id = ensure_container_up(
         project_path,
         provider_name,
         instance_path=instance_path,
@@ -235,3 +255,4 @@ def prepare_devcontainer(
     )
     if provider_name == "claude":
         _run_container_setup(project_path, koan_tmp_path=koan_tmp_path)
+    return container_id

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -970,9 +970,10 @@ def _run_iteration(
         _debug_log(f"[run] cli: cmd={' '.join(cmd_display)}... cwd={project_path}")
 
         # --- Devcontainer mode ---
+        _dc_container_id = ""
         if _dc_present:
             try:
-                _dc.prepare_devcontainer(
+                _dc_container_id = _dc.prepare_devcontainer(
                     project_path,
                     provider_name=provider_name,
                     instance_path=instance,
@@ -1001,6 +1002,10 @@ def _run_iteration(
             cmd, stdout_file, stderr_file, cwd=project_path,
             instance_dir=instance, project_name=project_name, run_num=run_num,
         )
+
+        if _dc_container_id:
+            log("devcontainer", f"Stopping container {_dc_container_id[:12]} after mission")
+            _dc.stop_container(_dc_container_id)
         _debug_log(f"[run] cli: exit_code={claude_exit}")
         elapsed_min = (int(time.time()) - mission_start) / 60
         log("koan", f"{provider_label} CLI finished (exit={claude_exit}, {elapsed_min:.1f}min)")

--- a/koan/tests/test_devcontainer.py
+++ b/koan/tests/test_devcontainer.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -359,3 +360,68 @@ class TestPrepareDevcontainer:
             prepare_devcontainer(str(tmp_path), provider_name="copilot")
 
         mock_setup.assert_not_called()
+
+    def test_returns_container_id_from_ensure_container_up(self, tmp_path):
+        from app.devcontainer import prepare_devcontainer
+        with patch("app.devcontainer.shutil.which", return_value="/usr/bin/devcontainer"), \
+             patch("app.devcontainer.ensure_container_up", return_value="cid456"), \
+             patch("app.devcontainer._run_container_setup"):
+            result = prepare_devcontainer(str(tmp_path), provider_name="claude")
+        assert result == "cid456"
+
+    def test_returns_empty_string_when_no_container_id(self, tmp_path):
+        from app.devcontainer import prepare_devcontainer
+        with patch("app.devcontainer.shutil.which", return_value="/usr/bin/devcontainer"), \
+             patch("app.devcontainer.ensure_container_up", return_value=""), \
+             patch("app.devcontainer._run_container_setup"):
+            result = prepare_devcontainer(str(tmp_path), provider_name="claude")
+        assert result == ""
+
+
+# ---------------------------------------------------------------------------
+# stop_container
+# ---------------------------------------------------------------------------
+
+class TestStopContainer:
+    def test_calls_docker_stop_with_container_id(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run") as mock_run:
+            stop_container("abc123")
+        cmd = mock_run.call_args[0][0]
+        assert "docker" in cmd
+        assert "stop" in cmd
+        assert "abc123" in cmd
+
+    def test_passes_graceful_timeout_via_time_flag(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run") as mock_run:
+            stop_container("abc123", graceful_timeout=7)
+        cmd = mock_run.call_args[0][0]
+        assert "--time" in cmd
+        idx = cmd.index("--time")
+        assert cmd[idx + 1] == "7"
+
+    def test_uses_default_timeout_of_5(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run") as mock_run:
+            stop_container("abc123")
+        cmd = mock_run.call_args[0][0]
+        assert "--time" in cmd
+        idx = cmd.index("--time")
+        assert cmd[idx + 1] == "5"
+
+    def test_swallows_oserror_silently(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run", side_effect=OSError("docker not found")):
+            stop_container("abc123")  # must not raise
+
+    def test_swallows_subprocess_error_silently(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run", side_effect=subprocess.SubprocessError()):
+            stop_container("abc123")  # must not raise
+
+    def test_noop_for_empty_container_id(self):
+        from app.devcontainer import stop_container
+        with patch("app.devcontainer.subprocess.run") as mock_run:
+            stop_container("")
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary

- Killing the host-side `devcontainer exec` wrapper does not kill processes inside the container — Docker exec is client/server, so the Claude CLI kept running and burning quota after `/abort`
- Added `stop_container(container_id, graceful_timeout=5)` to `devcontainer.py`: calls `docker stop --time 5` giving Claude a window to flush writes to the bind-mounted workspace before SIGKILL
- `prepare_devcontainer()` now returns the container ID so `mission_executor.py` can stop the container without a separate state file
- Container is stopped after **every** mission (not just abort): orphan subprocesses from normal completions are also cleaned up, and restart cost is negligible since auth setup already re-runs on each mission

## Test plan

- [x] `TestStopContainer` (6 new tests): verifies `docker stop --time N <id>` is called, default timeout is 5s, empty ID is a no-op, errors are swallowed
- [x] `TestPrepareDevcontainer` (2 new tests): verifies container ID is returned
- [x] Full suite: 15,741 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)