### PR TITLE
refactor(missions): add canonical_mission_key as single mission-ident…

### DIFF
--- a/koan/app/mission_history.py
+++ b/koan/app/mission_history.py
@@ -25,6 +25,10 @@ def _normalize_key(mission_text: str) -> str:
     Strips leading ``- ``, ``[project:X]`` / ``[projet:X]`` tags, and
     whitespace so the same mission recorded with or without a project tag
     shares one dedup counter.
+
+    Note: this is intentionally *not* ``missions.canonical_mission_key`` — that
+    keeps the project tag (mission identity for the stagnation tracker), whereas
+    history dedup wants to collapse across projects. Different concern (S2).
     """
     line = mission_text.strip().split("\n")[0]
     line = line.removeprefix("- ").strip()

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -187,6 +187,40 @@ def strip_all_lifecycle_markers(text: str) -> str:
     return text.rstrip()
 
 
+# Markers that vary across a mission's lifecycle but do not change its identity:
+# lifecycle timestamps (⏳ ▶ ✅/❌), the [r:N] crash-recovery counter, and the
+# [complexity:X] classifier tag. Stripping them yields a key that is stable
+# across requeue and crash-recovery cycles.
+_CANONICAL_KEY_STRIP_RE = re.compile(
+    r"\s*⏳\([^)]*\)"               # ⏳(queued-timestamp)
+    r"|\s*▶\([^)]*\)"               # ▶(started-timestamp)
+    r"|\s*[✅❌]\s*\([^)]*\)"       # ✅/❌ (completed-timestamp)
+    r"|\s*\[r:\d+\]"                # [r:N] crash-recovery counter
+    r"|\s*\[complexity:[^\]]*\]"    # [complexity:X] classifier tag
+)
+
+
+def canonical_mission_key(text: str) -> str:
+    """Return a stable identity string for a mission, independent of lifecycle.
+
+    Strips lifecycle timestamps (⏳ ▶ ✅ ❌), the ``[r:N]`` crash-recovery
+    counter, the ``[complexity:X]`` classifier tag, and a leading ``"- "`` so the
+    same logical mission maps to the same key across requeue and crash-recovery
+    cycles. This is the single source of truth for stable mission identity (S2);
+    ``stagnation_monitor._mission_key`` hashes its output.
+
+    Note: ``[project:X]`` tags are intentionally *kept* — two missions with the
+    same text but different projects are distinct. (Distinct from
+    ``mission_history._normalize_key``, which strips the project tag, and
+    ``recover._strip_recovery_counter``, which strips only ``[r:N]`` for display.
+    Those serve narrower purposes and are deliberately not folded in here.)
+    """
+    clean = _CANONICAL_KEY_STRIP_RE.sub("", text).strip()
+    if clean.startswith("- "):
+        clean = clean[2:].strip()
+    return clean
+
+
 def _normalize_now_flag(text: str) -> str:
     """Normalize Unicode dash variants of --now to ASCII --now.
 

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -371,16 +371,8 @@ class StagnationMonitor:
 # cycles.  Without stripping, a requeued mission acquires new ⏳/▶
 # timestamps and would hash to a different key, silently resetting the
 # stagnation retry counter on every cycle and making max_retry_on_stagnation
-# ineffective.
-
-# Compiled once: strips everything that changes between queue cycles.
-_STRIP_FOR_KEY_RE = re.compile(
-    r"\s*⏳\([^)]*\)"              # ⏳(queued-timestamp)
-    r"|\s*▶\([^)]*\)"              # ▶(started-timestamp)
-    r"|\s*[✅❌]\s*\([^)]*\)"      # ✅/❌ (completed-timestamp)
-    r"|\s*\[r:\d+\]"               # [r:N] crash-recovery counter
-    r"|\s*\[complexity:[^\]]*\]"    # [complexity:X] classifier tag
-)
+# ineffective. The stripping is delegated to the canonical identity function
+# in missions.py (S2) so there is one definition of "stable mission identity".
 
 
 def _retry_tracker_path(instance_dir: str) -> Path:
@@ -391,14 +383,12 @@ def _retry_tracker_path(instance_dir: str) -> Path:
 def _mission_key(mission_title: str) -> str:
     """Stable key for a mission title, independent of lifecycle state.
 
-    Strips timestamps, recovery counters, and complexity tags before
-    hashing so the same logical mission always maps to the same key
-    regardless of which requeue cycle it is currently in.
+    Hashes :func:`missions.canonical_mission_key`, which strips timestamps,
+    recovery counters, and complexity tags so the same logical mission always
+    maps to the same key regardless of which requeue cycle it is currently in.
     """
