### PR TITLE
ci: use Father-Koan as review fallback bot

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -15,7 +15,7 @@ jobs:
           github-token: ${{ secrets.BOT_TOKEN }}
           script: |
             const bot = 'Koan-Bot';
-            const fallbackBot = 'Koanex';
+            const fallbackBot = 'Father-Koan';
             const author = context.payload.pull_request.user.login;
             let commented = false;
 


### PR DESCRIPTION
**What**: Change the review-request fallback bot from `Koanex` to `Father-Koan`.

**Why**: `Koanex` is no longer the desired fallback reviewer. When the primary `Koan-Bot` review request fails (e.g. author is the bot itself, or the request errors), the workflow should fall back to `Father-Koan`.

**How**: Single-line change to `const fallbackBot` in `.github/workflows/request-review.yml`. Primary bot and control flow unchanged.

**Testing**: Config-only change to a github-script step; no test suite applies. Verified the diff is the intended one-line substitution.
