### PR TITLE
docs(missions): document requeue_mission top-of-queue insertion (B10)

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1235,6 +1235,14 @@ def requeue_mission(content: str, mission_text: str) -> str:
     the case where quota is detected after _finalize_mission already moved
     the mission to Failed.
 
+    Queue position — TOP, not bottom (intentional): the requeued mission is
+    inserted as the *first* item in Pending, unlike :func:`insert_mission`
+    which appends at the bottom (FIFO). This is deliberate — a mission that
+    was interrupted mid-flight (auth/quota pause, recoverable error) should
+    resume *before* unstarted work rather than going to the back of the
+    queue. Operators who see a requeued item jump ahead of other Pending
+    missions after a quota pause are observing this by design.
+
     Returns content unchanged if the mission is not found in either section.
     """
     needle = mission_text.strip()


### PR DESCRIPTION
## Problem
`requeue_mission()` inserts the recovered mission at the TOP of Pending, while `insert_mission()`
appends at the bottom (FIFO). Quota/auth-requeued missions therefore jump ahead of all other
pending work. This is intentional — interrupted work should resume before unstarted missions —
but was undocumented and surprised operators who saw queue ordering change after a quota pause.

## Changes
- Added a "Queue position — TOP, not bottom (intentional)" paragraph to the `requeue_mission()`
  docstring, contrasting it with `insert_mission()`'s FIFO append and explaining the rationale

## Test
Documentation-only change; behaviour unchanged. Existing requeue tests pass.