### PR TITLE
fix(activity_usage_logger): flush stale handlers on logger re-init

### DIFF
--- a/koan/app/activity_usage_logger.py
+++ b/koan/app/activity_usage_logger.py
@@ -57,16 +57,20 @@ def _get_logger() -> logging.Logger:
     _logger.setLevel(logging.INFO)
     _logger.propagate = False
 
-    # Avoid duplicate handlers on re-init
-    if not _logger.handlers:
-        handler = RotatingFileHandler(
-            str(log_path),
-            maxBytes=_MAX_BYTES,
-            backupCount=_BACKUP_COUNT,
-            encoding="utf-8",
-        )
-        handler.setFormatter(logging.Formatter("%(message)s"))
-        _logger.addHandler(handler)
+    # Clear any stale handlers (can persist in Python's global logger registry
+    # across reset() calls in parallel test workers on Python 3.14+).
+    for _h in _logger.handlers[:]:
+        _h.close()
+        _logger.removeHandler(_h)
+
+    handler = RotatingFileHandler(
+        str(log_path),
+        maxBytes=_MAX_BYTES,
+        backupCount=_BACKUP_COUNT,
+        encoding="utf-8",
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    _logger.addHandler(handler)
 
     return _logger
 


### PR DESCRIPTION
## Summary

- `_get_logger()` called `logging.getLogger("koan.activity_usage")` which returns the same Logger object from Python's process-global registry on every call — even after `reset()` clears `_logger = None`
- The `if not _logger.handlers` guard then silently skipped adding the new `RotatingFileHandler`, so `log_activity_usage()` wrote to the previous worker's path and the test-local `usage.log` was never created
- This manifests as flaky `FileNotFoundError` / `AssertionError` failures in `test_activity_usage_logger.py` under `pytest-xdist` parallel workers on Python 3.14

Fix: unconditionally clear any existing handlers before adding the new one each time `_get_logger()` initialises a fresh logger. The early-return `if _logger is not None` means this init path only runs once per reset cycle, so there is no performance impact in production.

## Test plan

- [x] `pytest koan/tests/test_activity_usage_logger.py` — all 14 tests pass
- [x] Full fast suite (`pytest -m "not slow" -n auto --dist loadfile`) — 14 173 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)