### PR TITLE
feat(docker): recommend prebuilt GHCR image

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -44,7 +44,22 @@ continue below.
 
 ## Docker
 
-To run Koan in a Docker container (for server deployment or local isolation), see the [Docker Setup Guide](docs/docker.md).
+Prefer to run Koan in a container (server deployment or local isolation)? The
+easiest path is the **prebuilt image** on GitHub Container Registry — no local build:
+
+```bash
+git clone https://github.com/Anantys-oss/koan.git && cd koan
+cp -r instance.example instance && cp env.example .env   # fill in messaging + auth creds
+./setup-docker.sh        # detect host paths, generate volume mounts
+make docker-auth         # subscription users: extract a Claude OAuth token from the host
+make docker-gh-auth      # inject your gh token for the container
+make docker-pull-up      # pull ghcr.io/anantys-oss/koan and start (or: make docker-up to build)
+```
+
+The image lives at [`ghcr.io/anantys-oss/koan`](https://github.com/Anantys-oss/koan/pkgs/container/koan)
+with `latest`, `stable`, and per-version tags. Building from source remains a
+first-class fallback. See the [Docker Setup Guide](docs/setup/docker.md) for the
+full walkthrough — authentication, GHCR access, image pinning, and troubleshooting.
 
 ## Prerequisites
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export
 .PHONY: ollama logs ssh-forward
 .PHONY: install-systemctl-service uninstall-systemctl-service
 .PHONY: install-launchd-service uninstall-launchd-service
-.PHONY: docker-setup docker-up docker-down docker-logs docker-test docker-auth docker-gh-auth
+.PHONY: docker-setup docker-pull-up docker-up docker-down docker-logs docker-test docker-auth docker-gh-auth
 
 .DEFAULT_GOAL := koan
 
@@ -295,9 +295,20 @@ uninstall-launchd-service:
 
 # --- Docker targets ---
 
+# Published image on GitHub Container Registry. Override the tag to pin a
+# release, e.g. make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:stable
+KOAN_IMAGE ?= ghcr.io/anantys-oss/koan:latest
+
 docker-setup:
 	@./setup-docker.sh
 
+# Recommended: pull the prebuilt image and start (no local build).
+docker-pull-up: docker-setup
+	KOAN_IMAGE="$(KOAN_IMAGE)" docker compose pull
+	KOAN_IMAGE="$(KOAN_IMAGE)" docker compose up -d --no-build
+	@echo "→ Kōan running from prebuilt image $(KOAN_IMAGE). Use 'make docker-logs' to watch output."
+
+# Fallback: build the image from source and start.
 docker-up: docker-setup
 	docker compose up --build -d
 	@echo "→ Kōan running in Docker. Use 'make docker-logs' to watch output."

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ This isn't a chatbot wrapper. It's a collaborator with memory, personality, and 
 
 ## Quick Start
 
+Run Kōan natively on your machine, or in a container — both are fully supported.
+
+### Native
+
 ```bash
 git clone https://github.com/Anantys-oss/koan.git
 cd koan
@@ -73,6 +77,23 @@ On macOS, keep your machine awake while Koan runs:
 ```bash
 caffeinate -s &
 ```
+
+### Docker
+
+Prefer containers (VPS/server hosting or a sandboxed local run)? Pull the
+prebuilt image from GitHub Container Registry — no local build:
+
+```bash
+git clone https://github.com/Anantys-oss/koan.git && cd koan
+cp -r instance.example instance && cp env.example .env   # then fill in messaging + auth creds
+./setup-docker.sh        # detect host paths, generate mounts
+make docker-pull-up      # pull & run prebuilt image (or: make docker-up to build from source)
+make docker-logs         # watch it work
+```
+
+The image lives at [`ghcr.io/anantys-oss/koan`](https://github.com/Anantys-oss/koan/pkgs/container/koan)
+(`latest`, `stable`, and per-version tags). Full guide — auth, GHCR access, pinning,
+and troubleshooting: [docs/setup/docker.md](docs/setup/docker.md).
 
 That's it. Send it a mission via Telegram: *"audit the auth module for security issues"* — and go live your life.
 
@@ -398,6 +419,8 @@ instance/                 # Your private data (gitignored)
 | `make dashboard` | Web UI (default: http://127.0.0.1:5001) |
 | `make test` | Run test suite |
 | `make say m="..."` | Send a test message |
+| `make docker-pull-up` | Pull the prebuilt GHCR image and run in Docker (recommended) |
+| `make docker-up` | Build the image from source and run in Docker |
 | `make rename-project old=X new=Y` | Rename a project everywhere (dry-run by default, add `apply=1` to execute) |
 | `make clean` | Remove virtualenv |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,15 +7,26 @@
 # Run ./setup-docker.sh first — it generates docker-compose.override.yml
 # with workspace mounts and GitHub CLI auth for your system.
 #
+# Two ways to get the image:
+#   - Prebuilt (recommended): set KOAN_IMAGE to the published GHCR ref and pull it.
+#       KOAN_IMAGE=ghcr.io/anantys-oss/koan:latest docker compose pull
+#       KOAN_IMAGE=ghcr.io/anantys-oss/koan:latest docker compose up -d --no-build
+#       (or just: make docker-pull-up)
+#   - Build from source (fallback): docker compose up --build  (tags koan:local)
+#
 # Usage:
 #   ./setup-docker.sh                        # Auto-detect host setup
 #   make docker-auth                         # Generate OAuth token from host CLI
-#   docker compose up --build                # Full stack (agent + bridge)
+#   make docker-pull-up                      # Pull prebuilt image + start (recommended)
+#   docker compose up --build                # Build from source (agent + bridge)
 #   docker compose run --rm koan test        # Run test suite
 #   docker compose run --rm koan shell       # Interactive shell
 
 services:
   koan:
+    # Defaults to a locally-built tag (koan:local). Override with the published
+    # GHCR ref to run the prebuilt image: KOAN_IMAGE=ghcr.io/anantys-oss/koan:latest
+    image: ${KOAN_IMAGE:-koan:local}
     build:
       context: .
       args:

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -17,10 +17,12 @@
 - **GitHub CLI (`gh`)** authenticated on the host (for PR/issue operations)
 - A messaging platform configured (**Telegram** or **Slack** — see [INSTALL.md](../../INSTALL.md#2-set-up-a-messaging-platform))
 
-## Quick Start
+## Quick Start (prebuilt image — recommended)
+
+Pull the published image from GitHub Container Registry — no local build needed.
 
 ```bash
-# 1. Clone and enter the repo
+# 1. Clone and enter the repo (needed for compose, setup-docker.sh, env template)
 git clone https://github.com/Anantys-oss/koan.git
 cd koan
 
@@ -51,12 +53,36 @@ make docker-gh-auth
 # Extracts your host's gh token and saves it to .env as GH_TOKEN.
 # Required because macOS Keychain tokens aren't accessible inside Docker.
 
-# 8. Build and start (runs setup-docker.sh first, then starts detached)
-make docker-up
-
-# Or start in the foreground to watch logs directly:
-# docker compose up --build
+# 8. Pull the prebuilt image and start (detached)
+make docker-pull-up
 ```
+
+> **GHCR access.** If `make docker-pull-up` fails with `denied` / `unauthorized`,
+> the package is private. Either ask an org owner to make it public
+> (`github.com/orgs/Anantys-oss → Packages → koan → Package settings →
+> Change visibility → Public`), or log in first with a Personal Access Token that
+> has the `read:packages` scope:
+>
+> ```bash
+> echo "$GH_PAT" | docker login ghcr.io -u YOUR_GH_USERNAME --password-stdin
+> ```
+
+> **Image tags & pinning.** `make docker-pull-up` defaults to
+> `ghcr.io/anantys-oss/koan:latest`. Pin a release with `KOAN_IMAGE`:
+>
+> ```bash
+> make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:stable
+> make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:v1.0   # major.minor
+> ```
+>
+> Available tags: `latest`, `stable`, and per-version (`vX.Y` / `X.Y.Z`).
+
+> **UID/GID on the prebuilt image.** The published image runs as UID/GID
+> **1000**. On Linux hosts whose user isn't 1000, bind-mounted `instance/` and
+> `logs/` can hit permission errors. If so, either build from source (below —
+> `setup-docker.sh` matches your host UID/GID) or run
+> `chown -R 1000:1000 instance logs`. macOS (Docker Desktop) maps UIDs
+> automatically, so this rarely bites there.
 
 Verify it's running:
 
@@ -66,6 +92,19 @@ docker compose logs -f
 
 # Send a test message (requires messaging to be configured)
 make say m="hello"
+```
+
+## Build from source (fallback)
+
+Build the image locally instead of pulling — useful for contributors, offline
+use, or to match a non-1000 host UID/GID exactly. Follow steps 1–7 above, then:
+
+```bash
+# 8. Build and start (runs setup-docker.sh first, then starts detached)
+make docker-up
+
+# Or start in the foreground to watch logs directly:
+# docker compose up --build
 ```
 
 ## Workspace Setup
@@ -249,19 +288,27 @@ regenerate them after changing your workspace layout.
 ### Make targets
 
 ```bash
-make docker-setup   # Run setup-docker.sh
-make docker-up      # Build and start (detached)
-make docker-down    # Stop the container
-make docker-logs    # Tail container logs
-make docker-test    # Run the test suite inside the container
-make docker-auth    # Extract Claude OAuth token from host CLI → .env
-make docker-gh-auth # Extract GitHub token from host gh CLI → .env
+make docker-setup    # Run setup-docker.sh
+make docker-pull-up  # Pull the prebuilt GHCR image and start (recommended)
+make docker-up       # Build from source and start (detached)
+make docker-down     # Stop the container
+make docker-logs     # Tail container logs
+make docker-test     # Run the test suite inside the container
+make docker-auth     # Extract Claude OAuth token from host CLI → .env
+make docker-gh-auth  # Extract GitHub token from host gh CLI → .env
+
+# Pin a specific published version (defaults to :latest):
+make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:stable
 ```
 
 ### Docker Compose commands
 
 ```bash
-# Start in foreground (see logs directly)
+# Pull the prebuilt image and start (what `make docker-pull-up` runs)
+KOAN_IMAGE=ghcr.io/anantys-oss/koan:latest docker compose pull
+KOAN_IMAGE=ghcr.io/anantys-oss/koan:latest docker compose up -d --no-build
+
+# Build from source and start in foreground (see logs directly)
 docker compose up --build
 
 # Generate OAuth token from host CLI (one-time, for subscription users)

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -72,10 +72,10 @@ make docker-pull-up
 >
 > ```bash
 > make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:stable
-> make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:v1.0   # major.minor
+> make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:1.0   # major.minor
 > ```
 >
-> Available tags: `latest`, `stable`, and per-version (`vX.Y` / `X.Y.Z`).
+> Available tags: `latest`, `stable`, and per-version (`X.Y` / `X.Y.Z`).
 
 > **UID/GID on the prebuilt image.** The published image runs as UID/GID
 > **1000**. On Linux hosts whose user isn't 1000, bind-mounted `instance/` and


### PR DESCRIPTION
The release workflow publishes an image to GHCR
(ghcr.io/anantys-oss/koan) on every release, but nothing told users it existed or how to run it, and the only documented container path built from source. Make the container a first-class, officially-recommended option that leads with the prebuilt image.

Wire the image path so it is actually runnable: add a parameterized `image: ${KOAN_IMAGE:-koan:local}` to the compose service (build section untouched) and a `docker-pull-up` Make target that pulls the published image and starts without building. `docker-up` (build from source) stays as the documented fallback.

Surface the recommendation early: split the README Quick Start into Native and Docker subsections, expand the INSTALL.md Docker section, and restructure docs/setup/docker.md to lead with the prebuilt-image quick start (with GHCR-access, tag-pinning, and UID/GID notes) ahead of the build-from-source flow.

Also fix the broken INSTALL.md link that pointed at docs/docker.md instead of docs/setup/docker.md.