### PR TITLE
Make /review finding locations clickable file links

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -544,6 +544,7 @@ The debug loop enforces four steps:
   - `--architecture` — Architecture-focused review (SOLID principles, layering, coupling, abstraction boundaries)
   - `--errors` — Run an additional **silent-failure-hunter** pass that scans for swallowed exceptions, silent null returns, unhandled promises, and other silent error paths. Also auto-triggered when the diff contains error-handling patterns (`try/except`, `catch`, etc.)
   - `--comments` — Comment quality review (factual accuracy, completeness, stale TODOs, misleading language)
+- **Output:** Findings are grouped into severity buckets (🔴 Blocking / 🟡 Important / 🟢 Suggestions), each folded into a collapsible section. Every finding's location is shown on its own line inside the summary as a **clickable link** that jumps straight to the exact file and lines on GitHub, pinned to the reviewed commit (so the link stays accurate even after the PR gets new commits).
 
 <details>
 <summary>Use cases</summary>

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -16,6 +16,7 @@ CLI:
     python3 -m app.review_runner <github-pr-url> --project-path <path>
 """
 
+import html
 import json
 import re
 import sys
@@ -23,6 +24,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 from typing import List, Optional, Tuple
+from urllib.parse import quote
 
 from app.claude_step import resolve_pr_location
 from app.config import get_review_reply_config, get_review_verdict_config, is_review_compressor_enabled
@@ -674,6 +676,7 @@ def _should_run_error_hunter(diff: str) -> bool:
 
 def _run_error_hunter(
     diff: str, project_path: str, skill_dir: Optional[Path],
+    owner: str = "", repo: str = "", head_sha: str = "",
 ) -> str:
     """Run the silent-failure-hunter pass and return formatted markdown section.
 
