### PR TITLE
fix(loop_manager): preserve checkpoint recovery context in create_pen…

### DIFF
--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -217,11 +217,12 @@ def create_pending_file(
     Returns:
         Path to the created pending.md file.
     """
-    import contextlib
     pending_path = Path(instance_dir) / "journal" / "pending.md"
     journal_dir = Path(instance_dir) / "journal" / datetime.now().strftime("%Y-%m-%d")
-    with contextlib.suppress(OSError):
+    try:
         journal_dir.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        log.warning("Failed to create journal dir %s: %s", journal_dir, exc)
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -189,6 +189,9 @@ def _drain_ci_queue_during_sleep(instance_dir: str, elapsed: float):
 # --- Pending.md creation ---
 
 
+_RECOVERY_CONTEXT_SENTINEL = "## Recovery Context (from previous interrupted run)"
+
+
 def create_pending_file(
     instance_dir: str,
     project_name: str,
@@ -198,6 +201,10 @@ def create_pending_file(
     mission_title: str = "",
 ) -> str:
     """Create the pending.md progress journal file for a run.
+
+    Preserves any checkpoint recovery context that recover.py injected into
+    pending.md at startup. Without this, the context written by
+    _inject_checkpoint_context() would be overwritten before Claude reads it.
 
     Args:
         instance_dir: Path to instance directory.
@@ -210,9 +217,11 @@ def create_pending_file(
     Returns:
         Path to the created pending.md file.
     """
+    import contextlib
     pending_path = Path(instance_dir) / "journal" / "pending.md"
     journal_dir = Path(instance_dir) / "journal" / datetime.now().strftime("%Y-%m-%d")
-    journal_dir.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        journal_dir.mkdir(parents=True, exist_ok=True)
 
     now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
 
@@ -231,6 +240,17 @@ Mode: {mode}
 
 ---
 """
+
+    # Preserve checkpoint recovery context written by recover.py at startup.
+    # It starts with a known sentinel so we can reliably detect its presence.
+    try:
+        existing = pending_path.read_text()
+        if _RECOVERY_CONTEXT_SENTINEL in existing:
+            recovery_start = existing.index(_RECOVERY_CONTEXT_SENTINEL)
+            content = content.rstrip() + "\n\n" + existing[recovery_start:].strip() + "\n"
+    except (FileNotFoundError, OSError):
+        pass
+
     atomic_write(pending_path, content)
     return str(pending_path)
 

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -249,8 +249,10 @@ Mode: {mode}
         if _RECOVERY_CONTEXT_SENTINEL in existing:
             recovery_start = existing.index(_RECOVERY_CONTEXT_SENTINEL)
             content = content.rstrip() + "\n\n" + existing[recovery_start:].strip() + "\n"
-    except (FileNotFoundError, OSError):
+    except FileNotFoundError:
         pass
+    except OSError as exc:
+        log.warning("Could not read existing pending.md for recovery context: %s", exc)
 
     atomic_write(pending_path, content)
     return str(pending_path)

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -376,6 +376,28 @@ class TestCreatePendingFile:
             assert str(args[0]).endswith("pending.md")
             assert "# Autonomous run" in args[1]
 
+    def test_pending_md_written_when_journal_dir_creation_fails(self, tmp_path):
+        """pending.md must be written even when journal_dir.mkdir() raises OSError."""
+        from unittest.mock import patch
+
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
+
+        with patch("pathlib.Path.mkdir", side_effect=OSError("no space left on device")):
+            path = create_pending_file(
+                instance_dir=instance,
+                project_name="koan",
+                run_num=1,
+                max_runs=10,
+                autonomous_mode="implement",
+                mission_title="Test mission",
+            )
+
+        content = Path(path).read_text()
+        assert "# Mission: Test mission" in content
+
     def test_preserves_recovery_context_from_pending_md(self, tmp_path):
         """Checkpoint recovery context injected by recover.py must survive create_pending_file."""
         from app.loop_manager import create_pending_file

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -385,7 +385,15 @@ class TestCreatePendingFile:
         instance = str(tmp_path / "instance")
         os.makedirs(os.path.join(instance, "journal"), exist_ok=True)
 
-        with patch("pathlib.Path.mkdir", side_effect=OSError("no space left on device")):
+        import re
+        original_mkdir = Path.mkdir
+
+        def failing_mkdir(self, *a, **kw):
+            if "journal" in str(self) and re.search(r"\d{4}-\d{2}-\d{2}", str(self)):
+                raise OSError("no space left on device")
+            return original_mkdir(self, *a, **kw)
+
+        with patch.object(Path, "mkdir", failing_mkdir):
             path = create_pending_file(
                 instance_dir=instance,
                 project_name="koan",

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -376,6 +376,68 @@ class TestCreatePendingFile:
             assert str(args[0]).endswith("pending.md")
             assert "# Autonomous run" in args[1]
 
+    def test_preserves_recovery_context_from_pending_md(self, tmp_path):
+        """Checkpoint recovery context injected by recover.py must survive create_pending_file."""
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        journal_dir = Path(instance) / "journal"
+        journal_dir.mkdir(parents=True)
+
+        # Simulate what recover.py._inject_checkpoint_context() writes
+        recovery_ctx = (
+            "## Recovery Context (from previous interrupted run)\n\n"
+            "- **Branch**: `koan/my-fix`\n"
+            "- **Project**: my-project\n\n"
+            "### Steps already completed:\n"
+            "- Updated the config file\n"
+        )
+        (journal_dir / "pending.md").write_text(recovery_ctx)
+
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="my-project",
+            run_num=1,
+            max_runs=10,
+            autonomous_mode="implement",
+            mission_title="Fix the thing",
+        )
+
+        content = Path(path).read_text()
+        # New header should be present
+        assert "# Mission: Fix the thing" in content
+        # Recovery context must be preserved
+        assert "## Recovery Context (from previous interrupted run)" in content
+        assert "koan/my-fix" in content
+        assert "Updated the config file" in content
+
+    def test_does_not_preserve_regular_pending_md(self, tmp_path):
+        """Only checkpoint recovery context is preserved; regular pending.md content is not."""
+        from app.loop_manager import create_pending_file
+
+        instance = str(tmp_path / "instance")
+        journal_dir = Path(instance) / "journal"
+        journal_dir.mkdir(parents=True)
+
+        # Regular pending.md from a completed run (no recovery context sentinel)
+        (journal_dir / "pending.md").write_text(
+            "# Mission: Old task\nProject: old\nStarted: 2025-01-01\n---\n"
+        )
+
+        path = create_pending_file(
+            instance_dir=instance,
+            project_name="new-project",
+            run_num=1,
+            max_runs=10,
+            autonomous_mode="implement",
+            mission_title="New task",
+        )
+
+        content = Path(path).read_text()
+        assert "# Mission: New task" in content
+        # Old mission content should NOT be carried over
+        assert "Old task" not in content
+
 
 # --- Test interruptible_sleep ---
 


### PR DESCRIPTION
## Problem
`recover.py._inject_checkpoint_context()` writes structured recovery data to pending.md at
startup. `create_pending_file()` called when the mission starts then overwrote it completely,
making the "partial" state classification a no-op.

Additionally, if `instance/journal/YYYY-MM-DD/` could not be created (disk full, permissions),
pending.md was never written, losing checkpoint context for Claude.

## Changes
- `create_pending_file()` reads existing pending.md before writing
- If the recovery context sentinel (`## Recovery Context (from previous interrupted run)`) is
  found, the checkpoint section is appended after the new header
- Regular pending.md content (no sentinel) is not carried over
- `journal_dir.mkdir()` wrapped in `contextlib.suppress(OSError)` — pending.md write proceeds
  regardless of dated subdir failure

## Test
Added `test_preserves_recovery_context_from_pending_md` and
`test_does_not_preserve_regular_pending_md`.