### PR TITLE
feat(memory): confidence-weight FTS5 retrieval ranking

### DIFF
--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -23,7 +23,11 @@ for concurrent safety.
 
 A read-optimized projection of the JSONL log. Provides BM25-ranked full-text
 search so mission-relevant entries surface in agent prompts instead of pure
-recency. Dual-written alongside JSONL (best-effort — JSONL succeeds regardless
+recency. Ranking is confidence-weighted: BM25 `rank` is scaled by the entry's
+`confidence` (`EXTRACTED`→1.0, `INFERRED`→0.75, `AMBIGUOUS`→0.4, numeric values
+used directly, absent→0.9) so a high-confidence match outranks a marginally
+better-matching but low-confidence one. Entries without confidence keep pure
+BM25 order. Dual-written alongside JSONL (best-effort — JSONL succeeds regardless
 of SQLite errors). Populated by a dedicated, always-run startup step
 (`startup_manager.index_memory_sqlite`) that bulk-indexes existing JSONL entries.
 This step is self-gated: `migrate_jsonl_to_sqlite()` only runs when `memory.db`
@@ -79,7 +83,7 @@ Each JSONL entry has four required and four optional fields:
 | `content` | string | yes | Entry text (capped at 2000 chars) |
 | `source_skill` | string | no | Skill that produced this entry (e.g. `"review"`, `"fix"`) |
 | `tags` | list of strings | no | Freeform classification tags |
-| `confidence` | float 0.0–1.0 | no | Confidence level of the observation |
+| `confidence` | float 0.0–1.0 or label (`EXTRACTED`/`INFERRED`/`AMBIGUOUS`) | no | Confidence of the observation; weights FTS5 ranking |
 | `expires_at` | ISO8601 string | no | Auto-expiry timestamp; entry is pruned after this time |
 
 Optional fields are omitted from the JSON when not set (not stored as null).

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -218,6 +218,32 @@ def _is_expired(exp_str: str, now_iso: str) -> bool:
     return exp_str < now_iso
 
 
+# Confidence → ranking weight. Higher weight ranks better. Supports both
+# Graphify-style labels and numeric [0,1] confidences. Absent/unknown sits
+# just below EXTRACTED so unlabelled entries aren't unduly penalised.
+_CONFIDENCE_WEIGHTS = {"extracted": 1.0, "inferred": 0.75, "ambiguous": 0.4}
+_DEFAULT_CONFIDENCE_WEIGHT = 0.9
+_MIN_CONFIDENCE_WEIGHT = 0.1
+
+
+def _confidence_weight(conf_str: str) -> float:
+    """Map a stored confidence value to a ranking weight in (0, 1].
+
+    Accepts label strings (EXTRACTED/INFERRED/AMBIGUOUS) or numeric
+    confidences. Empty/unknown values get a neutral default. Numerics are
+    clamped to a small floor so a zero confidence never erases an entry.
+    """
+    if not conf_str:
+        return _DEFAULT_CONFIDENCE_WEIGHT
+    label = conf_str.strip().lower()
+    if label in _CONFIDENCE_WEIGHTS:
+        return _CONFIDENCE_WEIGHTS[label]
+    try:
+        return max(_MIN_CONFIDENCE_WEIGHT, min(1.0, float(conf_str)))
+    except (ValueError, TypeError):
+        return _DEFAULT_CONFIDENCE_WEIGHT
+
+
 def _build_entry_dict(proj, type_, content, ts, skill, tags_str, conf_str, exp):
     """Build a result dict from FTS5 row columns, including optional metadata."""
     entry = {
@@ -236,8 +262,10 @@ def _build_entry_dict(proj, type_, content, ts, skill, tags_str, conf_str, exp):
     if conf_str:
         try:
             entry["confidence"] = float(conf_str)
-        except (ValueError, TypeError) as e:
-            logger.warning("[memory_db] Malformed confidence in entry ts=%s: %s", ts, e)
+        except (ValueError, TypeError):
+            # Non-numeric confidence (e.g. EXTRACTED/AMBIGUOUS labels) is kept
+            # verbatim — it still drives ranking via _confidence_weight().
+            entry["confidence"] = conf_str.strip()
     if exp:
         entry["expires_at"] = exp
     return entry
@@ -265,12 +293,16 @@ def search_entries(
 
     try:
         project_lower = project.lower() if project else ""
-        results = []
+        # Collect a candidate pool larger than max_results so confidence
+        # re-ranking has room to promote high-confidence matches over
+        # marginally-better-BM25 low-confidence ones.
+        candidates: List[tuple] = []
+        pool_size = max_results * 3
         limit = max_results * 3
         hard_cap = max_results * 20
         offset = 0
 
-        while len(results) < max_results and offset < hard_cap:
+        while len(candidates) < pool_size and offset < hard_cap:
             rows = conn.execute(
                 "SELECT project, type, content, ts, source_skill, tags, "
                 "confidence, expires_at, rank "
@@ -284,18 +316,23 @@ def search_entries(
             if not rows:
                 break
 
-            for proj, type_, content, ts, skill, tags_str, conf_str, exp, _rank in rows:
+            for proj, type_, content, ts, skill, tags_str, conf_str, exp, rank in rows:
                 if _is_expired(exp, now_iso):
                     continue
                 entry_proj = proj or ""
                 if entry_proj == "" or (project_lower and entry_proj.lower() == project_lower):
-                    results.append(_build_entry_dict(proj, type_, content, ts, skill, tags_str, conf_str, exp))
-                    if len(results) >= max_results:
-                        break
+                    # rank is negative (lower = better match); scaling by a
+                    # weight <= 1 pulls low-confidence rows toward 0 (worse).
+                    adjusted = rank * _confidence_weight(conf_str)
+                    entry = _build_entry_dict(proj, type_, content, ts, skill, tags_str, conf_str, exp)
+                    candidates.append((adjusted, entry))
 
             offset += limit
 
-        return results
+        # Stable sort by adjusted rank preserves BM25 order when confidences
+        # are equal/absent — so the no-confidence case is unchanged.
+        candidates.sort(key=lambda c: c[0])
+        return [entry for _, entry in candidates[:max_results]]
     except sqlite3.DatabaseError as e:
         logger.warning("[memory_db] search_entries failed: %s", e)
         return []

--- a/koan/tests/test_memory_db.py
+++ b/koan/tests/test_memory_db.py
@@ -173,6 +173,76 @@ class TestInsertAndSearch:
         )
         conn.close()
 
+    def test_high_confidence_outranks_low_on_equal_match(self, instance_dir):
+        from app.memory_db import ensure_db, insert_entry, search_entries
+        conn = ensure_db(instance_dir)
+        # Identical content → identical BM25 rank; confidence breaks the tie.
+        insert_entry(conn, {
+            "ts": "2026-01-01T00:00:00Z", "type": "session", "project": "koan",
+            "content": "authentication retry backoff bug",
+            "confidence": "AMBIGUOUS",
+        })
+        insert_entry(conn, {
+            "ts": "2026-01-02T00:00:00Z", "type": "session", "project": "koan",
+            "content": "authentication retry backoff bug",
+            "confidence": "EXTRACTED",
+        })
+        results = search_entries(conn, "koan", "authentication retry backoff", max_results=5)
+        assert len(results) == 2
+        assert results[0]["confidence"] == "EXTRACTED"  # ranked first
+        conn.close()
+
+    def test_numeric_confidence_breaks_tie(self, instance_dir):
+        from app.memory_db import ensure_db, insert_entry, search_entries
+        conn = ensure_db(instance_dir)
+        insert_entry(conn, {
+            "ts": "2026-01-01T00:00:00Z", "type": "session", "project": "koan",
+            "content": "deadlock in lock manager path", "confidence": "0.2",
+        })
+        insert_entry(conn, {
+            "ts": "2026-01-02T00:00:00Z", "type": "session", "project": "koan",
+            "content": "deadlock in lock manager path", "confidence": "0.95",
+        })
+        results = search_entries(conn, "koan", "deadlock lock manager", max_results=5)
+        assert results[0]["confidence"] == 0.95
+        conn.close()
+
+    def test_absent_confidence_preserves_bm25_order(self, instance_dir):
+        from app.memory_db import ensure_db, insert_entry, search_entries
+        conn = ensure_db(instance_dir)
+        # No confidence on either → ranking is pure BM25 (unchanged behavior).
+        insert_entry(conn, {
+            "ts": "2026-01-01T00:00:00Z", "type": "session", "project": "koan",
+            "content": "cache eviction policy tuning for the memory window",
+        })
+        insert_entry(conn, {
+            "ts": "2026-01-02T00:00:00Z", "type": "session", "project": "koan",
+            "content": "unrelated note mentioning cache once",
+        })
+        results = search_entries(conn, "koan", "cache eviction policy", max_results=5)
+        assert results[0]["content"].startswith("cache eviction policy")
+        conn.close()
+
+
+class TestConfidenceWeight:
+
+    def test_labels(self):
+        from app.memory_db import _confidence_weight
+        assert _confidence_weight("EXTRACTED") == 1.0
+        assert _confidence_weight("inferred") == 0.75
+        assert _confidence_weight("AMBIGUOUS") == 0.4
+
+    def test_absent_and_unknown_default(self):
+        from app.memory_db import _confidence_weight
+        assert _confidence_weight("") == 0.9
+        assert _confidence_weight("garbage") == 0.9
+
+    def test_numeric_clamped(self):
+        from app.memory_db import _confidence_weight
+        assert _confidence_weight("0.5") == 0.5
+        assert _confidence_weight("0.0") == 0.1   # floored, never zero
+        assert _confidence_weight("5") == 1.0     # capped at 1.0
+
 
 class TestSearchLearnings:
 


### PR DESCRIPTION
**What**: Confidence-weight FTS5 memory retrieval so high-confidence entries outrank marginally-better-matching low-confidence ones.

**Why**: `search_entries()` stored a `confidence` per entry but ranked purely by BM25. An `AMBIGUOUS` memory could beat an `EXTRACTED` one on identical keyword overlap — a silent quality regression on every mission's context window (#2125).

**How**:
- New `_confidence_weight()`: `EXTRACTED`→1.0, `INFERRED`→0.75, `AMBIGUOUS`→0.4, numeric clamped to (0.1,1.0], absent/unknown→0.9.
- `search_entries()` now scales BM25 `rank` by the weight (`adjusted = rank * weight`; rank is negative so a weight <1 pulls low-confidence rows toward 0 = worse), collects a candidate pool, and re-sorts before trimming.
- Note: the issue's suggested `rank / weight` is direction-inverted (it would *promote* AMBIGUOUS). Implemented the behaviorally correct `rank * weight`.
- Non-numeric confidence labels are now surfaced verbatim in results (previously dropped with a warning).
- Entries without confidence keep pure BM25 order → no behavior change for the current corpus.

**Testing**: `make lint` clean; added unit tests for `_confidence_weight` and ranking behavior (label tie-break, numeric tie-break, absent→BM25-preserved). Full memory suite (235 tests) green.

Closes #2125
