### PR TITLE
fix(skills): scope core discovery to koan/skills/core/

### DIFF
--- a/koan/app/skills.py
+++ b/koan/app/skills.py
@@ -956,18 +956,57 @@ def get_default_skills_dir() -> Path:
     return Path(__file__).parent.parent / "skills"
 
 
+def get_core_skills_dir() -> Path:
+    """Return the core skills directory (koan/skills/core/).
+
+    Core discovery is scoped to this subdirectory: ``koan/skills/`` is reserved
+    for core skills, and custom scopes belong under ``instance/skills/<scope>/``.
+    Scanning only ``core/`` keeps a stray custom scope dropped under the core
+    tree out of the core registry. See CLAUDE.md skills boundary + issue #2084.
+    """
+    return get_default_skills_dir() / "core"
+
+
+def _warn_misplaced_core_scopes() -> None:
+    """Emit one guidance warning if a non-core scope sits under koan/skills/.
+
+    Such a scope is ignored by core discovery; without this the operator gets
+    no hint why their skill is invisible (and previously got per-build
+    'missing required field' spam, one line per misplaced skill). See #2084.
+    """
+    default_dir = get_default_skills_dir()
+    try:
+        strays = sorted(
+            p.name for p in default_dir.iterdir()
+            if p.is_dir() and p.name not in {"core", "__pycache__"}
+        )
+    except OSError:
+        return
+    if strays:
+        _log.warning(
+            "Ignoring non-core skill scope(s) under %s: %s — move custom "
+            "skills to instance/skills/<scope>/ so they load correctly.",
+            default_dir, ", ".join(strays),
+        )
+
+
 def build_registry(extra_dirs: Optional[List[Path]] = None) -> SkillRegistry:
-    """Build a registry from the default skills dir + optional extra dirs.
+    """Build a registry from the core skills dir + optional extra dirs.
 
     Args:
         extra_dirs: Additional directories to scan (e.g., instance/skills/).
+
+    Core discovery is scoped to ``koan/skills/core/`` (see
+    ``get_core_skills_dir``); custom scopes belong under ``extra_dirs``.
 
     Skills under ``extra_dirs`` are filtered through the approval gate:
     any SKILL.md whose own directory or an ancestor up to the extra dir
     carries a ``.koan-pending`` marker is silently skipped so the bridge
     cannot exec a handler that has not been approved.
     """
-    registry = SkillRegistry(get_default_skills_dir())
+    core_dir = get_core_skills_dir()
+    registry = SkillRegistry(core_dir if core_dir.is_dir() else get_default_skills_dir())
+    _warn_misplaced_core_scopes()
 
     if extra_dirs:
         from app.skill_approval import find_pending_ancestor

--- a/koan/tests/test_skills.py
+++ b/koan/tests/test_skills.py
@@ -23,6 +23,7 @@ from app.skills import (
     build_registry,
     ensure_requirements,
     execute_skill,
+    get_core_skills_dir,
     get_default_skills_dir,
     parse_skill_md,
     validate_skill_metadata,
@@ -1266,6 +1267,69 @@ class TestBuildRegistryPendingGate:
         self._write_skill(tmp_path, "legacy", "preexisting")
         registry = build_registry(extra_dirs=[tmp_path])
         assert "legacy.preexisting" in registry
+
+
+class TestCoreDiscoveryScoping:
+    """#2084: core discovery is scoped to koan/skills/core/, so a stray
+    custom scope dropped under the core tree is ignored (no per-build
+    'missing required field' spam) and the operator gets one guidance line."""
+
+    @staticmethod
+    def _write_skill(parent, scope, name):
+        skill_dir = parent / scope / name
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(textwrap.dedent(f"""\
+            ---
+            name: {name}
+            scope: {scope}
+            description: x
+            commands:
+              - name: {name}
+                description: x
+            ---
+        """))
+
+    def _fake_default_tree(self, tmp_path):
+        """A koan/skills/-shaped tree: a core skill plus a misplaced scope."""
+        self._write_skill(tmp_path, "core", "status")
+        # Misplaced operator scope (the real-world cause: a Claude-format
+        # skill with no commands block landing under the core tree).
+        stray = tmp_path / "anantys" / "atoomic.review"
+        stray.mkdir(parents=True)
+        (stray / "SKILL.md").write_text(textwrap.dedent("""\
+            ---
+            name: review
+            description: claude-format skill, no commands block
+            ---
+        """))
+        return tmp_path
+
+    def test_get_core_skills_dir_is_core_subdir(self):
+        assert get_core_skills_dir() == get_default_skills_dir() / "core"
+
+    def test_stray_scope_not_registered(self, tmp_path, monkeypatch):
+        self._fake_default_tree(tmp_path)
+        monkeypatch.setattr("app.skills.get_default_skills_dir", lambda: tmp_path)
+        registry = build_registry()
+        assert "core.status" in registry
+        assert "anantys.review" not in registry
+        assert registry.scopes() == ["core"]
+
+    def test_misplaced_scope_warns_once(self, tmp_path, monkeypatch, caplog):
+        self._fake_default_tree(tmp_path)
+        monkeypatch.setattr("app.skills.get_default_skills_dir", lambda: tmp_path)
+        with caplog.at_level("WARNING", logger="app.skills"):
+            build_registry()
+        misplaced = [r for r in caplog.records if "non-core skill scope" in r.message]
+        assert len(misplaced) == 1
+        assert "anantys" in misplaced[0].getMessage()
+
+    def test_no_warning_without_stray(self, tmp_path, monkeypatch, caplog):
+        self._write_skill(tmp_path, "core", "status")
+        monkeypatch.setattr("app.skills.get_default_skills_dir", lambda: tmp_path)
+        with caplog.at_level("WARNING", logger="app.skills"):
+            build_registry()
+        assert not [r for r in caplog.records if "non-core skill scope" in r.message]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
**What**: Scope core skill discovery to `koan/skills/core/` so stray scopes under the core tree stop spamming the logs.

**Why**: `koan/skills/` is reserved for core skills (custom scopes belong under `instance/skills/<scope>/`), but `SkillRegistry._discover` used unrestricted `rglob("SKILL.md")` over the whole `koan/skills/` tree. An operator-local Claude-format scope dropped there got picked up by the core registry, failed Kōan-format validation, and logged `missing required field 'commands'` for each skill on every registry rebuild — recurring noise that buries real warnings.

**How**: `build_registry` now scans `get_core_skills_dir()` (`koan/skills/core/`) instead of the whole tree — scope stays `core` (all core skills are exactly `core/<name>/SKILL.md`). A single `_warn_misplaced_core_scopes()` line replaces the N per-skill warnings: it names the misplaced scope(s) and points the operator to `instance/skills/<scope>/`. `extra_dirs` discovery (the `instance/skills/` path) is unchanged.

**Testing**: `make lint` clean. New `TestCoreDiscoveryScoping` covers: core dir resolution, stray scope not registered, exactly-one guidance warning, and no warning when clean. Full `test_skills.py` (221) + broad skill/registry/dispatch/help sweep (3956) green.

Closes #2084
