### PR TITLE
fix(awake): persist Telegram polling offset across bridge restarts

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -66,8 +66,32 @@ from app.conversation_history import (
 )
 from app.signals import HEARTBEAT_FILE, PAUSE_FILE, STOP_FILE
 from app.utils import (
+    atomic_write,
     parse_project as _parse_project,
 )
+
+# Path where the Telegram polling offset is persisted across restarts.
+_OFFSET_FILE = INSTANCE_DIR / ".telegram-offset.json"
+
+
+def _load_offset() -> int | None:
+    """Load the last persisted Telegram polling offset, or None if absent."""
+    try:
+        import json
+        data = json.loads(_OFFSET_FILE.read_text())
+        v = data.get("offset")
+        return int(v) if v is not None else None
+    except (FileNotFoundError, ValueError, KeyError, TypeError):
+        return None
+
+
+def _save_offset(offset: int) -> None:
+    """Persist the Telegram polling offset to disk (best-effort)."""
+    try:
+        import json
+        atomic_write(_OFFSET_FILE, json.dumps({"offset": offset}))
+    except OSError:
+        pass
 
 
 # ---------------------------------------------------------------------------
@@ -830,7 +854,9 @@ def _bridge_loop():
             f"GitHub webhook receiver failed to start: {e}\n{traceback.format_exc()}")
 
     log("init", f"Polling every {POLL_INTERVAL}s (chat mode: fast reply)")
-    offset = None
+    offset = _load_offset()
+    if offset is not None:
+        log("init", f"Resuming Telegram polling from persisted offset {offset}")
     first_poll = True
 
     try:
@@ -855,6 +881,7 @@ def _bridge_loop():
                 # forever (see logs/awake.log KeyError: 'update_id').
                 if "update_id" in update:
                     offset = update["update_id"] + 1
+                    _save_offset(offset)
 
                 # Handle reaction updates
                 if "message_reaction" in update:

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -1469,7 +1469,8 @@ class TestMainLoop:
     def mock_pid_manager(self):
         """Auto-mock PID file management for all main() tests."""
         with patch("app.pid_manager.acquire_pidfile") as mock_acquire, \
-             patch("app.pid_manager.release_pidfile"):
+             patch("app.pid_manager.release_pidfile"), \
+             patch("app.awake._load_offset", return_value=None):
             mock_acquire.return_value = MagicMock()
             yield
 


### PR DESCRIPTION
## Problem
Telegram `offset` was in-memory only. After bridge restart the offset reset to `None`, causing
Telegram to re-deliver all updates from the ~60s window before the restart. This could cause
duplicate mission queuing and commands executed twice.

## Changes
- `_save_offset(offset)` persists to `instance/.telegram-offset.json` atomically on each
  `update_id` advance
- `_load_offset()` reads the persisted value at startup, logging a resume message
- `TestMainLoop` autouse fixture mocks `_load_offset` to return `None` for test isolation

## Test
267 tests pass. 1 pre-existing root-permission test excluded.