### PR TITLE
fix(github): trust existing GH_TOKEN instead of false auth warning

### DIFF
--- a/koan/app/github_auth.py
+++ b/koan/app/github_auth.py
@@ -4,7 +4,10 @@ Kōan -- GitHub CLI authentication helper.
 
 Manages GitHub CLI identity switching for gh commands. When GITHUB_USER
 is configured, retrieves a session token via `gh auth token --user <user>`
-and exports it as GH_TOKEN for all gh CLI calls in the session.
+and exports it as GH_TOKEN for all gh CLI calls in the session. If a
+GH_TOKEN is already present in the environment, it is trusted as-is and the
+`gh auth token --user` lookup is skipped (that lookup only reads gh's stored
+config, so it would otherwise warn falsely about env-var-based auth).
 
 Usage from Python:
     from app.github_auth import get_gh_env, setup_github_auth
@@ -94,6 +97,16 @@ def setup_github_auth() -> bool:
     username = get_github_user()
     if not username:
         return True  # No user configured, nothing to do
+
+    # A GH_TOKEN already in the environment (e.g. exported via .env or the
+    # shell) is valid auth on its own — gh CLI uses it directly. The
+    # `gh auth token --user` lookup below only reads gh's *stored* config
+    # (~/.config/gh/hosts.yml) and returns nothing for an env-var token,
+    # which would raise a false "authentication failed" warning. Trust the
+    # existing token, matching get_gh_env()'s behavior.
+    if os.environ.get("GH_TOKEN", "").strip():
+        print(f"[github_auth] Using GH_TOKEN from environment for {username}")
+        return True
 
     token = get_gh_token(username)
     if token:

--- a/koan/tests/test_github_auth.py
+++ b/koan/tests/test_github_auth.py
@@ -117,6 +117,20 @@ class TestSetupGithubAuth:
 
     @patch("app.notify.send_telegram")
     @patch("app.github_auth.get_gh_token", return_value=None)
+    def test_trusts_existing_gh_token_without_user_lookup(
+        self, mock_token, mock_send, monkeypatch
+    ):
+        # GH_TOKEN exported in env should be trusted directly: no
+        # `gh auth token --user` lookup, no false-failure alert.
+        monkeypatch.setenv("GITHUB_USER", "my-bot")
+        monkeypatch.setenv("GH_TOKEN", "existing-token-123")
+        assert setup_github_auth() is True
+        mock_token.assert_not_called()
+        mock_send.assert_not_called()
+        assert os.environ.get("GH_TOKEN") == "existing-token-123"
+
+    @patch("app.notify.send_telegram")
+    @patch("app.github_auth.get_gh_token", return_value=None)
     def test_sends_alert_on_failure(self, mock_token, mock_send, monkeypatch):
         monkeypatch.setenv("GITHUB_USER", "my-bot")
         monkeypatch.delenv("GH_TOKEN", raising=False)


### PR DESCRIPTION
setup_github_auth() resolved the token solely via `gh auth token --user <user>`, which only reads gh's stored config (~/.config/gh/hosts.yml). When auth is provided through the GH_TOKEN env var (e.g. exported from .env), that lookup returns nothing and a misleading "GitHub authentication failed" warning fires on every session start — even though gh works fine with the env token.

Now setup_github_auth() honors an existing GH_TOKEN first, matching the behavior get_gh_env() already had, and only falls back to the user lookup when no token is present.