### PR TITLE
fix: stop infinite mission re-pick loop on [complexity:X] tags (#2082)

### DIFF
--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1043,12 +1043,16 @@ def _remove_item_by_text(
         (ln.strip() for ln in needle.splitlines() if ln.strip()),
         needle,
     )
-    # Collapse internal whitespace runs in the needle so it matches the
-    # collapsed `comparable` below. Without this, a mission whose text
-    # contains double spaces (e.g. inline /plan context) can never match —
-    # the runner succeeds but the mission is never moved out of Pending,
-    # so it re-dispatches on every loop iteration forever.
-    line_needle = re.sub(r"\s+", " ", line_needle)
+    # Normalise the needle the SAME way `comparable` is normalised below:
+    # strip any [complexity:X] tag, then collapse whitespace runs. The picker
+    # may hand us a title that still carries the `[complexity:simple]` tag
+    # while the stored line has had it stripped (or vice-versa); without
+    # normalising both sides identically the substring check never matches,
+    # the runner succeeds but the mission is never moved out of Pending, and
+    # it re-dispatches on every loop iteration forever (the infinite re-pick
+    # loop). The same hazard exists for missions whose text contains double
+    # spaces (e.g. inline /plan context).
+    line_needle = re.sub(r"\s+", " ", _COMPLEXITY_TAG_RE.sub("", line_needle))
 
     lines = content.splitlines()
     boundaries = find_section_boundaries(lines)

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -1970,6 +1970,55 @@ class TestStartMission:
         assert "Already running task" in failed_text
         assert "[flushed]" in failed_text
 
+    def test_picked_title_with_complexity_tag_matches(self):
+        """Regression: infinite re-pick loop (issue #2082).
+
+        The picker can hand start_mission a title that still carries a
+        ``[complexity:X]`` tag while the stored Pending line has had its tag
+        position/spacing normalised. The needle and candidate must be
+        normalised identically, otherwise the mission is never moved out of
+        Pending and the agent loop re-dispatches it forever.
+        """
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- [project:koan] /plan https://example.com/issues/1 \U0001f4ec "
+            "[complexity:simple] ⏳(2026-06-24T12:23)\n\n"
+            "## In Progress\n\n"
+            "## Done\n"
+        )
+        # Title as returned by the picker — retains the complexity tag.
+        title = (
+            "[project:koan] /plan https://example.com/issues/1 \U0001f4ec "
+            "[complexity:simple] ⏳(2026-06-24T12:23)"
+        )
+        result = start_mission(content, title)
+        sections = parse_sections(result)
+        assert len(sections["pending"]) == 0
+        assert len(sections["in_progress"]) == 1
+        assert "/plan https://example.com/issues/1" in sections["in_progress"][0]
+
+    def test_pending_line_with_stale_started_marker_self_heals(self):
+        """Regression: a Pending line left with a stale ``▶`` started marker
+        (from a prior crash mid-transition) must still be movable, so the loop
+        self-heals instead of spinning on it forever (issue #2082)."""
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- [project:koan] /implement https://example.com/issues/1 \U0001f4ec "
+            "[complexity:simple] ⏳(2026-06-24T12:23) ▶(2026-06-24T12:24)\n\n"
+            "## In Progress\n\n"
+            "## Done\n"
+        )
+        title = (
+            "[project:koan] /implement https://example.com/issues/1 \U0001f4ec "
+            "[complexity:simple] ⏳(2026-06-24T12:23) ▶(2026-06-24T12:24)"
+        )
+        result = start_mission(content, title)
+        sections = parse_sections(result)
+        assert len(sections["pending"]) == 0
+        assert len(sections["in_progress"]) == 1
+
 
 # ---------------------------------------------------------------------------
 # complete_mission / fail_mission — from In Progress (Bug fix)


### PR DESCRIPTION
## Problem

The agent loop entered an **infinite re-pick loop** on a single mission and made zero progress: the same `/plan` (then `/implement`) mission was picked every iteration, the run aborted with `Mission transition unconfirmed`, and the loop restarted immediately. No GitHub reply, no other mission ever ran, quota burned. Observed twice in a row (issue #2082).

## Root cause

`koan/app/missions.py::_remove_item_by_text()` strips the `[complexity:X]` tag from each **candidate** Pending line before comparing (`comparable = _COMPLEXITY_TAG_RE.sub("", stripped)`), but it did **not** strip the same tag from the **needle**.

When the picker handed `start_mission()` a title still carrying `[complexity:simple]`, the needle (`… 📬 [complexity:simple] ⏳…`) could never be a substring of the tag-stripped candidate (`… 📬 ⏳…`). The Pending item was never removed → `start_mission()` early-returned unchanged → `run.py`'s post-transition confirmation failed → the run aborted → the picker re-selected the same mission → ∞.

## Fix

Normalise the needle identically to the candidate (strip `[complexity:X]`, then collapse whitespace) before the substring check.

- **Self-heals** the stuck local state: a Pending line left with a stale `▶` started marker (crash mid-transition) can now be matched and moved instead of spun on forever — no manual `missions.md` edit needed.
- **Prevents recurrence**: needle and candidate now go through the same normalisation path.

## Tests

Two regression tests in `TestStartMission` reproduce the exact scenario (picked title with a `[complexity:X]` tag, and a Pending line carrying a stale `▶` marker). Both fail on `main`, pass with the fix. Full `test_missions*` / `test_pick_mission` / `test_complexity_tags` suites green; `make lint` clean.

Fixes #2082

🤖 Generated with [Claude Code](https://claude.com/claude-code)