@@ -697,7 +700,9 @@ def _run_error_hunter(
     if not findings:
         return ""
 
-    return _format_error_hunter_findings(findings)
+    return _format_error_hunter_findings(
+        findings, owner=owner, repo=repo, head_sha=head_sha,
+    )
 
 
 def _parse_error_hunter_output(raw_output: str) -> list:
@@ -736,7 +741,9 @@ def _parse_error_hunter_output(raw_output: str) -> list:
 _ERROR_HUNTER_SEVERITY_EMOJI = {"CRITICAL": "🔴", "HIGH": "🟠", "MEDIUM": "🟡"}
 
 
-def _format_error_hunter_findings(findings: list) -> str:
+def _format_error_hunter_findings(
+    findings: list, owner: str = "", repo: str = "", head_sha: str = "",
+) -> str:
     """Format error-hunter findings as a markdown section with collapsible details."""
     severity_order = {"CRITICAL": 0, "HIGH": 1, "MEDIUM": 2}
     findings = sorted(findings, key=lambda f: severity_order.get(f.get("severity", "MEDIUM"), 2))
@@ -754,11 +761,31 @@ def _format_error_hunter_findings(findings: list) -> str:
         suggestion = f.get("suggestion", "")
 
         title = f"{emoji} **{severity}** — {pattern}"
+        # Link the location on its own line when line_hint is numeric and a
+        # head-SHA permalink can be built; else keep the plain-text suffix.
+        loc_line = ""
         if location:
-            title += f" (`{location}`)"
+            line_start, line_end = _parse_line_hint(line_hint)
+            url = _github_blob_url(owner, repo, head_sha, file_path, line_start, line_end)
+            if url:
+                # Build the display text from the parsed line numbers so it
+                # stays in sync with the link target (line_hint may carry
+                # extra free-form text). Escape since file_path is model output.
+                loc_text = f"{file_path}:{line_start}"
+                if line_end and line_end != line_start:
+                    loc_text += f"-{line_end}"
+                loc_line = f'<a href="{url}">{html.escape(loc_text)}</a>'
+            else:
+                title += f" (`{location}`)"
 
         lines.append("<details>")
-        lines.append(f"<summary>{title}</summary>")
+        if loc_line:
+            lines.append("<summary>")
+            lines.append(f"{title}<br>")
+            lines.append(loc_line)
+            lines.append("</summary>")
+        else:
+            lines.append(f"<summary>{title}</summary>")
         lines.append("")
         if explanation:
             lines.append(f"**Risk**: {explanation}")
@@ -1076,7 +1103,49 @@ _UNPARSEABLE_REVIEW_NOTICE = (
 )
 
 
-def _format_review_as_markdown(review_data: dict, title: str = "", bot_username: str = "") -> str:
+def _github_blob_url(
+    owner: str, repo: str, sha: str, path: str,
+    line_start: int, line_end: Optional[int] = None,
+) -> str:
+    """Build a GitHub blob permalink with a line anchor.
+
+    Returns ``""`` when any component required to build a precise, durable
+    link is missing (owner/repo/sha/path/positive line). Pinning to the head
+    SHA keeps the anchor accurate even after the PR gets new commits. The
+    range anchor uses GitHub's ``#L<start>-L<end>`` form (end is also
+    ``L``-prefixed), distinct from the plain-text ``L514-537`` display style.
+    """
+    if not (owner and repo and sha and path and line_start and line_start > 0):
+        return ""
+    anchor = f"#L{line_start}"
+    if line_end and line_end != line_start:
+        anchor += f"-L{line_end}"
+    # path may contain spaces / unicode — percent-encode but keep separators.
+    safe_path = quote(path, safe="/")
+    return f"https://github.com/{owner}/{repo}/blob/{sha}/{safe_path}{anchor}"
+
+
+def _parse_line_hint(line_hint: str) -> Tuple[int, int]:
+    """Parse an error-hunter ``line_hint`` string into (start, end).
+
+    ``line_hint`` is free-form model output (e.g. ``"42"`` or ``"38-45"``).
+    Returns ``(0, 0)`` when no leading integer can be extracted, so callers
+    fall back to plain-text rendering.
+    """
+    if not line_hint:
+        return 0, 0
+    m = re.search(r"(\d+)(?:\s*-\s*(\d+))?", str(line_hint))
+    if not m:
+        return 0, 0
+    start = int(m.group(1))
+    end = int(m.group(2)) if m.group(2) else start
+    return start, end
+
+
+def _format_review_as_markdown(
+    review_data: dict, title: str = "", bot_username: str = "",
+    owner: str = "", repo: str = "", head_sha: str = "",
+) -> str:
     """Convert validated review JSON into the markdown format for GitHub.
 
     Produces the standard ## PR Review format: the summary as the lead
@@ -1140,17 +1209,27 @@ def _format_review_as_markdown(review_data: dict, title: str = "", bot_username:
         lines.append(f"### {emoji} {heading}")
         lines.append("")
         for i, item in enumerate(items, 1):
-            has_loc = item.get("line_start") and item["line_start"] > 0
-            if has_loc:
-                loc = f"`{item['file']}`, L{item['line_start']}"
-                if item.get("line_end") and item["line_end"] != item["line_start"]:
-                    loc += f"-{item['line_end']}"
-                summary_line = f"<b>{i}. {item['title']}</b> ({loc})"
-            else:
-                summary_line = f"<b>{i}. {item['title']}</b>"
+            title_line = f"<b>{i}. {item['title']}</b>"
+            line_start = item.get("line_start") or 0
+            line_end = item.get("line_end") or 0
             lines.append("<details>")
             lines.append("<summary>")
-            lines.append(summary_line)
+            if line_start > 0:
+                # Location on its own line inside the summary, as a clickable
+                # head-SHA permalink when one can be built, else plain code.
+                loc_text = f"{item['file']}:{line_start}"
+                if line_end and line_end != line_start:
+                    loc_text += f"-{line_end}"
+                url = _github_blob_url(
+                    owner, repo, head_sha, item["file"], line_start, line_end,
+                )
+                # Escape: loc_text is built from model-provided file paths.
+                safe_loc = html.escape(loc_text)
+                loc_line = f'<a href="{url}">{safe_loc}</a>' if url else f"<code>{safe_loc}</code>"
+                lines.append(f"{title_line}<br>")
+                lines.append(loc_line)
+            else:
+                lines.append(title_line)
             lines.append("</summary>")
             lines.append("")
             lines.append(_fix_nested_fences(item["comment"]))
@@ -1868,6 +1947,8 @@ def run_review(
         review_body = _format_review_as_markdown(
             review_data, title=context.get("title", ""),
             bot_username=bot_username,
+            owner=owner, repo=repo,
+            head_sha=(current_shas[-1] if current_shas else ""),
         )
     else:
         # Fallback: use regex extraction for non-JSON responses
@@ -1910,7 +1991,11 @@ def run_review(
     run_error_hunter = errors or _should_run_error_hunter(diff)
     if run_error_hunter:
         notify_fn(f"Running silent-failure-hunter on PR #{pr_number}...")
-        error_section = _run_error_hunter(diff, project_path, skill_dir)
+        error_section = _run_error_hunter(
+            diff, project_path, skill_dir,
+            owner=owner, repo=repo,
+            head_sha=(current_shas[-1] if current_shas else ""),
+        )
         if error_section:
             review_body = review_body + "\n\n---\n\n" + error_section
         else:

--- a/koan/system-prompts/_partials/review-output-rules.md
+++ b/koan/system-prompts/_partials/review-output-rules.md
@@ -1,6 +1,6 @@
 - **file_comments**: Array of per-file inline comments. Empty array `[]` if no issues found.
 - **file**: File path as shown in the diff (e.g. `src/auth.py`).
-- **line_start** / **line_end**: Line numbers from the diff. Same value for single-line issues. Use `0` for whole-file comments.
+- **line_start** / **line_end**: Line numbers in the **new (post-change) file as it appears at the PR head** — i.e. the line numbers on the added/`+` side of the diff, not diff-relative offsets. These are used to build a direct link into the file, so they must point at the real lines in the updated file. Same value for single-line issues. Use `0` for whole-file comments.
 - **severity**: Must be exactly one of: `"critical"` (blocking, must fix), `"warning"` (important, should fix), `"suggestion"` (nice to have).
 - **title**: Short title for the issue.
 - **comment**: Detailed explanation with suggested fix. Structure as: what's wrong → why it matters (real-world impact) → how to fix. Use markdown for readability: separate distinct thoughts into short paragraphs (blank line between them) and use `-` bullet points when listing more than one item. Avoid one dense block of text.

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -30,6 +30,8 @@ from app.review_runner import (
     _fetch_pr_commit_shas,
     _safe_code_fence,
     _fix_nested_fences,
+    _github_blob_url,
+    _parse_line_hint,
 )
 
 
@@ -683,8 +685,10 @@ class TestFormatReviewAsMarkdown:
         assert "## PR Review — Fix auth" in md
         assert "### 🔴 Blocking" in md
         assert "Missing validation" in md
-        assert "`auth.py`" in md
-        assert "L42" in md
+        # Without owner/repo/head_sha the location renders as plain code on its
+        # own line inside the summary (no clickable link).
+        assert "auth.py:42" in md
+        assert "<code>auth.py:42</code>" in md
         assert "<details>" in md
         assert "<summary>" in md
         assert "</details>" in md
@@ -749,7 +753,7 @@ class TestFormatReviewAsMarkdown:
         assert "### 🔴 Blocking" in md
         assert "### 🟡 Important" in md
         assert "### 🟢 Suggestions" in md
-        assert "L10-15" in md  # multi-line range
+        assert "b.py:10-15" in md  # multi-line range
 
     def test_checklist_rendering(self):
         data = {
@@ -809,6 +813,115 @@ class TestFormatReviewAsMarkdown:
         md = _format_review_as_markdown(data)
         assert "x = eval(input())" in md
         assert "```" in md
+
+
+# ---------------------------------------------------------------------------
+# _github_blob_url / _parse_line_hint
+# ---------------------------------------------------------------------------
+
+class TestGithubBlobUrl:
+    def test_single_line_anchor(self):
+        url = _github_blob_url("octo", "repo", "abc123", "src/auth.py", 42)
+        assert url == "https://github.com/octo/repo/blob/abc123/src/auth.py#L42"
+
+    def test_range_anchor_uses_double_l(self):
+        url = _github_blob_url("octo", "repo", "abc123", "src/auth.py", 42, 87)
+        # GitHub range anchors prefix BOTH ends with L.
+        assert url == "https://github.com/octo/repo/blob/abc123/src/auth.py#L42-L87"
+
+    def test_equal_start_end_collapses_to_single(self):
+        url = _github_blob_url("octo", "repo", "abc123", "a.py", 5, 5)
+        assert url.endswith("#L5")
+
+    def test_path_with_space_is_percent_encoded(self):
+        url = _github_blob_url("octo", "repo", "abc123", "my dir/a b.py", 1)
+        assert "my%20dir/a%20b.py" in url
+        # Path separators are preserved (not encoded).
+        assert "/blob/abc123/my%20dir/" in url
+
+    def test_missing_components_return_empty(self):
+        assert _github_blob_url("", "repo", "sha", "a.py", 1) == ""
+        assert _github_blob_url("o", "repo", "", "a.py", 1) == ""
+        assert _github_blob_url("o", "repo", "sha", "a.py", 0) == ""
+        assert _github_blob_url("o", "repo", "sha", "", 1) == ""
+
+
+class TestParseLineHint:
+    def test_single_number(self):
+        assert _parse_line_hint("42") == (42, 42)
+
+    def test_range(self):
+        assert _parse_line_hint("38-45") == (38, 45)
+
+    def test_range_with_spaces(self):
+        assert _parse_line_hint("38 - 45") == (38, 45)
+
+    def test_non_numeric_returns_zero(self):
+        assert _parse_line_hint("near the top") == (0, 0)
+        assert _parse_line_hint("") == (0, 0)
+
+
+# ---------------------------------------------------------------------------
+# _format_review_as_markdown — clickable location links
+# ---------------------------------------------------------------------------
+
+class TestReviewLocationLinks:
+    def _data(self, line_start=42, line_end=42):
+        return {
+            "file_comments": [{
+                "file": "src/auth.py", "line_start": line_start,
+                "line_end": line_end, "severity": "critical",
+                "title": "Missing validation", "comment": "Fix it",
+                "code_snippet": "",
+            }],
+            "review_summary": {"lgtm": False, "summary": "Needs work.",
+                               "checklist": []},
+        }
+
+    def test_link_built_with_sha(self):
+        md = _format_review_as_markdown(
+            self._data(), owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert (
+            '<a href="https://github.com/octo/repo/blob/abc123/src/auth.py#L42">'
+            "src/auth.py:42</a>"
+        ) in md
+        # Location is on its own line, after a <br> following the title.
+        assert "</b><br>" in md
+
+    def test_range_link(self):
+        md = _format_review_as_markdown(
+            self._data(line_start=42, line_end=87),
+            owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert "#L42-L87" in md
+        assert "src/auth.py:42-87</a>" in md
+
+    def test_plain_code_fallback_without_sha(self):
+        md = _format_review_as_markdown(self._data())
+        assert "<code>src/auth.py:42</code>" in md
+        assert "<a href=" not in md
+
+    def test_whole_file_comment_has_no_location_line(self):
+        md = _format_review_as_markdown(
+            self._data(line_start=0, line_end=0),
+            owner="octo", repo="repo", head_sha="abc123",
+        )
+        # No line means no location link and no <br> location line.
+        assert "src/auth.py:" not in md
+        assert "<a href=" not in md
+
+    def test_link_text_html_escaped(self):
+        # A file path carrying HTML-significant characters must be escaped in
+        # the rendered link text so it cannot corrupt the surrounding markup.
+        data = self._data()
+        data["file_comments"][0]["file"] = "src/<x>&y.py"
+        md = _format_review_as_markdown(
+            data, owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert "src/&lt;x&gt;&amp;y.py:42" in md
+        # Raw angle brackets from the path never reach the rendered text.
+        assert "<x>" not in md
 
 
 # ---------------------------------------------------------------------------
@@ -4392,6 +4505,63 @@ class TestFormatErrorHunterFindings:
         result = _format_error_hunter_findings(findings)
         assert "<details>" in result
         assert "bare except" in result
+
+    def test_numeric_line_hint_becomes_link_with_sha(self):
+        from app.review_runner import _format_error_hunter_findings
+
+        findings = [{
+            "severity": "HIGH", "pattern": "swallowed exception",
+            "file": "src/auth.py", "line_hint": "42",
+        }]
+        result = _format_error_hunter_findings(
+            findings, owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert (
+            '<a href="https://github.com/octo/repo/blob/abc123/src/auth.py#L42">'
+            "src/auth.py:42</a>"
+        ) in result
+        # Plain-text suffix is dropped once a link is built.
+        assert "(`src/auth.py:42`)" not in result
+
+    def test_range_line_hint_becomes_link(self):
+        from app.review_runner import _format_error_hunter_findings
+
+        findings = [{
+            "severity": "HIGH", "pattern": "swallowed exception",
+            "file": "src/auth.py", "line_hint": "38-45",
+        }]
+        result = _format_error_hunter_findings(
+            findings, owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert "#L38-L45" in result
+
+    def test_non_numeric_line_hint_stays_plain_text(self):
+        from app.review_runner import _format_error_hunter_findings
+
+        findings = [{
+            "severity": "HIGH", "pattern": "swallowed exception",
+            "file": "src/auth.py", "line_hint": "near the top",
+        }]
+        result = _format_error_hunter_findings(
+            findings, owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert "<a href=" not in result
+        assert "`src/auth.py:near the top`" in result
+
+    def test_link_text_synced_with_parsed_lines(self):
+        from app.review_runner import _format_error_hunter_findings
+
+        # Free-form text around the number: the displayed location must be
+        # rebuilt from the parsed line number, not echo the raw line_hint.
+        findings = [{
+            "severity": "HIGH", "pattern": "swallowed exception",
+            "file": "src/auth.py", "line_hint": "line 42 (in the loop)",
+        }]
+        result = _format_error_hunter_findings(
+            findings, owner="octo", repo="repo", head_sha="abc123",
+        )
+        assert ">src/auth.py:42</a>" in result
+        assert "in the loop" not in result
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Review findings folded into collapsible <details> blocks previously showed the file path and line range as plain inline-code text on the title line. Move the location to its own line inside the <summary> and render it as a clickable GitHub permalink pinned to the reviewed head commit, so a single click jumps to the exact file and lines (and the anchor stays accurate after the PR gets new commits).

- Add _github_blob_url() (head-SHA permalink, #L<start>-L<end>, path percent-encoding) and _parse_line_hint(); thread owner/repo/head_sha into _format_review_as_markdown and _format_error_hunter_findings.
- Fall back to plain <code>file:line</code> when no SHA is available.
- Clarify in review-output-rules that line numbers refer to the post-change file at the PR head, so links land on the right lines.
- Document the clickable-link output under /review in the user manual.