### PR TITLE
fix(missions): report found-status from complete/fail; fix silent no-…

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1039,23 +1039,31 @@ def _remove_item_by_text(
 def _move_pending_to_section(
     content: str, mission_text: str, section_key: str, marker: str, header: str,
     cause_tag: str = "",
-) -> str:
+) -> tuple[str, bool]:
     """Move a mission from Pending (or In Progress) to a target section.
 
     Shared implementation for complete_mission() and fail_mission().
     Searches Pending first, then falls back to In Progress.
-    Returns content unchanged if the mission is not found in either section.
 
     When *cause_tag* is a non-empty string, it is appended in square
     brackets after the timestamp — e.g. ``❌ (2026-04-19 03:45) [stagnation]``.
     Used to surface why a mission failed without parsing logs.
+
+    Returns:
+        A ``(content, found)`` tuple. ``found`` is ``True`` when the mission
+        was located and moved, ``False`` when it was not present in either
+        Pending or In Progress (in which case *content* is returned
+        unchanged). Reporting *found* explicitly lets callers distinguish a
+        genuine no-op from a move whose net content happens to match — a
+        distinction the previous before/after string comparison could not
+        make reliably once unrelated side effects (e.g. history pruning) ran.
     """
     needle = mission_text.strip()
     result = _remove_pending_by_text(content, needle)
     if result is None:
         result = _remove_item_by_text(content, needle, "in_progress")
     if result is None:
-        return content
+        return content, False
 
     updated = result[0]
 
