### PR TITLE
feat(deep_research): git-churn hotspot detection for topic selection

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -23,9 +23,17 @@ Returns JSON with suggested topics and reasoning.
 
 import json
 import re
+import subprocess
 import sys
 from datetime import datetime, timedelta
 from pathlib import Path
+
+from app.diff_triage import _GENERATED_PATTERNS, _LOCKFILE_NAMES
+
+# Below this many commits a churn ranking is statistical noise — skip entirely.
+_MIN_COMMITS_FOR_HOTSPOTS = 20
+# Test files are intentionally high-churn; they are not debt hotspots.
+_TEST_PATH_RE = re.compile(r"(?:^|/)(?:tests?|__tests__)/|(?:^|/)test_[^/]+\.[a-z]+$|_test\.[a-z]+$")
 
 
 _STOP_WORDS = frozenset({
@@ -292,6 +300,78 @@ class DeepResearch:
             print(f"[deep_research] Topic categorization failed: {e}", file=sys.stderr)
             return "other"
 
+    def _gather_file_hotspots(self, top_n: int = 10) -> list[dict]:
+        """Rank source files by git churn over the last 200 commits.
+
+        High-churn files are simultaneously the most likely to harbor tech
+        debt and the most likely to break under autonomous modification, so
+        they make good DEEP-mode investment targets.
+
+        Excludes test, lockfile, and generated files (same sets as
+        ``diff_triage``). Returns ``[]`` when git is unavailable, the project
+        is too young (< 20 commits), or no qualifying files are found.
+
+        Each entry: ``{"file": str, "churn": float (0-1), "hint": str}``.
+        """
+        try:
+            output = subprocess.run(
+                ["git", "log", "--numstat", "--format=%H", "-200"],
+                cwd=str(self.project_path),
+                capture_output=True,
+                text=True,
+                timeout=30,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError) as e:
+            print(f"[deep_research] git churn unavailable: {e}", file=sys.stderr)
+            return []
+
+        if output.returncode != 0:
+            return []
+
+        commits = 0
+        counts: dict[str, int] = {}
+        for line in output.stdout.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # Commit hash lines (40 hex chars, no tab) delimit each commit.
+            if "\t" not in line:
+                commits += 1
+                continue
+            # numstat line: "<added>\t<removed>\t<path>"
+            parts = line.split("\t")
+            if len(parts) != 3:
+                continue
+            path = parts[2]
+            # Binary files report "-\t-"; rename arrows make the path ambiguous.
+            if "=>" in path or not self._is_hotspot_candidate(path):
+                continue
+            counts[path] = counts.get(path, 0) + 1
+
+        if commits < _MIN_COMMITS_FOR_HOTSPOTS or not counts:
+            return []
+
+        max_count = max(counts.values())
+        ranked = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)[:top_n]
+        return [
+            {
+                "file": path,
+                "churn": round(count / max_count, 2),
+                "hint": "High-churn file — consider test coverage or modularization",
+            }
+            for path, count in ranked
+        ]
+
+    @staticmethod
+    def _is_hotspot_candidate(path: str) -> bool:
+        """Reject test, lockfile, and generated paths from churn analysis."""
+        if _TEST_PATH_RE.search(path):
+            return False
+        if path.rsplit("/", 1)[-1] in _LOCKFILE_NAMES:
+            return False
+        return all(not pat.search(path) for pat in _GENERATED_PATTERNS)
+
     def suggest_topics(self) -> list[dict]:
         """
         Analyze all sources and suggest prioritized topics.
@@ -348,6 +428,19 @@ class DeepResearch:
                 "topic": item,
                 "source": "priorities.md (Technical Debt)",
                 "reasoning": "Known tech debt item, good for DEEP mode",
+                "priority": 2,
+            })
+
+        # Priority 2: Git-churn hotspots — structurally unstable files.
+        # Weighted below human priorities (1) but above journal recaps.
+        for spot in self._gather_file_hotspots():
+            topic = f"Investigate high-churn file: {spot['file']}"
+            if any(spot["file"].lower() in t.lower() for t in recent_topics):
+                continue
+            suggestions.append({
+                "topic": topic,
+                "source": "hotspot",
+                "reasoning": f"{spot['hint']} (churn score {spot['churn']})",
                 "priority": 2,
             })
 

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -1572,3 +1572,83 @@ class TestPrCoverage:
 
         assert "pending_prs" in data
         assert data["pending_prs"][0]["number"] == 42
+
+
+class TestFileHotspots:
+    """Tests for git-churn hotspot detection (_gather_file_hotspots)."""
+
+    def _research(self, env):
+        return DeepResearch(env["instance"], env["project_name"], env["project_path"])
+
+    def _git_log(self, lines):
+        """Build a fake `git log --numstat --format=%H` stdout."""
+        return "\n".join(lines) + "\n"
+
+    def test_ranks_files_by_change_count(self, research_env):
+        """Higher commit-frequency files rank first with normalized churn."""
+        # 25 commits to clear the min-commit gate; hot.py touched 3x, cold.py 1x.
+        lines = []
+        for i in range(25):
+            lines.append(f"{'a' * 40}")
+            lines.append("1\t0\tcold.py" if i == 0 else "1\t0\thot.py")
+        # ensure cold.py appears at least once and hot.py dominates
+        lines[1] = "1\t0\tcold.py"
+        completed = subprocess.CompletedProcess([], 0, self._git_log(lines), "")
+        with patch("app.deep_research.subprocess.run", return_value=completed):
+            spots = self._research(research_env)._gather_file_hotspots()
+
+        files = [s["file"] for s in spots]
+        assert files[0] == "hot.py"
+        assert spots[0]["churn"] == 1.0
+        assert all(0 < s["churn"] <= 1.0 for s in spots)
+
+    def test_skips_when_too_few_commits(self, research_env):
+        """A young project (< 20 commits) yields no hotspots."""
+        lines = []
+        for _ in range(5):
+            lines.append("a" * 40)
+            lines.append("1\t0\tapp.py")
+        completed = subprocess.CompletedProcess([], 0, self._git_log(lines), "")
+        with patch("app.deep_research.subprocess.run", return_value=completed):
+            assert self._research(research_env)._gather_file_hotspots() == []
+
+    def test_excludes_tests_and_generated(self, research_env):
+        """Test, lockfile, and generated paths are not ranked as hotspots."""
+        lines = []
+        for _ in range(25):
+            lines.append("a" * 40)
+            lines.append("1\t0\ttests/test_foo.py")
+            lines.append("1\t0\tpoetry.lock")
+            lines.append("1\t0\tdist/bundle.js")
+            lines.append("1\t0\tsrc/core.py")
+        completed = subprocess.CompletedProcess([], 0, self._git_log(lines), "")
+        with patch("app.deep_research.subprocess.run", return_value=completed):
+            spots = self._research(research_env)._gather_file_hotspots()
+
+        assert [s["file"] for s in spots] == ["src/core.py"]
+
+    def test_git_unavailable_returns_empty(self, research_env):
+        """A git failure degrades gracefully to no hotspots."""
+        with patch("app.deep_research.subprocess.run",
+                   side_effect=OSError("git not found")):
+            assert self._research(research_env)._gather_file_hotspots() == []
+
+        failed = subprocess.CompletedProcess([], 128, "", "fatal: not a repo")
+        with patch("app.deep_research.subprocess.run", return_value=failed):
+            assert self._research(research_env)._gather_file_hotspots() == []
+
+    def test_suggestions_include_hotspot_source(self, research_env):
+        """Hotspots surface in suggest_topics() as a 'hotspot' source tier."""
+        research = self._research(research_env)
+        research._pending_prs = []
+        with patch.object(research, "_gather_file_hotspots", return_value=[
+            {"file": "koan/app/mission_runner.py", "churn": 0.87,
+             "hint": "High-churn file"},
+        ]), patch.object(research, "get_open_issues", return_value=[]), \
+             patch.object(research, "get_recent_journal_topics", return_value=[]):
+            topics = research.suggest_topics()
+
+        hotspots = [t for t in topics if t["source"] == "hotspot"]
+        assert len(hotspots) == 1
+        assert "mission_runner.py" in hotspots[0]["topic"]
+        assert hotspots[0]["priority"] == 2


### PR DESCRIPTION
**What**: Add git-churn hotspot detection to DEEP-mode topic selection.

**Why**: `DeepResearch` picked topics from five text sources but was blind to *structural* instability — which files churn most. High-churn files are simultaneously the most likely to harbor tech debt and the most likely to break under autonomous modification, so they're prime DEEP-mode targets. (Aligns with the top project priority: better topic selection.)

**How**:
- `_gather_file_hotspots()` runs `git log --numstat --format=%H -200`, counts per-file changes, normalizes to a 0–1 churn score, returns the top-10.
- Excludes test, lockfile, and generated paths by reusing `diff_triage._LOCKFILE_NAMES` / `_GENERATED_PATTERNS` (no duplication).
- Degrades gracefully: returns `[]` on git failure, non-repo, or projects with < 20 commits (churn ranking is noise below that).
- Surfaces in `suggest_topics()` as a new `"hotspot"` source at priority 2 — below human `current_focus` (1), above journal recaps/strategic (3).

The #2126 provenance cross-reference (acceptance criterion 4) is deferred — that module isn't merged yet. Git-only churn works standalone, as the issue notes.

**Testing**: 5 new tests cover ranking, the <20-commit skip, test/generated exclusion, git-unavailable degradation, and `suggest_topics()` integration. Full file suite (79) green, `make lint` clean.

Closes #2128
