### PR TITLE
fix(stagnation): strip lifecycle markers from mission key before hashing

### DIFF
--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -365,9 +365,22 @@ class StagnationMonitor:
 # detection — Claude can be unstuck by a fresh start. The tracker records
 # how many times each mission has stagnated so :func:`run._finalize_mission`
 # can decide between "requeue and try again" and "give up, mark Failed".
-# Counters are keyed by a stable SHA-256 of the mission title so very long
-# titles don't bloat the JSON, and identical titles in different instances
-# are isolated by living under ``instance/``.
+# Counters are keyed by a stable SHA-256 of the *clean* mission title —
+# stripped of lifecycle markers (timestamps, recovery counters, complexity
+# tags) — so the SAME logical mission maps to the SAME key across requeue
+# cycles.  Without stripping, a requeued mission acquires new ⏳/▶
+# timestamps and would hash to a different key, silently resetting the
+# stagnation retry counter on every cycle and making max_retry_on_stagnation
+# ineffective.
+
+# Compiled once: strips everything that changes between queue cycles.
+_STRIP_FOR_KEY_RE = re.compile(
+    r"\s*⏳\([^)]*\)"              # ⏳(queued-timestamp)
+    r"|\s*▶\([^)]*\)"              # ▶(started-timestamp)
+    r"|\s*[✅❌]\s*\([^)]*\)"      # ✅/❌ (completed-timestamp)
+    r"|\s*\[r:\d+\]"               # [r:N] crash-recovery counter
+    r"|\s*\[complexity:[^\]]*\]"    # [complexity:X] classifier tag
+)
 
 
 def _retry_tracker_path(instance_dir: str) -> Path:
@@ -376,8 +389,17 @@ def _retry_tracker_path(instance_dir: str) -> Path:
 
 
 def _mission_key(mission_title: str) -> str:
-    """Stable, length-bounded key for a mission title."""
-    return hashlib.sha256(mission_title.encode("utf-8", errors="replace")).hexdigest()
+    """Stable key for a mission title, independent of lifecycle state.
+
+    Strips timestamps, recovery counters, and complexity tags before
+    hashing so the same logical mission always maps to the same key
+    regardless of which requeue cycle it is currently in.
+    """
+    clean = _STRIP_FOR_KEY_RE.sub("", mission_title)
+    clean = clean.strip()
+    if clean.startswith("- "):
+        clean = clean[2:].strip()
+    return hashlib.sha256(clean.encode("utf-8", errors="replace")).hexdigest()
 
 
 def _extract_count(raw) -> int:

--- a/koan/tests/test_stagnation_monitor.py
+++ b/koan/tests/test_stagnation_monitor.py
@@ -507,6 +507,35 @@ class TestMissionKey:
         assert len(key) == 64  # SHA-256 hex
         assert all(c in "0123456789abcdef" for c in key)
 
+    def test_strips_queued_timestamp(self):
+        base = _mission_key("fix the bug [project:foo]")
+        with_ts = _mission_key("fix the bug [project:foo] ⏳(2026-01-01T12:00)")
+        assert base == with_ts
+
+    def test_strips_started_timestamp(self):
+        base = _mission_key("fix the bug [project:foo]")
+        with_ts = _mission_key("fix the bug [project:foo] ⏳(2026-01-01T12:00) ▶(2026-01-01T12:05)")
+        assert base == with_ts
+
+    def test_strips_recovery_counter(self):
+        base = _mission_key("fix the bug [project:foo]")
+        with_r = _mission_key("fix the bug [project:foo] [r:2]")
+        assert base == with_r
+
+    def test_strips_complexity_tag(self):
+        base = _mission_key("fix the bug [project:foo]")
+        with_c = _mission_key("fix the bug [project:foo] [complexity:large]")
+        assert base == with_c
+
+    def test_stable_across_requeue_cycle(self):
+        """Key must match across all lifecycle states of the same mission."""
+        clean = _mission_key("fix the bug [project:foo]")
+        in_progress = _mission_key(
+            "- fix the bug [project:foo] [r:1] ⏳(2026-01-01T12:00) ▶(2026-01-01T12:05)"
+        )
+        requeued = _mission_key("- fix the bug [project:foo] [r:1]")
+        assert clean == in_progress == requeued
+
 
 class TestRetryTracker:
     """Cover get_retry_count, increment_retry_count, clear_retry_count."""


### PR DESCRIPTION
## Problem
`_mission_key()` hashed the raw mission title including ⏳/▶ timestamps, `[r:N]` recovery
counters, and `[complexity:X]` tags. After `requeue_mission()` strips those markers, the
re-picked mission acquires new timestamps — producing a different hash and silently resetting
the stagnation retry counter on every cycle. `max_retry_on_stagnation` was therefore never
reached and a persistently-stagnating mission would loop indefinitely.

Additionally, `[r:N]` tags from crash recovery cause the same key instability — each recovery
cycle produces a new key, abandoning the stagnation retry history.

## Changes
- `_STRIP_FOR_KEY_RE` now strips timestamps, `[r:N]` tags, and `[complexity:X]` tags before
  hashing, making the key stable across requeue and crash-recovery cycles

## Test
Tests added for key stability across requeue cycles.