### PR TITLE
ci: bump GitHub Actions to latest major versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     name: release
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           fetch-tags: true

--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -10,7 +10,7 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,7 +40,7 @@ jobs:
     name: test (py${{ matrix.python-version }}, ${{ matrix.group.name }})
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ⚙️ Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6
@@ -89,7 +89,7 @@ jobs:
     name: check-coverage
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: ⚙️ Set up Python 3.14
         uses: actions/setup-python@v6
@@ -101,7 +101,7 @@ jobs:
         run: pip install coverage
 
       - name: ⬇️ Download all coverage artifacts
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: coverage-py*
           path: coverage-parts


### PR DESCRIPTION
Update actions to their most recent major stable release, resolving the Node 20 deprecation warning emitted by actions/github-script@v7.

- actions/github-script v7 -> v9 (Node 24; fixes deprecation warning)
- actions/checkout v6 -> v7
- actions/download-artifact v7 -> v8

setup-python, upload-artifact, and the docker/* actions were already on their latest major versions.