### PR TITLE
refactor(recover): single pending.md read; reuse caller value

### DIFF
--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -29,6 +29,7 @@ import re
 import sys
 from datetime import datetime
 from pathlib import Path
+from typing import Optional
 
 from app.notify import format_and_send
 
@@ -173,7 +174,11 @@ def check_pending_journal(instance_dir: str) -> bool:
 # Main recovery logic
 # ---------------------------------------------------------------------------
 
-def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
+def recover_missions(
+    instance_dir: str,
+    dry_run: bool = False,
+    has_pending_journal: Optional[bool] = None,
+) -> tuple:
     """Move stale in-progress missions back to pending or escalate to failed.
 
     Enhanced recovery with state classification:
@@ -188,6 +193,13 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     Args:
         instance_dir: Path to instance directory.
         dry_run: If True, classify and log but do not modify missions.md.
+        has_pending_journal: Optional pre-computed pending.md presence. When
+            a caller has already read pending.md (e.g. the CLI entry point via
+            ``check_pending_journal()``), it passes the result here so this
+            function does not read the same file a second time — removing the
+            redundant double-read and closing the TOCTOU window between the two
+            reads. When ``None`` (default, daemon path), it is computed here as
+            before.
 
     Returns:
         Tuple of (count of missions moved to Pending, list of escalated mission lines).
@@ -201,13 +213,15 @@ def recover_missions(instance_dir: str, dry_run: bool = False) -> tuple:
     from app.missions import find_section_boundaries, normalize_content
     from app.utils import atomic_write, modify_missions_file
 
-    # Check pending.md once for the partial state detection
-    # Use try/except to avoid TOCTOU race (file deleted between check and read)
-    pending_path = Path(instance_dir) / "journal" / "pending.md"
-    try:
-        has_pending_journal = pending_path.read_text().strip() != ""
-    except FileNotFoundError:
-        has_pending_journal = False
+    # Determine pending.md presence for partial-state detection. Reuse a
+    # caller-supplied value when available (single read); otherwise read once
+    # here. try/except avoids a TOCTOU race (file deleted between check and read).
+    if has_pending_journal is None:
+        pending_path = Path(instance_dir) / "journal" / "pending.md"
+        try:
+            has_pending_journal = pending_path.read_text().strip() != ""
+        except FileNotFoundError:
+            has_pending_journal = False
 
     # Import checkpoint manager for per-mission checkpoint lookup
     try:
@@ -488,8 +502,12 @@ if __name__ == "__main__":
         sys.exit(1)
 
     instance_dir = args[0]
+    # Single read of pending.md: check_pending_journal() reads + logs once,
+    # then hands the result to recover_missions() so it does not re-read the file.
     has_pending = check_pending_journal(instance_dir)
-    count, escalated_lines = recover_missions(instance_dir, dry_run=dry_run)
+    count, escalated_lines = recover_missions(
+        instance_dir, dry_run=dry_run, has_pending_journal=has_pending,
+    )
 
     # Build escalated message list from current run only (not historical log)
     escalated_msgs = [

--- a/koan/tests/test_recover.py
+++ b/koan/tests/test_recover.py
@@ -809,6 +809,37 @@ class TestRecoveryJSONLLog:
         assert ev["state"] == "dead"
         assert ev["action"] == "recovered"
 
+    def test_passed_has_pending_overrides_file_read(self, instance_dir):
+        """A caller-supplied has_pending_journal is honored without a file read.
+
+        No pending.md exists on disk, but passing has_pending_journal=True must
+        still classify the mission as 'partial' — proving recover_missions used
+        the supplied value instead of reading the file a second time.
+        """
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        assert not (instance_dir / "journal" / "pending.md").exists()
+
+        recover_missions(str(instance_dir), has_pending_journal=True)
+
+        log_path = instance_dir / "recovery.jsonl"
+        events = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+        assert events[0]["state"] == "partial"
+
+    def test_default_none_still_reads_file(self, instance_dir):
+        """With no override (daemon path), presence is still read from disk."""
+        missions = instance_dir / "missions.md"
+        missions.write_text(_missions(in_progress="- Fix the bug"))
+        journal = instance_dir / "journal"
+        journal.mkdir(exist_ok=True)
+        (journal / "pending.md").write_text("interrupted\n---\nstep 1 done\n")
+
+        recover_missions(str(instance_dir))  # has_pending_journal=None
+
+        log_path = instance_dir / "recovery.jsonl"
+        events = [json.loads(line) for line in log_path.read_text().splitlines() if line.strip()]
+        assert events[0]["state"] == "partial"
+
     def test_log_escalated_action(self, instance_dir):
         """Unrecoverable missions are logged with action=escalated."""
         missions = instance_dir / "missions.md"


### PR DESCRIPTION
## Problem
recover.py's CLI entry point read pending.md twice — once via check_pending_journal() for the
summary message, then again inside recover_missions() for partial-state classification — with a
TOCTOU window between the reads. (The daemon startup path only ever did the single internal read.)

## Changes
- recover_missions() gained an optional has_pending_journal kwarg. When the caller already read
  pending.md, it passes the result in and the function skips its own read.
- Default None preserves the daemon path (compute internally) and every existing caller/test
  (return shape unchanged).
- CLI main() reads once via check_pending_journal() and hands the value down.

## Test
test_passed_has_pending_overrides_file_read (supplied True classifies partial with no file on
disk), test_default_none_still_reads_file (daemon path still reads from disk).