### PR TITLE
robustness(enrichment): route fetch_github_issues through run_gh (#2077)

### DIFF
--- a/koan/app/issue_tracker/enrichment.py
+++ b/koan/app/issue_tracker/enrichment.py
@@ -150,32 +150,26 @@ def fetch_github_issues(refs: List[Tuple[str, str, int]]) -> str:
         refs = refs[:MAX_REFS]
     import json
 
+    from app.github import run_gh
+
     lines: List[str] = []
     for owner, repo, number in refs:
         slug = f"{owner}/{repo}#{number}"
         try:
-            proc = subprocess.run(
-                [
-                    "gh", "issue", "view", str(number),
-                    "--repo", f"{owner}/{repo}",
-                    "--json", "title,body",
-                ],
-                capture_output=True,
-                text=True,
+            stdout = run_gh(
+                "issue", "view", str(number),
+                "--repo", f"{owner}/{repo}",
+                "--json", "title,body",
                 timeout=GH_TIMEOUT_SECONDS,
-                check=False,
             )
         except FileNotFoundError:
             logger.warning("[enrichment] gh CLI unavailable; skipping GitHub issue enrichment")
             return ""
-        except (OSError, subprocess.TimeoutExpired) as e:
+        except (RuntimeError, OSError, subprocess.TimeoutExpired) as e:
             logger.debug("[enrichment] gh fetch failed for %s: %s", slug, e)
             continue
-        if proc.returncode != 0:
-            logger.debug("[enrichment] gh non-zero for %s: %s", slug, proc.stderr.strip())
-            continue
         try:
-            data = json.loads(proc.stdout)
+            data = json.loads(stdout)
         except (json.JSONDecodeError, TypeError):
             continue
         title = (data.get("title") or "").strip()

--- a/koan/app/issue_tracker/enrichment.py
+++ b/koan/app/issue_tracker/enrichment.py
@@ -34,14 +34,19 @@ _GITHUB_REF_RE = re.compile(
 MAX_EXCERPT_CHARS = 500
 MAX_TOTAL_CHARS = 1000
 # Upper bound on the number of tracker references fetched per review. Each ref
-# costs one bounded network/subprocess round-trip (up to *_TIMEOUT_SECONDS each),
-# so an uncapped PR body (a changelog listing dozens of tickets, or an adversarial
-# author seeding ``a/b#1 a/b#2 …``) could otherwise add N×5s of latency and burn
-# API quota / spawn dozens of ``gh`` subprocesses. Bounding the *fetch count*
-# (not just the output size) keeps worst-case review latency bounded at roughly
-# MAX_REFS × *_TIMEOUT_SECONDS regardless of PR body content. This bound only
-# holds because each ref is one bounded request: the Jira path uses the
-# title/body-only fetch (no comment pagination) with a JIRA_TIMEOUT_SECONDS cap.
+# costs one bounded network/subprocess round-trip, so an uncapped PR body (a
+# changelog listing dozens of tickets, or an adversarial author seeding
+# ``a/b#1 a/b#2 …``) could otherwise add large latency and burn API quota /
+# spawn dozens of ``gh`` subprocesses. Bounding the *fetch count* (not just the
+# output size) keeps worst-case review latency bounded regardless of PR body
+# content. The per-path bound differs:
+#   - Jira path: single-shot fetch (no retry), so MAX_REFS × JIRA_TIMEOUT_SECONDS
+#     (5 × 5 = 25s) worst case.
+#   - GitHub path: routed through ``run_gh``, which wraps each call in
+#     retry_with_backoff (up to 3 attempts, 1+2s backoff sleeps) on transient
+#     failures. A consistently-timing-out ref costs ~3 × GH_TIMEOUT_SECONDS + 3s
+#     ≈ 18s, so MAX_REFS × that ≈ 90s worst case. The retry buys resilience
+#     against network flaps at the cost of a looser latency bound on that path.
 MAX_REFS = 5
 JIRA_TIMEOUT_SECONDS = 5
 GH_TIMEOUT_SECONDS = 5

--- a/koan/tests/test_issue_tracker_enrichment.py
+++ b/koan/tests/test_issue_tracker_enrichment.py
@@ -113,40 +113,27 @@ class TestFetchJiraIssues:
         assert mock.call_count == MAX_REFS
 
 
-def _gh_result(returncode=0, stdout="", stderr=""):
-    return subprocess.CompletedProcess(
-        args=["gh"], returncode=returncode, stdout=stdout, stderr=stderr
-    )
-
-
 class TestFetchGithubIssues:
     def test_formats_summary(self):
         payload = json.dumps({"title": "Add feature", "body": "Details here."})
-        with patch(
-            "app.issue_tracker.enrichment.subprocess.run",
-            return_value=_gh_result(stdout=payload),
-        ):
+        with patch("app.github.run_gh", return_value=payload):
             out = fetch_github_issues([("o", "r", 5)])
         assert "- o/r#5: Add feature" in out
         assert "> Details here." in out
 
-    def test_returns_empty_on_nonzero(self):
-        with patch(
-            "app.issue_tracker.enrichment.subprocess.run",
-            return_value=_gh_result(returncode=1, stderr="not found"),
-        ):
+    def test_returns_empty_on_gh_error(self):
+        # run_gh raises RuntimeError on non-zero exit (and SSOAuthRequired,
+        # its subclass); best-effort enrichment swallows it.
+        with patch("app.github.run_gh", side_effect=RuntimeError("gh failed: not found")):
             assert fetch_github_issues([("o", "r", 5)]) == ""
 
     def test_returns_empty_when_gh_missing(self):
-        with patch(
-            "app.issue_tracker.enrichment.subprocess.run",
-            side_effect=FileNotFoundError(),
-        ):
+        with patch("app.github.run_gh", side_effect=FileNotFoundError()):
             assert fetch_github_issues([("o", "r", 5)]) == ""
 
     def test_returns_empty_on_timeout(self):
         with patch(
-            "app.issue_tracker.enrichment.subprocess.run",
+            "app.github.run_gh",
             side_effect=subprocess.TimeoutExpired(cmd="gh", timeout=5),
         ):
             assert fetch_github_issues([("o", "r", 5)]) == ""
@@ -156,12 +143,9 @@ class TestFetchGithubIssues:
 
     def test_fetch_count_capped_at_max_refs(self):
         payload = json.dumps({"title": "T", "body": "b"})
-        with patch(
-            "app.issue_tracker.enrichment.subprocess.run",
-            return_value=_gh_result(stdout=payload),
-        ) as mock:
+        with patch("app.github.run_gh", return_value=payload) as mock:
             fetch_github_issues([("o", "r", i) for i in range(MAX_REFS + 10)])
-        # Only MAX_REFS gh subprocesses are spawned, regardless of ref count.
+        # Only MAX_REFS gh round-trips happen, regardless of how many refs parse.
         assert mock.call_count == MAX_REFS
 
 


### PR DESCRIPTION
## What
Route `fetch_github_issues` (PR-review tracker enrichment) through `run_gh` instead of a raw `subprocess.run`.

## Why
Closes #2077. The direct `subprocess.run` bypassed three things `run_gh` provides: retry-with-backoff for transient failures (connection reset, timeout, 503), `SSOAuthRequired` detection, and `GIT_OPERATION` audit logging. A network flap during PR review silently dropped tracker context with no retry.

## How
Replaced the `subprocess.run` block with `run_gh(...)`. The best-effort contract (return `""` on any failure) is preserved by catching `RuntimeError` (which covers the `SSOAuthRequired` subclass), `OSError`, and `subprocess.TimeoutExpired`; `FileNotFoundError` still short-circuits to `""` when `gh` is unavailable.

## Testing
Updated `TestFetchGithubIssues` to mock at the `run_gh` level (per the project's "mock above retry_with_backoff" convention). 27 enrichment tests + 386 review_runner tests pass. Lint clean.
