### PR TITLE
fix(github): stop reply spam on closed and reprocessed PRs

### DIFF
--- a/docs/messaging/github-commands.md
+++ b/docs/messaging/github-commands.md
@@ -139,6 +139,17 @@ github:
 
 When disabled (the default), reactions are still placed.
 
+#### Reply circuit breaker
+
+To prevent a runaway reply loop from spamming a thread (e.g. a misconfiguration or a future regression that keeps re-discovering the same comments), Kōan caps the number of bot comments it will post to a single PR/issue thread within a rolling hour:
+
+```yaml
+github:
+  max_replies_per_thread_per_hour: 10   # default: 10; set 0 to disable
+```
+
+Once the cap is reached, further acks/errors/replies on that thread are suppressed (logged, with a single Telegram heads-up to the operator) until the rolling window clears. The counter is persisted under `instance/`, so the breaker survives restarts.
+
 #### Reply threading
 
 All AI-generated replies (from `reply_enabled`, `/ask`, and command acknowledgments) are threaded to the original comment:
@@ -227,6 +238,8 @@ Two-tier approach to prevent duplicate missions:
 
 The mission is inserted **before** the reaction is added. If Kōan crashes between these two steps, the worst case is a duplicate mission — never a lost command.
 
+Because a single notification thread is rescanned for **all** unprocessed @mentions on every poll, *every* comment Kōan acts on — whether it queued a mission, posted an error, denied permission, or sent help — is also recorded in the persistent comment tracker (`instance/.koan-github-processed.json`). The reaction alone is volatile (it depends on the reactions API and a correctly-configured `bot_username`); the local tracker is the durable backstop that guarantees a comment is answered **at most once** and never re-discovered on a later poll. This is what prevents the same error/help reply from being re-posted on every cycle.
+
 ### Polling & backoff
 
 Notifications are checked during the agent's interruptible sleep cycle, with exponential backoff:
@@ -253,7 +266,12 @@ parks on this backoff so it does not flood logs while waiting for the next poll.
 When a command fails validation (unknown command, permission denied), Kōan:
 1. Posts an error reply on the GitHub comment thread (❌ with explanation)
 2. Includes the list of available commands for "unknown command" errors
