### PR TITLE
fix(missions): flush abandoned in-progress missions to Failed, not Done

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1089,11 +1089,16 @@ def _move_pending_to_section(
 
 
 def _flush_in_progress_to_done(content: str) -> str:
-    """Move all In Progress missions to Done.
+    """Move all stale In Progress missions to Failed with a [flushed] tag.
 
     Sanity enforcement: only one mission should be in progress at a time.
     When a new mission is about to start, any stale In Progress missions
-    are automatically completed with a timestamp.
+    are moved to Failed \u2014 not Done \u2014 because they never completed successfully.
+    Marking them Done (\u2705) would produce false history.
+
+    Under normal operation this path never fires because recover.py moves
+    stale In Progress entries back to Pending at startup. This is a second
+    line of defence for edge cases recover.py misses (e.g. complex ### missions).
     """
     sections = parse_sections(content)
     stale = sections.get("in_progress", [])
@@ -1105,13 +1110,13 @@ def _flush_in_progress_to_done(content: str) -> str:
         first_line = item.split("\n")[0].strip()
         if first_line.startswith("- "):
             first_line = first_line[2:]
-        content = _move_in_progress_to_done(content, first_line)
+        content = _flush_abandoned_in_progress(content, first_line)
 
     return content
 
 
-def _move_in_progress_to_done(content: str, needle: str) -> str:
-    """Move a single mission from In Progress to Done with a timestamp."""
+def _flush_abandoned_in_progress(content: str, needle: str) -> str:
+    """Move a single stale In Progress mission to Failed with a [flushed] tag."""
     result = _remove_item_by_text(content, needle, "in_progress")
     if result is None:
         return content
@@ -1121,28 +1126,30 @@ def _move_in_progress_to_done(content: str, needle: str) -> str:
     display = removed.removeprefix("- ") if removed.startswith("- ") else removed
 
     timestamp = time.strftime("%Y-%m-%d %H:%M")
-    entry = f"- {display} \u2705 ({timestamp})"
+    entry = f"- {display} \u274c ({timestamp}) [flushed]"
 
     lines = updated.splitlines()
     boundaries = find_section_boundaries(lines)
-    if "done" in boundaries:
-        start, end = boundaries["done"]
+    if "failed" in boundaries:
+        start, end = boundaries["failed"]
         insert_at = start + 1
         while insert_at < end and lines[insert_at].strip() == "":
             insert_at += 1
         lines.insert(insert_at, entry)
         return normalize_content("\n".join(lines))
 
-    return normalize_content(updated + f"\n## Done\n\n{entry}\n")
+    return normalize_content(updated + f"\n## Failed\n\n{entry}\n")
 
 
 def start_mission(content: str, mission_text: str) -> str:
     """Move a mission from Pending to In Progress with a started timestamp.
 
     Used at the beginning of mission execution to mark it as active.
-    As a sanity enforcement, any existing In Progress missions are moved
-    to Done before the new mission is inserted — only one mission can be
-    in progress at a time.
+    As a sanity enforcement, any stale In Progress missions are moved to
+    Failed (with a [flushed] tag) before the new mission is inserted.
+    Under normal operation In Progress is empty here because recover.py
+    handles stale entries at startup; this is a fallback safety net.
+
     Returns content unchanged if the mission is not found in Pending.
     """
     needle = mission_text.strip()
@@ -1164,7 +1171,10 @@ def start_mission(content: str, mission_text: str) -> str:
     # Add started timestamp
     entry = stamp_started(entry)
 
-    # Sanity enforcement: move any existing In Progress missions to Done
+    # Sanity enforcement: move any stale In Progress missions to Failed.
+    # Under normal operation In Progress is always empty here because
+    # recover.py runs at startup. This is a fallback for cases recover.py
+    # misses (e.g. complex ### missions — see analysis-state-bugs.md B2).
     updated = _flush_in_progress_to_done(updated)
 
     lines = updated.splitlines()

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1088,7 +1088,7 @@ def _move_pending_to_section(
     return normalize_content(updated + f"\n## {header}\n\n{entry}\n")
 
 
-def _flush_in_progress_to_done(content: str) -> str:
+def _flush_in_progress_to_failed(content: str) -> str:
     """Move all stale In Progress missions to Failed with a [flushed] tag.
 
     Sanity enforcement: only one mission should be in progress at a time.
@@ -1175,7 +1175,7 @@ def start_mission(content: str, mission_text: str) -> str:
     # Under normal operation In Progress is always empty here because
     # recover.py runs at startup. This is a fallback for cases recover.py
     # misses (e.g. complex ### missions — see analysis-state-bugs.md B2).
-    updated = _flush_in_progress_to_done(updated)
+    updated = _flush_in_progress_to_failed(updated)
 
     lines = updated.splitlines()
     boundaries = find_section_boundaries(lines)

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1174,7 +1174,7 @@ def start_mission(content: str, mission_text: str) -> str:
     # Sanity enforcement: move any stale In Progress missions to Failed.
     # Under normal operation In Progress is always empty here because
     # recover.py runs at startup. This is a fallback for cases recover.py
-    # misses (e.g. complex ### missions — see analysis-state-bugs.md B2).
+    # misses (e.g. complex ### missions with nested headers).
     updated = _flush_in_progress_to_failed(updated)
 
     lines = updated.splitlines()

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -1883,8 +1883,8 @@ class TestStartMission:
         # Should not have a YYYY-MM-DD HH:MM timestamp
         assert not re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", in_progress_text)
 
-    def test_existing_in_progress_flushed_to_done(self):
-        """Sanity enforcement: existing In Progress missions move to Done."""
+    def test_existing_in_progress_flushed_to_failed(self):
+        """Sanity enforcement: existing In Progress missions are abandoned to Failed."""
         content = (
             "# Missions\n\n"
             "## Pending\n\n"
@@ -1898,10 +1898,10 @@ class TestStartMission:
         # Only the new task should be In Progress
         assert len(sections["in_progress"]) == 1
         assert "New task" in sections["in_progress"][0]
-        # The old task should have been moved to Done
-        done_text = "\n".join(sections["done"])
-        assert "Already running task" in done_text
-        assert "\u2705" in done_text
+        # The old task should have been moved to Failed with [flushed] tag
+        failed_text = "\n".join(sections["failed"])
+        assert "Already running task" in failed_text
+        assert "[flushed]" in failed_text
 
 
 # ---------------------------------------------------------------------------
@@ -2214,8 +2214,7 @@ class TestModifyMissionsFileReturn:
 # ---------------------------------------------------------------------------
 
 class TestFlushInProgressToDone:
-    """Tests for _flush_in_progress_to_done() — ensures only one mission
-    can be In Progress at a time."""
+    """Tests for _flush_in_progress_to_done() — stale In Progress → Failed."""
 
     def test_empty_in_progress_noop(self):
         content = (
@@ -2228,7 +2227,7 @@ class TestFlushInProgressToDone:
         result = _flush_in_progress_to_done(content)
         assert result == normalize_content(content)
 
-    def test_single_in_progress_moved_to_done(self):
+    def test_single_in_progress_moved_to_failed(self):
         content = (
             "# Missions\n\n"
             "## Pending\n\n"
@@ -2239,11 +2238,14 @@ class TestFlushInProgressToDone:
         result = _flush_in_progress_to_done(content)
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
-        done_text = "\n".join(sections["done"])
-        assert "Stale mission" in done_text
-        assert "\u2705" in done_text
+        # Moved to Failed (not Done) with \u274c marker and [flushed] tag
+        failed_text = "\n".join(sections["failed"])
+        assert "Stale mission" in failed_text
+        assert "\u274c" in failed_text
+        assert "[flushed]" in failed_text
+        assert len(sections["done"]) == 0
 
-    def test_multiple_in_progress_all_moved(self):
+    def test_multiple_in_progress_all_moved_to_failed(self):
         content = (
             "# Missions\n\n"
             "## Pending\n\n"
@@ -2256,11 +2258,12 @@ class TestFlushInProgressToDone:
         result = _flush_in_progress_to_done(content)
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
-        assert len(sections["done"]) == 3
-        done_text = "\n".join(sections["done"])
-        assert "First stale" in done_text
-        assert "Second stale" in done_text
-        assert "Third stale" in done_text
+        assert len(sections["failed"]) == 3
+        assert len(sections["done"]) == 0
+        failed_text = "\n".join(sections["failed"])
+        assert "First stale" in failed_text
+        assert "Second stale" in failed_text
+        assert "Third stale" in failed_text
 
     def test_preserves_project_tags(self):
         content = (
@@ -2272,9 +2275,9 @@ class TestFlushInProgressToDone:
         )
         result = _flush_in_progress_to_done(content)
         sections = parse_sections(result)
-        done_entry = sections["done"][0]
-        assert "[project:koan]" in done_entry
-        assert "Stale koan mission" in done_entry
+        failed_entry = sections["failed"][0]
+        assert "[project:koan]" in failed_entry
+        assert "Stale koan mission" in failed_entry
 
     def test_preserves_existing_done(self):
         content = (
@@ -2289,7 +2292,9 @@ class TestFlushInProgressToDone:
         sections = parse_sections(result)
         done_text = "\n".join(sections["done"])
         assert "Old done task" in done_text
-        assert "Stale" in done_text
+        assert "Stale" not in done_text  # Stale goes to Failed, not Done
+        failed_text = "\n".join(sections["failed"])
+        assert "Stale" in failed_text
 
     def test_creates_done_section_if_missing(self):
         content = (
@@ -2299,10 +2304,11 @@ class TestFlushInProgressToDone:
             "- Stale mission\n"
         )
         result = _flush_in_progress_to_done(content)
-        assert "## Done" in result
+        assert "## Failed" in result
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
-        assert len(sections["done"]) == 1
+        assert len(sections["failed"]) == 1
+        assert len(sections["done"]) == 0
 
     def test_timestamp_added_to_flushed_missions(self):
         import re
@@ -2315,8 +2321,8 @@ class TestFlushInProgressToDone:
         )
         result = _flush_in_progress_to_done(content)
         sections = parse_sections(result)
-        done_entry = sections["done"][0]
-        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", done_entry)
+        failed_entry = sections["failed"][0]
+        assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", failed_entry)
 
 
 # ---------------------------------------------------------------------------
@@ -2324,7 +2330,7 @@ class TestFlushInProgressToDone:
 # ---------------------------------------------------------------------------
 
 class TestStartMissionSanityEnforcement:
-    """Tests that start_mission() flushes stale In Progress missions to Done."""
+    """Tests that start_mission() flushes stale In Progress missions to Failed."""
 
     def test_single_stale_in_progress_flushed(self):
         content = (
@@ -2339,9 +2345,10 @@ class TestStartMissionSanityEnforcement:
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 1
         assert "New mission" in sections["in_progress"][0]
-        done_text = "\n".join(sections["done"])
-        assert "Old stale mission" in done_text
-        assert "\u2705" in done_text
+        # Stale mission goes to Failed, not Done
+        failed_text = "\n".join(sections["failed"])
+        assert "Old stale mission" in failed_text
+        assert "[flushed]" in failed_text
 
     def test_multiple_stale_in_progress_all_flushed(self):
         content = (
@@ -2358,11 +2365,11 @@ class TestStartMissionSanityEnforcement:
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 1
         assert "Fresh task" in sections["in_progress"][0]
-        assert len(sections["done"]) == 3
-        done_text = "\n".join(sections["done"])
-        assert "Stale A" in done_text
-        assert "Stale B" in done_text
-        assert "Stale C" in done_text
+        assert len(sections["failed"]) == 3
+        failed_text = "\n".join(sections["failed"])
+        assert "Stale A" in failed_text
+        assert "Stale B" in failed_text
+        assert "Stale C" in failed_text
 
     def test_no_stale_in_progress_still_works(self):
         content = (
@@ -2378,7 +2385,7 @@ class TestStartMissionSanityEnforcement:
         assert "New task" in sections["in_progress"][0]
         assert len(sections["done"]) == 0
 
-    def test_stale_mission_preserves_project_tag_in_done(self):
+    def test_stale_mission_preserves_project_tag_in_failed(self):
         content = (
             "# Missions\n\n"
             "## Pending\n\n"
@@ -2389,9 +2396,9 @@ class TestStartMissionSanityEnforcement:
         )
         result = start_mission(content, "New task")
         sections = parse_sections(result)
-        done_entry = sections["done"][0]
-        assert "[project:backend]" in done_entry
-        assert "Old backend work" in done_entry
+        failed_entry = sections["failed"][0]
+        assert "[project:backend]" in failed_entry
+        assert "Old backend work" in failed_entry
 
     def test_full_lifecycle_with_sanity_enforcement(self):
         """Simulate: mission A starts, then mission B starts without A finishing."""
@@ -2409,14 +2416,14 @@ class TestStartMissionSanityEnforcement:
         assert len(sections["in_progress"]) == 1
         assert "Mission A" in sections["in_progress"][0]
 
-        # Start mission B without completing A — A should be flushed to Done
+        # Start mission B without completing A — A should be flushed to Failed
         after_b = start_mission(after_a, "Mission B")
         sections = parse_sections(after_b)
         assert len(sections["in_progress"]) == 1
         assert "Mission B" in sections["in_progress"][0]
-        assert len(sections["done"]) == 1
-        assert "Mission A" in sections["done"][0]
-        assert "\u2705" in sections["done"][0]
+        assert len(sections["failed"]) == 1
+        assert "Mission A" in sections["failed"][0]
+        assert "[flushed]" in sections["failed"][0]
 
     def test_sanity_enforcement_preserves_pending(self):
         content = (
@@ -2447,7 +2454,9 @@ class TestStartMissionSanityEnforcement:
         sections = parse_sections(result)
         done_text = "\n".join(sections["done"])
         assert "Previously done task" in done_text
-        assert "Stale task" in done_text
+        # Stale task goes to Failed, not Done
+        failed_text = "\n".join(sections["failed"])
+        assert "Stale task" in failed_text
 
     def test_nonexistent_mission_skips_sanity_check(self):
         """If mission not found in Pending, no sanity check runs."""
@@ -2482,10 +2491,11 @@ class TestStartMissionSanityEnforcement:
         assert len(sections["pending"]) == 0
         assert len(sections["in_progress"]) == 1
         assert "Gamma" in sections["in_progress"][0]
-        assert len(sections["done"]) == 2
-        done_text = "\n".join(sections["done"])
-        assert "Alpha" in done_text
-        assert "Beta" in done_text
+        # Alpha and Beta are flushed to Failed (not Done) by sanity enforcement
+        assert len(sections["failed"]) == 2
+        failed_text = "\n".join(sections["failed"])
+        assert "Alpha" in failed_text
+        assert "Beta" in failed_text
 
 
 # --- stamp_queued / stamp_started ---

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -45,7 +45,7 @@ from app.missions import (
     prune_done_section,
     prune_failed_section,
     _enforce_quarantine_cap,
-    _flush_in_progress_to_done,
+    _flush_in_progress_to_failed,
     DEFAULT_SKELETON,
 )
 
@@ -2210,11 +2210,11 @@ class TestModifyMissionsFileReturn:
 
 
 # ---------------------------------------------------------------------------
-# _flush_in_progress_to_done — sanity enforcement
+# _flush_in_progress_to_failed — sanity enforcement
 # ---------------------------------------------------------------------------
 
-class TestFlushInProgressToDone:
-    """Tests for _flush_in_progress_to_done() — stale In Progress → Failed."""
+class TestFlushInProgressToFailed:
+    """Tests for _flush_in_progress_to_failed() — stale In Progress → Failed."""
 
     def test_empty_in_progress_noop(self):
         content = (
@@ -2224,7 +2224,7 @@ class TestFlushInProgressToDone:
             "## In Progress\n\n"
             "## Done\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         assert result == normalize_content(content)
 
     def test_single_in_progress_moved_to_failed(self):
@@ -2235,7 +2235,7 @@ class TestFlushInProgressToDone:
             "- Stale mission\n\n"
             "## Done\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
         # Moved to Failed (not Done) with \u274c marker and [flushed] tag
@@ -2255,7 +2255,7 @@ class TestFlushInProgressToDone:
             "- Third stale\n\n"
             "## Done\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
         assert len(sections["failed"]) == 3
@@ -2273,7 +2273,7 @@ class TestFlushInProgressToDone:
             "- [project:koan] Stale koan mission\n\n"
             "## Done\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         sections = parse_sections(result)
         failed_entry = sections["failed"][0]
         assert "[project:koan]" in failed_entry
@@ -2288,7 +2288,7 @@ class TestFlushInProgressToDone:
             "## Done\n\n"
             "- Old done task\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         sections = parse_sections(result)
         done_text = "\n".join(sections["done"])
         assert "Old done task" in done_text
@@ -2296,14 +2296,14 @@ class TestFlushInProgressToDone:
         failed_text = "\n".join(sections["failed"])
         assert "Stale" in failed_text
 
-    def test_creates_done_section_if_missing(self):
+    def test_creates_failed_section_if_missing(self):
         content = (
             "# Missions\n\n"
             "## Pending\n\n"
             "## In Progress\n\n"
             "- Stale mission\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         assert "## Failed" in result
         sections = parse_sections(result)
         assert len(sections["in_progress"]) == 0
@@ -2319,7 +2319,7 @@ class TestFlushInProgressToDone:
             "- Stale mission\n\n"
             "## Done\n"
         )
-        result = _flush_in_progress_to_done(content)
+        result = _flush_in_progress_to_failed(content)
         sections = parse_sections(result)
         failed_entry = sections["failed"][0]
         assert re.search(r"\d{4}-\d{2}-\d{2} \d{2}:\d{2}", failed_entry)

--- a/koan/tests/test_missions_parallel.py
+++ b/koan/tests/test_missions_parallel.py
@@ -229,7 +229,7 @@ class TestBackwardCompatibility:
         # Old in-progress should be flushed to done
         assert len(sections["in_progress"]) == 1
         assert "New mission" in sections["in_progress"][0]
-        assert any("Stale mission" in d for d in sections["done"])
+        assert any("Stale mission" in d for d in sections["failed"])
 
     def test_complete_mission_still_works(self):
         content = start_mission(SIMPLE_CONTENT, "Fix the bug")

--- a/koan/tests/test_missions_parallel.py
+++ b/koan/tests/test_missions_parallel.py
@@ -226,7 +226,7 @@ class TestBackwardCompatibility:
         )
         result = start_mission(content, "New mission")
         sections = parse_sections(result)
-        # Old in-progress should be flushed to done
+        # Old in-progress should be flushed to failed
         assert len(sections["in_progress"]) == 1
         assert "New mission" in sections["in_progress"][0]
         assert any("Stale mission" in d for d in sections["failed"])


### PR DESCRIPTION
## Problem
When `start_mission()` finds stale In Progress missions (sanity enforcement), it was silently
moving them to Done with a ✅ marker — creating false history that the work completed
successfully. This fires when `recover.py` misses a mission (complex mission blocks, import errors).

## Changes
- Renamed `_move_in_progress_to_done()` → `_flush_abandoned_in_progress()` for clarity
- Changed the marker to ❌ with a `[flushed]` tag inserted into the Failed section
- Creates the Failed section if it doesn't already exist
- Updated all test assertions to check `sections["failed"]` instead of `sections["done"]`

## Test
All 415 existing tests pass (1 pre-existing root-permission test excluded).