### PR TITLE
fix(hooks): automation pause action auto-resumes after cooldown

### DIFF
--- a/koan/app/hooks.py
+++ b/koan/app/hooks.py
@@ -309,10 +309,21 @@ class HookRegistry:
         insert_pending_mission(missions_path, text)
 
     def _action_pause(self, instance_dir: str) -> None:
-        """Write .koan-pause to pause the agent."""
-        pause_file = Path(instance_dir).parent / ".koan-pause"
-        # Idempotent — overwrite is harmless
-        pause_file.write_text("automation_rule\n")
+        """Pause the agent via the pause_manager protocol.
+
+        A direct one-line write produces a malformed pause file (no
+        timestamp), which strands `should_auto_resume` on its
+        `timestamp <= 0` early-return — the pause never lifts. Going
+        through `create_pause` stamps the current time so the standard
+        5h cooldown applies.
+        """
+        from app.pause_manager import create_pause
+        koan_root = str(Path(instance_dir).parent)
+        create_pause(
+            koan_root,
+            reason="automation_rule",
+            display="Paused by automation rule",
+        )
 
     def _action_resume(self, instance_dir: str) -> None:
         """Remove .koan-pause if it exists."""

--- a/koan/tests/test_hooks.py
+++ b/koan/tests/test_hooks.py
@@ -687,6 +687,36 @@ class TestAutomationRuleExecution:
         registry.fire("pre_mission")
         assert pause_file.exists()
 
+    def test_pause_action_writes_auto_resumable_pause(self, tmp_path):
+        """A pause from an automation rule must auto-resume after cooldown.
+
+        Regression for #2079: the action used to write a one-line file with
+        no timestamp, so `should_auto_resume` hit its `timestamp <= 0`
+        early-return and the pause became permanent. Going through
+        `create_pause` stamps the current time, so the standard 5h cooldown
+        applies and the agent recovers on its own.
+        """
+        from app.pause_manager import (
+            DEFAULT_COOLDOWN_SECONDS,
+            get_pause_state,
+            should_auto_resume,
+        )
+        _write_rules(str(tmp_path), [
+            {"id": "r1", "event": "pre_mission", "action": "pause",
+             "enabled": True, "created": ""},
+        ])
+        registry = self._make_registry(tmp_path)
+        registry.fire("pre_mission")
+        state = get_pause_state(str(tmp_path.parent))
+        assert state is not None
+        assert state.timestamp > 0
+        # Not yet eligible immediately after pausing...
+        assert should_auto_resume(state, now=state.timestamp) is False
+        # ...but eligible once the cooldown has elapsed.
+        assert should_auto_resume(
+            state, now=state.timestamp + DEFAULT_COOLDOWN_SECONDS
+        ) is True
+
     def test_resume_action_removes_koan_pause(self, tmp_path):
         _write_rules(str(tmp_path), [
             {"id": "r1", "event": "session_start", "action": "resume",


### PR DESCRIPTION
## What
Route the `pause` automation-rule action through `pause_manager.create_pause()` instead of writing `.koan-pause` by hand.

## Why
The old `_action_pause` wrote a single line (`automation_rule\n`) with no timestamp. `read_pause_state` then parses `timestamp=0`, so `should_auto_resume` hits its `timestamp <= 0` early-return and always returns `False`. The pause became **permanent** — it never lifted after the 5h cooldown that other non-quota pauses honor, and nothing in the logs explained why. Any rule like "pause on repeated CI failure" stranded the agent until a manual `/resume`. Fixes #2079.

## How
`create_pause()` stamps the current time and writes the canonical 3-line format, so the standard non-quota 5h cooldown applies and the agent recovers on its own.

## Testing
Added `test_pause_action_writes_auto_resumable_pause`: fires a pause rule, then asserts the persisted state has a real timestamp and that `should_auto_resume` returns `False` immediately but `True` once the cooldown elapses. Full `test_hooks.py` (53 tests) and `make lint` pass.
