### PR TITLE
feat(observability): truthful provider execution state via liveness signal

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -100,7 +100,8 @@ Response:
       "project": "my-project",
       "run_num": 12,
       "elapsed": 42,
-      "last_output_age": 3.1
+      "last_output_age": 3.1,
+      "sessions": 0
     }
   },
   "missions": {
@@ -127,14 +128,21 @@ The `execution` block reports **observed** runtime state — backed by the live
 provider PID in `.koan-active` and provider-output recency — not the
 declarative `missions.md` ▶ timestamp, which can silently diverge (#2086):
 
-- `working` — a live provider PID with recent (or not-yet-produced) output.
-- `stalled` — a live PID but no output for over 120s (hung session).
+- `working` — a live provider PID with recent (or not-yet-produced) output, or
+  a live parallel worktree session (tracked in `sessions.json`).
+- `stalled` — a live PID but no output for over 120s (hung session). A recorded
+  stdout file that has vanished is treated as stalled, never as `working`.
 - `zombie` — a recorded PID that is no longer alive.
 - `idle` — no provider running.
 
 The top-level `execution.zombie` is `true` when an *In Progress* mission line
-exists but no live provider process backs it — surfacing the gap loudly instead
-of reporting a stuck/never-launched mission as "running".
+exists but no live provider process backs it. To avoid flapping during the
+brief start/stop windows where the `missions.md` line and the `.koan-active`
+signal momentarily disagree, the orphan check requires that the run-loop
+heartbeat (`.koan-run-heartbeat`) has gone stale before flagging the `idle`
+case — a recorded-but-dead PID is always flagged immediately. Live parallel
+sessions also suppress the flag. The same cross-check backs the `make status`
+`execution:` line.
 
 ### Missions
 

--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -80,7 +80,7 @@ All responses are JSON. Errors use a uniform envelope:
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET` | `/v1/status` | yes | Agent state, mode, mission counts, signal flags, attention count |
+| `GET` | `/v1/status` | yes | Agent state, mode, mission counts, signal flags, attention count, live execution truth |
 
 Response:
 ```json
@@ -93,7 +93,15 @@ Response:
     "focus": false,
     "status_text": "Run 12/20 — executing",
     "pause": {},
-    "elapsed_seconds": 42
+    "elapsed_seconds": 42,
+    "execution": {
+      "state": "idle|working|stalled|zombie",
+      "pid": 12345,
+      "project": "my-project",
+      "run_num": 12,
+      "elapsed": 42,
+      "last_output_age": 3.1
+    }
   },
   "missions": {
     "pending": 3,
@@ -106,9 +114,27 @@ Response:
     "quota_paused": false,
     "paused": false
   },
-  "attention_count": 2
+  "attention_count": 2,
+  "execution": {
+    "provider_state": "idle|working|stalled|zombie",
+    "in_progress_lines": 1,
+    "zombie": false
+  }
 }
 ```
+
+The `execution` block reports **observed** runtime state — backed by the live
+provider PID in `.koan-active` and provider-output recency — not the
+declarative `missions.md` ▶ timestamp, which can silently diverge (#2086):
+
+- `working` — a live provider PID with recent (or not-yet-produced) output.
+- `stalled` — a live PID but no output for over 120s (hung session).
+- `zombie` — a recorded PID that is no longer alive.
+- `idle` — no provider running.
+
+The top-level `execution.zombie` is `true` when an *In Progress* mission line
+exists but no live provider process backs it — surfacing the gap loudly instead
+of reporting a stuck/never-launched mission as "running".
 
 ### Missions
 

--- a/koan/app/active_mission.py
+++ b/koan/app/active_mission.py
@@ -14,6 +14,7 @@ inferred timestamp. See issue #2086.
 """
 
 import json
+import logging
 import os
 import time
 from pathlib import Path
@@ -21,6 +22,8 @@ from typing import Optional
 
 from app.signals import ACTIVE_FILE
 from app.utils import atomic_write_json
+
+log = logging.getLogger("koan.active_mission")
 
 # Live PID but no provider output for this long → "stalled" rather than "working".
 STALL_THRESHOLD_SECONDS = 120
@@ -57,10 +60,19 @@ def clear_active(koan_root) -> None:
 
 
 def read_active(koan_root) -> Optional[dict]:
-    """Return the active-mission record, or None if absent/unreadable."""
+    """Return the active-mission record, or None if absent/unreadable.
+
+    An absent signal is the normal idle case (no log). A *present but
+    unparseable* signal is an anomaly during an active mission, so the
+    corruption case is logged before degrading to None.
+    """
+    path = _active_path(koan_root)
     try:
-        return json.loads(_active_path(koan_root).read_text())
-    except (OSError, ValueError):
+        return json.loads(path.read_text())
+    except OSError:
+        return None
+    except ValueError as e:
+        log.warning("active-mission signal %s is corrupt: %s", path, e)
         return None
 
 
@@ -83,37 +95,68 @@ def _pid_alive(pid) -> bool:
 
 
 def _last_output_age(record: dict) -> Optional[float]:
-    """Seconds since the provider last wrote stdout, or None if unknown."""
+    """Seconds since the provider last wrote stdout.
+
+    Returns ``None`` only when no stdout file was recorded (legitimately
+    unknown → callers treat as "working"). When a file *was* recorded but
+    cannot be stat'd (deleted/unreadable while the provider hangs), the age is
+    unknowable yet suspicious — return ``inf`` so the session is classified
+    "stalled" rather than masking a stall behind the optimistic "working".
+    """
     f = record.get("stdout_file")
     if not f:
         return None
     try:
         return max(0.0, time.time() - Path(f).stat().st_mtime)
-    except OSError:
-        return None
+    except OSError as e:
+        log.warning("active-mission stdout %s unreadable: %s", f, e)
+        return float("inf")
+
+
+def _live_session_count(koan_root) -> int:
+    """Number of parallel worktree sessions still running with a live PID.
+
+    The single ``.koan-active`` record only covers the main run-loop provider;
+    the parallel-session executor (``session_manager``) spawns its own provider
+    subprocesses tracked in ``sessions.json``. Best-effort: any failure to read
+    the registry counts as zero live sessions.
+    """
+    try:
+        from app.session_manager import SessionRegistry
+
+        instance_dir = Path(koan_root) / "instance"
+        sessions = SessionRegistry(str(instance_dir)).get_active()
+    except Exception:
+        return 0
+    return sum(1 for s in sessions if _pid_alive(getattr(s, "pid", None)))
 
 
 def get_execution_state(koan_root) -> dict:
     """Classify real provider execution from the ``.koan-active`` signal.
 
     Returns a dict with keys ``state``, ``pid``, ``mission``, ``project``,
-    ``run_num``, ``elapsed`` and ``last_output_age``. ``state`` is one of:
+    ``run_num``, ``elapsed``, ``last_output_age`` and ``sessions``. ``state``
+    is one of:
 
-    - ``idle``    — no active-mission signal (no provider running)
-    - ``working`` — live PID and recent (or unknown) output
+    - ``idle``    — no provider running (no active signal, no parallel session)
+    - ``working`` — live PID and recent (or unknown) output, or a live parallel
+      session
     - ``stalled`` — live PID but no output for ``STALL_THRESHOLD_SECONDS``
     - ``zombie``  — signal present but the recorded PID is not alive
     """
     record = read_active(koan_root)
+    sessions = _live_session_count(koan_root)
     if not record:
+        # No main-loop provider signal — but parallel sessions may be running.
         return {
-            "state": "idle",
+            "state": "working" if sessions > 0 else "idle",
             "pid": None,
             "mission": "",
             "project": "",
             "run_num": 0,
             "elapsed": 0,
             "last_output_age": None,
+            "sessions": sessions,
         }
 
     pid = record.get("pid")
@@ -128,6 +171,10 @@ def get_execution_state(koan_root) -> dict:
     started = record.get("started_at") or 0
     elapsed = int(time.time() - started) if started else 0
 
+    # ``inf`` (unreadable stdout) drives the "stalled" classification above but
+    # must not leak into JSON output, where it serializes as invalid ``Infinity``.
+    reported_age = out_age if (out_age is not None and out_age != float("inf")) else None
+
     return {
         "state": state,
         "pid": pid,
@@ -135,5 +182,34 @@ def get_execution_state(koan_root) -> dict:
         "project": record.get("project", ""),
         "run_num": record.get("run_num", 0),
         "elapsed": max(0, elapsed),
-        "last_output_age": out_age,
+        "last_output_age": reported_age,
+        "sessions": sessions,
     }
+
+
+def is_zombie(koan_root, *, in_progress: bool, execution: Optional[dict] = None) -> bool:
+    """Reconcile a declarative *In Progress* mission against observed liveness.
+
+    A genuine zombie (#2086) is an In Progress mission with no live provider
+    backing it. The naive check — In Progress but no active signal — flaps
+    ``true`` during the brief start/stop windows where the ``missions.md`` line
+    and the ``.koan-active`` signal momentarily disagree (mission marked In
+    Progress just before the provider spawns, or signal cleared just before the
+    mission is finalized). Those windows happen while ``run.py`` is alive and
+    its heartbeat fresh, so the ``idle`` case is only treated as an orphan once
+    the run-loop heartbeat has gone stale.
+    """
+    if not in_progress:
+        return False
+    ex = execution if execution is not None else get_execution_state(koan_root)
+    state = ex.get("state")
+    if state == "zombie":
+        return True  # recorded provider PID is dead — unambiguous orphan
+    if state in ("working", "stalled"):
+        return False  # a provider (or parallel session) is alive
+    # state == "idle": no provider signal at all. Only an orphan if the run
+    # loop itself is no longer healthy — otherwise this is a normal
+    # between-missions window that will resolve within seconds.
+    from app.health_check import check_run_heartbeat
+
+    return not check_run_heartbeat(str(koan_root))

--- a/koan/app/active_mission.py
+++ b/koan/app/active_mission.py
@@ -6,9 +6,10 @@ have no live provider process (a *zombie*), or a hung provider keeps aging and
 reads as "running" forever. The run-loop heartbeat (``health_check.py``) only
 proves ``run.py`` itself is alive, not that it is actually executing a mission.
 
-This module records the live provider PID plus a start time and mission id into
-``.koan-active`` when ``run_claude_task`` spawns the subprocess, and clears it on
-exit. Status consumers (dashboard, ``make status``, REST ``/v1/status``) read it
+This module records the live provider PID plus a start time, project and run
+number into ``.koan-active`` when ``run_claude_task`` spawns the subprocess, and
+clears it on exit. Status consumers (dashboard, ``make status``, REST
+``/v1/status``) read it
 via :func:`get_execution_state` to report *observed* runtime state instead of an
 inferred timestamp. See issue #2086.
 """
@@ -37,7 +38,6 @@ def write_active(
     koan_root,
     *,
     pid: int,
-    mission: str = "",
     project: str = "",
     run_num: int = 0,
     stdout_file: str = "",
@@ -45,7 +45,6 @@ def write_active(
     """Record the live provider subprocess as the active mission."""
     record = {
         "pid": pid,
-        "mission": (mission or "").strip()[:200],
         "project": project or "",
         "run_num": run_num,
         "started_at": time.time(),
@@ -126,7 +125,12 @@ def _live_session_count(koan_root) -> int:
 
         instance_dir = Path(koan_root) / "instance"
         sessions = SessionRegistry(str(instance_dir)).get_active()
-    except Exception:
+    except Exception as e:
+        # A swallowed read failure both masks a genuinely working parallel
+        # session (reported idle) and can produce a false zombie flag, since
+        # live sessions are what suppress that flag — log it so a registry
+        # regression surfaces instead of degrading silently to zero (#2086).
+        log.warning("active-mission session registry read failed: %s", e)
         return 0
     return sum(1 for s in sessions if _pid_alive(getattr(s, "pid", None)))
 
@@ -134,9 +138,8 @@ def _live_session_count(koan_root) -> int:
 def get_execution_state(koan_root) -> dict:
     """Classify real provider execution from the ``.koan-active`` signal.
 
-    Returns a dict with keys ``state``, ``pid``, ``mission``, ``project``,
-    ``run_num``, ``elapsed``, ``last_output_age`` and ``sessions``. ``state``
-    is one of:
+    Returns a dict with keys ``state``, ``pid``, ``project``, ``run_num``,
+    ``elapsed``, ``last_output_age`` and ``sessions``. ``state`` is one of:
 
     - ``idle``    — no provider running (no active signal, no parallel session)
     - ``working`` — live PID and recent (or unknown) output, or a live parallel
@@ -151,7 +154,6 @@ def get_execution_state(koan_root) -> dict:
         return {
             "state": "working" if sessions > 0 else "idle",
             "pid": None,
-            "mission": "",
             "project": "",
             "run_num": 0,
             "elapsed": 0,
@@ -178,7 +180,6 @@ def get_execution_state(koan_root) -> dict:
     return {
         "state": state,
         "pid": pid,
-        "mission": record.get("mission", ""),
         "project": record.get("project", ""),
         "run_num": record.get("run_num", 0),
         "elapsed": max(0, elapsed),

--- a/koan/app/active_mission.py
+++ b/koan/app/active_mission.py
@@ -1,0 +1,139 @@
+"""Provider-subprocess liveness signal (``.koan-active``).
+
+Declarative mission state — the ``▶`` timestamp written into ``missions.md`` —
+can silently diverge from real execution: a mission marked *In Progress* may
+have no live provider process (a *zombie*), or a hung provider keeps aging and
+reads as "running" forever. The run-loop heartbeat (``health_check.py``) only
+proves ``run.py`` itself is alive, not that it is actually executing a mission.
+
+This module records the live provider PID plus a start time and mission id into
+``.koan-active`` when ``run_claude_task`` spawns the subprocess, and clears it on
+exit. Status consumers (dashboard, ``make status``, REST ``/v1/status``) read it
+via :func:`get_execution_state` to report *observed* runtime state instead of an
+inferred timestamp. See issue #2086.
+"""
+
+import json
+import os
+import time
+from pathlib import Path
+from typing import Optional
+
+from app.signals import ACTIVE_FILE
+from app.utils import atomic_write_json
+
+# Live PID but no provider output for this long → "stalled" rather than "working".
+STALL_THRESHOLD_SECONDS = 120
+
+
+def _active_path(koan_root) -> Path:
+    return Path(koan_root) / ACTIVE_FILE
+
+
+def write_active(
+    koan_root,
+    *,
+    pid: int,
+    mission: str = "",
+    project: str = "",
+    run_num: int = 0,
+    stdout_file: str = "",
+) -> None:
+    """Record the live provider subprocess as the active mission."""
+    record = {
+        "pid": pid,
+        "mission": (mission or "").strip()[:200],
+        "project": project or "",
+        "run_num": run_num,
+        "started_at": time.time(),
+        "stdout_file": stdout_file or "",
+    }
+    atomic_write_json(_active_path(koan_root), record)
+
+
+def clear_active(koan_root) -> None:
+    """Remove the active-mission signal (provider exited)."""
+    _active_path(koan_root).unlink(missing_ok=True)
+
+
+def read_active(koan_root) -> Optional[dict]:
+    """Return the active-mission record, or None if absent/unreadable."""
+    try:
+        return json.loads(_active_path(koan_root).read_text())
+    except (OSError, ValueError):
+        return None
+
+
+def _pid_alive(pid) -> bool:
+    """Best-effort check that *pid* names a live process.
+
+    PID reuse is possible if the signal file is left stale by a hard crash of
+    ``run.py`` (the ``finally`` clear is skipped). Acceptable for a best-effort
+    liveness hint — output recency disambiguates the common cases.
+    """
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True  # exists but owned by another user
+    return True
+
+
+def _last_output_age(record: dict) -> Optional[float]:
+    """Seconds since the provider last wrote stdout, or None if unknown."""
+    f = record.get("stdout_file")
+    if not f:
+        return None
+    try:
+        return max(0.0, time.time() - Path(f).stat().st_mtime)
+    except OSError:
+        return None
+
+
+def get_execution_state(koan_root) -> dict:
+    """Classify real provider execution from the ``.koan-active`` signal.
+
+    Returns a dict with keys ``state``, ``pid``, ``mission``, ``project``,
+    ``run_num``, ``elapsed`` and ``last_output_age``. ``state`` is one of:
+
+    - ``idle``    — no active-mission signal (no provider running)
+    - ``working`` — live PID and recent (or unknown) output
+    - ``stalled`` — live PID but no output for ``STALL_THRESHOLD_SECONDS``
+    - ``zombie``  — signal present but the recorded PID is not alive
+    """
+    record = read_active(koan_root)
+    if not record:
+        return {
+            "state": "idle",
+            "pid": None,
+            "mission": "",
+            "project": "",
+            "run_num": 0,
+            "elapsed": 0,
+            "last_output_age": None,
+        }
+
+    pid = record.get("pid")
+    out_age = _last_output_age(record)
+    if not _pid_alive(pid):
+        state = "zombie"
+    elif out_age is not None and out_age > STALL_THRESHOLD_SECONDS:
+        state = "stalled"
+    else:
+        state = "working"
+
+    started = record.get("started_at") or 0
+    elapsed = int(time.time() - started) if started else 0
+
+    return {
+        "state": state,
+        "pid": pid,
+        "mission": record.get("mission", ""),
+        "project": record.get("project", ""),
+        "run_num": record.get("run_num", 0),
+        "elapsed": max(0, elapsed),
+        "last_output_age": out_age,
+    }

--- a/koan/app/agent_state.py
+++ b/koan/app/agent_state.py
@@ -179,6 +179,10 @@ def get_agent_state(koan_root: Path) -> dict:
         if m:
             project = m.group(1)
 
+    from app.active_mission import get_execution_state
+
+    execution = get_execution_state(koan_root)
+
     return {
         "state": state,
         "label": label,
@@ -190,4 +194,5 @@ def get_agent_state(koan_root: Path) -> dict:
         "focus": focus,
         "elapsed": elapsed,
         "badge_color": BADGE_COLORS.get(state, "muted"),
+        "execution": execution,
     }

--- a/koan/app/api/routes_status.py
+++ b/koan/app/api/routes_status.py
@@ -96,16 +96,21 @@ def _attention_count() -> int:
         return 0
 
 
-def _execution_truth(agent: dict, missions: dict) -> dict:
+def _execution_truth(agent: dict, missions: dict, koan_root: Path) -> dict:
     """Reconcile declarative In Progress state against observed liveness (#2086).
 
     A mission line in *In Progress* with no live provider process is a zombie:
-    surfaced loudly here rather than silently reported as "running".
+    surfaced loudly here rather than silently reported as "running". The
+    zombie determination is shared with ``make status`` via
+    ``active_mission.is_zombie`` (debounced against the normal start/stop
+    windows and aware of parallel sessions).
     """
+    from app.active_mission import is_zombie
+
     execution = agent.get("execution") or {}
     exec_state = execution.get("state", "idle")
     in_progress = missions.get("in_progress", 0) > 0
-    zombie = in_progress and exec_state in ("idle", "zombie")
+    zombie = is_zombie(koan_root, in_progress=in_progress, execution=execution)
     return {
         "provider_state": exec_state,
         "in_progress_lines": missions.get("in_progress", 0),
@@ -124,6 +129,6 @@ def status():
             "missions": missions,
             "signals": _signal_flags(),
             "attention_count": _attention_count(),
-            "execution": _execution_truth(agent, missions),
+            "execution": _execution_truth(agent, missions, _koan_root()),
         }
     )

--- a/koan/app/api/routes_status.py
+++ b/koan/app/api/routes_status.py
@@ -51,6 +51,7 @@ def _get_agent_state() -> dict:
         "status_text": full["label"],
         "pause": pause_info,
         "elapsed_seconds": full["elapsed"],
+        "execution": full.get("execution"),
     }
 
 
@@ -95,14 +96,34 @@ def _attention_count() -> int:
         return 0
 
 
+def _execution_truth(agent: dict, missions: dict) -> dict:
+    """Reconcile declarative In Progress state against observed liveness (#2086).
+
+    A mission line in *In Progress* with no live provider process is a zombie:
+    surfaced loudly here rather than silently reported as "running".
+    """
+    execution = agent.get("execution") or {}
+    exec_state = execution.get("state", "idle")
+    in_progress = missions.get("in_progress", 0) > 0
+    zombie = in_progress and exec_state in ("idle", "zombie")
+    return {
+        "provider_state": exec_state,
+        "in_progress_lines": missions.get("in_progress", 0),
+        "zombie": zombie,
+    }
+
+
 @bp.route("/v1/status")
 @require_token
 def status():
+    agent = _get_agent_state()
+    missions = _mission_counts()
     return jsonify(
         {
-            "agent": _get_agent_state(),
-            "missions": _mission_counts(),
+            "agent": agent,
+            "missions": missions,
             "signals": _signal_flags(),
             "attention_count": _attention_count(),
+            "execution": _execution_truth(agent, missions),
         }
     )

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -558,19 +558,46 @@ def _read_runner_state(koan_root: Path) -> dict:
     return state
 
 
+def _in_progress_count(koan_root: Path) -> int:
+    """Best-effort count of In Progress mission lines (#2086)."""
+    try:
+        from app.missions import parse_sections
+
+        missions_file = Path(koan_root) / "instance" / "missions.md"
+        content = missions_file.read_text() if missions_file.exists() else ""
+        return len(parse_sections(content).get("in_progress", []))
+    except Exception:
+        return 0
+
+
 def _format_execution_line(koan_root: Path) -> str:
-    """One-line truthful provider-execution state (#2086)."""
-    from app.active_mission import get_execution_state
+    """One-line truthful provider-execution state (#2086).
+
+    Cross-checks the declarative In Progress count against observed liveness so
+    the loud zombie warning also fires for the common "In Progress but nothing
+    ever launched" case — parity with the REST ``/v1/status`` cross-check —
+    not only when a dead PID is recorded.
+    """
+    from app.active_mission import get_execution_state, is_zombie
 
     ex = get_execution_state(koan_root)
     state = ex["state"]
+    in_progress = _in_progress_count(koan_root)
+
+    if is_zombie(koan_root, in_progress=in_progress > 0, execution=ex):
+        pid = ex["pid"]
+        if pid:
+            return f"execution: ⚠ ZOMBIE — In Progress but PID {pid} not alive"
+        return "execution: ⚠ ZOMBIE — In Progress but no live provider"
+    if state == "zombie":
+        # Stale signal: a recorded provider PID is dead even though no mission
+        # line is currently In Progress (leftover from a hard crash).
+        return f"execution: ⚠ ZOMBIE — stale signal, PID {ex['pid']} not alive"
     if state == "idle":
         return "execution: idle — no provider running"
     pid = ex["pid"]
     elapsed = ex["elapsed"]
     age = ex["last_output_age"]
-    if state == "zombie":
-        return f"execution: ⚠ ZOMBIE — In Progress but PID {pid} not alive"
     if state == "stalled":
         age_s = f"{int(age)}s" if age is not None else "?"
         return f"execution: stalled (PID {pid}, no output for {age_s})"

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -566,7 +566,11 @@ def _in_progress_count(koan_root: Path) -> int:
         missions_file = Path(koan_root) / "instance" / "missions.md"
         content = missions_file.read_text() if missions_file.exists() else ""
         return len(parse_sections(content).get("in_progress", []))
-    except Exception:
+    except Exception as e:
+        # A chronic parse failure silently reports zero In Progress lines,
+        # which would suppress the zombie warning for the exact "In Progress
+        # but nothing launched" case this feature targets — log it (#2086).
+        print(f"[pid_manager] in-progress count failed: {e}", file=sys.stderr)
         return 0
 
 

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -558,6 +558,26 @@ def _read_runner_state(koan_root: Path) -> dict:
     return state
 
 
+def _format_execution_line(koan_root: Path) -> str:
+    """One-line truthful provider-execution state (#2086)."""
+    from app.active_mission import get_execution_state
+
+    ex = get_execution_state(koan_root)
+    state = ex["state"]
+    if state == "idle":
+        return "execution: idle — no provider running"
+    pid = ex["pid"]
+    elapsed = ex["elapsed"]
+    age = ex["last_output_age"]
+    if state == "zombie":
+        return f"execution: ⚠ ZOMBIE — In Progress but PID {pid} not alive"
+    if state == "stalled":
+        age_s = f"{int(age)}s" if age is not None else "?"
+        return f"execution: stalled (PID {pid}, no output for {age_s})"
+    age_s = f"{int(age)}s ago" if age is not None else "unknown"
+    return f"execution: working (PID {pid}, {elapsed}s, last output {age_s})"
+
+
 def format_status_all(koan_root: Path) -> list:
     """Build a rich status display for 'make status'.
 
@@ -599,6 +619,10 @@ def format_status_all(koan_root: Path) -> list:
         project = runner_state.get("project", "")
         if project and not runner_state.get("paused"):
             lines.append(f"       project: {project}")
+
+        # Truthful provider-execution state from the live PID signal (#2086),
+        # not the inferred missions.md timestamp.
+        lines.append(f"       {_format_execution_line(koan_root)}")
     else:
         lines.append("  run: not running")
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -342,6 +342,9 @@ def run_claude_task(
     mission_timeout = get_mission_timeout()
 
     exit_code = 1  # default if subprocess never completes
+    # Read once up front so the outer finally can always clear the liveness
+    # signal, even if an exception fires before the subprocess loop (#2086).
+    koan_root_active = os.environ.get("KOAN_ROOT", "")
     try:
         with open(stdout_file, "w") as out_f, open(stderr_file, "w") as err_f:
             proc, cleanup = popen_cli(
@@ -355,10 +358,9 @@ def run_claude_task(
 
             # Record the live provider PID so status consumers can report
             # observed runtime state instead of an inferred timestamp (#2086).
-            koan_root_active = os.environ.get("KOAN_ROOT", "")
             if koan_root_active:
                 from app.active_mission import write_active
-                with contextlib.suppress(OSError):
+                try:
                     write_active(
                         koan_root_active,
                         pid=proc.pid,
@@ -366,6 +368,11 @@ def run_claude_task(
                         run_num=run_num,
                         stdout_file=stdout_file,
                     )
+                except OSError as e:
+                    # A chronically failing write would make every status
+                    # consumer report the running mission as idle/zombie —
+                    # log it so the cause is diagnosable rather than invisible.
+                    log("error", f"liveness signal write failed: {e}")
 
             from app.subprocess_runner import ProcessWatchdog
 
@@ -432,10 +439,6 @@ def run_claude_task(
                         _last_mission_stagnated.set()
                         _stagnation_pattern_type = stagnation_monitor.pattern_type
                         _stagnation_pattern_excerpt = stagnation_monitor.pattern_excerpt
-                if koan_root_active:
-                    from app.active_mission import clear_active
-                    with contextlib.suppress(OSError):
-                        clear_active(koan_root_active)
                 cleanup()
 
         exit_code = proc.returncode
@@ -447,6 +450,13 @@ def run_claude_task(
         elif _last_mission_stagnated.is_set():
             exit_code = 1
     finally:
+        # Clear the liveness signal on every exit path — including exceptions
+        # raised before the subprocess wait loop — so no stale .koan-active
+        # survives to be misread as a live (then zombie) mission (#2086).
+        if koan_root_active:
+            from app.active_mission import clear_active
+            with contextlib.suppress(OSError):
+                clear_active(koan_root_active)
         # Always stop journal streaming, even on exception
         if journal_stream:
             from app.cli_journal_streamer import stop_journal_stream

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -353,6 +353,20 @@ def run_claude_task(
             )
             _sig.claude_proc = proc
 
+            # Record the live provider PID so status consumers can report
+            # observed runtime state instead of an inferred timestamp (#2086).
+            koan_root_active = os.environ.get("KOAN_ROOT", "")
+            if koan_root_active:
+                from app.active_mission import write_active
+                with contextlib.suppress(OSError):
+                    write_active(
+                        koan_root_active,
+                        pid=proc.pid,
+                        project=project_name,
+                        run_num=run_num,
+                        stdout_file=stdout_file,
+                    )
+
             from app.subprocess_runner import ProcessWatchdog
 
             watchdog = None
@@ -418,6 +432,10 @@ def run_claude_task(
                         _last_mission_stagnated.set()
                         _stagnation_pattern_type = stagnation_monitor.pattern_type
                         _stagnation_pattern_excerpt = stagnation_monitor.pattern_excerpt
+                if koan_root_active:
+                    from app.active_mission import clear_active
+                    with contextlib.suppress(OSError):
+                        clear_active(koan_root_active)
                 cleanup()
 
         exit_code = proc.returncode

--- a/koan/app/signals.py
+++ b/koan/app/signals.py
@@ -29,6 +29,7 @@ RESET_COUNTER_FILE = ".koan-reset-counter"
 STATUS_FILE = ".koan-status"
 HEARTBEAT_FILE = ".koan-heartbeat"
 RUN_HEARTBEAT_FILE = ".koan-run-heartbeat"
+ACTIVE_FILE = ".koan-active"
 
 # -- Mode flags ----------------------------------------------------------------
 

--- a/koan/tests/test_active_mission.py
+++ b/koan/tests/test_active_mission.py
@@ -89,3 +89,78 @@ def test_record_is_valid_json(koan_root):
     am.write_active(koan_root, pid=os.getpid(), project="p")
     raw = (koan_root / ACTIVE_FILE).read_text()
     assert json.loads(raw)["project"] == "p"
+
+
+def test_unreadable_stdout_classifies_as_stalled(koan_root, tmp_path):
+    # A configured stdout file that vanished while the provider hangs must not
+    # be masked as "working" — it biases pessimistically to "stalled".
+    missing = tmp_path / "gone.log"
+    am.write_active(koan_root, pid=os.getpid(), stdout_file=str(missing))
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "stalled"
+    # ``inf`` must not leak into the serialized payload.
+    assert state["last_output_age"] is None
+
+
+def test_is_zombie_false_when_not_in_progress(koan_root):
+    assert am.is_zombie(koan_root, in_progress=False) is False
+
+
+def test_is_zombie_true_for_dead_recorded_pid(koan_root):
+    am.write_active(koan_root, pid=2_147_483_646)
+    assert am.is_zombie(koan_root, in_progress=True) is True
+
+
+def test_is_zombie_false_while_provider_alive(koan_root):
+    am.write_active(koan_root, pid=os.getpid())
+    assert am.is_zombie(koan_root, in_progress=True) is False
+
+
+def test_is_zombie_false_during_start_stop_window_with_fresh_heartbeat(koan_root):
+    # In Progress, no provider signal, but the run loop heartbeat is fresh →
+    # normal between-missions window, not a zombie (no flapping).
+    (koan_root / ".koan-run-heartbeat").write_text(str(time.time()))
+    assert am.is_zombie(koan_root, in_progress=True) is False
+
+
+def test_is_zombie_true_when_run_loop_stale(koan_root):
+    # The heartbeat age is the timestamp stored in the file, not its mtime.
+    (koan_root / ".koan-run-heartbeat").write_text(str(time.time() - 1200))
+    assert am.is_zombie(koan_root, in_progress=True) is True
+
+
+def _register_running_session(koan_root, pid):
+    """Register a running parallel session under koan_root/instance."""
+    from app.session_manager import Session, SessionRegistry
+
+    instance_dir = koan_root / "instance"
+    instance_dir.mkdir(exist_ok=True)
+    reg = SessionRegistry(str(instance_dir))
+    reg.register(
+        Session(
+            id="s1",
+            mission_text="m",
+            project_name="koan",
+            project_path="/p",
+            worktree_path="/w",
+            branch_name="koan/x",
+            pid=pid,
+            status="running",
+        )
+    )
+
+
+def test_parallel_session_reported_as_working(koan_root):
+    # No main-loop .koan-active signal, but a live parallel session is running.
+    _register_running_session(koan_root, os.getpid())
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "working"
+    assert state["sessions"] == 1
+
+
+def test_parallel_session_prevents_false_zombie(koan_root):
+    # In Progress with no main signal but a live parallel session → not a zombie
+    # even when the run-loop heartbeat is stale.
+    _register_running_session(koan_root, os.getpid())
+    (koan_root / ".koan-run-heartbeat").write_text(str(time.time() - 1200))
+    assert am.is_zombie(koan_root, in_progress=True) is False

--- a/koan/tests/test_active_mission.py
+++ b/koan/tests/test_active_mission.py
@@ -1,0 +1,91 @@
+"""Tests for provider-subprocess liveness signal (active_mission.py, #2086)."""
+
+import json
+import os
+import time
+
+import pytest
+
+from app import active_mission as am
+from app.signals import ACTIVE_FILE
+
+
+@pytest.fixture
+def koan_root(tmp_path):
+    return tmp_path
+
+
+def test_idle_when_no_signal(koan_root):
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "idle"
+    assert state["pid"] is None
+    assert am.read_active(koan_root) is None
+
+
+def test_write_and_read_roundtrip(koan_root):
+    am.write_active(koan_root, pid=os.getpid(), project="koan", run_num=3)
+    record = am.read_active(koan_root)
+    assert record["pid"] == os.getpid()
+    assert record["project"] == "koan"
+    assert record["run_num"] == 3
+    assert record["started_at"] > 0
+
+
+def test_clear_removes_signal(koan_root):
+    am.write_active(koan_root, pid=os.getpid())
+    am.clear_active(koan_root)
+    assert am.read_active(koan_root) is None
+    # Clearing an absent signal is a no-op, not an error.
+    am.clear_active(koan_root)
+
+
+def test_working_state_for_live_pid_with_recent_output(koan_root, tmp_path):
+    stdout = tmp_path / "out.log"
+    stdout.write_text("provider output")
+    am.write_active(koan_root, pid=os.getpid(), stdout_file=str(stdout))
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "working"
+    assert state["pid"] == os.getpid()
+    assert state["last_output_age"] is not None
+
+
+def test_working_state_when_output_unknown(koan_root):
+    # No stdout_file recorded → output age unknown → still "working" for a live PID.
+    am.write_active(koan_root, pid=os.getpid())
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "working"
+    assert state["last_output_age"] is None
+
+
+def test_stalled_state_for_live_pid_with_stale_output(koan_root, tmp_path):
+    stdout = tmp_path / "out.log"
+    stdout.write_text("old output")
+    old = time.time() - (am.STALL_THRESHOLD_SECONDS + 60)
+    os.utime(stdout, (old, old))
+    am.write_active(koan_root, pid=os.getpid(), stdout_file=str(stdout))
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "stalled"
+
+
+def test_zombie_state_for_dead_pid(koan_root):
+    # PID 2**31-1 is effectively guaranteed not to exist.
+    am.write_active(koan_root, pid=2_147_483_646)
+    state = am.get_execution_state(koan_root)
+    assert state["state"] == "zombie"
+
+
+def test_corrupt_signal_reads_as_idle(koan_root):
+    (koan_root / ACTIVE_FILE).write_text("{ not json")
+    assert am.read_active(koan_root) is None
+    assert am.get_execution_state(koan_root)["state"] == "idle"
+
+
+def test_invalid_pid_is_not_alive(koan_root):
+    am.write_active(koan_root, pid=0)
+    assert am.get_execution_state(koan_root)["state"] == "zombie"
+
+
+def test_record_is_valid_json(koan_root):
+    am.write_active(koan_root, pid=os.getpid(), project="p")
+    raw = (koan_root / ACTIVE_FILE).read_text()
+    assert json.loads(raw)["project"] == "p"

--- a/koan/tests/test_api_status.py
+++ b/koan/tests/test_api_status.py
@@ -106,17 +106,34 @@ class TestExecutionTruth:
         assert data["execution"]["provider_state"] == "working"
         assert data["execution"]["zombie"] is False
 
-    def test_zombie_when_in_progress_but_no_live_provider(
-        self, client, instance_dir
+    def test_zombie_when_in_progress_but_run_loop_stale(
+        self, client, instance_dir, tmp_path
     ):
-        # In Progress line present, but no .koan-active signal at all.
+        # In Progress line present, no .koan-active signal, and the run loop
+        # heartbeat is stale → genuine orphan, flagged loudly.
         (instance_dir / "missions.md").write_text(
             "# Missions\n\n## Pending\n\n## In Progress\n\n- task\n\n## Done\n"
         )
+        # The heartbeat age is the timestamp stored in the file, not its mtime.
+        (tmp_path / ".koan-run-heartbeat").write_text(str(time.time() - 1200))
+
         resp = client.get("/v1/status", headers=AUTH)
         data = resp.get_json()
         assert data["execution"]["in_progress_lines"] == 1
         assert data["execution"]["zombie"] is True
+
+    def test_no_zombie_during_start_stop_window(self, client, instance_dir, tmp_path):
+        # In Progress with no provider signal but a FRESH run-loop heartbeat is
+        # the normal start/stop window, not a zombie — must not flap true.
+        (instance_dir / "missions.md").write_text(
+            "# Missions\n\n## Pending\n\n## In Progress\n\n- task\n\n## Done\n"
+        )
+        (tmp_path / ".koan-run-heartbeat").write_text(str(time.time()))
+
+        resp = client.get("/v1/status", headers=AUTH)
+        data = resp.get_json()
+        assert data["execution"]["in_progress_lines"] == 1
+        assert data["execution"]["zombie"] is False
 
 
 class TestAttentionCount:

--- a/koan/tests/test_api_status.py
+++ b/koan/tests/test_api_status.py
@@ -89,6 +89,36 @@ class TestSignalFlags:
         assert data["signals"]["paused"] is True
 
 
+class TestExecutionTruth:
+    def test_idle_execution_when_no_active_signal(self, client):
+        resp = client.get("/v1/status", headers=AUTH)
+        data = resp.get_json()
+        assert data["execution"]["provider_state"] == "idle"
+        assert data["execution"]["zombie"] is False
+        assert data["agent"]["execution"]["state"] == "idle"
+
+    def test_working_execution_with_live_pid(self, client, tmp_path):
+        from app.active_mission import write_active
+
+        write_active(tmp_path, pid=os.getpid(), project="koan")
+        resp = client.get("/v1/status", headers=AUTH)
+        data = resp.get_json()
+        assert data["execution"]["provider_state"] == "working"
+        assert data["execution"]["zombie"] is False
+
+    def test_zombie_when_in_progress_but_no_live_provider(
+        self, client, instance_dir
+    ):
+        # In Progress line present, but no .koan-active signal at all.
+        (instance_dir / "missions.md").write_text(
+            "# Missions\n\n## Pending\n\n## In Progress\n\n- task\n\n## Done\n"
+        )
+        resp = client.get("/v1/status", headers=AUTH)
+        data = resp.get_json()
+        assert data["execution"]["in_progress_lines"] == 1
+        assert data["execution"]["zombie"] is True
+
+
 class TestAttentionCount:
     def test_returns_actual_count(self, client):
         with patch("app.attention.get_attention_count", return_value=5):


### PR DESCRIPTION
## What
Add a provider-subprocess liveness signal so status consumers report **observed** execution state, not an inferred timestamp.

## Why
`In Progress` status and the dashboard "running Xm" duration were derived purely from the `missions.md` ▶ timestamp. That declarative state silently diverges from reality (#2086): a mission marked In Progress may have no live provider process (a *zombie*), or a hung provider keeps aging and reads as "running" forever. The run-loop heartbeat only proves `run.py` is alive — not that it's actually executing a mission. Operators had no reliable way to answer *"is the agent doing anything right now?"*

## How
- `run_claude_task()` writes the live provider PID + start time + project/run to `.koan-active` on spawn, clears it on exit (best-effort, `OSError`-suppressed).
- New `active_mission.get_execution_state()` classifies `working` / `stalled` / `zombie` / `idle` from PID liveness (`os.kill(pid, 0)`) and provider-output recency (stdout mtime, 120s stall threshold).
- Surfaced everywhere status is read: `agent_state` (dashboard + REST), `make status` (truthful one-liner, loud ⚠ ZOMBIE), and `GET /v1/status` with a cross-check — an In Progress line backed by no live provider is flagged `execution.zombie: true`.
- PID-reuse after a hard `run.py` crash is a known best-effort limitation (documented inline); output recency disambiguates the common cases.

Auto-recovery of detected zombies (acceptance criterion #4) is left as follow-up — this PR makes zombies *loud and observable* first; recover.py already owns the recovery path.

## Testing
- `test_active_mission.py` (11 cases): roundtrip, idle/working/stalled/zombie classification, corrupt-signal and invalid-PID handling.
- `test_api_status.py` (3 new cases): execution block, working with live PID, zombie cross-check on In Progress with no provider.
- Existing `agent_state` / `pid_manager` / `api_status` suites pass; `make lint` clean. (The ~99 dashboard/usage/pr_tracker failures in the full suite pre-exist on `main` — auth-env / KeyError, unrelated.)

Closes #2086
