### PR TITLE
docs+log: cross-link crash-recovery safety nets; log sanity flush

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1099,6 +1099,13 @@ def _flush_in_progress_to_failed(content: str) -> str:
     Under normal operation this path never fires because recover.py moves
     stale In Progress entries back to Pending at startup. This is a second
     line of defence for edge cases recover.py misses (e.g. complex ### missions).
+
+    Relationship to crash recovery (two safety nets for the same scenario):
+    - ``recover.py`` runs once at startup, before the loop, and moves stale
+      In Progress missions back to *Pending* (with crash-recovery counting).
+    - This function runs per-mission, inside ``start_mission()``, and moves
+      whatever ``recover.py`` missed to *Failed*. When it fires, the caller
+      (``run._start_mission_in_file``) emits a WARNING so the flush is visible.
     """
     sections = parse_sections(content)
     stale = sections.get("in_progress", [])

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -185,6 +185,13 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     Uses modify_missions_file() for atomic read-modify-write under exclusive lock,
     preventing race conditions with concurrent mission additions.
 
+    This is the *primary* crash-recovery safety net — it runs once at startup,
+    before the agent loop, and recovers to Pending. A second, narrower net lives
+    in ``missions._flush_in_progress_to_failed`` (invoked per-mission by
+    ``start_mission()``): it sweeps anything this function misses (e.g. complex
+    ``###`` blocks) into Failed. If you are debugging a stale In Progress
+    mission, check both paths.
+
     Args:
         instance_dir: Path to instance directory.
         dry_run: If True, classify and log but do not modify missions.md.

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1784,7 +1784,7 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
         # start_mission() runs a sanity flush: any stale In Progress missions
         # are moved to Failed (with a [flushed] tag) before the new one starts.
         # Under normal operation this never fires because recover.py clears
-        # stale entries at startup — so when it DOES fire, surface it (S1).
+        # stale entries at startup — so when it DOES fire, surface it.
         # Capture the pre-flush In Progress inside the lock to stay race-safe.
         stale_flushed: list = []
 
@@ -1793,16 +1793,6 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
             return start_mission(content, mission_title)
 
         after = modify_missions_file(missions_path, _transform)
-        if stale_flushed:
-            titles = ", ".join(
-                s.split("\n")[0].strip().removeprefix("- ")[:50]
-                for s in stale_flushed
-            )
-            log("warning", (
-                f"Sanity flush: {len(stale_flushed)} stale In Progress mission(s) "
-                f"moved to Failed by start_mission() — recover.py missed them "
-                f"(see _flush_in_progress_to_failed): {titles}"
-            ))
         in_progress = parse_sections(after).get("in_progress", [])
         # Normalise for comparison: strip leading "- ", collapse whitespace
         import re
@@ -1810,6 +1800,21 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
         for entry in in_progress:
             entry_text = re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
             if clean_title in entry_text:
+                # Only surface the sanity flush once the transition is
+                # confirmed: start_mission() early-returns (skipping the
+                # flush) when the mission isn't in Pending, so stale_flushed
+                # being non-empty does NOT by itself mean a flush happened.
+                if stale_flushed:
+                    titles = ", ".join(
+                        s.split("\n")[0].strip().removeprefix("- ")[:50]
+                        for s in stale_flushed
+                    )
+                    log("warning", (
+                        f"Sanity flush: {len(stale_flushed)} stale In Progress "
+                        f"mission(s) moved to Failed by start_mission() — "
+                        f"recover.py missed them "
+                        f"(see _flush_in_progress_to_failed): {titles}"
+                    ))
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1780,7 +1780,29 @@ def _start_mission_in_file(instance: str, mission_title: str) -> bool:
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
             return False
-        after = modify_missions_file(missions_path, lambda c: start_mission(c, mission_title))
+
+        # start_mission() runs a sanity flush: any stale In Progress missions
+        # are moved to Failed (with a [flushed] tag) before the new one starts.
+        # Under normal operation this never fires because recover.py clears
+        # stale entries at startup — so when it DOES fire, surface it (S1).
+        # Capture the pre-flush In Progress inside the lock to stay race-safe.
+        stale_flushed: list = []
+
+        def _transform(content: str) -> str:
+            stale_flushed[:] = parse_sections(content).get("in_progress", [])
+            return start_mission(content, mission_title)
+
+        after = modify_missions_file(missions_path, _transform)
+        if stale_flushed:
+            titles = ", ".join(
+                s.split("\n")[0].strip().removeprefix("- ")[:50]
+                for s in stale_flushed
+            )
+            log("warning", (
+                f"Sanity flush: {len(stale_flushed)} stale In Progress mission(s) "
+                f"moved to Failed by start_mission() — recover.py missed them "
+                f"(see _flush_in_progress_to_failed): {titles}"
+            ))
         in_progress = parse_sections(after).get("in_progress", [])
         # Normalise for comparison: strip leading "- ", collapse whitespace
         import re

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6193,7 +6193,7 @@ class TestUpdateMissionInFile:
 
 
 class TestStartMissionSanityFlushLog:
-    """S1: a sanity flush during start_mission() is surfaced to operators."""
+    """A sanity flush during start_mission() is surfaced to operators."""
 
     def test_stale_in_progress_is_flushed_and_logged(self, tmp_path):
         from app.run import _start_mission_in_file
@@ -6242,6 +6242,39 @@ class TestStartMissionSanityFlushLog:
             if c.args and c.args[0] == "warning"
         ]
         assert not any("Sanity flush" in w for w in warnings)
+
+    def test_no_sanity_flush_log_when_mission_not_in_pending(self, tmp_path):
+        """False-positive guard: stale In Progress entries exist but the
+        mission isn't in Pending (e.g. a race removed it between pick and
+        start). start_mission() early-returns without flushing, so neither
+        the sanity-flush warning nor a successful transition should occur.
+        """
+        from app.run import _start_mission_in_file
+        from app.missions import parse_sections
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        # Stale In Progress entry present, but the mission we try to start
+        # is absent from Pending.
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n"
+            "## In Progress\n\n- /plan leftover stale ▶(2026-01-01T00:00)\n\n"
+            "## Done\n"
+        )
+
+        with patch("app.run.log") as mock_log:
+            assert _start_mission_in_file(str(missions.parent), "/plan absent work") is False
+
+        warnings = [
+            c.args[1] for c in mock_log.call_args_list
+            if c.args and c.args[0] == "warning"
+        ]
+        # No false "Sanity flush" warning — nothing was flushed.
+        assert not any("Sanity flush" in w for w in warnings)
+        # The stale entry is untouched: still In Progress, not moved to Failed.
+        sections = parse_sections(missions.read_text())
+        assert "leftover stale" in "\n".join(sections["in_progress"])
+        assert "leftover stale" not in "\n".join(sections.get("failed", []))
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6192,6 +6192,58 @@ class TestUpdateMissionInFile:
         assert "issues/15" in content.split("## Done")[1]
 
 
+class TestStartMissionSanityFlushLog:
+    """S1: a sanity flush during start_mission() is surfaced to operators."""
+
+    def test_stale_in_progress_is_flushed_and_logged(self, tmp_path):
+        from app.run import _start_mission_in_file
+        from app.missions import parse_sections
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        # A stale In Progress mission recover.py "missed", plus the one we start.
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n- /plan new work\n\n"
+            "## In Progress\n\n- /plan leftover stale ▶(2026-01-01T00:00)\n\n"
+            "## Done\n"
+        )
+
+        with patch("app.run.log") as mock_log:
+            assert _start_mission_in_file(str(missions.parent), "/plan new work") is True
+
+        # The stale mission was flushed to Failed with a [flushed] tag...
+        sections = parse_sections(missions.read_text())
+        failed_text = "\n".join(sections["failed"])
+        assert "leftover stale" in failed_text
+        assert "[flushed]" in failed_text
+        # ...and the new mission is now In Progress.
+        assert "/plan new work" in "\n".join(sections["in_progress"])
+        # ...and a warning naming the flush was emitted.
+        warnings = [
+            c.args[1] for c in mock_log.call_args_list
+            if c.args and c.args[0] == "warning"
+        ]
+        assert any("Sanity flush" in w and "leftover stale" in w for w in warnings)
+
+    def test_no_log_when_in_progress_empty(self, tmp_path):
+        from app.run import _start_mission_in_file
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n- /plan only work\n\n"
+            "## In Progress\n\n## Done\n"
+        )
+        with patch("app.run.log") as mock_log:
+            assert _start_mission_in_file(str(missions.parent), "/plan only work") is True
+
+        warnings = [
+            c.args[1] for c in mock_log.call_args_list
+            if c.args and c.args[0] == "warning"
+        ]
+        assert not any("Sanity flush" in w for w in warnings)
+
+
 # ---------------------------------------------------------------------------
 # Test: _run_iteration returns productive/idle boolean
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem
recover.py (startup, → Pending) and _flush_in_progress_to_failed (per-mission via
start_mission(), → Failed) are independent safety nets for the same stale In Progress
scenario, with no documented relationship and no visibility when the second net fires.

## Changes
- recover.recover_missions() docstring cross-links forward to the per-mission flush net
- missions._flush_in_progress_to_failed() docstring cross-links back to recover.py
- run._start_mission_in_file() captures stale In Progress inside the lock and emits a WARNING
  naming the flushed missions when the sanity flush fires (missions.py stays pure)

## Test
TestStartMissionSanityFlushLog — flush logged + mission moved to Failed with [flushed];
no log when In Progress is empty.