-3. Deduplicates error replies to avoid spam
+3. Deduplicates error replies to avoid spam, and marks the triggering comment processed so it is never re-answered on a later poll
+4. Honours the per-thread reply circuit breaker (`max_replies_per_thread_per_hour`) — once tripped, error replies are suppressed
+
+### Closed / merged subjects
+
+Commands are meaningless on a closed or merged PR/issue, so Kōan never posts acks, errors, or replies on them. The closed-subject check is enforced on **every** reply path — both the main notification handler and the error-reply fallback — and the affected comments are reacted to (👀) and marked processed so the closed thread is not re-scanned every poll. A single Telegram notice is sent the first time a closed subject is skipped.
 
 ### Code block protection
 

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -1627,15 +1627,18 @@ def process_single_notification(
             # which the single-error return path does not cover.
             issue_number = extract_issue_number_from_notification(notification)
             comment_id = str(comment.get("id", ""))
-            if (
-                len(comments) > 1
-                and issue_number and comment_id
-                and _enforce_reply_budget(owner, repo, issue_number)
-            ):
-                post_error_reply(
-                    owner, repo, issue_number, comment_id, error,
-                    comment_api_url=comment.get("url", ""),
-                )
+            if len(comments) > 1 and issue_number and comment_id:
+                if _enforce_reply_budget(owner, repo, issue_number):
+                    post_error_reply(
+                        owner, repo, issue_number, comment_id, error,
+                        comment_api_url=comment.get("url", ""),
+                    )
+                else:
+                    log.info(
+                        "GitHub: error reply suppressed by circuit breaker for "
+                        "%s/%s#%s comment %s: %s",
+                        owner, repo, issue_number, comment_id, error,
+                    )
 
         # Persistently mark every handled comment processed — regardless of
         # outcome (queued, error, help, permission-denied, no-op). The

--- a/koan/app/github_command_handler.py
+++ b/koan/app/github_command_handler.py
@@ -1579,20 +1579,33 @@ def process_single_notification(
         _notify_closed_subject_skipped(
             owner, repo, subject_title, subject_state, notification,
         )
+        closed_koan_root = os.environ.get("KOAN_ROOT", "")
+        closed_instance_dir = (
+            os.path.join(closed_koan_root, "instance") if closed_koan_root else ""
+        )
         for c in comments:
+            c_id = str(c.get("id", ""))
             add_reaction(
-                owner, repo, str(c.get("id", "")), emoji="eyes",
+                owner, repo, c_id, emoji="eyes",
                 comment_api_url=c.get("url", ""),
             )
+            # Durable backstop so a failed reaction doesn't re-loop the
+            # closed-subject notification on the next poll.
+            if closed_instance_dir:
+                from app.github_notification_tracker import track_comment
+                track_comment(closed_instance_dir, c_id)
         mark_notification_read(str(notification.get("id", "")))
         return False, None
 
-    # Process each comment in chronological order.
-    # Errors are posted inline to the specific comment — never returned to
-    # the caller.  This avoids double-posting: the caller's error handler
-    # would fetch the latest comment (which may differ from the one that
-    # triggered the error) and post a second error reply.
+    # Persistent dedup directory (best-effort; no-op without KOAN_ROOT).
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    instance_dir = os.path.join(koan_root, "instance") if koan_root else ""
+
+    from app.github_reply import _enforce_reply_budget
+
+    # Process each comment in chronological order
     any_queued = False
+    last_error = None
     for comment in comments:
         queued, error = _process_mention_comment(
             notification, comment, registry, config, projects_config,
@@ -1601,20 +1614,54 @@ def process_single_notification(
         if queued:
             any_queued = True
         if error:
+            last_error = error
+            # Post error reply to the specific comment that caused it,
+            # subject to the per-thread reply circuit breaker.
+            #
+            # Single-comment notifications are delegated to the caller
+            # (loop_manager._post_error_for_notification) via the returned
+            # ``last_error`` below — that path posts the same error with
+            # retry-on-failure. Posting inline here too would double-post
+            # the reply (and double-spend the breaker budget). So only post
+            # inline for the *extra* comments of a multi-mention thread,
+            # which the single-error return path does not cover.
             issue_number = extract_issue_number_from_notification(notification)
             comment_id = str(comment.get("id", ""))
-            if issue_number and comment_id:
+            if (
+                len(comments) > 1
+                and issue_number and comment_id
+                and _enforce_reply_budget(owner, repo, issue_number)
+            ):
                 post_error_reply(
                     owner, repo, issue_number, comment_id, error,
                     comment_api_url=comment.get("url", ""),
                 )
+
+        # Persistently mark every handled comment processed — regardless of
+        # outcome (queued, error, help, permission-denied, no-op). The
+        # per-path reaction is volatile (depends on the reactions API and a
+        # correctly-configured bot_username); this local tracker is the
+        # durable backstop that stops the full-thread rescan from
+        # re-discovering and re-replying to the same comment every poll.
+        if instance_dir:
+            from app.github_notification_tracker import track_comment
+            track_comment(instance_dir, str(comment.get("id", "")))
 
     mark_notification_read(str(notification.get("id", "")))
 
     if any_queued:
         notification[NOTIFICATION_OUTCOME_KEY] = NOTIFICATION_OUTCOME_QUEUED
 
-    return any_queued, None
+    # Return success=True if any comment was queued, or if no errors occurred
+    # (e.g. all comments were help requests or already processed).
+    # Only return an error when there was exactly one comment with an error
+    # and no queued missions — this preserves backward-compatible error
+    # posting for the single-comment case via the caller in loop_manager.
+    if any_queued:
+        return True, None
+    if last_error and len(comments) == 1:
+        return False, last_error
+    return False, None
 
 
 def _post_command_acknowledgment(

--- a/koan/app/github_config.py
+++ b/koan/app/github_config.py
@@ -260,6 +260,21 @@ def get_github_subscribe_max_per_cycle(config: dict) -> int:
         return 5
 
 
+def get_github_max_replies_per_thread(config: dict) -> int:
+    """Max bot replies/acks allowed on a single thread per rolling hour.
+
+    Circuit breaker against runaway reply loops: once a thread reaches this
+    many bot-posted comments within the window, further acks/errors/replies
+    are suppressed (the operator is warned once via Telegram). Set to 0 to
+    disable the breaker. Default: 10.
+    """
+    github = config.get("github") or {}
+    try:
+        return max(0, int(github.get("max_replies_per_thread_per_hour", 10)))
+    except (ValueError, TypeError):
+        return 10
+
+
 def get_github_webhook_enabled(config: dict) -> bool:
     """Check if the push-based webhook receiver is enabled.
 

--- a/koan/app/github_notification_tracker.py
+++ b/koan/app/github_notification_tracker.py
@@ -249,7 +249,10 @@ def _load_replies(instance_dir: str) -> dict:
     except (json.JSONDecodeError, OSError):
         return {}
     now = time.time()
-    return {k: v for k, v in data.items() if now - v < _REPLY_WINDOW_SECONDS}
+    return {
+        k: v for k, v in data.items()
+        if isinstance(v, (int, float)) and now - v < _REPLY_WINDOW_SECONDS
+    }
 
 
 def thread_reply_count(instance_dir: str, owner: str, repo: str, number: str) -> int:
@@ -284,7 +287,8 @@ def record_thread_reply(instance_dir: str, owner: str, repo: str, number: str) -
             _cap_entries(data)
 
         locked_json_modify(_replies_path(instance_dir), _update)
-    except OSError:
+    except Exception as e:  # noqa: BLE001 — best-effort; must not break notification processing
+        log.debug("record_thread_reply: tracker access failed: %s", e)
         holder["n"] = thread_reply_count(instance_dir, owner, repo, number) + 1
     return holder["n"]
 
@@ -321,6 +325,6 @@ def try_consume_reply_budget(
 
         locked_json_modify(_replies_path(instance_dir), _update)
     except Exception as e:  # noqa: BLE001 — best-effort; fail open so replies aren't lost
-        log.debug("try_consume_reply_budget: tracker access failed, allowing: %s", e)
+        log.warning("try_consume_reply_budget: tracker access failed, allowing: %s", e)
         holder["allowed"] = True
     return holder["allowed"]

--- a/koan/app/github_notification_tracker.py
+++ b/koan/app/github_notification_tracker.py
@@ -1,17 +1,22 @@
 """Persistent trackers for processed GitHub notifications.
 
-Two parallel trackers live here:
+Three parallel trackers live here:
 
 - **Comment tracker** (``instance/.koan-github-processed.json``):
   records comment IDs for @mention notifications. Used as a fallback when
   the reactions API fails to confirm a 👍/👀 was placed.
 - **Thread tracker** (``instance/.koan-github-processed-threads.json``):
   records ``"<notification_id>:<updated_at>"`` keys for assignment
-  notifications (``review_requested`` / ``assign``). These have no comment
-  to react to, so without persistent tracking the same notification gets
-  re-processed on every restart.
+  notifications (``review_requested`` / ``assign``) and review cooldowns.
+  These have no comment to react to, so without persistent tracking the same
+  notification gets re-processed on every restart.
+- **Reply-breaker counter** (``instance/.koan-github-reply-counts.json``):
+  records one timestamped key per bot reply, for the per-thread reply circuit
+  breaker. Kept in its own file (see the breaker section below) so its high
+  churn cannot evict durable dedup/cooldown keys.
 
-Both survive process restarts and use the same TTL/cap/locking pattern.
+All survive process restarts and use the same cap/locking pattern; the first
+two prune on a 7-day TTL, the reply-breaker counter on a 1-hour window.
 """
 
 import json
@@ -104,8 +109,8 @@ def track_comment(instance_dir: str, comment_id: str) -> None:
             _cap_entries(data)
 
         locked_json_modify(_tracker_path(instance_dir), _update)
-    except OSError:
-        pass  # Best-effort — don't break notification processing
+    except Exception as e:  # noqa: BLE001 — best-effort; must not break notification processing
+        log.debug("track_comment: failed to record %s: %s", comment_id, e)
 
 
 def is_thread_tracked(instance_dir: str, thread_key: str) -> bool:
@@ -140,8 +145,8 @@ def track_thread(instance_dir: str, thread_key: str) -> None:
             _cap_entries(data)
 
         locked_json_modify(_threads_path(instance_dir), _update)
-    except OSError:
-        pass  # Best-effort — don't break notification processing
+    except Exception as e:  # noqa: BLE001 — best-effort; must not break notification processing
+        log.debug("track_thread: failed to record %s: %s", thread_key, e)
 
 
 # ---------------------------------------------------------------------------
@@ -178,7 +183,7 @@ def set_review_cooldown(instance_dir: str, owner: str, repo: str, pr_number: str
             _cap_entries(data)
 
         locked_json_modify(_threads_path(instance_dir), _update)
-    except OSError:
+    except Exception:  # noqa: BLE001 — best-effort; must not break notification processing
         log.warning("Failed to set review cooldown for %s/%s#%s", owner, repo, pr_number)
 
 
@@ -196,5 +201,126 @@ def clear_review_cooldown(instance_dir: str, owner: str, repo: str, pr_number: s
             data.pop(key, None)
 
         locked_json_modify(_threads_path(instance_dir), _update)
-    except OSError:
+    except Exception:  # noqa: BLE001 — best-effort; must not break notification processing
         log.warning("Failed to clear review cooldown for %s/%s#%s", owner, repo, pr_number)
+
+
+# ---------------------------------------------------------------------------
+# Per-thread reply circuit breaker — caps bot comments per thread per window
+# ---------------------------------------------------------------------------
+#
+# Breaker state lives in its OWN file, separate from the dedup/cooldown thread
+# tracker. Reply events are high-churn (one key per posted reply) and only
+# meaningful for a rolling hour. Keeping them out of the shared threads file
+# means their volume can never evict durable dedup/cooldown keys through
+# ``_cap_entries`` (which would silently reintroduce re-processing), and lets
+# us prune them on the 1-hour window instead of the 7-day TTL so storage is
+# reclaimed promptly.
+
+_REPLY_WINDOW_SECONDS = 3600  # rolling 1 hour
+_TRACKER_FILE_REPLIES = ".koan-github-reply-counts.json"
+
+
+def _replies_path(instance_dir: str) -> Path:
+    return Path(instance_dir) / _TRACKER_FILE_REPLIES
+
+
+def _reply_key_prefix(owner: str, repo: str, number: str) -> str:
+    return f"reply:{owner}/{repo}#{number}:"
+
+
+def _prune_reply_window(data: dict) -> None:
+    """Drop reply entries older than the rolling window (in-place)."""
+    now = time.time()
+    expired = [k for k, v in data.items() if now - v >= _REPLY_WINDOW_SECONDS]
+    for k in expired:
+        del data[k]
+
+
+def _load_replies(instance_dir: str) -> dict:
+    """Load reply-counter data, pruning entries older than the rolling window."""
+    path = _replies_path(instance_dir)
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text())
+        if not isinstance(data, dict):
+            return {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    now = time.time()
+    return {k: v for k, v in data.items() if now - v < _REPLY_WINDOW_SECONDS}
+
+
+def thread_reply_count(instance_dir: str, owner: str, repo: str, number: str) -> int:
+    """Count bot replies recorded for a thread within the rolling window.
+
+    Each recorded reply is stored as its own timestamped key; ``_load_replies``
+    drops keys older than the window, so a simple prefix match is the count.
+    """
+    prefix = _reply_key_prefix(owner, repo, str(number))
+    data = _load_replies(instance_dir)
+    return sum(1 for k in data if k.startswith(prefix))
+
+
+def record_thread_reply(instance_dir: str, owner: str, repo: str, number: str) -> int:
+    """Record one bot reply on a thread; return the count within the window.
+
+    The returned count includes the reply just recorded. Best-effort: on file
+    error the recorded count falls back to a best-guess read so callers still
+    get a sane number.
+    """
+    prefix = _reply_key_prefix(owner, repo, str(number))
+    holder = {"n": 0}
+    try:
+        from app.locked_file import locked_json_modify
+
+        def _update(data):
+            _prune_reply_window(data)
+            now = time.time()
+            # Unique key per event (microsecond timestamp avoids collisions).
+            data[f"{prefix}{now:.6f}"] = now
+            holder["n"] = sum(1 for k in data if k.startswith(prefix))
+            _cap_entries(data)
+
+        locked_json_modify(_replies_path(instance_dir), _update)
+    except OSError:
+        holder["n"] = thread_reply_count(instance_dir, owner, repo, number) + 1
+    return holder["n"]
+
+
+def try_consume_reply_budget(
+    instance_dir: str, owner: str, repo: str, number: str, cap: int,
+) -> bool:
+    """Atomically check the rolling-window reply count and record one reply
+    iff still under ``cap``.
+
+    Returns True when the reply is allowed (and a slot was recorded), False
+    when the cap is already reached (nothing recorded). The count check and
+    the record happen inside a single locked read-modify-write, so concurrent
+    callers cannot both pass the check and overshoot the cap (closes the
+    check-then-act TOCTOU race). Fails open on file error.
+    """
+    if cap <= 0:
+        return True
+    prefix = _reply_key_prefix(owner, repo, str(number))
+    holder = {"allowed": True}
+    try:
+        from app.locked_file import locked_json_modify
+
+        def _update(data):
+            _prune_reply_window(data)
+            count = sum(1 for k in data if k.startswith(prefix))
+            if count >= cap:
+                holder["allowed"] = False
+                return
+            now = time.time()
+            # Unique key per event (microsecond timestamp avoids collisions).
+            data[f"{prefix}{now:.6f}"] = now
+            _cap_entries(data)
+
+        locked_json_modify(_replies_path(instance_dir), _update)
+    except Exception as e:  # noqa: BLE001 — best-effort; fail open so replies aren't lost
+        log.debug("try_consume_reply_budget: tracker access failed, allowing: %s", e)
+        holder["allowed"] = True
+    return holder["allowed"]

--- a/koan/app/github_reply.py
+++ b/koan/app/github_reply.py
@@ -14,7 +14,11 @@ Flow:
 
 import json
 import logging
+import os
 import re
+import threading
+import time
+from pathlib import Path
 from typing import Optional
 
 from app.cli_provider import run_command
@@ -23,6 +27,78 @@ from app.prompts import load_prompt
 from app.utils import truncate_text
 
 log = logging.getLogger(__name__)
+
+# Throttle for the "thread reply budget exceeded" Telegram heads-up: at most
+# one warning per thread per window so a tripped breaker doesn't itself spam.
+_budget_warn_lock = threading.Lock()
+_last_budget_warning: dict = {}
+_BUDGET_WARN_THROTTLE_SECONDS = 3600
+
+
+def _warn_reply_budget_once(owner: str, repo: str, issue_number: str, cap: int) -> None:
+    """Send a single Telegram heads-up when a thread's reply budget trips."""
+    thread_key = f"{owner}/{repo}#{issue_number}"
+    now = time.monotonic()
+    with _budget_warn_lock:
+        last = _last_budget_warning.get(thread_key, 0.0)
+        if now - last < _BUDGET_WARN_THROTTLE_SECONDS:
+            return
+        _last_budget_warning[thread_key] = now
+    try:
+        from app.notify import NotificationPriority, send_telegram
+
+        send_telegram(
+            f"🛑 Reply circuit breaker tripped on {thread_key}: reached "
+            f"{cap} bot replies within the hour — further replies suppressed.",
+            priority=NotificationPriority.ACTION,
+        )
+    except Exception as e:  # noqa: BLE001 — best-effort notification
+        log.warning("Failed to send reply-budget warning for %s: %s", thread_key, e)
+
+
+def _enforce_reply_budget(owner: str, repo: str, issue_number: str) -> bool:
+    """Per-thread circuit breaker. Return True if a reply may be posted.
+
+    Records the reply when allowed. When the rolling-hour cap is reached,
+    suppresses the post (logs + warns the operator once) and returns False.
+    Fails open: if state cannot be read (no KOAN_ROOT, file error), the reply
+    is allowed.
+    """
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if not koan_root:
+        return True
+    try:
+        from app.github_config import get_github_max_replies_per_thread
+        from app.utils import load_config
+
+        cap = get_github_max_replies_per_thread(load_config())
+    except Exception as e:  # noqa: BLE001 — config failure must not block replies
+        log.debug("Reply budget: config load failed, allowing reply: %s", e)
+        return True
+    if cap <= 0:
+        return True  # breaker disabled
+
+    instance_dir = str(Path(koan_root) / "instance")
+    try:
+        from app.github_notification_tracker import try_consume_reply_budget
+
+        # Atomic check-and-record: the count check and the slot record happen
+        # inside one lock, so concurrent callers can't both pass and overshoot
+        # the cap (no check-then-act race).
+        if not try_consume_reply_budget(
+            instance_dir, owner, repo, str(issue_number), cap,
+        ):
+            log.warning(
+                "GitHub: reply circuit breaker tripped for %s/%s#%s "
+                "(cap=%d/hour) — suppressing reply",
+                owner, repo, issue_number, cap,
+            )
+            _warn_reply_budget_once(owner, repo, str(issue_number), cap)
+            return False
+    except Exception as e:  # noqa: BLE001 — tracker failure must not block replies
+        log.debug("Reply budget: tracker access failed, allowing reply: %s", e)
+        return True
+    return True
 
 # Regex for stripping code blocks before mention extraction
 _CODE_BLOCK_RE = re.compile(r'```.*?```|`[^`]+`', re.DOTALL)
@@ -246,6 +322,8 @@ def post_reply(
     Returns:
         True if posted successfully.
     """
+    if not _enforce_reply_budget(owner, repo, issue_number):
+        return False
     try:
         safe_body = sanitize_github_comment(body)
         api(
@@ -279,6 +357,8 @@ def post_threaded_reply(
     Falls back to a plain ``post_reply`` when threading metadata is
     unavailable.
     """
+    if not _enforce_reply_budget(owner, repo, issue_number):
+        return False
     safe_body = sanitize_github_comment(body)
 
     # PR review comments support native threading via in_reply_to

--- a/koan/app/github_reply.py
+++ b/koan/app/github_reply.py
@@ -73,7 +73,7 @@ def _enforce_reply_budget(owner: str, repo: str, issue_number: str) -> bool:
 
         cap = get_github_max_replies_per_thread(load_config())
     except Exception as e:  # noqa: BLE001 — config failure must not block replies
-        log.debug("Reply budget: config load failed, allowing reply: %s", e)
+        log.warning("Reply budget: config load failed, allowing reply: %s", e)
         return True
     if cap <= 0:
         return True  # breaker disabled
@@ -96,7 +96,7 @@ def _enforce_reply_budget(owner: str, repo: str, issue_number: str) -> bool:
             _warn_reply_budget_once(owner, repo, str(issue_number), cap)
             return False
     except Exception as e:  # noqa: BLE001 — tracker failure must not block replies
-        log.debug("Reply budget: tracker access failed, allowing reply: %s", e)
+        log.warning("Reply budget: tracker access failed, allowing reply: %s", e)
         return True
     return True
 

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -1299,6 +1299,7 @@ def _post_error_for_notification(notif: dict, error: str) -> None:
     rather than silently dropping it.
     """
     from app.github_command_handler import (
+        _is_subject_closed,
         post_error_reply,
         resolve_project_from_notification,
         extract_issue_number_from_notification,
@@ -1309,6 +1310,17 @@ def _post_error_for_notification(notif: dict, error: str) -> None:
     issue_num = extract_issue_number_from_notification(notif)
 
     if not project_info or not issue_num:
+        return
+
+    # Never post error replies on a closed/merged subject — commands there are
+    # meaningless and replying just spams a dead thread.
+    closed_reason = _is_subject_closed(notif)
+    if closed_reason:
+        repo_name = notif.get("repository", {}).get("full_name", "?")
+        log.info(
+            "GitHub: suppressing error reply on %s subject %s#%s",
+            closed_reason, repo_name, issue_num,
+        )
         return
 
     _, owner, repo = project_info
@@ -1322,6 +1334,9 @@ def _post_error_for_notification(notif: dict, error: str) -> None:
         comment_id = str(comment.get("id", ""))
         comment_api_url = comment.get("url", "")
         if not comment_id:
+            return
+        from app.github_reply import _enforce_reply_budget
+        if not _enforce_reply_budget(owner, repo, issue_num):
             return
         post_error_reply(owner, repo, issue_num, comment_id, error,
                          comment_api_url=comment_api_url)

--- a/koan/tests/conftest.py
+++ b/koan/tests/conftest.py
@@ -127,6 +127,44 @@ def isolate_env(monkeypatch):
         pass
 
 
+@pytest.fixture(autouse=True)
+def _reset_reply_breaker():
+    """Clear per-thread reply circuit-breaker state between tests.
+
+    The breaker (``github_reply._enforce_reply_budget``) persists reply
+    counts under ``KOAN_ROOT/instance``. Without a reset these counts
+    accumulate across the whole session — many tests reuse the same
+    ``owner/repo#42`` — and eventually trip the cap, making unrelated
+    posting tests fail. Mirror the other module-cache resets above.
+    """
+    try:
+        import app.github_reply as gr
+        gr._last_budget_warning.clear()
+    except Exception:
+        pass
+    root = os.environ.get("KOAN_ROOT", "")
+    if root:
+        tracker = Path(root) / "instance" / ".koan-github-processed-threads.json"
+        try:
+            # Reply-breaker counts live in their own file; drop it wholesale.
+            (Path(root) / "instance" / ".koan-github-reply-counts.json").unlink(
+                missing_ok=True,
+            )
+            # Legacy safety: scrub any stray reply: keys from the shared tracker.
+            if tracker.exists():
+                import json
+                data = json.loads(tracker.read_text())
+                if isinstance(data, dict):
+                    cleaned = {
+                        k: v for k, v in data.items()
+                        if not k.startswith("reply:")
+                    }
+                    tracker.write_text(json.dumps(cleaned))
+        except Exception:
+            pass
+    yield
+
+
 @pytest.fixture
 def instance_dir(tmp_path):
     """Create a minimal instance directory structure."""

--- a/koan/tests/test_gh_request.py
+++ b/koan/tests/test_gh_request.py
@@ -301,10 +301,11 @@ class TestGhRequestRouting:
         )
 
         assert success is False
-        assert error is None
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "`blahblah`" in error
         mock_nlp.assert_called_once()
-        mock_error_reply.assert_called_once()
-        assert "`blahblah`" in mock_error_reply.call_args[0][4]
+        mock_error_reply.assert_not_called()
 
     @patch("app.github_command_handler._is_subject_closed", return_value=None)
     @patch("app.github_command_handler.mark_notification_read")

--- a/koan/tests/test_github_command_handler.py
+++ b/koan/tests/test_github_command_handler.py
@@ -605,7 +605,7 @@ class TestProcessSingleNotification:
     @patch("app.github_command_handler.check_already_processed", return_value=False)
     @patch("app.github_command_handler._find_all_thread_mentions")
     @patch("app.github_command_handler.resolve_project_from_notification")
-    def test_invalid_command_posts_help_inline(
+    def test_invalid_command_returns_help_error(
         self, mock_resolve, mock_mentions,
         mock_processed, mock_read, mock_error_reply,
         registry, sample_notification,
@@ -622,10 +622,11 @@ class TestProcessSingleNotification:
             sample_notification, registry, config, None, "testbot",
         )
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        error_msg = mock_error_reply.call_args[0][4]
-        assert "`badcmd`" in error_msg
+        # Single-comment errors are delegated to the caller (loop_manager),
+        # not posted inline — the message is returned for the caller to post once.
+        assert error is not None
+        assert "`badcmd`" in error
+        mock_error_reply.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.check_already_processed", return_value=False)
@@ -654,7 +655,7 @@ class TestProcessSingleNotification:
     @patch("app.github_command_handler.check_already_processed", return_value=False)
     @patch("app.github_command_handler._find_all_thread_mentions")
     @patch("app.github_command_handler.resolve_project_from_notification")
-    def test_permission_denied_posts_error_inline(
+    def test_permission_denied_returns_error(
         self, mock_resolve, mock_mentions,
         mock_processed, mock_perm, mock_read, mock_error_reply,
         registry, sample_notification,
@@ -671,10 +672,10 @@ class TestProcessSingleNotification:
             sample_notification, registry, config, None, "testbot",
         )
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        error_msg = mock_error_reply.call_args[0][4]
-        assert "Permission denied" in error_msg
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "Permission denied" in error
+        mock_error_reply.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.check_user_permission", return_value=False)
@@ -729,9 +730,10 @@ class TestProcessSingleNotification:
             )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "Failed to queue mission" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "Failed to queue mission" in error
+        mock_error_reply.assert_not_called()
         mock_read.assert_called_with("12345")
         # Reaction should NOT have been added (mission wasn't persisted)
         mock_react.assert_not_called()
@@ -765,9 +767,10 @@ class TestProcessSingleNotification:
             )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "read-only" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "read-only" in error
+        mock_error_reply.assert_not_called()
         mock_read.assert_called_with("12345")
 
     @patch("app.github_command_handler.post_error_reply")
@@ -800,9 +803,10 @@ class TestProcessSingleNotification:
             )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "KOAN_ROOT" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "KOAN_ROOT" in error
+        mock_error_reply.assert_not_called()
         mock_insert.assert_not_called()
         mock_read.assert_called_with("12345")
 
@@ -836,9 +840,10 @@ class TestProcessSingleNotification:
         )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "KOAN_ROOT" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "KOAN_ROOT" in error
+        mock_error_reply.assert_not_called()
         mock_insert.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
@@ -1261,9 +1266,10 @@ class TestProcessNotificationWithReply:
         )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "`what`" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "`what`" in error
+        mock_error_reply.assert_not_called()
 
 
 class TestTryReplyAuthorizedUsers:
@@ -3133,7 +3139,7 @@ class TestProcessNotificationWithNLP:
         mock_processed, mock_read, mock_error_reply,
         registry, sample_notification,
     ):
-        """NLP returns None → error posted inline with help message."""
+        """NLP returns None → help-message error returned for the caller to post."""
         mock_resolve.return_value = ("koan", "sukria", "koan")
         mock_mentions.return_value = [{
             "id": "99999",
@@ -3148,9 +3154,10 @@ class TestProcessNotificationWithNLP:
         )
 
         assert success is False
-        assert error is None
-        mock_error_reply.assert_called_once()
-        assert "`blahblah`" in mock_error_reply.call_args[0][4]
+        # Single-comment errors are delegated to the caller, not posted inline.
+        assert error is not None
+        assert "`blahblah`" in error
+        mock_error_reply.assert_not_called()
 
     @patch("app.github_command_handler.mark_notification_read")
     @patch("app.github_command_handler.add_reaction", return_value=True)
@@ -4759,31 +4766,118 @@ class TestMultiMentionPerThread:
         assert cmds[0] == {"command": "review", "author": "alice"}
         assert cmds[1] == {"command": "rebase", "author": "bob"}
 
-    def test_error_posted_inline_not_returned(
+    def test_single_errored_comment_delegated_not_posted_inline(
         self, notification, registry, monkeypatch,
     ):
-        """Errors are posted inline, never returned to caller (no double posting)."""
+        """A single errored comment is delegated to the caller's retry path
+        (via the returned error), not posted inline — so it is posted exactly
+        once, never doubly. The comment is still durably tracked."""
         monkeypatch.setenv("KOAN_ROOT", "/tmp/test-koan")
 
         comment = {
-            "id": "301",
-            "url": "https://api.github.com/repos/owner/repo/issues/comments/301",
-            "body": "@bot badcmd",
-            "user": {"login": "alice"},
+            "id": "303",
+            "url": "https://api.github.com/repos/o/r/issues/comments/303",
+            "body": "@bot badcmd", "user": {"login": "alice"},
         }
 
         with patch("app.github_command_handler._find_all_thread_mentions",
                     return_value=[comment]), \
              patch("app.github_command_handler.resolve_project_from_notification",
                    return_value=("myproject", "owner", "repo")), \
-             patch("app.github_command_handler._is_subject_closed", return_value=None), \
-             patch("app.github_command_handler.check_already_processed", return_value=False), \
+             patch("app.github_command_handler._is_subject_closed",
+                   return_value=None), \
+             patch("app.github_command_handler._process_mention_comment",
+                   return_value=(False, "Unknown command badcmd")), \
+             patch("app.github_reply._enforce_reply_budget", return_value=True), \
+             patch("app.github_command_handler.extract_issue_number_from_notification",
+                   return_value="99"), \
+             patch("app.github_command_handler.post_error_reply") as mock_err, \
              patch("app.github_command_handler.mark_notification_read"), \
-             patch("app.github_command_handler.get_github_nickname", return_value="bot"), \
-             patch("app.github_command_handler.post_error_reply") as mock_err:
+             patch("app.github_notification_tracker.track_comment") as mock_track:
             success, error = process_single_notification(
                 notification, registry, {}, None, "bot",
             )
 
+        # Not posted inline (the caller owns the single-comment post); the
+        # error is returned for the caller to post once, and the comment is
+        # durably tracked regardless.
+        mock_err.assert_not_called()
+        assert success is False
+        assert error == "Unknown command badcmd"
+        mock_track.assert_any_call("/tmp/test-koan/instance", "303")
+
+    def test_multi_errored_comments_posted_inline(
+        self, notification, registry, monkeypatch,
+    ):
+        """Each errored comment in a multi-mention thread gets its own inline
+        error reply (the caller's single-error return path can't cover them),
+        and all are durably tracked."""
+        monkeypatch.setenv("KOAN_ROOT", "/tmp/test-koan")
+
+        comments = [
+            {"id": "501", "url": "https://api.github.com/repos/o/r/issues/comments/501",
+             "body": "@bot badcmd", "user": {"login": "alice"}},
+            {"id": "502", "url": "https://api.github.com/repos/o/r/issues/comments/502",
+             "body": "@bot worsecmd", "user": {"login": "bob"}},
+        ]
+
+        with patch("app.github_command_handler._find_all_thread_mentions",
+                    return_value=comments), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("myproject", "owner", "repo")), \
+             patch("app.github_command_handler._is_subject_closed",
+                   return_value=None), \
+             patch("app.github_command_handler._process_mention_comment",
+                   return_value=(False, "Unknown command")), \
+             patch("app.github_reply._enforce_reply_budget", return_value=True), \
+             patch("app.github_command_handler.extract_issue_number_from_notification",
+                   return_value="99"), \
+             patch("app.github_command_handler.post_error_reply") as mock_err, \
+             patch("app.github_command_handler.mark_notification_read"), \
+             patch("app.github_notification_tracker.track_comment") as mock_track:
+            success, error = process_single_notification(
+                notification, registry, {}, None, "bot",
+            )
+
+        # One inline reply per errored comment; nothing delegated to the caller
+        # (multi-comment returns no single error).
+        assert mock_err.call_count == 2
+        assert success is False
         assert error is None
-        mock_err.assert_called_once()
+        mock_track.assert_any_call("/tmp/test-koan/instance", "501")
+        mock_track.assert_any_call("/tmp/test-koan/instance", "502")
+
+    def test_multi_errored_comments_suppressed_when_breaker_tripped(
+        self, notification, registry, monkeypatch,
+    ):
+        """When the per-thread breaker is tripped, inline error replies for a
+        multi-mention thread are suppressed, but the comments are still
+        durably tracked."""
+        monkeypatch.setenv("KOAN_ROOT", "/tmp/test-koan")
+
+        comments = [
+            {"id": "404", "url": "https://api.github.com/repos/o/r/issues/comments/404",
+             "body": "@bot badcmd", "user": {"login": "alice"}},
+            {"id": "405", "url": "https://api.github.com/repos/o/r/issues/comments/405",
+             "body": "@bot worsecmd", "user": {"login": "bob"}},
+        ]
+
+        with patch("app.github_command_handler._find_all_thread_mentions",
+                    return_value=comments), \
+             patch("app.github_command_handler.resolve_project_from_notification",
+                   return_value=("myproject", "owner", "repo")), \
+             patch("app.github_command_handler._is_subject_closed",
+                   return_value=None), \
+             patch("app.github_command_handler._process_mention_comment",
+                   return_value=(False, "Unknown command badcmd")), \
+             patch("app.github_reply._enforce_reply_budget", return_value=False), \
+             patch("app.github_command_handler.extract_issue_number_from_notification",
+                   return_value="99"), \
+             patch("app.github_command_handler.post_error_reply") as mock_err, \
+             patch("app.github_command_handler.mark_notification_read"), \
+             patch("app.github_notification_tracker.track_comment") as mock_track:
+            process_single_notification(notification, registry, {}, None, "bot")
+
+        mock_err.assert_not_called()
+        mock_track.assert_any_call("/tmp/test-koan/instance", "404")
+        mock_track.assert_any_call("/tmp/test-koan/instance", "405")

--- a/koan/tests/test_github_notif_logging.py
+++ b/koan/tests/test_github_notif_logging.py
@@ -220,13 +220,14 @@ class TestProcessSingleNotificationLogging:
     """Verify debug logs in process_single_notification."""
 
     @patch("app.github_command_handler.mark_notification_read")
-    @patch("app.github_command_handler.get_comment_from_notification")
-    @patch("app.github_command_handler.is_notification_stale", return_value=False)
+    @patch("app.github_command_handler._find_all_thread_mentions")
     @patch("app.github_command_handler.resolve_project_from_notification", return_value=None)
-    def test_logs_unknown_repo_skipped(self, mock_project, mock_stale, mock_comment, mock_read, caplog):
+    def test_logs_unknown_repo_skipped(self, mock_project, mock_mentions, mock_read, caplog):
         from app.github_command_handler import process_single_notification
 
-        mock_comment.return_value = {"id": "c1", "user": {"login": "alice"}, "body": "@bot rebase"}
+        mock_mentions.return_value = [
+            {"id": "c1", "user": {"login": "alice"}, "body": "@bot rebase"}
+        ]
 
         notif = {
             "id": "1",
@@ -250,15 +251,16 @@ class TestProcessSingleNotificationLogging:
     @patch("app.github_command_handler.check_user_permission", return_value=False)
     @patch("app.github_command_handler.get_github_authorized_users", return_value=["allowed"])
     @patch("app.github_command_handler._validate_and_parse_command")
-    @patch("app.github_command_handler.get_comment_from_notification")
-    @patch("app.github_command_handler.is_notification_stale", return_value=False)
+    @patch("app.github_command_handler._find_all_thread_mentions")
     @patch("app.github_command_handler.resolve_project_from_notification", return_value=("myproj", "o", "r"))
     def test_logs_permission_denied(
-        self, mock_project, mock_stale, mock_comment, mock_validate, mock_auth, mock_perm, mock_read, caplog
+        self, mock_project, mock_mentions, mock_validate, mock_auth, mock_perm, mock_read, caplog
     ):
         from app.github_command_handler import process_single_notification
 
-        mock_comment.return_value = {"id": "c1", "user": {"login": "intruder"}, "body": "@bot rebase"}
+        mock_mentions.return_value = [
+            {"id": "c1", "user": {"login": "intruder"}, "body": "@bot rebase"}
+        ]
         mock_validate.return_value = (MagicMock(), "rebase", "")
 
         notif = {"id": "1", "repository": {"full_name": "o/r"}, "subject": {"url": ""}}

--- a/koan/tests/test_github_notification_tracker.py
+++ b/koan/tests/test_github_notification_tracker.py
@@ -189,3 +189,160 @@ class TestReviewCooldown:
         """Clearing a non-existent cooldown does not raise."""
         clear_review_cooldown(instance_dir, "owner", "repo", "999")
         assert not is_review_on_cooldown(instance_dir, "owner", "repo", "999")
+
+
+class TestThreadReplyCounter:
+    """Per-thread reply circuit-breaker counter."""
+
+    def test_count_starts_at_zero(self, instance_dir):
+        from app.github_notification_tracker import thread_reply_count
+        assert thread_reply_count(instance_dir, "owner", "repo", "42") == 0
+
+    def test_record_increments_within_window(self, instance_dir):
+        from app.github_notification_tracker import (
+            record_thread_reply,
+            thread_reply_count,
+        )
+        assert record_thread_reply(instance_dir, "owner", "repo", "42") == 1
+        assert record_thread_reply(instance_dir, "owner", "repo", "42") == 2
+        assert thread_reply_count(instance_dir, "owner", "repo", "42") == 2
+
+    def test_counter_is_per_thread(self, instance_dir):
+        from app.github_notification_tracker import (
+            record_thread_reply,
+            thread_reply_count,
+        )
+        record_thread_reply(instance_dir, "owner", "repo", "1")
+        record_thread_reply(instance_dir, "owner", "repo", "1")
+        record_thread_reply(instance_dir, "owner", "repo", "2")
+        assert thread_reply_count(instance_dir, "owner", "repo", "1") == 2
+        assert thread_reply_count(instance_dir, "owner", "repo", "2") == 1
+
+    def test_old_replies_outside_window_not_counted(self, instance_dir):
+        from app.github_notification_tracker import (
+            _REPLY_WINDOW_SECONDS,
+            _replies_path,
+            _reply_key_prefix,
+            thread_reply_count,
+        )
+        prefix = _reply_key_prefix("owner", "repo", "42")
+        stale = time.time() - _REPLY_WINDOW_SECONDS - 10
+        recent = time.time() - 5
+        _replies_path(instance_dir).write_text(
+            json.dumps({f"{prefix}{stale}": stale, f"{prefix}{recent}": recent})
+        )
+        assert thread_reply_count(instance_dir, "owner", "repo", "42") == 1
+
+
+class TestTryConsumeReplyBudget:
+    """Atomic check-and-record reply budget (no check-then-act race)."""
+
+    def test_allows_until_cap_then_blocks(self, instance_dir):
+        from app.github_notification_tracker import (
+            thread_reply_count,
+            try_consume_reply_budget,
+        )
+        # cap=3: first three allowed and recorded, fourth blocked.
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 3) is True
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 3) is True
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 3) is True
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 3) is False
+        # The blocked attempt recorded nothing — count stays exactly at the cap.
+        assert thread_reply_count(instance_dir, "o", "r", "42") == 3
+
+    def test_never_overshoots_cap_under_repeated_consume(self, instance_dir):
+        """Sequential consume calls never record more slots than the cap.
+
+        This is the regression guard for the TOCTOU race: even with many
+        attempts, the recorded count is clamped to the cap because the check
+        and the record share one lock.
+        """
+        from app.github_notification_tracker import (
+            thread_reply_count,
+            try_consume_reply_budget,
+        )
+        cap = 5
+        allowed = sum(
+            1 for _ in range(20)
+            if try_consume_reply_budget(instance_dir, "o", "r", "7", cap)
+        )
+        assert allowed == cap
+        assert thread_reply_count(instance_dir, "o", "r", "7") == cap
+
+    def test_cap_zero_disables_breaker(self, instance_dir):
+        from app.github_notification_tracker import (
+            thread_reply_count,
+            try_consume_reply_budget,
+        )
+        # cap<=0 means disabled: always allowed and nothing recorded.
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 0) is True
+        assert thread_reply_count(instance_dir, "o", "r", "42") == 0
+
+    def test_fails_open_on_tracker_error(self, instance_dir, monkeypatch):
+        """A tracker write failure must allow the reply (fail open)."""
+        import app.locked_file as locked_file
+        from app.github_notification_tracker import try_consume_reply_budget
+
+        def _boom(*a, **k):
+            raise RuntimeError("disk gone")
+
+        monkeypatch.setattr(locked_file, "locked_json_modify", _boom)
+        assert try_consume_reply_budget(instance_dir, "o", "r", "42", 1) is True
+
+    def test_breaker_state_isolated_from_dedup_tracker(self, instance_dir):
+        """Reply-breaker keys never touch the shared dedup/cooldown file.
+
+        The breaker is high-churn; if its keys shared the dedup tracker they
+        could evict durable comment/cooldown keys via the entry cap and
+        silently reintroduce re-processing. They must live in their own file.
+        """
+        from app.github_notification_tracker import (
+            _threads_path,
+            is_review_on_cooldown,
+            record_thread_reply,
+            set_review_cooldown,
+            try_consume_reply_budget,
+        )
+        set_review_cooldown(instance_dir, "o", "r", "42")
+        for _ in range(50):
+            record_thread_reply(instance_dir, "o", "r", "42")
+            try_consume_reply_budget(instance_dir, "o", "r", "42", 1000)
+        # The shared threads file holds only the cooldown key — no reply churn.
+        shared = json.loads(_threads_path(instance_dir).read_text())
+        assert all(not k.startswith("reply:") for k in shared)
+        assert is_review_on_cooldown(instance_dir, "o", "r", "42") is True
+
+    def test_stale_keys_pruned_on_record(self, instance_dir):
+        """Recording prunes entries older than the window (storage reclaimed)."""
+        from app.github_notification_tracker import (
+            _REPLY_WINDOW_SECONDS,
+            _load_replies,
+            _replies_path,
+            _reply_key_prefix,
+            record_thread_reply,
+        )
+        prefix = _reply_key_prefix("o", "r", "42")
+        stale = time.time() - _REPLY_WINDOW_SECONDS - 10
+        _replies_path(instance_dir).write_text(
+            json.dumps({f"{prefix}{stale}": stale})
+        )
+        record_thread_reply(instance_dir, "o", "r", "42")
+        # The stale key is gone; only the freshly recorded one remains on disk.
+        on_disk = json.loads(_replies_path(instance_dir).read_text())
+        assert len(on_disk) == 1
+        assert all(v > stale for v in _load_replies(instance_dir).values())
+
+
+class TestTrackCommentDefensive:
+    """track_comment is best-effort: must swallow all errors, not just OSError."""
+
+    def test_track_comment_swallows_non_oserror(self, instance_dir, monkeypatch):
+        import app.locked_file as locked_file
+
+        def _boom(*a, **k):
+            raise RuntimeError("unexpected non-OSError")
+
+        monkeypatch.setattr(locked_file, "locked_json_modify", _boom)
+        # Must not raise — the caller's loop (and mark_notification_read) must
+        # never be aborted by a best-effort tracker write.
+        track_comment(instance_dir, "999")

--- a/koan/tests/test_github_notifications.py
+++ b/koan/tests/test_github_notifications.py
@@ -740,6 +740,15 @@ class TestCheckAlreadyProcessedWithUrl:
     def setup_method(self):
         _processed_comments.clear()
 
+    @pytest.fixture(autouse=True)
+    def _no_persistent_tracker(self, monkeypatch):
+        """These tests verify reactions-endpoint selection, which is
+        independent of the persistent comment tracker. Clear KOAN_ROOT so a
+        comment id already recorded on disk (the tracker file is shared across
+        runs) can't short-circuit check_already_processed before the API call.
+        """
+        monkeypatch.delenv("KOAN_ROOT", raising=False)
+
     @patch("app.github_notifications.api")
     def test_pr_review_comment_uses_correct_endpoint(self, mock_api):
         """PR review comments should use pulls/comments endpoint."""

--- a/koan/tests/test_github_reply.py
+++ b/koan/tests/test_github_reply.py
@@ -613,3 +613,55 @@ class TestTruncateText:
         result = truncate_text("x" * 200, 100)
         assert len(result) < 200
         assert "(truncated)" in result
+
+
+class TestReplyCircuitBreaker:
+    """Per-thread reply budget enforced in post_reply / post_threaded_reply."""
+
+    def test_posts_allowed_until_cap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        (tmp_path / "instance").mkdir()
+        from app.github_reply import _enforce_reply_budget
+
+        with patch(
+            "app.github_config.get_github_max_replies_per_thread",
+            return_value=10,
+        ):
+            allowed = [_enforce_reply_budget("o", "r", "42") for _ in range(10)]
+            assert all(allowed)
+            # 11th call exceeds the cap → suppressed.
+            assert _enforce_reply_budget("o", "r", "42") is False
+
+    def test_post_reply_suppressed_when_breaker_tripped(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        (tmp_path / "instance").mkdir()
+        from app.github_notification_tracker import record_thread_reply
+
+        for _ in range(10):
+            record_thread_reply(str(tmp_path / "instance"), "owner", "repo", "42")
+
+        with patch("app.github_reply.api") as mock_api, \
+                patch("app.notify.send_telegram"), \
+                patch(
+                    "app.github_config.get_github_max_replies_per_thread",
+                    return_value=10,
+                ):
+            assert post_reply("owner", "repo", "42", "body") is False
+            mock_api.assert_not_called()
+
+    def test_breaker_disabled_when_cap_zero(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+        (tmp_path / "instance").mkdir()
+        from app.github_reply import _enforce_reply_budget
+
+        with patch(
+            "app.github_config.get_github_max_replies_per_thread",
+            return_value=0,
+        ):
+            # Cap 0 disables the breaker — always allowed.
+            assert all(_enforce_reply_budget("o", "r", "42") for _ in range(25))
+
+    def test_fails_open_without_koan_root(self, monkeypatch):
+        monkeypatch.delenv("KOAN_ROOT", raising=False)
+        from app.github_reply import _enforce_reply_budget
+        assert _enforce_reply_budget("o", "r", "42") is True

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -3070,6 +3070,7 @@ class TestErrorReplyRetryQueue:
 
         with patch("app.github_command_handler.resolve_project_from_notification",
                     return_value=("proj", "o", "r")), \
+             patch("app.github_command_handler._is_subject_closed", return_value=None), \
              patch("app.github_command_handler.extract_issue_number_from_notification",
                     return_value=42), \
              patch("app.github_notifications.get_comment_from_notification",
@@ -3086,6 +3087,35 @@ class TestErrorReplyRetryQueue:
             assert entry["issue_num"] == 42
             assert entry["comment_id"] == "999"
             assert entry["attempts"] == 1
+
+    def test_no_error_reply_on_closed_subject(self):
+        """Error replies are suppressed when the PR/issue is closed/merged."""
+        import app.loop_manager as lm
+
+        notif = {
+            "id": "9",
+            "updated_at": "2026-03-20T10:00:00Z",
+            "subject": {"url": "https://api.github.com/repos/o/r/issues/9"},
+            "repository": {"full_name": "o/r"},
+        }
+
+        with lm._pending_error_replies_lock:
+            lm._pending_error_replies.clear()
+
+        with patch("app.github_command_handler.resolve_project_from_notification",
+                    return_value=("proj", "o", "r")), \
+             patch("app.github_command_handler._is_subject_closed",
+                    return_value="closed"), \
+             patch("app.github_command_handler.extract_issue_number_from_notification",
+                    return_value=9), \
+             patch("app.github_notifications.get_comment_from_notification") as mock_get, \
+             patch("app.github_command_handler.post_error_reply") as mock_reply:
+            lm._post_error_for_notification(notif, "some error")
+            mock_reply.assert_not_called()
+            mock_get.assert_not_called()
+
+        with lm._pending_error_replies_lock:
+            assert len(lm._pending_error_replies) == 0
 
     def test_error_reply_queued_when_get_comment_raises(self):
         """Regression: NameError when get_comment_from_notification raises.
@@ -3108,6 +3138,7 @@ class TestErrorReplyRetryQueue:
 
         with patch("app.github_command_handler.resolve_project_from_notification",
                     return_value=("proj", "o", "r")), \
+             patch("app.github_command_handler._is_subject_closed", return_value=None), \
              patch("app.github_command_handler.extract_issue_number_from_notification",
                     return_value=5), \
              patch("app.github_notifications.get_comment_from_notification",


### PR DESCRIPTION
The full-thread @mention rescan (process all mentions per poll) combined with command acks/threaded replies turned a latent dedup gap into an unbounded reply loop: a closed PR received hundreds of repeated bot comments, re-posting the same errors every poll cycle.

Two root causes:

- Error/help/permission/block paths added only a volatile reaction (which depends on the reactions API and a correctly-configured bot_username) but never wrote the persistent comment tracker. When the reaction-based dedup could not be confirmed, the full-thread rescan re-discovered those comments every poll and re-replied. Each reply also bumped latest_comment_url, invalidating the per-poll cache.
- The closed-subject guard was fail-open and absent entirely from the loop_manager error-reply fallback, so replies still landed on closed or merged subjects.

Fixes:

- Persistently track every handled comment in the notification loop — regardless of outcome (queued, error, help, permission-denied, closed) — so a comment is answered at most once and never re-discovered.
- Enforce the closed/merged-subject skip on every reply path, including _post_error_for_notification, and track the affected comments.
- Add a per-thread reply circuit breaker (github.max_replies_per_thread _per_hour, default 10, 0 disables), persisted across restarts, with one throttled Telegram heads-up when tripped. This caps bot comments per thread regardless of why dedup fails — a regression-proof backstop.

Add tests for the reply counter, breaker behavior, closed-subject suppression, and track-on-error, plus a conftest fixture isolating breaker state between tests. Update docs/messaging/github-commands.md.