### PR TITLE
docs(recover): document complex mission (### format) recovery behavio…

### DIFF
--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -15,6 +15,14 @@ and the human is notified via Telegram.
 
 All recovery events are logged to instance/recovery.jsonl for forensics.
 
+Complex mission format (### project:X sub-headers in In Progress):
+The ### block format is used for multi-step missions that group related sub-tasks
+under a project sub-header.  Recovery handles these as atomic blocks — the entire
+block is either requeued to Pending or escalated to Failed together.  The block
+boundary ends at the next blank line or the next ### header, whichever comes first.
+This is a second safety net; the primary is that start_mission() flushes stale
+In Progress entries to Failed via _flush_in_progress_to_failed().
+
 Usage from shell:
     python3 recover.py /path/to/instance [--dry-run]
 

--- a/koan/app/recover.py
+++ b/koan/app/recover.py
@@ -20,8 +20,9 @@ The ### block format is used for multi-step missions that group related sub-task
 under a project sub-header.  Recovery handles these as atomic blocks — the entire
 block is either requeued to Pending or escalated to Failed together.  The block
 boundary ends at the next blank line or the next ### header, whichever comes first.
-This is a second safety net; the primary is that start_mission() flushes stale
-In Progress entries to Failed via _flush_in_progress_to_failed().
+This is the primary handler for stale complex missions. The
+_flush_in_progress_to_failed() call inside start_mission() acts as a secondary
+safety net, catching any stale entries recover.py missed.
 
 Usage from shell:
     python3 recover.py /path/to/instance [--dry-run]


### PR DESCRIPTION
## Problem
recover.py's module docstring described simple crash recovery only. The ### sub-header format
for complex (multi-step) missions was undocumented — no mention of how ### blocks are treated
during recovery, what the block boundary is, or the relationship to the _flush_in_progress_to_failed()
secondary safety net.

Note: the underlying code issue (### blocks silently skipped) was already fixed by B2
(claude/fix-complex-mission-recovery, merged to main).

## Changes
- Added a 'Complex mission format' section to recover.py's module docstring explaining:
  - ### blocks are treated as atomic units (requeued or escalated together)
  - Block boundary: next blank line or next ### header
  - Cross-link to _flush_in_progress_to_failed() as secondary safety net