### PR TITLE
fix(awake): persist Telegram polling offset across bridge restarts (review fixes)

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -15,6 +15,7 @@ Module layout:
 - awake.py (this file) — main loop, chat, outbox, message classification
 """
 
+import contextlib
 import os
 import re
 import subprocess
@@ -66,11 +67,10 @@ from app.conversation_history import (
 )
 from app.signals import HEARTBEAT_FILE, PAUSE_FILE, STOP_FILE
 from app.utils import (
-    atomic_write,
+    atomic_write_json,
     parse_project as _parse_project,
 )
 
-# Path where the Telegram polling offset is persisted across restarts.
 _OFFSET_FILE = INSTANCE_DIR / ".telegram-offset.json"
 
 
@@ -81,17 +81,14 @@ def _load_offset() -> int | None:
         data = json.loads(_OFFSET_FILE.read_text())
         v = data.get("offset")
         return int(v) if v is not None else None
-    except (FileNotFoundError, ValueError, KeyError, TypeError):
+    except (FileNotFoundError, ValueError, KeyError, TypeError, AttributeError):
         return None
 
 
 def _save_offset(offset: int) -> None:
     """Persist the Telegram polling offset to disk (best-effort)."""
-    try:
-        import json
-        atomic_write(_OFFSET_FILE, json.dumps({"offset": offset}))
-    except OSError:
-        pass
+    with contextlib.suppress(OSError):
+        atomic_write_json(_OFFSET_FILE, {"offset": offset})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Review fixes for the Telegram polling offset persistence feature (already merged):

- Added `AttributeError` to `_load_offset` except clause — guards against non-dict JSON values (e.g. `null`, `[1]`)
- Switched `_save_offset` to use `atomic_write_json` instead of manual `json.dumps` + `atomic_write`
- Replaced `try/except OSError: pass` with `contextlib.suppress(OSError)` per ruff PERF guidance
- Removed redundant inline comment on `_OFFSET_FILE`

## Test plan

- [ ] Corrupt the offset file with non-dict JSON (`null`, `[]`) and confirm bridge starts cleanly with `offset = None`

🤖 Generated with [Claude Code](https://claude.com/claude-code)