@@ -1083,9 +1091,9 @@ def _move_pending_to_section(
         while insert_at < end and lines[insert_at].strip() == "":
             insert_at += 1
         lines.insert(insert_at, entry)
-        return normalize_content("\n".join(lines))
+        return normalize_content("\n".join(lines)), True
 
-    return normalize_content(updated + f"\n## {header}\n\n{entry}\n")
+    return normalize_content(updated + f"\n## {header}\n\n{entry}\n"), True
 
 
 def _flush_in_progress_to_failed(content: str) -> str:
@@ -1190,6 +1198,20 @@ def start_mission(content: str, mission_text: str) -> str:
     return normalize_content(updated + f"\n## In Progress\n\n{entry}\n")
 
 
+def complete_mission_checked(content: str, mission_text: str) -> tuple[str, bool]:
+    """Move a mission to Done, reporting whether it was found.
+
+    Same behaviour as :func:`complete_mission` but returns a
+    ``(content, found)`` tuple so callers can distinguish a genuine no-op
+    (mission absent) from a successful move. Prefer this over
+    :func:`complete_mission` when the caller needs to surface a missing
+    mission (e.g. to log a warning or abort).
+    """
+    from app.security_audit import MISSION_COMPLETE, log_event
+    log_event(MISSION_COMPLETE, details={"mission": mission_text})
+    return _move_pending_to_section(content, mission_text, "done", "\u2705", "Done")
+
+
 def complete_mission(content: str, mission_text: str) -> str:
     """Move a mission from Pending (or In Progress) to Done with a timestamp.
 
@@ -1197,11 +1219,28 @@ def complete_mission(content: str, mission_text: str) -> str:
 
     Returns:
         Updated content string. Returns original content unchanged if
-        the mission is not found in either section.
+        the mission is not found in either section. Use
+        :func:`complete_mission_checked` when you need to know which case
+        occurred.
     """
-    from app.security_audit import MISSION_COMPLETE, log_event
-    log_event(MISSION_COMPLETE, details={"mission": mission_text})
-    return _move_pending_to_section(content, mission_text, "done", "\u2705", "Done")
+    return complete_mission_checked(content, mission_text)[0]
+
+
+def fail_mission_checked(
+    content: str, mission_text: str, cause_tag: str = "",
+) -> tuple[str, bool]:
+    """Move a mission to Failed, reporting whether it was found.
+
+    Same behaviour as :func:`fail_mission` but returns a ``(content, found)``
+    tuple so callers can distinguish a genuine no-op (mission absent) from a
+    successful move.
+    """
+    from app.security_audit import MISSION_FAIL, log_event
+    log_event(MISSION_FAIL, details={"mission": mission_text, "cause_tag": cause_tag})
+    return _move_pending_to_section(
+        content, mission_text, "failed", "\u274c", "Failed",
+        cause_tag=cause_tag,
+    )
 
 
 def fail_mission(content: str, mission_text: str, cause_tag: str = "") -> str:
@@ -1215,13 +1254,9 @@ def fail_mission(content: str, mission_text: str, cause_tag: str = "") -> str:
     a stuck-in-a-loop abort from a regular failure at a glance.
 
     Returns content unchanged if the mission is not found in either section.
+    Use :func:`fail_mission_checked` when you need to know which case occurred.
     """
-    from app.security_audit import MISSION_FAIL, log_event
-    log_event(MISSION_FAIL, details={"mission": mission_text, "cause_tag": cause_tag})
-    return _move_pending_to_section(
-        content, mission_text, "failed", "\u274c", "Failed",
-        cause_tag=cause_tag,
-    )
+    return fail_mission_checked(content, mission_text, cause_tag=cause_tag)[0]
 
 
 def requeue_mission(content: str, mission_text: str) -> str:

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1063,7 +1063,11 @@ def _move_pending_to_section(
     if result is None:
         result = _remove_item_by_text(content, needle, "in_progress")
     if result is None:
-        return content, False
+        # Normalize even on the not-found path so callers receive content of
+        # the same shape (collapsed blank-line runs, no trailing whitespace)
+        # as the found paths below. Without this, found=False could return
+        # raw content that differs from a found=True return for the same input.
+        return normalize_content(content), False
 
     updated = result[0]
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1817,29 +1817,42 @@ def _update_mission_in_file(
     callers should surface this rather than let it loop silently.
     """
     try:
-        from app.missions import complete_mission, fail_mission, prune_completed_sections
+        from app.missions import (
+            complete_mission_checked,
+            fail_mission_checked,
+            prune_completed_sections,
+        )
         from app.utils import modify_missions_file
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
             return False
 
+        # The move functions report found-status directly. We capture it via a
+        # closure flag rather than comparing before/after content: pruning runs
+        # unconditionally and can change the content even when the mission was
+        # never found, which would otherwise mask a silent no-op as success.
+        found = [False]
+
         if failed:
             def transform(content):
-                return fail_mission(content, mission_title, cause_tag=cause_tag)
+                new_content, ok = fail_mission_checked(
+                    content, mission_title, cause_tag=cause_tag,
+                )
+                found[0] = ok
+                return new_content
         else:
             def transform(content):
-                return complete_mission(content, mission_title)
-
-        before = [None]
+                new_content, ok = complete_mission_checked(content, mission_title)
+                found[0] = ok
+                return new_content
 
         def tracked(content):
-            before[0] = content
             result = transform(content)
             result, _ = prune_completed_sections(result)
             return result
 
-        after = modify_missions_file(missions_path, tracked)
-        if before[0] is not None and after == before[0]:
+        modify_missions_file(missions_path, tracked)
+        if not found[0]:
             log("warning", f"Mission not found (no change): {mission_title[:80]}")
             return False
         return True

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -7,9 +7,11 @@ from app.missions import (
     cancel_pending_mission,
     classify_section,
     complete_mission,
+    complete_mission_checked,
     delete_idea,
     extract_timestamps,
     fail_mission,
+    fail_mission_checked,
     format_duration,
     insert_idea,
     insert_mission,
@@ -1590,6 +1592,70 @@ class TestFailMission:
         sections = parse_sections(result)
         assert len(sections["pending"]) == 0
         assert len(sections["failed"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# complete_mission_checked / fail_mission_checked — found-status reporting
+# ---------------------------------------------------------------------------
+
+class TestMissionCheckedVariants:
+    """The *_checked variants report whether the mission was found.
+
+    Callers use the boolean to distinguish a genuine no-op (mission absent)
+    from a successful move, so they can warn instead of looping silently.
+    """
+
+    CONTENT = (
+        "# Missions\n\n"
+        "## Pending\n\n"
+        "- /plan Add dark mode\n\n"
+        "## In Progress\n\n"
+        "- Fix the login bug ▶(2026-01-01T00:00)\n\n"
+        "## Done\n"
+    )
+
+    def test_complete_found_in_pending_reports_true(self):
+        content, found = complete_mission_checked(self.CONTENT, "/plan Add dark mode")
+        assert found is True
+        assert "/plan Add dark mode" in "\n".join(parse_sections(content)["done"])
+
+    def test_complete_found_in_progress_reports_true(self):
+        content, found = complete_mission_checked(self.CONTENT, "Fix the login bug")
+        assert found is True
+        assert "Fix the login bug" in "\n".join(parse_sections(content)["done"])
+
+    def test_complete_absent_reports_false_and_leaves_content(self):
+        content, found = complete_mission_checked(self.CONTENT, "/nonexistent thing")
+        assert found is False
+        assert content == normalize_content(self.CONTENT)
+
+    def test_fail_found_reports_true(self):
+        content, found = fail_mission_checked(self.CONTENT, "/plan Add dark mode")
+        assert found is True
+        assert "/plan Add dark mode" in "\n".join(parse_sections(content)["failed"])
+
+    def test_fail_absent_reports_false_and_leaves_content(self):
+        content, found = fail_mission_checked(self.CONTENT, "/nonexistent thing")
+        assert found is False
+        assert content == normalize_content(self.CONTENT)
+
+    def test_fail_checked_preserves_cause_tag(self):
+        content, found = fail_mission_checked(
+            self.CONTENT, "/plan Add dark mode", cause_tag="stagnation",
+        )
+        assert found is True
+        assert "[stagnation]" in "\n".join(parse_sections(content)["failed"])
+
+    def test_unchecked_wrappers_return_same_content(self):
+        """The str-returning wrappers must equal the checked variant's content."""
+        assert (
+            complete_mission(self.CONTENT, "/plan Add dark mode")
+            == complete_mission_checked(self.CONTENT, "/plan Add dark mode")[0]
+        )
+        assert (
+            fail_mission(self.CONTENT, "/plan Add dark mode")
+            == fail_mission_checked(self.CONTENT, "/plan Add dark mode")[0]
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6191,6 +6191,43 @@ class TestUpdateMissionInFile:
         assert mission not in content.split("## Pending")[1].split("##")[0]
         assert "issues/15" in content.split("## Done")[1]
 
+    def test_not_found_returns_false_even_when_pruning_changes_content(self, tmp_path):
+        """Regression (B11): a missing mission must report False even if the
+        unconditional history prune mutates the file.
+
+        Previously the function inferred success by comparing content before
+        and after the locked write. Because ``prune_completed_sections`` runs
+        regardless of whether the mission was found, an oversized Failed
+        section made the content differ on a genuine no-op — so an absent
+        mission was wrongly reported as moved, masking a stuck mission.
+        """
+        from app.run import _update_mission_in_file
+
+        # 35 Failed entries — above the default failed_keep=30 prune threshold,
+        # so the locked write WILL change the file even though the target
+        # mission is absent from Pending and In Progress.
+        failed_entries = "\n".join(
+            f"- old failure {i} ❌ (2026-01-01 00:00)" for i in range(35)
+        )
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n- /plan unrelated work\n\n"
+            "## In Progress\n\n"
+            f"## Failed\n\n{failed_entries}\n"
+        )
+
+        before = missions.read_text()
+        result = _update_mission_in_file(
+            str(missions.parent), "/plan absent mission",
+        )
+        after = missions.read_text()
+
+        # The mission was never present → must report not-found...
+        assert result is False
+        # ...even though pruning genuinely changed the file content.
+        assert after != before
+
 
 # ---------------------------------------------------------------------------
 # Test: _run_iteration returns productive/idle boolean


### PR DESCRIPTION
## Problem

`complete_mission()` / `fail_mission()` return content unchanged when the mission is absent
from Pending and In Progress, with no signal to the caller. `run.py`'s
`_update_mission_in_file()` then inferred success by comparing content before and after the
locked write — but `prune_completed_sections()` runs unconditionally on that path, so an
oversized Done/Failed section makes the content differ even on a genuine no-op. Result: an
absent mission was wrongly reported as moved (returning True), masking a stuck mission that
re-dispatches on every loop.

## Changes

- `missions._move_pending_to_section()` now returns a `(content, found: bool)` tuple
- New `complete_mission_checked()` / `fail_mission_checked()` expose the found flag;
  `complete_mission()` / `fail_mission()` keep their `str` return as thin wrappers, so no
  existing caller or test changes
- `run._update_mission_in_file()` captures found-status via a closure flag (the same pattern
  `insert_pending_mission()` already uses) and bases its WARNING + bool return on it —
  decoupled from the pruning side effect

## Test

968 related tests pass. New:
- `TestMissionCheckedVariants` — found=True/False across Pending, In Progress, and absent;
  cause_tag preserved; wrappers equal the checked variant's content
- `test_not_found_returns_false_even_when_pruning_changes_content` — regression proving an
  absent mission reports False even when pruning mutates the file (the exact false-positive
  the old before/after comparison produced)