### PR TITLE
fix(restart): route all restart triggers through request_restart; dro…

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -205,7 +205,7 @@ Secret fields (keys containing `token`, `password`, `secret`, `api_key`) are rep
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `POST` | `/v1/restart` | yes | Write `.koan-restart` signal (picked up by run loop) |
+| `POST` | `/v1/restart` | yes | Signal restart via per-consumer markers `.koan-restart-run` + `.koan-restart-bridge` (picked up by run loop and bridge) |
 | `POST` | `/v1/shutdown` | yes | Write `.koan-stop` signal |
 | `POST` | `/v1/update` | yes | Pull upstream + signal restart |
 

--- a/koan/app/api/routes_admin.py
+++ b/koan/app/api/routes_admin.py
@@ -100,10 +100,12 @@ def get_config():
 @bp.route("/v1/restart", methods=["POST"])
 @require_token
 def restart():
-    from app.signals import RESTART_FILE
-    restart_file = _koan_root() / RESTART_FILE
+    # Route through request_restart() so both per-consumer markers are written
+    # and the restart actually fires. Touching legacy .koan-restart was a
+    # no-op — no consumer polls it.
+    from app.restart_manager import request_restart
     try:
-        restart_file.touch()
+        request_restart(str(_koan_root()))
     except OSError as e:
         return jsonify({"error": {"code": "signal_error", "message": str(e)}}), 500
     return jsonify({"status": "restart_signaled"})
@@ -130,9 +132,9 @@ def update():
         if safety_msg:
             return jsonify({"error": {"code": "update_refused", "message": safety_msg}}), 409
         result = pull_upstream(_koan_root())
-        # Signal restart after update
-        from app.signals import RESTART_FILE
-        (_koan_root() / RESTART_FILE).touch()
+        # Signal restart after update (write both per-consumer markers).
+        from app.restart_manager import request_restart
+        request_restart(str(_koan_root()))
         return jsonify({"status": "updated", "result": str(result)})
     except Exception as e:
         return jsonify({"error": {"code": "update_error", "message": str(e)}}), 500

--- a/koan/app/dashboard.py
+++ b/koan/app/dashboard.py
@@ -40,7 +40,6 @@ from app.conversation_history import (
     load_recent_history,
     format_conversation_history,
 )
