### PR TITLE
refactor(run): replace startup flag pair with single _startup_phase

### DIFF
--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -464,10 +464,11 @@ def _run_iteration(
     # together take ~30-90s before any mission notification fires. Surface
     # progress to Telegram so the human knows what's happening. count>=1
     # iterations stay quiet to avoid steady-state spam.
-    is_first_iteration = not _run._startup_notified
-    is_boot_iteration = not _run._boot_notified
-    _run._startup_notified = True
-    _run._boot_notified = True
+    # Derive the two visibility flags from the single startup phase.
+    # boot → first+boot; resume → first only; running → neither.
+    is_boot_iteration = _run._startup_phase == "boot"
+    is_first_iteration = _run._startup_phase in ("boot", "resume")
+    _run._startup_phase = "running"
 
     # Load config once for both GitHub and Jira gating below
     from app.utils import load_config

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -934,8 +934,7 @@ def main_loop():
                     idle_notified = False
                     from app.feature_tips import mark_active
                     mark_active()
-                    global _startup_notified
-                    _startup_notified = False
+                    _mark_startup_resume()
                 continue
 
             # --- Reset counter check ---
@@ -950,7 +949,7 @@ def main_loop():
                 idle_notified = False
                 from app.feature_tips import mark_active
                 mark_active()
-                _startup_notified = False
+                _mark_startup_resume()
                 log("koan", f"Run counter reset (was {old_count}/{max_runs}, now 0/{max_runs}).")
                 _notify(instance, f"🔄 Run counter reset: {old_count} → 0 (max {max_runs}).")
 
@@ -1316,11 +1315,29 @@ _last_mission_stagnated = threading.Event()
 _stagnation_pattern_type = ""
 _stagnation_pattern_excerpt = ""
 
-# Tracks whether the cold-start Telegram burst has already fired.
-_startup_notified = False
+# Startup phase for first-iteration Telegram visibility. Replaces the old
+# _startup_notified / _boot_notified boolean pair: their only valid combinations
+# were (first+boot), (first only), and (neither), which map 1:1 to these states.
+#   "boot"    — the very first iteration since process start: emit boot banners
+#               (empty-state "Notifications clear", update hint) plus cold-start ping.
+#   "resume"  — first iteration after /resume or a counter reset (but not boot):
+#               cold-start ping only; boot-only banners stay silent.
+#   "running" — steady state: quiet (no first-iteration pings).
+_startup_phase = "boot"
 
-# Tracks whether the initial boot burst has already fired in this process.
-_boot_notified = False
+
+def _mark_startup_resume() -> None:
+    """Downgrade to the 'resume' phase after /resume or a counter reset.
+
+    Leaves the phase at 'boot' when the first boot iteration has not run yet
+    (start-paused, then resumed before any iteration) so boot-only banners
+    still fire exactly once. Only a completed boot iteration ('running')
+    downgrades to 'resume'.
+    """
+    global _startup_phase
+    if _startup_phase == "running":
+        _startup_phase = "resume"
+
 
 _warned_missing_projects: set = set()
 

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -3269,11 +3269,9 @@ class TestRunIterationFirstIterationNotifications:
     @pytest.fixture(autouse=True)
     def _reset_startup_flag(self):
         import app.run as run_mod
-        run_mod._startup_notified = False
-        run_mod._boot_notified = False
+        run_mod._startup_phase = "boot"
         yield
-        run_mod._startup_notified = False
-        run_mod._boot_notified = False
+        run_mod._startup_phase = "boot"
 
     @patch("app.jira_config.get_jira_enabled", return_value=True)
     @patch("app.github_config.get_github_commands_enabled", return_value=True)
@@ -3408,7 +3406,7 @@ class TestRunIterationFirstIterationNotifications:
     def test_resume_without_missions_suppresses_empty_state_pings(
         self, mock_gh, mock_jira, mock_notify, mock_notify_raw, mock_plan, mock_gh_enabled, mock_jira_enabled, koan_root,
     ):
-        """After resume (simulated by resetting _startup_notified only), the
+        """After resume (simulated by setting _startup_phase = "resume"), the
         empty-state "scanned, no new missions" and "Notifications clear" pings
         MUST be silenced. The "🔍 Scanning GitHub" progress ping still fires
         so the human knows the cold-start scan is happening.
@@ -3425,8 +3423,8 @@ class TestRunIterationFirstIterationNotifications:
                 projects=[("test", str(koan_root))],
                 count=0, max_runs=5, interval=10, git_sync_interval=5,
             )
-            # Simulate /resume: only _startup_notified is reset, not _boot_notified
-            run_mod._startup_notified = False
+            # Simulate /resume after a completed boot iteration: phase → "resume"
+            run_mod._startup_phase = "resume"
             mock_notify_raw.reset_mock()
             _run_iteration(
                 koan_root=str(koan_root), instance=instance,
@@ -3461,8 +3459,7 @@ class TestRunIterationFirstIterationNotifications:
         instance = str(koan_root / "instance")
 
         # Start in "already booted" state to simulate resume
-        run_mod._boot_notified = True
-        run_mod._startup_notified = False
+        run_mod._startup_phase = "resume"
 
         with patch("app.utils.get_known_projects", return_value=[("test", str(koan_root))]):
             _run_iteration(
@@ -3543,6 +3540,30 @@ class TestRunIterationFirstIterationNotifications:
         assert "GitHub" not in joined
         # Jira-only intermediate message fires instead
         assert "Scanning Jira notifications" in joined
+
+
+class TestStartupPhase:
+    """Single _startup_phase state replaces the two boolean flags."""
+
+    def test_running_downgrades_to_resume(self):
+        import app.run as run_mod
+        run_mod._startup_phase = "running"
+        run_mod._mark_startup_resume()
+        assert run_mod._startup_phase == "resume"
+
+    def test_boot_is_preserved_when_resumed_before_first_iteration(self):
+        """Start-paused, then resumed before any iteration: must stay 'boot' so
+        boot-only banners still fire once."""
+        import app.run as run_mod
+        run_mod._startup_phase = "boot"
+        run_mod._mark_startup_resume()
+        assert run_mod._startup_phase == "boot"
+
+    def test_resume_stays_resume(self):
+        import app.run as run_mod
+        run_mod._startup_phase = "resume"
+        run_mod._mark_startup_resume()
+        assert run_mod._startup_phase == "resume"
 
 
 class TestNotifyRaw:


### PR DESCRIPTION
## Problem
run.py tracked first-iteration Telegram visibility with two booleans
(_startup_notified, _boot_notified) whose semantics overlapped and were reset inconsistently.

## Changes
- Replace the pair with a single _startup_phase: "boot" → "resume" → "running"
- run.py: _mark_startup_resume() downgrades running→resume on /resume and counter reset, but
  preserves "boot" when no iteration has run yet (start-paused-then-resumed still gets boot
  banners once)
- mission_executor.py: derive is_boot_iteration (phase=="boot") and is_first_iteration
  (phase in boot/resume) from the phase, then set "running"

Behavior verified identical across normal boot, resume-after-boot, and resume-before-first-iteration.

## Test
TestStartupPhase (running→resume, boot preserved, resume idempotent); existing
first-iteration/resume notification suites updated to drive the phase.