### PR TITLE
perf(hooks): resolve loop-guard config once per event (#2078)

### DIFF
--- a/koan/app/hooks.py
+++ b/koan/app/hooks.py
@@ -219,12 +219,20 @@ class HookRegistry:
             print(f"[hooks] Failed to load automation rules: {exc}", file=sys.stderr)
             return
 
-        for rule in rules:
-            if rule.event != event:
-                continue
-            if not rule.enabled:
-                continue
-            if self._loop_guard(rule):
+        matching = [r for r in rules if r.event == event and r.enabled]
+        if not matching:
+            return
+
+        from app.utils import load_config
+        try:
+            config = load_config() or {}
+        except Exception as exc:
+            print(f"[hooks] Could not load config for loop guard: {exc}", file=sys.stderr)
+            config = {}
+        max_fires = config.get("automation_rules", {}).get("max_fires_per_minute", 5)
+
+        for rule in matching:
+            if self._loop_guard(rule, max_fires=max_fires):
                 print(
                     f"[hooks] Loop guard triggered for rule {rule.id} "
                     f"(action={rule.action}) — skipping.",
@@ -242,22 +250,14 @@ class HookRegistry:
                     file=sys.stderr,
                 )
 
-    def _loop_guard(self, rule: AutomationRule) -> bool:
+    def _loop_guard(self, rule: AutomationRule, max_fires: int = 5) -> bool:
         """Return True (skip) if rule has exceeded max_fires_per_minute.
 
-        The counter is in-memory and resets on process restart.
-        Threshold is read from instance/config.yaml under
-        automation_rules.max_fires_per_minute (default 5).
+        The counter is in-memory and resets on process restart. The threshold
+        is resolved once per event by the caller (from instance/config.yaml
+        under automation_rules.max_fires_per_minute, default 5) so all rules
+        in the same event fire see a consistent value.
         """
-        from app.utils import load_config
-        config = {}
-        try:
-            config = load_config() or {}
-        except Exception as exc:
-            print(f"[hooks] Could not load config for loop guard: {exc}", file=sys.stderr)
-        max_fires = (
-            config.get("automation_rules", {}).get("max_fires_per_minute", 5)
-        )
         window = 60.0  # seconds
         now = time.monotonic()
 

--- a/koan/tests/test_hooks.py
+++ b/koan/tests/test_hooks.py
@@ -655,6 +655,33 @@ class TestAutomationRuleExecution:
         outbox_text = (tmp_path / "outbox.md").read_text()
         assert outbox_text.count("tick") == 2
 
+    def test_config_loaded_once_per_event(self, tmp_path):
+        """All rules in a single event fire resolve max_fires from one config
+        read, so they cannot see inconsistent thresholds mid-loop."""
+        _write_rules(str(tmp_path), [
+            {"id": f"r{i}", "event": "post_mission", "action": "notify",
+             "params": {"message": f"m{i}"}, "enabled": True, "created": ""}
+            for i in range(3)
+        ])
+        registry = self._make_registry(tmp_path)
+        with patch("app.utils.load_config",
+                   return_value={"automation_rules": {"max_fires_per_minute": 5}}) as mock_cfg:
+            registry.fire("post_mission")
+        # 3 matching rules, but config read exactly once for the event
+        assert mock_cfg.call_count == 1
+        assert (tmp_path / "outbox.md").read_text().count("m") == 3
+
+    def test_no_config_read_when_no_rules_match(self, tmp_path):
+        """An event with no matching enabled rules skips config loading."""
+        _write_rules(str(tmp_path), [
+            {"id": "r1", "event": "session_start", "action": "notify",
+             "params": {"message": "x"}, "enabled": True, "created": ""},
+        ])
+        registry = self._make_registry(tmp_path)
+        with patch("app.utils.load_config") as mock_cfg:
+            registry.fire("post_mission")
+        mock_cfg.assert_not_called()
+
     def test_notify_action_appends_to_outbox(self, tmp_path):
         _write_rules(str(tmp_path), [
             {"id": "r1", "event": "post_mission", "action": "notify",


### PR DESCRIPTION
## What
Resolve the automation-rule loop-guard threshold once per event fire instead of once per rule.

## Why
Closes #2078. `_loop_guard` called `load_config()` on every invocation, and it runs inside the `for rule in rules` loop of `_fire_automation_rules` — so an instance with N rules parsed `config.yaml` N times per event (hot `post_mission` path). Worse, a mid-loop `config.yaml` change could make different rules in the same fire see different thresholds.

## How
- Load config once at the top of `_fire_automation_rules`, compute `max_fires`, and pass it into `_loop_guard(rule, max_fires=...)`.
- Early-return before any config read when no enabled rule matches the event.
- `_loop_guard` keeps a `max_fires` default (5) so the signature stays safe.

## Testing
- `make lint` clean.
- `test_hooks.py` (55 passed), incl. two new behavioral tests: config read exactly once across 3 matching rules, and no config read when nothing matches.