-    clean = _STRIP_FOR_KEY_RE.sub("", mission_title)
-    clean = clean.strip()
-    if clean.startswith("- "):
-        clean = clean[2:].strip()
+    from app.missions import canonical_mission_key
+    clean = canonical_mission_key(mission_title)
     return hashlib.sha256(clean.encode("utf-8", errors="replace")).hexdigest()
 
 

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -39,6 +39,7 @@ from app.missions import (
     stamp_queued,
     stamp_started,
     start_mission,
+    canonical_mission_key,
     strip_all_lifecycle_markers,
     strip_timestamps,
     prune_completed_sections,
@@ -2630,6 +2631,43 @@ class TestMissionTimingDisplay:
         text = "Bug ▶(2026-02-18T11:00) ✅ (2026-02-18 10:00)"
         result = mission_timing_display(text)
         assert result == ""
+
+
+# --- canonical_mission_key ---
+
+class TestCanonicalMissionKey:
+    """S2: single source of truth for stable mission identity."""
+
+    def test_strips_leading_dash(self):
+        assert canonical_mission_key("- fix bug") == "fix bug"
+
+    def test_strips_lifecycle_timestamps(self):
+        base = canonical_mission_key("fix bug [project:foo]")
+        full = canonical_mission_key(
+            "fix bug [project:foo] ⏳(2026-01-01T00:00) ▶(2026-01-01T00:05)"
+        )
+        assert base == full == "fix bug [project:foo]"
+
+    def test_strips_recovery_and_complexity_tags(self):
+        assert (
+            canonical_mission_key("fix bug [r:3] [complexity:large]") == "fix bug"
+        )
+
+    def test_keeps_project_tag(self):
+        """Project tag is identity-bearing and must be preserved."""
+        assert "[project:foo]" in canonical_mission_key("fix bug [project:foo]")
+        assert (
+            canonical_mission_key("fix bug [project:foo]")
+            != canonical_mission_key("fix bug [project:bar]")
+        )
+
+    def test_stable_across_full_lifecycle_line(self):
+        clean = canonical_mission_key("fix bug [project:foo]")
+        lifecycle = canonical_mission_key(
+            "- fix bug [project:foo] [r:2] [complexity:medium] "
+            "⏳(2026-01-01T00:00) ▶(2026-01-01T00:05)"
+        )
+        assert clean == lifecycle
 
 
 # --- strip_timestamps ---

--- a/koan/tests/test_stagnation_monitor.py
+++ b/koan/tests/test_stagnation_monitor.py
@@ -507,6 +507,27 @@ class TestMissionKey:
         assert len(key) == 64  # SHA-256 hex
         assert all(c in "0123456789abcdef" for c in key)
 
+    def test_golden_hash_unchanged(self):
+        """Regression guard (S2): the key is sha256 of the canonical-clean title.
+
+        If this value drifts, every existing stagnation/crash tracker entry is
+        orphaned (a live mission silently resets its retry counter). The
+        canonical key for "fix the bug" is just the text itself.
+        """
+        assert _mission_key("fix the bug") == (
+            "280fd7e3571b7c850d6fe771aee96db0ccdeef47910414e3a4a93bb06ea9f7c2"
+        )
+
+    def test_delegates_to_canonical_mission_key(self):
+        """_mission_key must hash exactly missions.canonical_mission_key output."""
+        import hashlib
+        from app.missions import canonical_mission_key
+        title = "- do thing [project:foo] [r:3] ⏳(2026-01-01T00:00) [complexity:large]"
+        expected = hashlib.sha256(
+            canonical_mission_key(title).encode("utf-8", errors="replace")
+        ).hexdigest()
+        assert _mission_key(title) == expected
+
     def test_strips_queued_timestamp(self):
         base = _mission_key("fix the bug [project:foo]")
         with_ts = _mission_key("fix the bug [project:foo] ⏳(2026-01-01T12:00)")


### PR DESCRIPTION
## Problem
stagnation_monitor._mission_key carried its own _STRIP_FOR_KEY_RE for deriving a stable mission
identity (strip timestamps + [r:N] + [complexity:X] + "- "). There was no shared canonical
function for "stable mission identity".

## Changes
- Add missions.canonical_mission_key() as the single source of truth.
- stagnation_monitor._mission_key hashes its output — the SHA-256 is byte-identical, so existing
  stagnation/crash trackers keep matching.
- Deliberately NOT folded in (different concerns, would change behavior): mission_history.
  _normalize_key (strips project tag for cross-project dedup) and recover._strip_recovery_counter
  (strips only [r:N], keeps timestamps — display helper). Both get a comment pointing at the
  canonical function.

## Test
TestCanonicalMissionKey; test_golden_hash_unchanged (locks the sha256 so future drift can't
silently orphan trackers); test_delegates_to_canonical_mission_key.