### PR TITLE
feat(telegram): self-diagnose group privacy-mode blocker

### DIFF
--- a/docs/messaging/telegram.md
+++ b/docs/messaging/telegram.md
@@ -77,8 +77,61 @@ Your `.env` file is missing or the variable name is wrong. Double-check the form
 - Telegram has a 4000-character limit per message. Long messages are auto-chunked.
 - Duplicate messages within 5 minutes are flood-protected (first duplicate triggers a warning, subsequent ones are silently dropped).
 
+## Group chats
+
+Kōan works in a group (or supergroup) as well as a 1:1 chat. **One instance
+serves one chat at a time** — either a private chat or a group, not both.
+
+### Setup
+
+1. **Add the bot to the group.**
+2. **Get the group's chat ID.** Send a message in the group, then run the
+   `getUpdates` call from Step 2. The group ID is a **negative** number
+   (e.g. `-1001234567890`). Set it as your chat ID:
+   ```bash
+   KOAN_TELEGRAM_CHAT_ID=-1001234567890
+   ```
+3. **Let the bot read every message** (see below).
+
+### Privacy Mode — required to respond to every message
+
+By default, Telegram bots run with **Privacy Mode ON**. In a group, a
+privacy-mode bot only receives `/commands`, `@mentions`, and replies to its own
+messages — Telegram **never delivers plain group messages** to it. This is a
+Telegram-side restriction; no Kōan setting can bypass it.
+
+To make the bot respond to every message (like a 1:1 chat), do **one** of:
+
+- **Disable Privacy Mode**: message [@BotFather](https://t.me/BotFather) →
+  `/setprivacy` → select your bot → **Disable**. Then **remove the bot from the
+  group and re-add it** — privacy changes only take effect after re-adding.
+  This is the most common gotcha: disabling without re-adding appears to do
+  nothing.
+- **Or promote the bot to administrator** in the group — admins receive all
+  messages regardless of the privacy setting.
+
+At startup Kōan probes this and tells you which case you're in. If the bot is
+blocked, it logs a warning **and posts a remediation message into the group**:
+
+```
+[init] Chat type: supergroup — group mode active
+[warn] Privacy Mode is ON — bot only sees /commands, @mentions, and replies in this group
+[warn] Fix: @BotFather /setprivacy → Disable then re-add the bot, OR promote the bot to admin
+```
+
+Once fixed you'll instead see:
+
+```
+[init] Group mode: bot can read all messages ✓
+```
+
+> **Quick check**: even with Privacy Mode on, a `/help` typed in the group
+> should get a reply — commands are always delivered. If it does, your chat ID
+> is correct and Privacy Mode is the only remaining blocker.
+
 ## Architecture Notes
 
 - **Polling**: Kōan polls the Telegram API every 3 seconds for new messages
 - **No webhooks**: No public URL or reverse proxy needed — works from any network
-- **Single chat**: Kōan only responds in the configured chat ID (ignores other chats)
+- **Single chat**: Kōan only responds in the configured chat ID (ignores other
+  chats). The chat ID may be a 1:1 chat or a group — see [Group chats](#group-chats).

--- a/env.example
+++ b/env.example
@@ -22,7 +22,10 @@
 # Your bot token from BotFather (format: 123456789:ABC-DEF1234...)
 # KOAN_TELEGRAM_TOKEN=
 
-# Your chat ID (find it via the getUpdates API call — see INSTALL.md)
+# Your chat ID (find it via the getUpdates API call — see INSTALL.md).
+# May be a 1:1 chat (positive) or a group (negative, e.g. -1001234567890).
+# For groups, the bot must have Privacy Mode disabled or be an admin to read
+# every message — see docs/messaging/telegram.md "Group chats".
 # KOAN_TELEGRAM_CHAT_ID=
 
 # =========================================================================

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -327,7 +327,10 @@ contemplative_chance: 10
 # These config values are only used if the env vars are not set.
 telegram:
   bot_token: ""   # Set via KOAN_TELEGRAM_TOKEN in .env (recommended)
-  chat_id: ""     # Set via KOAN_TELEGRAM_CHAT_ID in .env (recommended)
+  chat_id: ""     # Set via KOAN_TELEGRAM_CHAT_ID in .env (recommended).
+                  # May be a group ID (negative). For groups the bot must have
+                  # Privacy Mode disabled or be an admin to read every message —
+                  # see docs/messaging/telegram.md "Group chats".
 
 # Messaging provider configuration (optional)
 # Controls which messaging platform Kōan uses for communication.

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -693,10 +693,16 @@ def handle_message(text: str):
 
 
 def _check_group_chat_mode(provider) -> None:
-    """Detect group chats and warn about Telegram Bot Privacy Mode.
+    """Detect group chats and verify the bot can actually read every message.
 
-    In groups, bots with privacy mode enabled (the default) only receive
-    /commands, @mentions, and replies — not regular messages.
+    In groups, bots with Telegram Privacy Mode enabled (the default) only
+    receive /commands, @mentions, and replies — not regular messages. A bot can
+    read *every* message only if privacy mode is disabled
+    (``can_read_all_group_messages``) **or** the bot is a group administrator.
+
+    This probes both via the Bot API. When the bot is blocked, it warns loudly
+    (log + a message into the group itself) so the cause of an apparently
+    "ignored" chat is obvious instead of silent.
     """
     import requests
 
@@ -704,16 +710,66 @@ def _check_group_chat_mode(provider) -> None:
         return
     try:
         api_base = provider.get_api_base()
-        resp = requests.get(f"{api_base}/getChat", params={"chat_id": provider.get_channel_id()}, timeout=5)
+        chat_id = provider.get_channel_id()
+        resp = requests.get(f"{api_base}/getChat", params={"chat_id": chat_id}, timeout=5)
         data = resp.json()
         if not data.get("ok"):
             log("warn", f"getChat failed: {data.get('description', 'unknown')}")
             return
-        chat = data.get("result", {})
-        chat_type = chat.get("type", "")
-        if chat_type in ("group", "supergroup"):
-            log("init", f"Chat type: {chat_type} — group mode active")
-            log("init", "TIP: Disable Bot Privacy Mode via @BotFather (/setprivacy → Disable) to receive all group messages")
+        chat_type = data.get("result", {}).get("type", "")
+        if chat_type not in ("group", "supergroup"):
+            return
+
+        log("init", f"Chat type: {chat_type} — group mode active")
+
+        # The bot receives every message only if privacy mode is disabled OR it
+        # is a group admin. Probe getMe (privacy flag + bot id), then — only if
+        # still needed — getChatMember (admin status).
+        can_read_all = False
+        bot_id = None
+        try:
+            me = requests.get(f"{api_base}/getMe", timeout=5).json()
+            if me.get("ok"):
+                result = me.get("result", {})
+                bot_id = result.get("id")
+                can_read_all = bool(result.get("can_read_all_group_messages"))
+        except Exception as e:
+            log("warn", f"getMe failed: {e}")
+
+        is_admin = False
+        if not can_read_all and bot_id is not None:
+            try:
+                member = requests.get(
+                    f"{api_base}/getChatMember",
+                    params={"chat_id": chat_id, "user_id": bot_id},
+                    timeout=5,
+                ).json()
+                if member.get("ok"):
+                    status = member.get("result", {}).get("status", "")
+                    is_admin = status in ("administrator", "creator")
+            except Exception as e:
+                log("warn", f"getChatMember failed: {e}")
+
+        if can_read_all or is_admin:
+            log("init", "Group mode: bot can read all messages ✓")
+            return
+
+        # Blocked: privacy mode on and not an admin → plain messages never arrive.
+        log("warn", "Privacy Mode is ON — bot only sees /commands, @mentions, and replies in this group")
+        log("warn", "Fix: @BotFather /setprivacy → Disable then re-add the bot, OR promote the bot to admin")
+        try:
+            provider.send_message(
+                "⚠️ I can't see regular messages in this group because Telegram "
+                "Privacy Mode is enabled.\n\n"
+                "To let me reply to every message (like a 1:1 chat):\n"
+                "1. Message @BotFather → /setprivacy → select me → Disable, then "
+                "remove and re-add me to this group.\n"
+                "   — or —\n"
+                "2. Promote me to administrator in this group.\n\n"
+                "Until then I only respond to /commands, @mentions, and replies."
+            )
+        except Exception as e:
+            log("warn", f"Failed to send privacy-mode warning: {e}")
     except Exception as e:
         log("warn", f"Group chat detection failed: {e}")
 

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -26,6 +26,7 @@ from app.awake import (
     _run_in_worker,
     _flush_outbox_async,
     _strip_bot_mention_from_text,
+    _check_group_chat_mode,
     get_updates,
     check_config,
     _bridge_loop,
@@ -3454,6 +3455,104 @@ class TestStripBotMentionFromText:
     def test_mention_only(self):
         msg = {"entities": [{"type": "mention", "offset": 0, "length": 8}]}
         assert _strip_bot_mention_from_text("@BotName", msg) == ""
+
+
+# ---------------------------------------------------------------------------
+# _check_group_chat_mode — group detection + privacy-mode self-diagnosis
+# ---------------------------------------------------------------------------
+
+
+class TestCheckGroupChatMode:
+    """Verify the bot detects whether it can actually read group messages."""
+
+    def _provider(self):
+        provider = MagicMock()
+        provider.get_provider_name.return_value = "telegram"
+        provider.get_api_base.return_value = "http://api"
+        provider.get_channel_id.return_value = "-100123"
+        return provider
+
+    def _side_effect(self, getchat=None, getme=None, member=None):
+        """Build a requests.get side_effect that dispatches on URL suffix."""
+        def _dispatch(url, *args, **kwargs):
+            resp = MagicMock()
+            if url.endswith("/getChat"):
+                resp.json.return_value = getchat or {"ok": False}
+            elif url.endswith("/getMe"):
+                resp.json.return_value = getme or {"ok": False}
+            elif url.endswith("/getChatMember"):
+                resp.json.return_value = member or {"ok": False}
+            else:
+                resp.json.return_value = {"ok": False}
+            return resp
+        return _dispatch
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_privacy_disabled_no_warning(self, mock_get, mock_log):
+        provider = self._provider()
+        mock_get.side_effect = self._side_effect(
+            getchat={"ok": True, "result": {"type": "supergroup"}},
+            getme={"ok": True, "result": {"id": 99, "can_read_all_group_messages": True}},
+        )
+        _check_group_chat_mode(provider)
+        provider.send_message.assert_not_called()
+        assert any("can read all messages" in str(c.args) for c in mock_log.call_args_list)
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_privacy_on_not_admin_warns_and_sends(self, mock_get, mock_log):
+        provider = self._provider()
+        mock_get.side_effect = self._side_effect(
+            getchat={"ok": True, "result": {"type": "supergroup"}},
+            getme={"ok": True, "result": {"id": 99, "can_read_all_group_messages": False}},
+            member={"ok": True, "result": {"status": "member"}},
+        )
+        _check_group_chat_mode(provider)
+        provider.send_message.assert_called_once()
+        assert "Privacy Mode" in provider.send_message.call_args.args[0]
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_privacy_on_but_admin_no_warning(self, mock_get, mock_log):
+        provider = self._provider()
+        mock_get.side_effect = self._side_effect(
+            getchat={"ok": True, "result": {"type": "supergroup"}},
+            getme={"ok": True, "result": {"id": 99, "can_read_all_group_messages": False}},
+            member={"ok": True, "result": {"status": "administrator"}},
+        )
+        _check_group_chat_mode(provider)
+        provider.send_message.assert_not_called()
+        assert any("can read all messages" in str(c.args) for c in mock_log.call_args_list)
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_private_chat_short_circuits(self, mock_get, mock_log):
+        provider = self._provider()
+        mock_get.side_effect = self._side_effect(
+            getchat={"ok": True, "result": {"type": "private"}},
+        )
+        _check_group_chat_mode(provider)
+        provider.send_message.assert_not_called()
+        # Only getChat is called; no getMe / getChatMember probing for private chats.
+        assert mock_get.call_count == 1
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_api_failure_does_not_crash(self, mock_get, mock_log):
+        provider = self._provider()
+        mock_get.side_effect = RuntimeError("network down")
+        # Must not raise.
+        _check_group_chat_mode(provider)
+        provider.send_message.assert_not_called()
+
+    @patch("app.awake.log")
+    @patch("requests.get")
+    def test_non_telegram_provider_skipped(self, mock_get, mock_log):
+        provider = self._provider()
+        provider.get_provider_name.return_value = "slack"
+        _check_group_chat_mode(provider)
+        mock_get.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
In a group with Telegram Privacy Mode enabled (the default), Telegram never delivers plain group messages to the bot — only /commands, @mentions, and replies — so the bot appears to silently ignore the group. No code can bypass this Telegram-side restriction; the enabler is operational.

Make the blocker visible instead of silent: _check_group_chat_mode() now probes getMe (can_read_all_group_messages) and getChatMember (admin status) at startup. When the bot can read all messages it logs a confirmation; when it's blocked it logs a warning and posts remediation steps into the group itself. Detection is fully defensive — any API failure falls back without crashing the bridge.

Docs: add a "Group chats" section to docs/messaging/telegram.md (negative chat id, privacy-mode requirement, re-add-after-disable gotcha, admin alternative) and note the group/privacy caveat in env.example and instance.example.