### PR TITLE
fix(run): verify start_mission transition and abort on mismatch

### DIFF
--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -765,7 +765,10 @@ def _run_iteration(
     # needle recorded in missions.md "In Progress" section.
     original_mission_title = mission_title
     if mission_title:
-        _run._start_mission_in_file(instance, mission_title)
+        if not _run._start_mission_in_file(instance, mission_title):
+            log("warning", f"start_mission transition failed for '{mission_title[:60]}' — "
+                "mission may still be in Pending; aborting this run to avoid duplicate execution.")
+            return False
 
     # --- Create structured checkpoint for recovery ---
     if mission_title:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1773,10 +1773,12 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
             return False
         after = modify_missions_file(missions_path, lambda c: start_mission(c, mission_title))
         in_progress = parse_sections(after).get("in_progress", []) if after else []
-        # Normalise for comparison: strip leading "- " and whitespace
-        clean_title = mission_title.strip()
+        # Normalise for comparison: strip leading "- ", collapse whitespace
+        import re as _re
+        clean_title = _re.sub(r"\s+", " ", mission_title.strip())
         for entry in in_progress:
-            if clean_title in entry:
+            entry_text = _re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
+            if clean_title in entry_text:
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1757,17 +1757,34 @@ def _reset_usage_session(instance: str):
         log("error", f"Usage session reset failed: {e}")
 
 
-def _start_mission_in_file(instance: str, mission_title: str):
-    """Move mission from Pending to In Progress via locked write."""
+def _start_mission_in_file(instance: str, mission_title: str) -> bool:
+    """Move mission from Pending to In Progress via locked write.
+
+    Returns True if the transition was confirmed (mission visible in In Progress
+    after the write), False if the mission was not found or the transition could
+    not be verified. A False return is logged as a WARNING — the caller should
+    treat the mission as if it never started.
+    """
     try:
-        from app.missions import start_mission
+        from app.missions import parse_sections, start_mission
         from app.utils import modify_missions_file
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
-            return
-        modify_missions_file(missions_path, lambda c: start_mission(c, mission_title))
+            return False
+        after = modify_missions_file(missions_path, lambda c: start_mission(c, mission_title))
+        in_progress = parse_sections(after).get("in_progress", []) if after else []
+        # Normalise for comparison: strip leading "- " and whitespace
+        clean_title = mission_title.strip()
+        for entry in in_progress:
+            if clean_title in entry:
+                return True
+        log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
+            "not found in In Progress after start_mission(). "
+            "Possible text normalisation mismatch or race condition.")
+        return False
     except Exception as e:
         log("error", f"Could not start mission in missions.md: {e}")
+        return False
 
 
 def _update_mission_in_file(

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1772,12 +1772,12 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
         if not missions_path.exists():
             return False
         after = modify_missions_file(missions_path, lambda c: start_mission(c, mission_title))
-        in_progress = parse_sections(after).get("in_progress", []) if after else []
+        in_progress = parse_sections(after).get("in_progress", [])
         # Normalise for comparison: strip leading "- ", collapse whitespace
-        import re as _re
-        clean_title = _re.sub(r"\s+", " ", mission_title.strip())
+        import re
+        clean_title = re.sub(r"\s+", " ", mission_title.strip())
         for entry in in_progress:
-            entry_text = _re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
+            entry_text = re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
             if clean_title in entry_text:
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -1032,7 +1032,6 @@ def filter_diff_by_ignore(
     """
     import fnmatch
     import os
-    import re as _re
 
     if not diff:
         return diff, []
@@ -1044,8 +1043,8 @@ def filter_diff_by_ignore(
     compiled_regexes = []
     for pat in regex_patterns:
         try:
-            compiled_regexes.append(_re.compile(pat))
-        except _re.error as e:
+            compiled_regexes.append(re.compile(pat))
+        except re.error as e:
             print(
                 f"[utils] filter_diff_by_ignore: skipping malformed regex {pat!r}: {e}",
                 file=sys.stderr,
@@ -1053,7 +1052,7 @@ def filter_diff_by_ignore(
 
     # Split diff into file blocks. Each block starts with 'diff --git'.
     # Re-join the delimiter with the block that follows it.
-    raw_blocks = _re.split(r'(?=^diff --git )', diff, flags=_re.MULTILINE)
+    raw_blocks = re.split(r'(?=^diff --git )', diff, flags=re.MULTILINE)
 
     # If splitting yields <=1 block, the format is unexpected — return unchanged
     if len(raw_blocks) <= 1:
@@ -1080,7 +1079,7 @@ def filter_diff_by_ignore(
 
     kept_blocks = []
     skipped_files = []
-    _diff_git_re = _re.compile(r'^diff --git a/(.+) b/(.+)$', _re.MULTILINE)
+    _diff_git_re = re.compile(r'^diff --git a/(.+) b/(.+)$', re.MULTILINE)
 
     for block in raw_blocks:
         if not block.strip():

--- a/koan/tests/conftest.py
+++ b/koan/tests/conftest.py
@@ -162,7 +162,7 @@ def patched_run_iteration(prep_result, extra_patches=None):
         "app.run.run_claude_task": MagicMock(return_value=0),
         "app.run._run_preflight_check": MagicMock(return_value=False),
         "app.run._handle_skill_dispatch": MagicMock(return_value=(False, "test mission")),
-        "app.run._start_mission_in_file": MagicMock(),
+        "app.run._start_mission_in_file": MagicMock(return_value=True),
         "app.run._finalize_mission": MagicMock(),
         "app.run._notify": MagicMock(),
         "app.run._notify_mission_end": MagicMock(),

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6966,7 +6966,7 @@ class TestRunIterationPaths:
             "_handle_skill_dispatch": MagicMock(
                 return_value=(False, plan.get("mission_title", ""))
             ),
-            "_start_mission_in_file": MagicMock(),
+            "_start_mission_in_file": MagicMock(return_value=True),
             "_finalize_mission": MagicMock(),
             "_notify": MagicMock(),
             "_notify_mission_end": MagicMock(),
@@ -7104,6 +7104,21 @@ class TestRunIterationPaths:
             mocks["_finalize_mission"].assert_called_once()
             mocks["_notify_mission_end"].assert_called_once()
             assert result is True
+
+    # --- start_mission transition failure aborts run ---
+
+    def test_start_mission_failure_aborts_execution(self, tmp_path):
+        """When _start_mission_in_file returns False, execution is aborted."""
+        plan = self._make_plan("mission", mission_title="implement feature X")
+        with self._patched_iteration(
+            tmp_path, plan,
+            _start_mission_in_file=MagicMock(return_value=False),
+        ) as mocks:
+            result = self._call(tmp_path)
+            mocks["_start_mission_in_file"].assert_called_once()
+            mocks["run_claude_task"].assert_not_called()
+            mocks["_finalize_mission"].assert_not_called()
+            assert result is False
 
     # --- Mission failure still finalizes ---
 


### PR DESCRIPTION
## Problem
`_start_mission_in_file()` discarded the return value of `modify_missions_file()` and could not
detect whether the mission actually moved to In Progress. Silent failure left the mission in
Pending while Claude executed it, causing:
- `/list` showing the mission as still Pending during execution
- Potential duplicate queuing by the user
- No In Progress entry for `recover.py` to find on crash

## Changes
- `_start_mission_in_file()` returns `bool` (True = confirmed in In Progress)
- After locked write, reads resulting content via `parse_sections()` to verify mission is in
  In Progress
- Logs WARNING on mismatch
- `mission_executor.py` aborts the run (returns `False`) when unconfirmed

## Test
749 tests pass.