-from app.signals import RESTART_FILE
 from app.missions import (
     cancel_pending_mission,
     edit_pending_mission,
@@ -1330,8 +1329,12 @@ def api_agent_resume():
 @app.route("/api/agent/restart", methods=["POST"])
 def api_agent_restart():
     """Signal the agent loop to restart."""
+    # Route through request_restart() so both per-consumer markers are written
+    # and the restart actually fires. Touching legacy .koan-restart was a
+    # no-op — matches the working /api/config/restart endpoint below.
+    from app.restart_manager import request_restart
     try:
-        (KOAN_ROOT / RESTART_FILE).touch()
+        request_restart(str(KOAN_ROOT))
     except OSError as e:
         return jsonify({"ok": False, "error": str(e)}), 500
     return jsonify({"ok": True, "status": "restart_signaled"})

--- a/koan/app/restart_manager.py
+++ b/koan/app/restart_manager.py
@@ -4,19 +4,26 @@ Provides file-based restart signaling between bridge and run loop.
 
 Two consumers (bridge and runner) each get their own marker so a fast
 wrapper-restart of the runner can no longer wipe the signal before the
-bridge's polling tick sees it.  The legacy single-file marker is also
-written so a pre-upgrade incarnation polling ``.koan-restart`` can still
-detect the request and re-exec into the new code.
+bridge's polling tick sees it.
 
 The restart flow:
-1. ``request_restart`` writes ``.koan-restart-bridge``,
-   ``.koan-restart-run`` and (for backward compat) ``.koan-restart``.
+1. ``request_restart`` writes ``.koan-restart-bridge`` and ``.koan-restart-run``.
 2. Bridge's main loop notices ``.koan-restart-bridge`` and re-execs via
    ``os.execv`` (same PID, fresh interpreter).
 3. Runner's main loop notices ``.koan-restart-run`` and exits with
    ``RESTART_EXIT_CODE``; its wrapper relaunches it.
 4. Each process clears only its own marker on startup, so neither can
    silence the signal for the other.
+
+Legacy ``.koan-restart`` (DEPRECATED): the single combined marker is no
+longer *written* by Kōan. It is read by nothing in-tree (both consumers poll
+their own per-process marker), so writing it was a no-op that lingered on disk.
+``check_restart``/``clear_restart`` still accept ``target=None`` → ``.koan-restart``
+purely so any out-of-tree script polling the old path keeps working; remove that
+mapping once you are certain no external consumer depends on it. All in-tree
+restart triggers (run loop, bridge, auto-update, REST API, dashboard) now go
+through ``request_restart`` so both consumer markers are written and the restart
+actually fires.
 
 Exit code 42 is the restart sentinel — any other exit is a real stop.
 """
@@ -32,16 +39,20 @@ from app.signals import RESTART_FILE
 RESTART_EXIT_CODE = 42
 
 # Per-consumer marker files. The legacy ``RESTART_FILE`` (``.koan-restart``)
-# is kept for backward compatibility: a pre-upgrade bridge that is still
-# polling the old single-file marker can pick up the first post-upgrade
-# request and re-exec into the new code.
+# is DEPRECATED: no longer written by ``request_restart``. The ``None``
+# entry below is retained only so ``check_restart``/``clear_restart`` keep
+# honouring ``target=None`` for any out-of-tree caller still polling the old
+# path; nothing in-tree reads or writes it.
 RESTART_BRIDGE_FILE = ".koan-restart-bridge"
 RESTART_RUN_FILE = ".koan-restart-run"
+
+# Files written by request_restart() — the two live per-consumer markers only.
+_WRITE_TARGETS = (RESTART_BRIDGE_FILE, RESTART_RUN_FILE)
 
 _TARGET_FILES = {
     "bridge": RESTART_BRIDGE_FILE,
     "run": RESTART_RUN_FILE,
-    None: RESTART_FILE,
+    None: RESTART_FILE,  # deprecated, read-only compat (see module docstring)
 }
 
 
@@ -57,16 +68,17 @@ def _marker_path(koan_root: str, target: Optional[str]) -> str:
 
 
 def request_restart(koan_root: str) -> None:
-    """Create restart signal files for both consumers (and the legacy file).
+    """Create restart signal files for both consumers.
 
-    Writes three markers so each consumer can clear its own without
-    silencing the other, and so a pre-upgrade incarnation still polling
-    the legacy ``.koan-restart`` will also wake up and re-exec.
+    Writes the two per-consumer markers (``.koan-restart-bridge`` and
+    ``.koan-restart-run``) so each consumer can clear its own without
+    silencing the other. The deprecated legacy ``.koan-restart`` is no
+    longer written — nothing reads it.
     """
     from app.utils import atomic_write
 
     body = f"restart requested at {time.strftime('%H:%M:%S')}\n"
-    for fname in _TARGET_FILES.values():
+    for fname in _WRITE_TARGETS:
         atomic_write(Path(koan_root) / fname, body)
 
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -38,7 +38,12 @@ from app.constants import IDLE_LOOP_BREATH_SECONDS
 from app.iteration_manager import plan_iteration
 from app.loop_manager import check_pending_missions, interruptible_sleep
 from app.pid_manager import acquire_pidfile, release_pidfile
-from app.restart_manager import check_restart, clear_restart, RESTART_EXIT_CODE
+from app.restart_manager import (
+    check_restart,
+    clear_restart,
+    RESTART_EXIT_CODE,
+    RESTART_RUN_FILE,
+)
 from app.run_log import (  # noqa: F401 — re-exported for backward compat
     _ANSI_RESET,
     _CATEGORY_COLORS,
@@ -57,7 +62,6 @@ from app.signals import (
     PAUSE_FILE,
     PROJECT_FILE,
     RESET_COUNTER_FILE,
-    RESTART_FILE,
     SHUTDOWN_FILE,
     ABORT_FILE,
     STATUS_FILE,
@@ -591,7 +595,7 @@ def _startup_delay(koan_root: str) -> None:
     - ``startup_delay`` is set to ``0``.
 
     The delay is interrupted early if any lifecycle signal appears
-    (.koan-pause, .koan-stop, .koan-shutdown, .koan-restart).
+    (.koan-pause, .koan-stop, .koan-shutdown, .koan-restart-run).
     """
     from app.utils import load_config
 
@@ -616,8 +620,10 @@ def _startup_delay(koan_root: str) -> None:
         time.sleep(min(tick, delay - elapsed))
         elapsed += tick
 
-        # Any lifecycle signal → break out
-        for sig in (PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE, RESTART_FILE):
+        # Any lifecycle signal → break out. Use the runner's own restart marker
+        # (RESTART_RUN_FILE) — the legacy combined .koan-restart is deprecated
+        # and no longer written.
+        for sig in (PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE, RESTART_RUN_FILE):
             if Path(koan_root, sig).exists():
                 log("koan", f"Signal detected during startup delay ({sig}), proceeding.")
                 return

--- a/koan/tests/test_api_admin.py
+++ b/koan/tests/test_api_admin.py
@@ -114,7 +114,11 @@ class TestRestart:
     def test_restart_creates_signal_file(self, api_client, tmp_path):
         resp = api_client.post("/v1/restart", headers=_AUTH)
         assert resp.status_code == 200
-        assert (tmp_path / ".koan-restart").exists()
+        # writes both per-consumer markers so the restart actually fires,
+        # not the deprecated (no-op) legacy .koan-restart.
+        assert (tmp_path / ".koan-restart-run").exists()
+        assert (tmp_path / ".koan-restart-bridge").exists()
+        assert not (tmp_path / ".koan-restart").exists()
         data = resp.get_json()
         assert data["status"] == "restart_signaled"
 
@@ -137,8 +141,9 @@ class TestUpdate:
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["status"] == "updated"
-        # Restart should also be signaled
-        assert (tmp_path / ".koan-restart").exists()
+        # Restart should also be signaled — via the per-consumer markers.
+        assert (tmp_path / ".koan-restart-run").exists()
+        assert (tmp_path / ".koan-restart-bridge").exists()
 
     def test_update_returns_500_on_error(self, api_client):
         with patch("app.update_manager.pull_upstream", side_effect=RuntimeError("git error")):

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -2099,7 +2099,10 @@ class TestAgentControls:
         data = resp.get_json()
         assert resp.status_code == 200
         assert data["ok"] is True
-        assert (tmp_path / ".koan-restart").exists()
+        # writes both per-consumer markers so the restart actually fires.
+        assert (tmp_path / ".koan-restart-run").exists()
+        assert (tmp_path / ".koan-restart-bridge").exists()
+        assert not (tmp_path / ".koan-restart").exists()
 
     def test_pause_button_hidden_when_paused(self, app_client, tmp_path):
         (tmp_path / ".koan-pause").write_text("manual\n")

--- a/koan/tests/test_restart.py
+++ b/koan/tests/test_restart.py
@@ -14,6 +14,7 @@ from app.restart_manager import (
     clear_restart,
     reexec_bridge,
     RESTART_FILE,
+    RESTART_RUN_FILE,
     RESTART_EXIT_CODE,
 )
 
@@ -26,15 +27,17 @@ from app.restart_manager import (
 class TestRequestRestart:
     def test_creates_restart_file(self, tmp_path):
         request_restart(str(tmp_path))
-        assert (tmp_path / RESTART_FILE).exists()
+        # per-consumer marker is written, not the legacy combined file.
+        assert (tmp_path / RESTART_RUN_FILE).exists()
+        assert not (tmp_path / RESTART_FILE).exists()
 
     def test_restart_file_contains_timestamp(self, tmp_path):
         request_restart(str(tmp_path))
-        content = (tmp_path / RESTART_FILE).read_text()
+        content = (tmp_path / RESTART_RUN_FILE).read_text()
         assert "restart requested at" in content
 
     def test_overwrites_existing_file(self, tmp_path):
-        restart_file = tmp_path / RESTART_FILE
+        restart_file = tmp_path / RESTART_RUN_FILE
         restart_file.write_text("old content")
         request_restart(str(tmp_path))
         content = restart_file.read_text()
@@ -183,10 +186,10 @@ class TestRestartLoopPrevention:
         assert check_restart(str(tmp_path), since=startup_time) is False
 
     def test_fresh_file_triggers_restart(self, tmp_path):
-        """A new .koan-restart file (after startup) triggers restart."""
+        """A fresh per-consumer marker (after startup) triggers restart."""
         startup_time = time.time() - 10
         request_restart(str(tmp_path))
-        assert check_restart(str(tmp_path), since=startup_time) is True
+        assert check_restart(str(tmp_path), since=startup_time, target="run") is True
 
 
 class TestRestartIsStandaloneSkill:

--- a/koan/tests/test_restart_manager.py
+++ b/koan/tests/test_restart_manager.py
@@ -38,19 +38,24 @@ class TestConstants:
 
 
 class TestRequestRestart:
-    def test_creates_file(self, tmp_path):
+    def test_creates_both_consumer_markers(self, tmp_path):
         request_restart(str(tmp_path))
-        restart_file = tmp_path / RESTART_FILE
-        assert restart_file.exists()
+        assert (tmp_path / RESTART_BRIDGE_FILE).exists()
+        assert (tmp_path / RESTART_RUN_FILE).exists()
+
+    def test_does_not_write_legacy_marker(self, tmp_path):
+        """The deprecated .koan-restart is no longer written."""
+        request_restart(str(tmp_path))
+        assert not (tmp_path / RESTART_FILE).exists()
 
     def test_file_contains_timestamp(self, tmp_path):
         request_restart(str(tmp_path))
-        content = (tmp_path / RESTART_FILE).read_text()
+        content = (tmp_path / RESTART_RUN_FILE).read_text()
         assert "restart requested at" in content
         assert ":" in content  # Time format HH:MM:SS
 
     def test_overwrites_existing_file(self, tmp_path):
-        restart_file = tmp_path / RESTART_FILE
+        restart_file = tmp_path / RESTART_RUN_FILE
         restart_file.write_text("old content")
         request_restart(str(tmp_path))
         content = restart_file.read_text()
@@ -59,13 +64,15 @@ class TestRequestRestart:
 
     def test_uses_atomic_write(self, tmp_path):
         """request_restart should use atomic_write for thread safety,
-        once per consumer marker plus the legacy single-file marker."""
+        once per consumer marker — and NOT for the deprecated legacy marker."""
         with patch("app.utils.atomic_write") as mock_aw:
             request_restart(str(tmp_path))
             written = [str(call.args[0]) for call in mock_aw.call_args_list]
             assert any(p.endswith(RESTART_BRIDGE_FILE) for p in written)
             assert any(p.endswith(RESTART_RUN_FILE) for p in written)
-            assert any(p.endswith(RESTART_FILE) for p in written)
+            # .koan-restart is not a suffix of the -run / -bridge markers, so the
+            # bare endswith() (matching the positive checks above) is unambiguous.
+            assert not any(p.endswith(RESTART_FILE) for p in written)
 
 
 # ---------------------------------------------------------------------------
@@ -195,25 +202,25 @@ class TestReexecBridge:
 
 class TestRestartWorkflow:
     def test_full_restart_cycle(self, tmp_path):
-        """Test the complete request → check → clear cycle."""
+        """Test the complete request → check → clear cycle (per-consumer marker)."""
         root = str(tmp_path)
         # Initially no restart pending
-        assert check_restart(root) is False
+        assert check_restart(root, target="run") is False
 
         # Request restart
         request_restart(root)
-        assert check_restart(root) is True
+        assert check_restart(root, target="run") is True
 
         # Clear it
-        clear_restart(root)
-        assert check_restart(root) is False
+        clear_restart(root, target="run")
+        assert check_restart(root, target="run") is False
 
     def test_stale_signal_ignored(self, tmp_path):
         """Stale restart signals from previous incarnation should be ignored."""
         root = str(tmp_path)
         # Create a restart signal
         request_restart(root)
-        restart_file = tmp_path / RESTART_FILE
+        restart_file = tmp_path / RESTART_RUN_FILE
 
         # Backdate the file to simulate stale signal
         old_mtime = time.time() - 300  # 5 minutes ago
@@ -223,7 +230,7 @@ class TestRestartWorkflow:
         startup_time = time.time()
 
         # Stale signal should be ignored
-        assert check_restart(root, since=startup_time) is False
+        assert check_restart(root, since=startup_time, target="run") is False
 
         # But a fresh request should work
         request_restart(root)
@@ -232,15 +239,15 @@ class TestRestartWorkflow:
         # so explicitly forward-date the file by 1 second.
         future_mtime = startup_time + 1
         os.utime(restart_file, (future_mtime, future_mtime))
-        assert check_restart(root, since=startup_time) is True
+        assert check_restart(root, since=startup_time, target="run") is True
 
     def test_accepts_str_not_path(self, tmp_path):
         """All functions should accept str, not Path objects."""
         root = str(tmp_path)
         request_restart(root)
-        assert check_restart(root) is True
-        clear_restart(root)
-        assert check_restart(root) is False
+        assert check_restart(root, target="run") is True
+        clear_restart(root, target="run")
+        assert check_restart(root, target="run") is False
 
 
 # ---------------------------------------------------------------------------
@@ -259,14 +266,12 @@ class TestPerProcessRestartMarkers:
     leaving the bridge with a stale ``sys.modules`` and ``/list`` broken.
     """
 
-    def test_request_restart_writes_all_three_markers(self, tmp_path):
+    def test_request_restart_writes_both_consumer_markers(self, tmp_path):
         request_restart(str(tmp_path))
         assert (tmp_path / RESTART_BRIDGE_FILE).exists()
         assert (tmp_path / RESTART_RUN_FILE).exists()
-        assert (tmp_path / RESTART_FILE).exists(), (
-            "legacy marker must still be written so a pre-upgrade bridge "
-            "polling .koan-restart can re-exec into the new code"
-        )
+        # the deprecated legacy marker is no longer written.
+        assert not (tmp_path / RESTART_FILE).exists()
 
     def test_check_restart_target_isolation(self, tmp_path):
         """Writing only one consumer's marker must not satisfy the other."""
@@ -282,8 +287,8 @@ class TestPerProcessRestartMarkers:
         clear_restart(str(tmp_path), target="run")
         assert not (tmp_path / RESTART_RUN_FILE).exists()
         assert (tmp_path / RESTART_BRIDGE_FILE).exists()
-        # Legacy file is also untouched — only its own consumer clears it.
-        assert (tmp_path / RESTART_FILE).exists()
+        # legacy marker is never written, so it never exists here.
+        assert not (tmp_path / RESTART_FILE).exists()
 
     def test_runner_wrapper_restart_does_not_silence_bridge(self, tmp_path):
         """Simulate the /update race directly: a request_restart followed

--- a/koan/tests/test_startup_delay.py
+++ b/koan/tests/test_startup_delay.py
@@ -11,7 +11,8 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from app.signals import PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE, RESTART_FILE
+from app.signals import PAUSE_FILE, STOP_FILE, SHUTDOWN_FILE
+from app.restart_manager import RESTART_RUN_FILE
 
 
 @pytest.fixture
@@ -131,7 +132,7 @@ class TestStartupDelay:
         assert call_count == 1
 
     def test_restart_signal_interrupts(self, koan_root):
-        """If .koan-restart appears during the delay, it stops early."""
+        """If the runner restart marker appears during the delay, it stops early."""
         fn = self._import_fn()
         call_count = 0
 
@@ -139,7 +140,7 @@ class TestStartupDelay:
             nonlocal call_count
             call_count += 1
             if call_count == 2:
-                Path(koan_root, RESTART_FILE).touch()
+                Path(koan_root, RESTART_RUN_FILE).touch()
 
         with patch("app.utils.load_config", return_value={"startup_delay": 30}), \
              patch("time.sleep", side_effect=sleep_then_restart):


### PR DESCRIPTION
## Problem
The legacy combined .koan-restart marker was written "for backward compat" but nothing reads it
— both consumers poll their own per-process marker (.koan-restart-run / .koan-restart-bridge).
Worse, the REST API (/v1/restart, /v1/update) and the dashboard /api/agent/restart endpoint
signalled restarts by touching ONLY that dead legacy file, so those endpoints were silent no-ops
(the run loop and bridge never saw the request). The dashboard's /api/config/restart already did
it correctly via request_restart().

## Changes
- routes_admin /v1/restart + /v1/update, dashboard /api/agent/restart: call request_restart() so
  both per-consumer markers are written and the restart actually fires
- request_restart() writes only the two live markers; the deprecated legacy .koan-restart is no
  longer written
- run._startup_delay() wakes on .koan-restart-run instead of the dead legacy file
- restart_manager: keep target=None → .koan-restart read mapping for any out-of-tree poller,
  documented as deprecated read-only compat

## Test
Tests updated across test_restart_manager, test_restart, test_api_admin, test_dashboard,
test_startup_delay to assert both consumer markers are written and the legacy file is not.
check_restart/clear_restart (target="run"/"bridge") behavior unchanged.