### PR TITLE
fix(missions): stop zombie In Progress entries from start_mission TOCTOU (#2087)

### DIFF
--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -918,8 +918,22 @@ def _run_iteration(
     original_mission_title = mission_title
     if mission_title:
         if not _run._start_mission_in_file(instance, mission_title, project_name):
+            reason = (
+                "could not confirm the Pending→In Progress transition "
+                "(mission not found in In Progress after start_mission)"
+            )
             log("warning", f"start_mission transition failed for '{mission_title[:60]}' — "
-                "mission may still be in Pending; aborting this run to avoid duplicate execution.")
+                f"{reason}; aborting this run to avoid duplicate execution.")
+            # Never fail silently: surface the abort on Telegram with the reason
+            # so the operator knows the mission did not run (see issue #2087).
+            try:
+                _run._notify(
+                    instance,
+                    f"❌ [{project_name}] Mission not started: {mission_title}\n"
+                    f"Reason: {reason}.",
+                )
+            except Exception as notify_err:  # notification must never mask the abort
+                log("error", f"Failed to notify start_mission abort: {notify_err}")
             return False
 
     # --- Create structured checkpoint for recovery ---

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2197,12 +2197,23 @@ def _start_mission_in_file(instance: str, mission_title: str, project_name: str 
 
         after = modify_missions_file(missions_path, _transform)
         in_progress = parse_sections(after).get("in_progress", [])
-        # Normalise for comparison: strip leading "- ", collapse whitespace
+        # Confirm the transition using the SAME canonical identity that the
+        # removal step (_remove_item_by_text) uses, not a raw substring. The
+        # complexity classifier rewrites the on-disk Pending line by injecting
+        # ``[complexity:X]`` *between* the mission body and the ⏳ timestamp
+        # (tag_complexity_in_pending) AFTER ``mission_title`` was captured. A
+        # naive ``mission_title in entry`` check then fails because the in-memory
+        # title (``… 📬 ⏳(…)``) is no longer a contiguous substring of the stored
+        # line (``… 📬 [complexity:X] ⏳(…)``), even though the move succeeded —
+        # leaving an orphaned "zombie" In Progress entry. canonical_mission_key()
+        # strips the complexity tag and lifecycle timestamps from both sides, so
+        # the same logical mission matches regardless of when the tag was added.
         import re
-        clean_title = re.sub(r"\s+", " ", mission_title.strip())
+        from app.missions import canonical_mission_key
+        clean_title = re.sub(r"\s+", " ", canonical_mission_key(mission_title))
         for entry in in_progress:
-            entry_text = re.sub(r"\s+", " ", entry.strip().removeprefix("- "))
-            if clean_title in entry_text:
+            entry_text = re.sub(r"\s+", " ", canonical_mission_key(entry))
+            if clean_title and clean_title in entry_text:
                 # Clear counter only if a cap was previously hit (human deliberate
                 # retry) — stagnation-retry requeus must keep their count intact
                 # so the stagnation cap check in _finalize_mission still fires.

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6408,6 +6408,43 @@ class TestStartMissionSanityFlushLog:
         assert "leftover stale" not in "\n".join(sections.get("failed", []))
 
 
+class TestStartMissionComplexityTagTOCTOU:
+    """Regression for #2087: a [complexity:X] tag injected into the Pending
+    line *after* the mission title was captured must not break the transition
+    confirmation. Before the fix, the raw-substring check failed because the
+    captured title (``… 📬 ⏳(…)``) was no longer a contiguous substring of the
+    stored line (``… 📬 [complexity:medium] ⏳(…)``), leaving a zombie entry.
+    """
+
+    def test_transition_confirmed_when_complexity_tag_injected_midline(self, tmp_path):
+        from app.run import _start_mission_in_file
+        from app.missions import parse_sections
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        # The on-disk Pending line already carries the mid-line [complexity:X]
+        # tag (injected by the classifier), but the title we pass in is the
+        # pre-tag value the picker captured — exactly the production TOCTOU.
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n"
+            "- [project:koan] /implement \U0001F4EC [complexity:medium] "
+            "⏳(2026-06-24T15:15)\n\n"
+            "## In Progress\n\n## Done\n"
+        )
+
+        # Captured title: no project tag, no complexity tag, with queued stamp.
+        captured_title = "/implement \U0001F4EC ⏳(2026-06-24T15:15)"
+        with patch("app.run.log"):
+            assert _start_mission_in_file(
+                str(missions.parent), captured_title, "koan"
+            ) is True
+
+        sections = parse_sections(missions.read_text())
+        # The mission really moved to In Progress — no zombie left in Pending.
+        assert "/implement" in "\n".join(sections["in_progress"])
+        assert "/implement" not in "\n".join(sections["pending"])
+
+
 class TestPruneDecoupledFromFinalization:
     """History pruning is a standalone step, not a finalization side effect."""
 
@@ -7484,6 +7521,11 @@ class TestRunIterationPaths:
             mocks["run_claude_task"].assert_not_called()
             mocks["_finalize_mission"].assert_not_called()
             assert result is False
+            # Regression #2087: the abort must NOT be silent — the operator
+            # gets a Telegram message naming the mission and the reason.
+            notify_calls = [str(c) for c in mocks["_notify"].call_args_list]
+            assert any("not started" in c.lower() for c in notify_calls)
+            assert any("implement feature X" in c for c in notify_calls)
 
     # --- Mission failure still finalizes ---
 


### PR DESCRIPTION
Fixes #2087.

## Problem

Every fresh GitHub-triggered mission (`/implement`, `/plan`, `/review` …) was **silently dropped**: moved to `## In Progress` in `missions.md` but never executed, leaving an orphaned "zombie" entry that is never re-picked — and **no Telegram notification**. The operator saw a mission marked *In Progress* / "running Xm" while nothing happened. Deterministic, fired on every new GitHub mission.

## Root cause — TOCTOU between two commits

- **f7cc9422** (Apr 19) — `tag_complexity_in_pending()` injects `[complexity:X]` **in the middle** of the Pending line (before the `⏳` timestamp), after the picker captured `mission_title`. The in-memory title is never updated.
- **921560bb** (Jun 12) — added a **strict** post-move confirmation in `_start_mission_in_file()`: `clean_title in entry_text` (raw substring). It aborts on mismatch. This turned the latent inconsistency into a hard failure.

The removal step (`_remove_item_by_text`) is complexity-tag-tolerant so the move succeeds, but the confirmation was not — and because the tag is injected mid-line, the captured title (`… 📬 ⏳(…)`) is no longer a contiguous substring of the stored line (`… 📬 [complexity:X] ⏳(…)`). Confirmation fails → abort → zombie. Only fires on a cache miss (fresh classification), i.e. every new GitHub mission.

## Fix

- **`run.py`** — confirm the transition using the same canonical identity the removal step uses: `canonical_mission_key()` strips the `[complexity:X]` tag and lifecycle timestamps from **both** sides before the containment check. One definition of "two lines are the same mission".
- **`mission_executor.py`** — never fail silently: any unconfirmed start now emits a Telegram message `❌ [project] Mission not started: … Reason: …` so failures are operator-visible (the issue's explicit requirement).
- **tests** — regression reproducing the mid-line tag injection (confirmation must succeed, no zombie) + assert the abort path notifies Telegram.

## Verification

- New regression test fails on `main`, passes here.
- `koan/tests/test_run.py` + `test_complexity_tags.py`: **457 passed**.
- `make lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
