### PR TITLE
feat(slack): in-thread replies + Hermes-style thinking status

### DIFF
--- a/docs/messaging/slack-app-manifest.json
+++ b/docs/messaging/slack-app-manifest.json
@@ -8,12 +8,16 @@
         "bot_user": {
             "display_name": "Koan",
             "always_online": true
+        },
+        "assistant_view": {
+            "assistant_description": "Autonomous background coding assistant"
         }
     },
     "oauth_config": {
         "scopes": {
             "bot": [
                 "app_mentions:read",
+                "assistant:write",
                 "channels:history",
                 "channels:read",
                 "groups:history",
@@ -32,6 +36,8 @@
         "event_subscriptions": {
             "bot_events": [
                 "app_mention",
+                "assistant_thread_started",
+                "assistant_thread_context_changed",
                 "message.channels",
                 "message.groups",
                 "message.im"

--- a/docs/messaging/slack-app-manifest.json
+++ b/docs/messaging/slack-app-manifest.json
@@ -1,0 +1,47 @@
+{
+    "display_information": {
+        "name": "Kōan",
+        "description": "Autonomous background coding assistant",
+        "background_color": "#000000"
+    },
+    "features": {
+        "bot_user": {
+            "display_name": "Koan",
+            "always_online": true
+        }
+    },
+    "oauth_config": {
+        "scopes": {
+            "bot": [
+                "app_mentions:read",
+                "channels:history",
+                "channels:read",
+                "groups:history",
+                "groups:read",
+                "im:history",
+                "im:read",
+                "im:write",
+                "chat:write",
+                "files:read",
+                "files:write",
+                "users:read"
+            ]
+        }
+    },
+    "settings": {
+        "event_subscriptions": {
+            "bot_events": [
+                "app_mention",
+                "message.channels",
+                "message.groups",
+                "message.im"
+            ]
+        },
+        "interactivity": {
+            "is_enabled": true
+        },
+        "org_deploy_enabled": false,
+        "socket_mode_enabled": true,
+        "token_rotation_enabled": false
+    }
+}

--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -41,7 +41,8 @@ Then continue from Step 4 (Install to Workspace) to collect your tokens.
 
    | Scope | Purpose |
    |-------|---------|
-   | `chat:write` | Send messages |
+   | `chat:write` | Send messages and set the "thinking" status |
+   | `assistant:write` | Show the assistant "thinking" status (optional; `chat:write` also works) |
    | `channels:history` | Read messages in public channels |
    | `groups:history` | Read messages in private channels |
    | `im:history` | Read direct messages |
@@ -53,6 +54,8 @@ Then continue from Step 4 (Install to Workspace) to collect your tokens.
    - `message.groups`
    - `message.im`
    - `app_mention`
+   - `assistant_thread_started` (optional — for the Assistant "thinking" status)
+   - `assistant_thread_context_changed` (optional)
 
 ## Step 4: Install App to Workspace
 
@@ -170,6 +173,30 @@ You should see in the logs:
   recognizes threads it is already participating in and keeps answering there.
 - **De-duplication**: Slack delivers both an `app_mention` and a `message` event
   for the same channel mention; Kōan acts on it exactly once.
+- **"Thinking" status**: While Kōan works on a chat reply, it shows a rotating
+  status (greyed italic text under the bot name — "Thinking…", "Reading the
+  code…", …) via Slack's assistant status API. It clears automatically when the
+  reply posts. This is best-effort: if the API call fails it is silently skipped
+  and never affects the reply itself. See "Thinking status" below.
+
+## Thinking status
+
+When you @mention Kōan, it shows a live status in the thread while it works,
+then replaces it with the answer — the same idea as Slack's own assistant
+"thinking" indicator.
+
+- **How it works**: Kōan calls `assistant.threads.setStatus` with a rotating
+  phrase, refreshed every few seconds, and clears it when the reply is sent.
+- **Scope**: this uses the `chat:write` scope the app already has — no extra
+  setup is strictly required. (`assistant:write` is also accepted and is
+  included in the manifest for the richest experience.)
+- **Where it renders**: Slack shows this status most reliably inside **Assistant
+  threads** (the AI-apps pane / DMs with the app). On a plain channel @mention it
+  may not render, depending on your workspace. If you don't see it in a channel,
+  reinstall the app with the updated manifest (which enables the Assistant
+  feature) or chat with Kōan in the Assistant pane.
+- **Safe by design**: a failed status update is logged at most once to stderr
+  and never blocks or alters the actual reply.
 
 ## Architecture Notes
 

--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -190,11 +190,16 @@ then replaces it with the answer — the same idea as Slack's own assistant
 - **Scope**: this uses the `chat:write` scope the app already has — no extra
   setup is strictly required. (`assistant:write` is also accepted and is
   included in the manifest for the richest experience.)
-- **Where it renders**: Slack shows this status most reliably inside **Assistant
-  threads** (the AI-apps pane / DMs with the app). On a plain channel @mention it
-  may not render, depending on your workspace. If you don't see it in a channel,
-  reinstall the app with the updated manifest (which enables the Assistant
-  feature) or chat with Kōan in the Assistant pane.
+- **Where it renders**: Slack renders this status most reliably inside
+  **Assistant threads**; on a plain channel @mention it may not show, depending
+  on your workspace. Reinstalling with the updated manifest (which enables the
+  `assistant:write` scope and the Assistant feature) gives it the best chance of
+  rendering on channel threads. If it still doesn't appear, that's a Slack
+  rendering limitation, not a failure — the reply is unaffected.
+- **Scope note**: Kōan currently listens and replies **only in the configured
+  channel** (`KOAN_SLACK_CHANNEL_ID`). It does not yet hold conversations in the
+  Assistant pane / DMs, so enabling the Assistant feature affects status
+  rendering only, not where Kōan responds.
 - **Safe by design**: a failed status update is logged at most once to stderr
   and never blocks or alters the actual reply.
 

--- a/docs/messaging/slack.md
+++ b/docs/messaging/slack.md
@@ -6,7 +6,19 @@ This guide covers setting up Kōan with Slack as the messaging provider. Slack u
 
 - A Slack workspace where you have permission to install apps (or can request admin approval)
 
-## Step 1: Create a Slack App
+## Fast path: create the app from a manifest
+
+The quickest setup is to create the app from the ready-made manifest, which
+pre-configures Socket Mode, scopes, and event subscriptions in one shot:
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From a manifest**
+2. Select your workspace
+3. Paste the contents of [`slack-app-manifest.json`](./slack-app-manifest.json) and create the app
+4. Generate the tokens it needs (Steps 2 and 4 below) and skip the manual scope/event setup (Steps 3)
+
+Then continue from Step 4 (Install to Workspace) to collect your tokens.
+
+## Step 1: Create a Slack App (manual alternative)
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps)
 2. Click **Create New App** → **From scratch**
@@ -78,7 +90,9 @@ pip install 'slack-sdk>=3.27'
 Edit your `.env` file:
 
 ```bash
-# Messaging provider
+# Messaging provider — REQUIRED. Without this, Kōan defaults to Telegram and
+# ignores the KOAN_SLACK_* credentials entirely (the #1 "Slack isn't working"
+# cause). Setting only the three tokens below is not enough.
 KOAN_MESSAGING_PROVIDER=slack
 
 # Slack credentials (all required)
@@ -93,6 +107,8 @@ Or in `instance/config.yaml`:
 messaging:
   provider: "slack"
 ```
+
+The env var takes precedence over `config.yaml`.
 
 ## Step 9: Start Kōan
 
@@ -120,17 +136,40 @@ You should see in the logs:
 - Make sure Socket Mode is enabled (Step 2)
 - The `connections:write` scope must be on the App-Level Token
 
+### Bot connects but never replies
+
+- **Confirm the provider is actually Slack.** Run `make logs` and look for
+  `Messaging provider: SLACK`. If it says `TELEGRAM`, `KOAN_MESSAGING_PROVIDER=slack`
+  is not set — setting only the `KOAN_SLACK_*` tokens is not enough.
+- **You must @mention the bot.** Kōan ignores un-addressed channel chatter by
+  design. Ping `@Koan ...` to start; after that you can keep replying in the
+  thread without re-mentioning.
+
 ### Bot not receiving messages
 
 - Make sure the bot is invited to the channel (`/invite @koan`)
 - Verify the `KOAN_SLACK_CHANNEL_ID` matches the channel
 - Check that event subscriptions are enabled (Step 3)
-- Messages from other bots and message subtypes (edits, joins) are filtered out
+- Messages from other bots, the bot's own messages, and message subtypes (edits, joins) are filtered out
 
 ### Messages not delivered or rate limiting
 
 - Slack limits `chat.postMessage` to ~1 message/second. Kōan handles this automatically with built-in rate limiting.
 - Long messages are chunked to 4000 characters per message.
+
+## How Kōan behaves in Slack
+
+- **Mention to start**: In the configured channel, Kōan stays quiet until you
+  @mention it (or it receives an `app_mention`). Ordinary channel chatter is
+  ignored, so the bot is safe to drop into a shared channel.
+- **Replies go in a thread**: When you @mention Kōan on a channel-root message,
+  it replies in a **thread** under your message rather than cluttering the
+  channel.
+- **Threads continue without re-mentioning**: Once Kōan is engaged in a thread,
+  you can keep replying in that thread without @mentioning it each time — it
+  recognizes threads it is already participating in and keeps answering there.
+- **De-duplication**: Slack delivers both an `app_mention` and a `message` event
+  for the same channel mention; Kōan acts on it exactly once.
 
 ## Architecture Notes
 
@@ -138,3 +177,10 @@ You should see in the logs:
 - **Event buffering**: Incoming messages are buffered in a thread-safe queue and processed on each poll cycle
 - **Single channel**: Kōan only listens and responds in the configured channel (ignores DMs and other channels)
 - **@mention stripping**: When you @mention the bot, the mention prefix is automatically removed before processing
+- **Threading internals**: Slack threads are keyed by `thread_ts`. Kōan emits
+  inbound events in the same Telegram-shaped envelope every provider uses, with
+  an integer token as the `message_id`; that token maps back to the message's
+  `thread_ts` so the bridge's existing reply-context plumbing routes replies into
+  the right thread without any Slack-specific code in the main loop. Asynchronous
+  agent notifications (mission updates from the outbox) have no reply context and
+  post to the channel root.

--- a/koan/app/messaging/base.py
+++ b/koan/app/messaging/base.py
@@ -104,17 +104,37 @@ class MessagingProvider(ABC):
         """
         return ""
 
-    def send_typing(self) -> bool:
-        """Send a typing indicator to the channel.
+    def send_typing(self, reply_to_message_id: int = 0, status: str = "") -> bool:
+        """Send a typing / "thinking" indicator to the channel.
 
-        Shows the user that the bot is "thinking". The indicator typically
+        Shows the user that the bot is working. The indicator typically
         expires after a few seconds (5s on Telegram). Callers that need
         a persistent indicator should use TypingIndicator context manager.
+
+        Args:
+            reply_to_message_id: If non-zero, target the conversation/thread
+                that message belongs to (used by providers like Slack whose
+                status is thread-scoped). Ignored by providers with a single
+                channel-wide indicator (e.g. Telegram).
+            status: Optional human-readable status text (e.g. "Thinking…").
+                Ignored by providers that only support a generic indicator.
 
         Returns:
             True if the action was sent (or is unsupported — no-op is success).
         """
         return True  # No-op by default; providers override if supported
+
+    def stop_typing(self, reply_to_message_id: int = 0) -> bool:
+        """Clear a persistent "thinking" indicator, if the provider has one.
+
+        Providers whose indicator auto-expires (e.g. Telegram) need do nothing.
+        Providers with a sticky status (e.g. Slack's assistant status) override
+        this to clear it.
+
+        Returns:
+            True if cleared (or nothing to clear — no-op is success).
+        """
+        return True  # No-op by default; providers override if needed
 
     def chunk_message(self, text: str, max_size: int = DEFAULT_MAX_MESSAGE_SIZE) -> List[str]:
         """Split a message into chunks respecting the provider's size limit.

--- a/koan/app/messaging/matrix.py
+++ b/koan/app/messaging/matrix.py
@@ -303,8 +303,13 @@ class MatrixProvider(MessagingProvider):
             print(f"[matrix] Send error after retries: {e}", file=sys.stderr)
             return False
 
-    def send_typing(self) -> bool:
-        """Send a typing indicator to the room (auto-expires after ~10s)."""
+    def send_typing(self, reply_to_message_id: int = 0, status: str = "") -> bool:
+        """Send a typing indicator to the room (auto-expires after ~10s).
+
+        Matrix has a single room-wide typing indicator with no custom text, so
+        ``reply_to_message_id`` and ``status`` are accepted for interface
+        compatibility but ignored.
+        """
         if not self._access_token or not self._room_id or not self._user_id:
             return False
         url = (

--- a/koan/app/messaging/slack.py
+++ b/koan/app/messaging/slack.py
@@ -16,6 +16,7 @@ import re
 import sys
 import threading
 import time
+from collections import OrderedDict
 from typing import List, Optional
 
 from app.messaging.base import DEFAULT_MAX_MESSAGE_SIZE, Message, MessagingProvider, Update
@@ -25,6 +26,12 @@ from app.messaging import register_provider
 # Rate limit: Slack allows ~1 msg/sec for chat.postMessage
 SLACK_RATE_LIMIT_SECONDS = 1.0
 MAX_MESSAGE_SIZE = DEFAULT_MAX_MESSAGE_SIZE
+
+# Bounded memory for threading/dedup state. These cap unbounded growth on a
+# long-running bridge; oldest entries are evicted FIFO.
+_MAX_THREAD_TOKENS = 1000   # int token -> thread_ts, for routing replies
+_MAX_ENGAGED_THREADS = 1000  # thread_ts the bot is participating in
+_MAX_SEEN_TS = 2000          # event ts already processed (dedup)
 
 
 @register_provider("slack")
@@ -51,6 +58,20 @@ class SlackProvider(MessagingProvider):
         self._last_send_time: float = 0.0
         self._connect_lock = threading.Lock()
         self._connected: bool = False
+
+        # Threading state. Slack threads are keyed by ``thread_ts`` (a string),
+        # but the bridge's reply-context plumbing carries an int
+        # ``reply_to_message_id``. We bridge the two with a token map: each
+        # inbound message gets an int token (used as ``message_id`` in the
+        # Telegram-shaped envelope) that maps back to its ``thread_ts`` here.
+        self._state_lock = threading.Lock()
+        self._thread_by_token: "OrderedDict[int, str]" = OrderedDict()
+        # thread_ts values the bot is engaged in (was mentioned / replied in),
+        # so follow-up messages in the thread are handled without re-mention.
+        self._engaged_threads: "OrderedDict[str, None]" = OrderedDict()
+        # Slack delivers both ``app_mention`` and ``message`` for a channel
+        # mention; dedup by event ts so we only act once.
+        self._seen_ts: "OrderedDict[str, None]" = OrderedDict()
 
     # -- MessagingProvider interface ------------------------------------------
 
@@ -110,9 +131,14 @@ class SlackProvider(MessagingProvider):
 
     def send_message(self, text: str, reply_to_message_id: int = 0) -> bool:
         """Send a message to the configured Slack channel with rate limiting.
-        
+
         Applies rate limiting between chunks to comply with Slack's ~1 msg/sec limit.
-        
+
+        When ``reply_to_message_id`` maps to a known thread (set by the bridge's
+        reply context after an inbound message), the reply is posted into that
+        Slack thread via ``thread_ts``. Otherwise it goes to the channel root —
+        which is the case for asynchronous agent notifications (outbox).
+
         Returns:
             True if all chunks sent successfully, False otherwise.
         """
@@ -120,16 +146,21 @@ class SlackProvider(MessagingProvider):
             print("[slack] Not configured — cannot send.", file=sys.stderr)
             return False
 
+        thread_ts = ""
+        if reply_to_message_id:
+            with self._state_lock:
+                thread_ts = self._thread_by_token.get(reply_to_message_id, "")
+
         ok = True
         for chunk in self.chunk_message(text, max_size=MAX_MESSAGE_SIZE):
             with self._send_lock:
                 self._apply_rate_limit()
 
+                kwargs = {"channel": self._channel_id, "text": chunk}
+                if thread_ts:
+                    kwargs["thread_ts"] = thread_ts
                 try:
-                    resp = self._web_client.chat_postMessage(
-                        channel=self._channel_id,
-                        text=chunk,
-                    )
+                    resp = self._web_client.chat_postMessage(**kwargs)
                     if not resp.get("ok"):
                         print(f"[slack] API error: {resp.get('error', 'unknown')}",
                               file=sys.stderr)
@@ -193,6 +224,12 @@ class SlackProvider(MessagingProvider):
         if not self._should_process_event(event):
             return
 
+        # Dedup: Slack delivers both ``app_mention`` and ``message`` for a
+        # channel mention. Act on the first; ignore the redelivery.
+        ts = event.get("ts", "")
+        if ts and self._is_duplicate(ts):
+            return
+
         text = self._extract_message_text(event)
         if not text:
             return
@@ -210,7 +247,14 @@ class SlackProvider(MessagingProvider):
             pass
 
     def _should_process_event(self, event: dict) -> bool:
-        """Check if event should be processed (correct type, channel, not a bot)."""
+        """Decide whether an incoming event is for the bot.
+
+        Accepts: message/app_mention events, in the configured channel, not from
+        a bot or our own user, that either (a) @mention the bot / are
+        app_mentions, or (b) are replies in a thread the bot is already engaged
+        in. This keeps the bot quiet in shared channels until it is pinged, then
+        lets a conversation continue in-thread without re-mentioning.
+        """
         event_type = event.get("type", "")
         if event_type not in ("message", "app_mention"):
             return False
@@ -219,11 +263,59 @@ class SlackProvider(MessagingProvider):
         if event.get("channel", "") != self._channel_id:
             return False
 
-        # Skip bot messages and subtypes (edits, joins, etc.)
+        # Skip bot messages, subtypes (edits, joins, etc.), and our own messages
         if event.get("bot_id") or event.get("subtype"):
             return False
+        if self._bot_user_id and event.get("user", "") == self._bot_user_id:
+            return False
 
-        return True
+        return self._is_addressed_to_bot(event)
+
+    def _is_addressed_to_bot(self, event: dict) -> bool:
+        """Return True for app_mentions, direct @mentions, or engaged threads.
+
+        Side effect: when the bot is addressed, the conversation's thread root is
+        marked engaged so subsequent replies in that thread are handled too.
+        """
+        text = event.get("text", "")
+        mentioned = bool(self._bot_user_id) and f"<@{self._bot_user_id}>" in text
+        # For a channel-root message Slack omits thread_ts; the message's own ts
+        # is the root of the thread the bot will reply into.
+        thread_root = event.get("thread_ts") or event.get("ts", "")
+
+        if event.get("type") == "app_mention" or mentioned:
+            if thread_root:
+                self._mark_engaged(thread_root)
+            return True
+
+        # Continuation: a reply within a thread the bot is already part of.
+        event_thread = event.get("thread_ts", "")
+        with self._state_lock:
+            return bool(event_thread) and event_thread in self._engaged_threads
+
+    # -- bounded-state helpers -------------------------------------------------
+
+    @staticmethod
+    def _bounded_add(store: "OrderedDict", key, value, limit: int) -> None:
+        store[key] = value
+        store.move_to_end(key)
+        while len(store) > limit:
+            store.popitem(last=False)
+
+    def _mark_engaged(self, thread_ts: str) -> None:
+        with self._state_lock:
+            self._bounded_add(self._engaged_threads, thread_ts, None, _MAX_ENGAGED_THREADS)
+
+    def _is_duplicate(self, ts: str) -> bool:
+        with self._state_lock:
+            if ts in self._seen_ts:
+                return True
+            self._bounded_add(self._seen_ts, ts, None, _MAX_SEEN_TS)
+            return False
+
+    def _remember_thread(self, token: int, thread_ts: str) -> None:
+        with self._state_lock:
+            self._bounded_add(self._thread_by_token, token, thread_ts, _MAX_THREAD_TOKENS)
 
     def _extract_message_text(self, event: dict) -> str:
         """Extract and clean message text from event."""
@@ -238,16 +330,35 @@ class SlackProvider(MessagingProvider):
         return text
 
     def _queue_update(self, text: str, event: dict, payload: dict):
-        """Create and queue an Update from processed event data."""
+        """Create and queue an Update from processed event data.
+
+        ``raw_data`` is built in the Telegram-shaped envelope the bridge main
+        loop expects (``message.text`` / ``message.chat.id`` / ``message.message_id``)
+        so a single provider-agnostic loop handles every provider. The int
+        ``message_id`` is a token mapping back to this message's ``thread_ts`` so
+        the bridge's reply context can route the reply into the right thread.
+        """
+        thread_ts = event.get("thread_ts") or event.get("ts", "")
+        token = next(self._update_counter)
+        if thread_ts:
+            self._remember_thread(token, thread_ts)
+
+        envelope = {
+            "message": {
+                "text": text,
+                "chat": {"id": self._channel_id},
+                "message_id": token,
+            }
+        }
         update = Update(
-            update_id=next(self._update_counter),
+            update_id=token,
             message=Message(
                 text=text,
                 role="user",
                 timestamp=event.get("ts", ""),
                 raw_data=event,
             ),
-            raw_data=payload,
+            raw_data=envelope,
         )
         self._message_queue.put(update)
 

--- a/koan/app/messaging/slack.py
+++ b/koan/app/messaging/slack.py
@@ -72,6 +72,8 @@ class SlackProvider(MessagingProvider):
         # Slack delivers both ``app_mention`` and ``message`` for a channel
         # mention; dedup by event ts so we only act once.
         self._seen_ts: "OrderedDict[str, None]" = OrderedDict()
+        # Warn only once if the assistant status API is unavailable.
+        self._status_warned: bool = False
 
     # -- MessagingProvider interface ------------------------------------------
 
@@ -191,7 +193,56 @@ class SlackProvider(MessagingProvider):
                 break
         return updates
 
+    def send_typing(self, reply_to_message_id: int = 0, status: str = "") -> bool:
+        """Show a "thinking" status in the message's thread.
+
+        Uses Slack's assistant status API (``assistant.threads.setStatus``),
+        which renders greyed italic text under the bot name. It accepts the
+        ``chat:write`` scope the app already has and needs only the channel and
+        a ``thread_ts``. Slack auto-clears the status when the bot posts its
+        reply; ``stop_typing()`` covers error/early-exit paths.
+
+        Failures (e.g. the thread is not assistant-enabled) are swallowed: the
+        status is best-effort UX and must never affect the actual reply.
+        """
+        thread_ts = self._thread_for_token(reply_to_message_id)
+        if not thread_ts or not self._web_client:
+            return True
+        return self._set_status(thread_ts, status or "is thinking…")
+
+    def stop_typing(self, reply_to_message_id: int = 0) -> bool:
+        """Clear the assistant status for the message's thread."""
+        thread_ts = self._thread_for_token(reply_to_message_id)
+        if not thread_ts or not self._web_client:
+            return True
+        return self._set_status(thread_ts, "")
+
     # -- Internal helpers -----------------------------------------------------
+
+    def _thread_for_token(self, token: int) -> str:
+        """Resolve an inbound message token back to its Slack thread_ts."""
+        if not token:
+            return ""
+        with self._state_lock:
+            return self._thread_by_token.get(token, "")
+
+    def _set_status(self, thread_ts: str, status: str) -> bool:
+        """Best-effort assistant status update; swallow API/SDK errors."""
+        try:
+            self._web_client.assistant_threads_setStatus(
+                channel_id=self._channel_id,
+                thread_ts=thread_ts,
+                status=status,
+            )
+            return True
+        except Exception as e:
+            # Common when the thread is not assistant-enabled — non-fatal.
+            # Warn once per process so a 4s refresh loop doesn't spam stderr.
+            if not self._status_warned:
+                self._status_warned = True
+                print(f"[slack] assistant status unavailable (skipping): {e}",
+                      file=sys.stderr)
+            return True
 
     def _apply_rate_limit(self):
         """Sleep if needed to comply with Slack's rate limit (~1 msg/sec)."""

--- a/koan/app/messaging/telegram.py
+++ b/koan/app/messaging/telegram.py
@@ -357,8 +357,13 @@ class TelegramProvider(MessagingProvider):
             self._last_message_ids.append(msg_id)
         return True
 
-    def send_typing(self) -> bool:
-        """Send 'typing...' indicator to the Telegram chat."""
+    def send_typing(self, reply_to_message_id: int = 0, status: str = "") -> bool:
+        """Send 'typing...' indicator to the Telegram chat.
+
+        Telegram has a single chat-wide typing action with no custom text, so
+        ``reply_to_message_id`` and ``status`` are accepted for interface
+        compatibility but ignored.
+        """
         if not self._bot_token or not self._chat_id:
             return False
         try:

--- a/koan/app/notify.py
+++ b/koan/app/notify.py
@@ -143,12 +143,29 @@ def _write_suppressed_to_journal(text: str, priority: NotificationPriority):
         log.warning("Failed to write suppressed message to journal: %s", e)
 
 
-class TypingIndicator:
-    """Context manager that sends typing indicators at regular intervals.
+# Rotating "thinking" phrases. Providers that render status text (Slack) cycle
+# through these; providers with a generic indicator (Telegram, Matrix) ignore
+# the text. Cosmetic UI strings — not LLM prompts.
+THINKING_PHRASES = (
+    "Thinking…",
+    "Reading the code…",
+    "Working on it…",
+    "Putting it together…",
+)
 
-    Telegram's typing indicator expires after ~5 seconds. This keeps
-    re-sending it every `interval` seconds in a background thread until
-    the context exits.
+
+class TypingIndicator:
+    """Context manager that sends typing / "thinking" indicators periodically.
+
+    Telegram's typing indicator expires after ~5 seconds, so this re-sends it
+    every `interval` seconds in a background thread until the context exits.
+    For providers with a sticky, text-bearing status (Slack's assistant
+    status), it rotates through `THINKING_PHRASES` and clears the status on
+    exit.
+
+    The reply context (which thread to target) is captured from the *entering*
+    thread, because the background loop thread has no thread-local reply
+    context of its own.
 
     Usage:
         with TypingIndicator():
@@ -159,9 +176,12 @@ class TypingIndicator:
         self._interval = interval
         self._stop_event = threading.Event()
         self._thread: Optional[threading.Thread] = None
+        self._reply_to: int = 0
+        self._phrase_idx: int = 0
 
     def __enter__(self):
-        send_typing()  # Send immediately
+        self._reply_to = get_reply_context()
+        self._tick()  # Send immediately
         self._thread = threading.Thread(target=self._loop, daemon=True)
         self._thread.start()
         return self
@@ -170,19 +190,35 @@ class TypingIndicator:
         self._stop_event.set()
         if self._thread:
             self._thread.join(timeout=2)
+        stop_typing(self._reply_to)
         return False
+
+    def _tick(self):
+        phrase = THINKING_PHRASES[self._phrase_idx % len(THINKING_PHRASES)]
+        self._phrase_idx += 1
+        send_typing(reply_to=self._reply_to, status=phrase)
 
     def _loop(self):
         while not self._stop_event.wait(self._interval):
-            send_typing()
+            self._tick()
 
 
-def send_typing() -> bool:
-    """Send a typing indicator via the active messaging provider."""
+def send_typing(reply_to: int = 0, status: str = "") -> bool:
+    """Send a typing / "thinking" indicator via the active messaging provider."""
     try:
         from app.messaging import get_messaging_provider
         provider = get_messaging_provider()
-        return provider.send_typing()
+        return provider.send_typing(reply_to_message_id=reply_to, status=status)
+    except SystemExit:
+        return False
+
+
+def stop_typing(reply_to: int = 0) -> bool:
+    """Clear a persistent "thinking" indicator via the active provider."""
+    try:
+        from app.messaging import get_messaging_provider
+        provider = get_messaging_provider()
+        return provider.stop_typing(reply_to_message_id=reply_to)
     except SystemExit:
         return False
 

--- a/koan/app/onboarding_helpers.py
+++ b/koan/app/onboarding_helpers.py
@@ -202,5 +202,7 @@ def _has_koan_remote(path: Path) -> bool:
         return False
     if result.returncode != 0:
         return False
-    remotes = result.stdout.lower()
+    # Normalize SSH form (git@github.com:owner/repo) to the HTTPS path form
+    # so both remote styles match the expected repository.
+    remotes = result.stdout.lower().replace("github.com:", "github.com/")
     return "github.com/anantys-oss/koan" in remotes

--- a/koan/requirements.txt
+++ b/koan/requirements.txt
@@ -11,5 +11,6 @@ pytest-xdist>=3.5
 # stdlib: sqlite3 (used by memory_db.py — FTS5 extension required for ranked
 # search; graceful fallback to JSONL when FTS5 unavailable)
 
-# Optional: Slack provider (install with: pip install slack-sdk)
-# slack-sdk>=3.27
+# Slack provider (Socket Mode bridge). Pure-Python, light; only loaded when
+# KOAN_MESSAGING_PROVIDER=slack. Telegram remains the default provider.
+slack-sdk>=3.27

--- a/koan/tests/test_notify.py
+++ b/koan/tests/test_notify.py
@@ -8,7 +8,8 @@ import pytest
 
 from app.notify import (
     send_telegram, format_and_send, reset_flood_state,
-    send_typing, TypingIndicator,
+    send_typing, stop_typing, TypingIndicator, THINKING_PHRASES,
+    set_reply_context, clear_reply_context,
     _send_raw_bypass_flood, _direct_send,
     invalidate_file_cache, _file_cache,
     NotificationPriority, NOTIFICATION_SUPPRESSED,
@@ -389,6 +390,32 @@ class TestSendTyping:
     def test_returns_false_on_system_exit(self, mock_get_provider):
         assert send_typing() is False
 
+    @patch("app.messaging.get_messaging_provider")
+    def test_passes_reply_to_and_status(self, mock_get_provider):
+        mock_provider = MagicMock()
+        mock_provider.send_typing.return_value = True
+        mock_get_provider.return_value = mock_provider
+        send_typing(reply_to=7, status="Thinking…")
+        mock_provider.send_typing.assert_called_once_with(
+            reply_to_message_id=7, status="Thinking…"
+        )
+
+
+class TestStopTyping:
+    """Tests for the stop_typing() facade."""
+
+    @patch("app.messaging.get_messaging_provider")
+    def test_delegates_to_provider(self, mock_get_provider):
+        mock_provider = MagicMock()
+        mock_provider.stop_typing.return_value = True
+        mock_get_provider.return_value = mock_provider
+        assert stop_typing(7) is True
+        mock_provider.stop_typing.assert_called_once_with(reply_to_message_id=7)
+
+    @patch("app.messaging.get_messaging_provider", side_effect=SystemExit(1))
+    def test_returns_false_on_system_exit(self, mock_get_provider):
+        assert stop_typing() is False
+
 
 class TestTypingIndicator:
     """Tests for TypingIndicator context manager."""
@@ -400,6 +427,34 @@ class TestTypingIndicator:
             with TypingIndicator():
                 time.sleep(0.02)
             mock_provider.send_typing.assert_called()
+
+    def test_clears_status_on_exit(self):
+        mock_provider = MagicMock()
+        mock_provider.send_typing.return_value = True
+        with patch("app.messaging.get_messaging_provider", return_value=mock_provider):
+            with TypingIndicator():
+                time.sleep(0.02)
+        mock_provider.stop_typing.assert_called()
+
+    def test_captures_reply_context_and_rotates_phrases(self):
+        mock_provider = MagicMock()
+        mock_provider.send_typing.return_value = True
+        with patch("app.messaging.get_messaging_provider", return_value=mock_provider):
+            set_reply_context(42)
+            try:
+                with TypingIndicator(interval=0.05):
+                    time.sleep(0.15)
+            finally:
+                clear_reply_context()
+        statuses = [c.kwargs.get("status") for c in mock_provider.send_typing.call_args_list]
+        reply_tos = {c.kwargs.get("reply_to_message_id") for c in mock_provider.send_typing.call_args_list}
+        # Reply context captured at enter and reused on the background thread.
+        assert reply_tos == {42}
+        # Phrases come from the rotating set, and at least two distinct ones used.
+        assert all(s in THINKING_PHRASES for s in statuses)
+        assert len(set(statuses)) >= 2
+        # Status cleared for the same thread on exit.
+        mock_provider.stop_typing.assert_called_with(reply_to_message_id=42)
 
     def test_stops_sending_on_exit(self):
         mock_provider = MagicMock()

--- a/koan/tests/test_skills.py
+++ b/koan/tests/test_skills.py
@@ -3143,7 +3143,7 @@ class TestValidateSkillMetadata:
 
     def test_unknown_key_typo_suggests_correction(self, tmp_path):
         meta = self._meta()
-        meta["descrption"] = "typo"  # noqa: typo intentional
+        meta["descrption"] = "typo"  # 'descrption' typo is intentional
         warnings = validate_skill_metadata(meta, tmp_path / "SKILL.md")
         assert any("unknown key 'descrption'" in w and "description" in w for w in warnings)
 
@@ -3175,7 +3175,7 @@ class TestValidateSkillMetadata:
         skill_md.write_text(
             "---\n"
             "name: demo\n"
-            "descrption: typo here\n"  # noqa: typo intentional
+            "descrption: typo here\n"  # 'descrption' typo is intentional
             "commands:\n"
             "  - name: demo\n"
             "---\n"
@@ -3210,6 +3210,6 @@ class TestValidateSkillMetadata:
                 failures.extend(f"{name}: {w}" for w in warnings)
 
         assert not failures, (
-            f"Core skills with validation warnings:\n"
+            "Core skills with validation warnings:\n"
             + "\n".join(f"  - {f}" for f in failures)
         )

--- a/koan/tests/test_slack_provider.py
+++ b/koan/tests/test_slack_provider.py
@@ -140,7 +140,8 @@ class TestHandleSocketEvent:
     """Test Socket Mode event handling and filtering logic."""
     
     def _make_request(self, event_type, channel, text,
-                      bot_id=None, subtype=None, ts="123.456"):
+                      bot_id=None, subtype=None, ts="123.456",
+                      user="U100", thread_ts=None):
         """Create a mock Socket Mode request with the given event properties."""
         req = MagicMock()
         req.envelope_id = "env-1"
@@ -150,15 +151,19 @@ class TestHandleSocketEvent:
             "text": text,
             "ts": ts,
         }
+        if user:
+            event["user"] = user
         if bot_id:
             event["bot_id"] = bot_id
         if subtype:
             event["subtype"] = subtype
+        if thread_ts:
+            event["thread_ts"] = thread_ts
         req.payload = {"event": event}
         return req
 
-    def test_message_event(self, provider):
-        req = self._make_request("message", "C123", "hello")
+    def test_app_mention_event(self, provider):
+        req = self._make_request("app_mention", "C123", "<@U999> hello")
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.qsize() == 1
         update = provider._message_queue.get_nowait()
@@ -170,23 +175,41 @@ class TestHandleSocketEvent:
         update = provider._message_queue.get_nowait()
         assert update.message.text == "do something"
 
+    def test_plain_message_without_mention_ignored(self, provider):
+        # Mention-gating: ordinary channel chatter must not trigger the bot.
+        req = self._make_request("message", "C123", "just chatting")
+        provider._handle_socket_event(MagicMock(), req)
+        assert provider._message_queue.empty()
+
+    def test_inline_mention_in_message_processed(self, provider):
+        req = self._make_request("message", "C123", "hey <@U999> ship it")
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == "hey ship it"
+
     def test_ignores_other_channels(self, provider):
-        req = self._make_request("message", "C999", "wrong channel")
+        req = self._make_request("app_mention", "C999", "<@U999> wrong channel")
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.empty()
 
     def test_ignores_bot_messages(self, provider):
-        req = self._make_request("message", "C123", "bot msg", bot_id="B123")
+        req = self._make_request("message", "C123", "<@U999> bot msg", bot_id="B123")
+        provider._handle_socket_event(MagicMock(), req)
+        assert provider._message_queue.empty()
+
+    def test_ignores_own_messages(self, provider):
+        req = self._make_request("app_mention", "C123", "<@U999> echo", user="U999")
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.empty()
 
     def test_ignores_subtypes(self, provider):
-        req = self._make_request("message", "C123", "edited", subtype="message_changed")
+        req = self._make_request("message", "C123", "<@U999> edited",
+                                 subtype="message_changed")
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.empty()
 
     def test_ignores_empty_text(self, provider):
-        req = self._make_request("message", "C123", "")
+        req = self._make_request("app_mention", "C123", "")
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.empty()
 
@@ -195,9 +218,40 @@ class TestHandleSocketEvent:
         provider._handle_socket_event(MagicMock(), req)
         assert provider._message_queue.empty()
 
+    def test_duplicate_ts_processed_once(self, provider):
+        # app_mention + message double-delivery share a ts; act once.
+        mention = self._make_request("app_mention", "C123", "<@U999> go", ts="9.1")
+        echo = self._make_request("message", "C123", "<@U999> go", ts="9.1")
+        provider._handle_socket_event(MagicMock(), mention)
+        provider._handle_socket_event(MagicMock(), echo)
+        assert provider._message_queue.qsize() == 1
+
+    def test_thread_continuation_without_mention(self, provider):
+        # First a mention at channel root (ts=10.0) engages the thread...
+        root = self._make_request("app_mention", "C123", "<@U999> start", ts="10.0")
+        provider._handle_socket_event(MagicMock(), root)
+        provider._message_queue.get_nowait()
+        # ...then a plain reply in that thread is handled without re-mention.
+        reply = self._make_request("message", "C123", "and continue",
+                                   ts="11.0", thread_ts="10.0")
+        provider._handle_socket_event(MagicMock(), reply)
+        update = provider._message_queue.get_nowait()
+        assert update.message.text == "and continue"
+
+    def test_envelope_is_telegram_shaped(self, provider):
+        # The bridge main loop reads message.text / message.chat.id / message_id.
+        req = self._make_request("app_mention", "C123", "<@U999> hi")
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        env = update.raw_data
+        assert env["message"]["text"] == "hi"
+        assert env["message"]["chat"]["id"] == "C123"
+        assert isinstance(env["message"]["message_id"], int)
+        assert env["message"]["message_id"] != 0
+
     def test_update_counter_increments(self, provider):
-        req1 = self._make_request("message", "C123", "first")
-        req2 = self._make_request("message", "C123", "second")
+        req1 = self._make_request("app_mention", "C123", "<@U999> first", ts="1.0")
+        req2 = self._make_request("app_mention", "C123", "<@U999> second", ts="2.0")
         provider._handle_socket_event(MagicMock(), req1)
         provider._handle_socket_event(MagicMock(), req2)
         u1 = provider._message_queue.get_nowait()
@@ -217,6 +271,42 @@ class TestHandleSocketEvent:
         }):
             provider._handle_socket_event(mock_client, req)
         mock_client.send_socket_mode_response.assert_called_once()
+
+
+class TestThreadedSend:
+    """Replies route into the Slack thread of the originating message."""
+
+    def test_reply_uses_thread_ts(self, provider):
+        provider._web_client.chat_postMessage.return_value = {"ok": True}
+        # Simulate an inbound mention that registered token 1 -> thread_ts.
+        req = MagicMock()
+        req.envelope_id = "e1"
+        req.payload = {"event": {
+            "type": "app_mention", "channel": "C123",
+            "text": "<@U999> hi", "ts": "100.5", "user": "U100",
+        }}
+        provider._handle_socket_event(MagicMock(), req)
+        update = provider._message_queue.get_nowait()
+        token = update.raw_data["message"]["message_id"]
+
+        assert provider.send_message("reply", reply_to_message_id=token) is True
+        provider._web_client.chat_postMessage.assert_called_once_with(
+            channel="C123", text="reply", thread_ts="100.5"
+        )
+
+    def test_unknown_token_posts_to_channel_root(self, provider):
+        provider._web_client.chat_postMessage.return_value = {"ok": True}
+        assert provider.send_message("hi", reply_to_message_id=4242) is True
+        provider._web_client.chat_postMessage.assert_called_once_with(
+            channel="C123", text="hi"
+        )
+
+    def test_no_reply_context_posts_to_channel_root(self, provider):
+        provider._web_client.chat_postMessage.return_value = {"ok": True}
+        assert provider.send_message("async note") is True
+        provider._web_client.chat_postMessage.assert_called_once_with(
+            channel="C123", text="async note"
+        )
 
 
 class TestSendRaw:

--- a/koan/tests/test_slack_provider.py
+++ b/koan/tests/test_slack_provider.py
@@ -309,6 +309,58 @@ class TestThreadedSend:
         )
 
 
+class TestTypingStatus:
+    """Slack 'thinking' status via assistant.threads.setStatus."""
+
+    def _register_token(self, provider, token, thread_ts):
+        provider._thread_by_token[token] = thread_ts
+
+    def test_send_typing_sets_status_in_thread(self, provider):
+        self._register_token(provider, 5, "100.5")
+        provider._web_client.assistant_threads_setStatus.return_value = {"ok": True}
+        assert provider.send_typing(reply_to_message_id=5, status="Thinking…") is True
+        provider._web_client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123", thread_ts="100.5", status="Thinking…"
+        )
+
+    def test_send_typing_defaults_status_text(self, provider):
+        self._register_token(provider, 5, "100.5")
+        provider._web_client.assistant_threads_setStatus.return_value = {"ok": True}
+        provider.send_typing(reply_to_message_id=5)
+        _, kwargs = provider._web_client.assistant_threads_setStatus.call_args
+        assert kwargs["status"]  # non-empty fallback
+
+    def test_send_typing_unknown_token_is_noop(self, provider):
+        assert provider.send_typing(reply_to_message_id=999, status="Thinking…") is True
+        provider._web_client.assistant_threads_setStatus.assert_not_called()
+
+    def test_send_typing_zero_token_is_noop(self, provider):
+        assert provider.send_typing(reply_to_message_id=0, status="Thinking…") is True
+        provider._web_client.assistant_threads_setStatus.assert_not_called()
+
+    def test_stop_typing_clears_status(self, provider):
+        self._register_token(provider, 5, "100.5")
+        provider._web_client.assistant_threads_setStatus.return_value = {"ok": True}
+        assert provider.stop_typing(reply_to_message_id=5) is True
+        provider._web_client.assistant_threads_setStatus.assert_called_once_with(
+            channel_id="C123", thread_ts="100.5", status=""
+        )
+
+    def test_api_errors_are_swallowed(self, provider):
+        self._register_token(provider, 5, "100.5")
+        provider._web_client.assistant_threads_setStatus.side_effect = Exception("nope")
+        # Best-effort UX: never propagate, never block the reply.
+        assert provider.send_typing(reply_to_message_id=5, status="Thinking…") is True
+        assert provider.stop_typing(reply_to_message_id=5) is True
+
+    def test_not_configured_is_noop(self):
+        from app.messaging.slack import SlackProvider
+        p = SlackProvider()
+        p._thread_by_token[5] = "100.5"
+        assert p.send_typing(reply_to_message_id=5, status="Thinking…") is True
+        assert p.stop_typing(reply_to_message_id=5) is True
+
+
 class TestSendRaw:
     def test_send_raw(self, provider):
         provider._web_client.chat_postMessage.return_value = {"ok": True}


### PR DESCRIPTION
## Summary

Makes the Slack provider a fully working, first-class messaging bridge and adds a Hermes-style "thinking" status — without touching Telegram.

### 1. Fix the Slack bridge (it was effectively non-functional)
- **Inbound was silently dropped**: the bridge main loop parses every update as a Telegram-shaped envelope (`message.text` / `message.chat.id` / `message.message_id`), but the Slack provider exposed the raw Socket Mode payload — so every Slack message was ignored. Now it emits the same Telegram-shaped envelope, so one provider-agnostic loop handles both.
- **`slack-sdk`** promoted from an optional, commented-out dependency to a real one (it failed at import on a clean install).
- **Threading**: reply in a thread when @mentioned, and continue in-thread without re-mentioning. Slack threads are keyed by `thread_ts` (string), carried through the existing int `reply_to_message_id` plumbing via a bounded token map.
- **Mention-gating + dedup**: the bot stays quiet until pinged, then continues in engaged threads; Slack's `app_mention`+`message` double-delivery is de-duplicated; the bot skips its own messages.
- Ready-to-paste **app manifest** + setup docs.

### 2. "Thinking" status while replying
- While processing a chat reply, Kōan shows a rotating greyed status under the bot name via Slack's assistant status API (`assistant.threads.setStatus`), cleared when the reply posts.
- Extends the provider contract: `send_typing(reply_to_message_id, status)` + new `stop_typing()`; `TypingIndicator` captures reply context and rotates phrases. Telegram/Matrix ignore the new args (behavior unchanged).
- Best-effort: a failed status call is warned once and never blocks or alters the reply.

### 3. Onboarding SSH fix (bundled)
- `setup_workspace_koan` now recognizes the canonical repo via an SSH remote (`git@github.com:…`), not just the HTTPS form — a clean fork checkout (origin=fork, upstream=SSH canonical) no longer fails the `workspace_koan` setup step.

## Testing
- `make lint` clean; full messaging/bridge suite green (1023 passed), incl. new Slack threading/status + notify rotation/stop tests.
- Verified live: bridge selects Slack, Socket Mode connects, in-thread replies work.

## Notes
- Telegram behavior is unchanged; all changes are isolated to the messaging layer.
- Scope: Kōan replies only in the configured channel; the Assistant pane is not yet conversational (docs clarified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)