### PR TITLE
fix(github): default github.ack_enabled to false

### DIFF
--- a/docs/messaging/github-commands.md
+++ b/docs/messaging/github-commands.md
@@ -128,14 +128,16 @@ github:
 
 #### Command acknowledgment
 
-When a command is dispatched from a GitHub @mention, Kōan posts a brief acknowledgment reply (e.g. "🤖 `/review` queued — I'll get to it shortly.") so the user knows their request was received. Replies are threaded: PR review comments get native GitHub threading, issue comments include a blockquote of the original message.
+When a command is dispatched from a GitHub @mention, Kōan can post a brief acknowledgment reply (e.g. "🤖 `/review` queued — I'll get to it shortly.") so the user knows their request was received. Replies are threaded: PR review comments get native GitHub threading, issue comments include a blockquote of the original message.
+
+Acknowledgment replies are **off by default** — the emoji reaction Kōan places on the comment already signals receipt, and the extra reply can be noisy. Opt in by setting `ack_enabled: true`:
 
 ```yaml
 github:
-  ack_enabled: true   # Post acknowledgment replies (default: true)
+  ack_enabled: true   # Post acknowledgment replies (default: false)
 ```
 
-Set `ack_enabled: false` to disable acknowledgment replies (reactions are still placed).
+When disabled (the default), reactions are still placed.
 
 #### Reply threading
 

--- a/koan/app/github_config.py
+++ b/koan/app/github_config.py
@@ -15,7 +15,7 @@ Config schema in config.yaml:
       reply_enabled: false
       reply_authorized_users: ["*"]   # separate from command permissions
       reply_rate_limit: 5             # max replies per user per hour
-      ack_enabled: true               # post acknowledgment when a command is queued
+      ack_enabled: false              # post acknowledgment when a command is queued (opt-in)
       check_interval_seconds: 60       # optional provider override
 
 Per-project override in projects.yaml:
@@ -231,10 +231,10 @@ def get_github_ack_enabled(config: dict) -> bool:
 
     When enabled, the bot posts a brief reply to the triggering comment
     when a command is queued, so the user knows the bot received it.
-    Default: True.
+    Default: False (opt-in; the emoji reaction already signals receipt).
     """
     github = config.get("github") or {}
-    return bool(github.get("ack_enabled", True))
+    return bool(github.get("ack_enabled", False))
 
 
 def get_github_subscribe_enabled(config: dict) -> bool:

--- a/koan/tests/test_github_config.py
+++ b/koan/tests/test_github_config.py
@@ -167,8 +167,8 @@ class TestGetGithubReplyEnabled:
 
 
 class TestGetGithubAckEnabled:
-    def test_default_enabled(self):
-        assert get_github_ack_enabled({}) is True
+    def test_default_disabled(self):
+        assert get_github_ack_enabled({}) is False
 
     def test_explicitly_enabled(self):
         assert get_github_ack_enabled({"github": {"ack_enabled": True}}) is True
@@ -177,7 +177,7 @@ class TestGetGithubAckEnabled:
         assert get_github_ack_enabled({"github": {"ack_enabled": False}}) is False
 
     def test_none_section(self):
-        assert get_github_ack_enabled({"github": None}) is True
+        assert get_github_ack_enabled({"github": None}) is False
 
 
 class TestGetGithubMaxAgeHours:


### PR DESCRIPTION
Command acknowledgment replies on GitHub @mentions were on by default (introduced in 3d3b627), posting a reply on every queued command in addition to the emoji reaction. This is too noisy — the reaction already signals receipt. Flip the default to false so acks are opt-in.