### PR TITLE
feat(missions): startup integrity self-heal + size bounds for missions.md (#2085)

### DIFF
--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -92,14 +92,19 @@ file healthy:
 
 - **Validation** — `validate_missions_structure()` checks the canonical
   sections are present exactly once, that no `## ` header is glued to the
-  preceding item (the production corruption mode), and that no item lines fall
+  preceding item (the production corruption mode; the `# Missions` H1 title
+  sitting above the first section is not flagged), and that no item lines fall
   before any section header. Content inside ` ``` ` code fences (mission bodies
   routinely contain fenced markdown with `## ` / `- ` lines) is treated as text,
   never structure.
-- **Self-heal** — `repair_missions_structure()` conservatively restores missing
-  blank lines around headers and appends any missing canonical sections, never
-  dropping mission lines (Pending/In Progress items and non-canonical sections
-  like Ideas are preserved). Fenced mission-body content is left verbatim. A
+- **Self-heal** — `repair_missions_structure()` resolves every issue validation
+  classifies as serious, so re-validating its output is always clean (it
+  converges, never re-alarming a stuck file): it restores missing blank lines
+  around headers, merges duplicate canonical sections into their first
+  occurrence, re-homes orphan items found before any header under `## Pending`,
+  and appends any missing canonical sections — never dropping mission lines
+  (Pending/In Progress items and non-canonical sections like Ideas are
+  preserved, fenced mission-body content left verbatim). A
   merely incomplete file (e.g. a fresh install without `## Failed`) is healed
   silently; genuine corruption is first backed up to
   `instance/.missions.md.bak-<ts>` and surfaced to the operator via the outbox.

--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -82,3 +82,34 @@ missions continue through the configured provider.
 Crash recovery moves stale In Progress work back to a safe state. Stagnation
 retries are tracked separately so a stuck provider session can be retried a
 limited number of times before regular failure handling and user notification.
+
+## File Integrity And Size Bounds
+
+`missions.md` is on the hot path of every loop iteration, so a malformed write
+can silently degrade the whole agent. `startup_manager.prune_missions_done`
+(run at startup) and `run._prune_missions_history` (run post-mission) keep the
+file healthy:
+
+- **Validation** — `validate_missions_structure()` checks the canonical
+  sections are present exactly once, that no `## ` header is glued to the
+  preceding item (the production corruption mode), and that no item lines fall
+  outside a section.
+- **Self-heal** — `repair_missions_structure()` conservatively restores missing
+  blank lines around headers and appends any missing canonical sections, never
+  dropping mission lines (Pending/In Progress items and non-canonical sections
+  like Ideas are preserved). A merely incomplete file (e.g. a fresh install
+  without `## Failed`) is healed silently; genuine corruption is first backed up
+  to `instance/.missions.md.bak-<ts>` and surfaced to the operator via the
+  outbox.
+- **Size bounds** — `enforce_size_bound()` prunes Done/Failed history to the
+  configured keeps, then progressively sheds more old completed entries until
+  the file is under the line cap. Pending and In Progress are never pruned.
+
+Configurable under a `missions:` section in `config.yaml`:
+
+```yaml
+missions:
+  done_keep: 50      # max Done items retained
+  failed_keep: 30    # max Failed items retained
+  max_lines: 500     # hard line cap (0 disables)
+```

--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -93,14 +93,20 @@ file healthy:
 - **Validation** — `validate_missions_structure()` checks the canonical
   sections are present exactly once, that no `## ` header is glued to the
   preceding item (the production corruption mode), and that no item lines fall
-  outside a section.
+  before any section header. Content inside ` ``` ` code fences (mission bodies
+  routinely contain fenced markdown with `## ` / `- ` lines) is treated as text,
+  never structure.
 - **Self-heal** — `repair_missions_structure()` conservatively restores missing
   blank lines around headers and appends any missing canonical sections, never
   dropping mission lines (Pending/In Progress items and non-canonical sections
-  like Ideas are preserved). A merely incomplete file (e.g. a fresh install
-  without `## Failed`) is healed silently; genuine corruption is first backed up
-  to `instance/.missions.md.bak-<ts>` and surfaced to the operator via the
-  outbox.
+  like Ideas are preserved). Fenced mission-body content is left verbatim. A
+  merely incomplete file (e.g. a fresh install without `## Failed`) is healed
+  silently; genuine corruption is first backed up to
+  `instance/.missions.md.bak-<ts>` and surfaced to the operator via the outbox.
+  If the backup write fails, the destructive repair is skipped entirely and the
+  corrupt file is left untouched — the only copy of the data is never
+  overwritten without a verified backup. Backups are capped at the 5 most
+  recent.
 - **Size bounds** — `enforce_size_bound()` prunes Done/Failed history to the
   configured keeps, then progressively sheds more old completed entries until
   the file is under the line cap. Pending and In Progress are never pruned.

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -243,6 +243,18 @@ skill_timeout: 7200
 # Default: 300 (5 minutes).
 # post_mission_timeout: 300
 
+# missions.md integrity and size bounds. The mission queue file is read/rewritten
+# every loop iteration; these caps keep it bounded and structurally healthy.
+# At startup the file is validated and conservatively self-healed (missing blank
+# lines around headers restored, missing canonical sections appended). Genuine
+# corruption is backed up to instance/.missions.md.bak-<ts> and surfaced to the
+# outbox before repair. Old completed history is pruned to the keeps below, then
+# further shed if the file still exceeds max_lines (Pending/In Progress untouched).
+# missions:
+#   done_keep: 50      # max Done items retained (default 50)
+#   failed_keep: 30    # max Failed items retained (default 30)
+#   max_lines: 500     # hard line cap; 0 disables (default 500)
+
 # Forward Claude's final result text to outbox.md when a mission's outcome is an
 # alert (SKIP / FAIL / ERROR / BLOCKED, "permission deadlock", "no PR opened",
 # etc.) or when the mission title matches a skill that opted in via SKILL.md

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -807,6 +807,25 @@ def get_skill_timeout() -> int:
     return _safe_int(config.get("skill_timeout", 7200), 7200)
 
 
+def _missions_section() -> dict:
+    return _load_config().get("missions", {}) or {}
+
+
+def get_missions_done_keep() -> int:
+    """Max Done items retained in missions.md. Config: missions.done_keep (50)."""
+    return _safe_int(_missions_section().get("done_keep", 50), 50)
+
+
+def get_missions_failed_keep() -> int:
+    """Max Failed items retained in missions.md. Config: missions.failed_keep (30)."""
+    return _safe_int(_missions_section().get("failed_keep", 30), 30)
+
+
+def get_missions_max_lines() -> int:
+    """Hard line cap for missions.md; 0 disables. Config: missions.max_lines (500)."""
+    return _safe_int(_missions_section().get("max_lines", 500), 500)
+
+
 def get_mission_timeout() -> int:
     """Get timeout in seconds for regular mission execution.
 

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1831,7 +1831,11 @@ def validate_missions_structure(content: str) -> List[str]:
             prev_line = line
             continue
         if stripped.startswith("## "):
-            if prev_line is not None and prev_line.strip() != "":
+            prev_stripped = prev_line.strip() if prev_line is not None else ""
+            # The ``# Missions`` H1 title sitting directly above the first
+            # section is not corruption — only an item glued to a header is.
+            is_h1_title = prev_stripped.startswith("# ") and not prev_stripped.startswith("## ")
+            if prev_stripped != "" and not is_h1_title:
                 issues.append(
                     f"Section header glued to preceding item (missing blank line): {stripped!r}"
                 )
@@ -1857,11 +1861,17 @@ def repair_missions_structure(content: str) -> str:
     """Conservatively repair structural corruption in missions.md content.
 
     Repairs applied (all content-preserving):
-    - Insert a blank line before any ``## `` header glued to a preceding
-      item, so section boundaries are unambiguous.
+    - Restore the blank line before any ``## `` header glued to a
+      preceding item, so section boundaries are unambiguous.
+    - Merge duplicate canonical sections into their first occurrence
+      (later bodies appended), so a section appears exactly once.
+    - Re-home orphan ``- `` items that appear before any section header
+      under ``## Pending``.
     - Append any missing required canonical section headers at the end.
     - Collapse runaway blank lines via :func:`normalize_content`.
 
+    This converges: every issue ``validate_missions_structure`` classifies
+    as serious is resolved, so re-validating the output yields no issues.
     Items, ideas, and any non-canonical content are preserved verbatim;
     this never drops mission lines. ``## `` lines inside ```` ``` ````
     code fences are mission body text and are left untouched. Returns the
@@ -1870,40 +1880,75 @@ def repair_missions_structure(content: str) -> str:
     if not content.strip():
         return DEFAULT_SKELETON
 
-    lines = content.splitlines()
-    out: List[str] = []
+    # Parse into a preamble (lines before the first header) plus an ordered
+    # list of section blocks, fence-aware so fenced bodies are never read as
+    # structure.
+    preamble: List[str] = []
+    blocks: List[dict] = []
+    current = None
     in_code_fence = False
-    for line in lines:
+    for line in content.splitlines():
         stripped = line.strip()
         if stripped.startswith("```"):
             in_code_fence = not in_code_fence
-            out.append(line)
-            continue
-        if (
-            not in_code_fence
-            and stripped.startswith("## ")
-            and out
-            and out[-1].strip() != ""
-        ):
-            out.append("")  # restore the missing blank line before the header
-        out.append(line)
-
-    repaired = "\n".join(out)
-
-    present = set()
-    in_code_fence = False
-    for ln in repaired.splitlines():
-        stripped = ln.strip()
-        if stripped.startswith("```"):
-            in_code_fence = not in_code_fence
+            (blocks[current]["body"] if current is not None else preamble).append(line)
             continue
         if not in_code_fence and stripped.startswith("## "):
-            present.add(classify_section(stripped[3:].strip()))
-    missing = [k for k in _REQUIRED_SECTIONS if k not in present]
-    for key in missing:
-        repaired += f"\n\n{_CANONICAL_HEADERS[key]}\n"
+            blocks.append(
+                {"key": classify_section(stripped[3:].strip()), "header": line, "body": []}
+            )
+            current = len(blocks) - 1
+            continue
+        (blocks[current]["body"] if current is not None else preamble).append(line)
 
-    return normalize_content(repaired)
+    # Split the preamble: keep the title/blank/comment lines, lift any orphan
+    # item lines (and their continuations) out to re-home under Pending.
+    kept_preamble: List[str] = []
+    orphans: List[str] = []
+    for line in preamble:
+        stripped = line.strip()
+        if stripped.startswith("- ") or stripped.startswith("### "):
+            orphans.append(line)
+        elif stripped == "" or stripped.startswith("#"):
+            kept_preamble.append(line)
+        elif orphans:
+            orphans.append(line)  # continuation of an orphan item
+        else:
+            kept_preamble.append(line)
+
+    # Merge duplicate canonical sections into their first occurrence.
+    merged: List[dict] = []
+    index_by_key: Dict[str, int] = {}
+    for block in blocks:
+        key = block["key"]
+        if key is not None and key in index_by_key:
+            merged[index_by_key[key]]["body"].extend(block["body"])
+        else:
+            merged.append(block)
+            if key is not None:
+                index_by_key[key] = len(merged) - 1
+
+    # Re-home orphan items under Pending (creating the section if absent).
+    if orphans:
+        if "pending" not in index_by_key:
+            merged.insert(0, {"key": "pending", "header": _CANONICAL_HEADERS["pending"], "body": []})
+            index_by_key = {b["key"]: i for i, b in enumerate(merged) if b["key"] is not None}
+        merged[index_by_key["pending"]]["body"].extend(orphans)
+
+    # Append any missing required canonical sections.
+    for key in _REQUIRED_SECTIONS:
+        if key not in index_by_key:
+            merged.append({"key": key, "header": _CANONICAL_HEADERS[key], "body": []})
+            index_by_key[key] = len(merged) - 1
+
+    out: List[str] = list(kept_preamble)
+    for block in merged:
+        out.append("")  # guarantee a blank line before every header
+        out.append(block["header"])
+        out.append("")
+        out.extend(block["body"])
+
+    return normalize_content("\n".join(out))
 
 
 def enforce_size_bound(

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1777,6 +1777,137 @@ def prune_completed_sections(
 
 
 # ---------------------------------------------------------------------------
+# Structural integrity: validation, conservative self-heal, size bounds
+# ---------------------------------------------------------------------------
+
+# Sections that must exist (in this order) for a healthy missions.md.
+# CI is optional (migrated lazily) so it is not required here.
+_REQUIRED_SECTIONS = ("pending", "in_progress", "done", "failed")
+_CANONICAL_HEADERS = {
+    "pending": "## Pending",
+    "in_progress": "## In Progress",
+    "done": "## Done",
+    "failed": "## Failed",
+}
+
+
+def validate_missions_structure(content: str) -> List[str]:
+    """Check structural invariants of missions.md content.
+
+    Returns a list of human-readable issue descriptions. An empty list
+    means the file is structurally healthy. This is a read-only check —
+    it never mutates content.
+
+    Invariants checked:
+    - Each required canonical section is present exactly once.
+    - No ``## `` header is glued to a preceding non-blank line (the
+      production corruption mode from issue #2085).
+    - Every ``- `` item line falls under a recognised section.
+    """
+    issues: List[str] = []
+
+    if not content.strip():
+        # Empty file is not corrupt — startup recreates the skeleton.
+        return issues
+
+    lines = content.splitlines()
+    seen: Dict[str, int] = {}
+    current = None
+    prev_line = None
+
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("## "):
+            if prev_line is not None and prev_line.strip() != "":
+                issues.append(
+                    f"Section header glued to preceding item (missing blank line): {stripped!r}"
+                )
+            key = classify_section(stripped[3:].strip())
+            current = key
+            if key:
+                seen[key] = seen.get(key, 0) + 1
+        elif stripped.startswith("- ") and current is None:
+            issues.append(f"Item line outside any section: {stripped[:60]!r}")
+        prev_line = line
+
+    for key in _REQUIRED_SECTIONS:
+        count = seen.get(key, 0)
+        if count == 0:
+            issues.append(f"Missing required section: {_CANONICAL_HEADERS[key]}")
+        elif count > 1:
+            issues.append(f"Duplicate section header ({count}x): {_CANONICAL_HEADERS[key]}")
+
+    return issues
+
+
+def repair_missions_structure(content: str) -> str:
+    """Conservatively repair structural corruption in missions.md content.
+
+    Repairs applied (all content-preserving):
+    - Insert a blank line before any ``## `` header glued to a preceding
+      item, so section boundaries are unambiguous.
+    - Append any missing required canonical section headers at the end.
+    - Collapse runaway blank lines via :func:`normalize_content`.
+
+    Items, ideas, and any non-canonical content are preserved verbatim;
+    this never drops mission lines. Returns the repaired content.
+    """
+    if not content.strip():
+        return DEFAULT_SKELETON
+
+    lines = content.splitlines()
+    out: List[str] = []
+    for line in lines:
+        if line.strip().startswith("## ") and out and out[-1].strip() != "":
+            out.append("")  # restore the missing blank line before the header
+        out.append(line)
+
+    repaired = "\n".join(out)
+
+    present = {
+        classify_section(ln.strip()[3:].strip())
+        for ln in repaired.splitlines()
+        if ln.strip().startswith("## ")
+    }
+    missing = [k for k in _REQUIRED_SECTIONS if k not in present]
+    for key in missing:
+        repaired += f"\n\n{_CANONICAL_HEADERS[key]}\n"
+
+    return normalize_content(repaired)
+
+
+def enforce_size_bound(
+    content: str,
+    max_lines: int,
+    done_keep: int,
+    failed_keep: int,
+) -> Tuple[str, int]:
+    """Prune completed sections so the file stays within ``max_lines``.
+
+    First prunes Done/Failed to the configured keeps. If the file is still
+    over the line cap, progressively shrinks the keeps (Done first, then
+    Failed) until under the cap or nothing left to prune. Pending and
+    In Progress items are never touched — only completed history is shed.
+
+    Returns (new_content, total_pruned).
+    """
+    content, total_pruned = prune_completed_sections(content, done_keep, failed_keep)
+    if max_lines <= 0:
+        return content, total_pruned
+
+    keep_done, keep_failed = done_keep, failed_keep
+    while len(content.splitlines()) > max_lines and (keep_done > 0 or keep_failed > 0):
+        if keep_done >= keep_failed and keep_done > 0:
+            keep_done = max(0, keep_done - 5)
+        else:
+            keep_failed = max(0, keep_failed - 5)
+        content, pruned = prune_completed_sections(content, keep_done, keep_failed)
+        total_pruned += pruned
+
+    return content, total_pruned
+
+
+# ---------------------------------------------------------------------------
 # Parallel session support
 # ---------------------------------------------------------------------------
 

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -1802,7 +1802,12 @@ def validate_missions_structure(content: str) -> List[str]:
     - Each required canonical section is present exactly once.
     - No ``## `` header is glued to a preceding non-blank line (the
       production corruption mode from issue #2085).
-    - Every ``- `` item line falls under a recognised section.
+    - Every ``- `` item line falls under some section header.
+
+    Content inside ```` ``` ```` code fences is treated as mission body
+    text, never structure — fenced ``## `` / ``- `` lines are ignored.
+    Items under non-canonical sections (e.g. ``## Ideas``) are not flagged
+    as orphans; only items appearing before any section header are.
     """
     issues: List[str] = []
 
@@ -1812,21 +1817,29 @@ def validate_missions_structure(content: str) -> List[str]:
 
     lines = content.splitlines()
     seen: Dict[str, int] = {}
-    current = None
+    seen_any_header = False
+    in_code_fence = False
     prev_line = None
 
     for line in lines:
         stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_fence = not in_code_fence
+            prev_line = line
+            continue
+        if in_code_fence:
+            prev_line = line
+            continue
         if stripped.startswith("## "):
             if prev_line is not None and prev_line.strip() != "":
                 issues.append(
                     f"Section header glued to preceding item (missing blank line): {stripped!r}"
                 )
             key = classify_section(stripped[3:].strip())
-            current = key
+            seen_any_header = True
             if key:
                 seen[key] = seen.get(key, 0) + 1
-        elif stripped.startswith("- ") and current is None:
+        elif stripped.startswith("- ") and not seen_any_header:
             issues.append(f"Item line outside any section: {stripped[:60]!r}")
         prev_line = line
 
@@ -1850,25 +1863,42 @@ def repair_missions_structure(content: str) -> str:
     - Collapse runaway blank lines via :func:`normalize_content`.
 
     Items, ideas, and any non-canonical content are preserved verbatim;
-    this never drops mission lines. Returns the repaired content.
+    this never drops mission lines. ``## `` lines inside ```` ``` ````
+    code fences are mission body text and are left untouched. Returns the
+    repaired content.
     """
     if not content.strip():
         return DEFAULT_SKELETON
 
     lines = content.splitlines()
     out: List[str] = []
+    in_code_fence = False
     for line in lines:
-        if line.strip().startswith("## ") and out and out[-1].strip() != "":
+        stripped = line.strip()
+        if stripped.startswith("```"):
+            in_code_fence = not in_code_fence
+            out.append(line)
+            continue
+        if (
+            not in_code_fence
+            and stripped.startswith("## ")
+            and out
+            and out[-1].strip() != ""
+        ):
             out.append("")  # restore the missing blank line before the header
         out.append(line)
 
     repaired = "\n".join(out)
 
-    present = {
-        classify_section(ln.strip()[3:].strip())
-        for ln in repaired.splitlines()
-        if ln.strip().startswith("## ")
-    }
+    present = set()
+    in_code_fence = False
+    for ln in repaired.splitlines():
+        stripped = ln.strip()
+        if stripped.startswith("```"):
+            in_code_fence = not in_code_fence
+            continue
+        if not in_code_fence and stripped.startswith("## "):
+            present.add(classify_section(stripped[3:].strip()))
     missing = [k for k in _REQUIRED_SECTIONS if k not in present]
     for key in missing:
         repaired += f"\n\n{_CANONICAL_HEADERS[key]}\n"

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2486,7 +2486,12 @@ def _prune_missions_history(instance: str) -> None:
     is logged and swallowed.
     """
     try:
-        from app.missions import prune_completed_sections
+        from app.config import (
+            get_missions_done_keep,
+            get_missions_failed_keep,
+            get_missions_max_lines,
+        )
+        from app.missions import enforce_size_bound
         from app.utils import modify_missions_file
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
@@ -2495,7 +2500,12 @@ def _prune_missions_history(instance: str) -> None:
         pruned = [0]
 
         def _transform(content):
-            new_content, count = prune_completed_sections(content)
+            new_content, count = enforce_size_bound(
+                content,
+                max_lines=get_missions_max_lines(),
+                done_keep=get_missions_done_keep(),
+                failed_keep=get_missions_failed_keep(),
+            )
             pruned[0] = count
             return new_content
 

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -7,7 +7,6 @@ blocking the entire startup.
 Called from run.py's main_loop() during process initialization.
 """
 
-import contextlib
 import os
 import time
 from pathlib import Path
@@ -348,8 +347,13 @@ def _prune_old_missions_backups(missions_path: Path, keep: int = 5) -> None:
     """
     backups = sorted(missions_path.parent.glob(".missions.md.bak-*"))
     for old in backups[:-keep]:
-        with contextlib.suppress(OSError):
+        try:
             old.unlink()
+        except OSError as exc:
+            # Surface a recurring inability to prune backups instead of
+            # letting them silently accumulate (the exact failure this
+            # helper guards against).
+            log("warn", f"Could not prune old missions backup {old.name}: {exc}")
 
 
 def prune_missions_done(instance: str):

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -339,24 +339,80 @@ def cleanup_memory(instance: str):
 
 
 def prune_missions_done(instance: str):
-    """Prune old Done and Failed items from missions.md to keep file size bounded.
+    """Validate, self-heal, and size-bound missions.md at startup.
 
-    missions.md grows unbounded as completed missions accumulate. At 190KB+,
-    the agent wastes context tokens reading it. Keep only the last 50 Done
-    and 30 Failed items.
+    missions.md is the hot-path source of truth for the mission queue. In
+    production it has grown gigantic and structurally corrupted (see issue
+    #2085), silently degrading the agent loop. This startup task:
+
+    1. Validates structural invariants (canonical sections present, no
+       headers glued to preceding items).
+    2. On corruption, backs up the original to ``.missions.md.bak-<ts>``,
+       conservatively repairs it, and surfaces a loud warning.
+    3. Enforces configurable size bounds (done_keep / failed_keep /
+       max_lines under the ``missions:`` config section), shedding old
+       completed history first.
     """
     missions_path = Path(instance) / "missions.md"
     if not missions_path.exists():
         return
 
-    from app.missions import prune_completed_sections
+    from app.config import (
+        get_missions_done_keep,
+        get_missions_failed_keep,
+        get_missions_max_lines,
+    )
+    from app.missions import (
+        enforce_size_bound,
+        repair_missions_structure,
+        validate_missions_structure,
+    )
     from app.utils import atomic_write
 
     content = missions_path.read_text()
-    new_content, pruned = prune_completed_sections(content)
-    if pruned > 0:
+
+    # 1+2. Structural validation and conservative self-heal. A merely
+    # incomplete file (a missing canonical section, e.g. fresh installs
+    # without ## Failed) is healed silently; genuine corruption (headers
+    # glued to items, duplicate headers, orphan items) is backed up and
+    # surfaced loudly to the operator.
+    issues = validate_missions_structure(content)
+    if issues:
+        serious = [i for i in issues if "Missing required section" not in i]
+        if serious:
+            ts = time.strftime("%Y%m%d-%H%M%S")
+            backup = missions_path.with_name(f".missions.md.bak-{ts}")
+            try:
+                backup.write_text(content)
+            except OSError as exc:
+                log("warn", f"Could not back up corrupt missions.md: {exc}")
+            summary = "; ".join(serious[:5])
+            log("warn", f"missions.md structural corruption detected and repaired: {summary}")
+            try:
+                from app.notify import NotificationPriority
+                from app.utils import append_to_outbox
+                append_to_outbox(
+                    Path(instance) / "outbox.md",
+                    "⚠️ missions.md was structurally corrupt and has been auto-repaired "
+                    f"(backup: {backup.name}). Issues: {summary}\n",
+                    priority=NotificationPriority.WARNING,
+                )
+            except Exception as exc:
+                log("warn", f"Failed to notify about missions.md repair: {exc}")
+        content = repair_missions_structure(content)
+
+    # 3. Enforce configurable size bounds.
+    new_content, pruned = enforce_size_bound(
+        content,
+        max_lines=get_missions_max_lines(),
+        done_keep=get_missions_done_keep(),
+        failed_keep=get_missions_failed_keep(),
+    )
+
+    if issues or pruned > 0 or new_content != content:
         atomic_write(missions_path, new_content)
-        log("health", f"Pruned {pruned} old Done/Failed items from missions.md")
+        if pruned > 0:
+            log("health", f"Pruned {pruned} old Done/Failed items from missions.md")
 
 
 def cleanup_mission_history(instance: str):

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -7,6 +7,7 @@ blocking the entire startup.
 Called from run.py's main_loop() during process initialization.
 """
 
+import contextlib
 import os
 import time
 from pathlib import Path
@@ -338,6 +339,19 @@ def cleanup_memory(instance: str):
             log("health", f"Global memory capped: {name} ({value} lines removed)")
 
 
+def _prune_old_missions_backups(missions_path: Path, keep: int = 5) -> None:
+    """Keep only the most recent ``keep`` ``.missions.md.bak-*`` backups.
+
+    Backups are timestamped (``YYYYMMDD-HHMMSS``) so lexical sort is
+    chronological. Prevents a flapping/corrupt file from accumulating an
+    unbounded set of backups in ``instance/``.
+    """
+    backups = sorted(missions_path.parent.glob(".missions.md.bak-*"))
+    for old in backups[:-keep]:
+        with contextlib.suppress(OSError):
+            old.unlink()
+
+
 def prune_missions_done(instance: str):
     """Validate, self-heal, and size-bound missions.md at startup.
 
@@ -382,10 +396,24 @@ def prune_missions_done(instance: str):
         if serious:
             ts = time.strftime("%Y%m%d-%H%M%S")
             backup = missions_path.with_name(f".missions.md.bak-{ts}")
+            backup_ok = False
             try:
                 backup.write_text(content)
+                backup_ok = backup.exists()
             except OSError as exc:
                 log("warn", f"Could not back up corrupt missions.md: {exc}")
+            if not backup_ok:
+                # Backup is the only safeguard before the destructive
+                # atomic_write below; without it, repairing would overwrite
+                # the sole copy of the data. Leave the file untouched and
+                # surface a hard error instead of silently destroying it.
+                log(
+                    "warn",
+                    "missions.md is corrupt but backup failed — leaving file "
+                    "untouched, skipping repair",
+                )
+                return
+            _prune_old_missions_backups(missions_path)
             summary = "; ".join(serious[:5])
             log("warn", f"missions.md structural corruption detected and repaired: {summary}")
             try:

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -45,6 +45,9 @@ from app.missions import (
     strip_all_lifecycle_markers,
     strip_timestamps,
     prune_completed_sections,
+    validate_missions_structure,
+    repair_missions_structure,
+    enforce_size_bound,
     prune_done_section,
     prune_failed_section,
     _enforce_quarantine_cap,
@@ -3345,6 +3348,143 @@ class TestPruneCompletedSections:
         content = "# Missions\n\n## Pending\n\n- Task\n"
         result, total = prune_completed_sections(content)
         assert total == 0
+
+
+HEALTHY_MISSIONS = (
+    "# Missions\n\n"
+    "## Pending\n\n"
+    "- Pending task\n\n"
+    "## In Progress\n\n"
+    "## Done\n\n"
+    "- Done task ✅\n\n"
+    "## Failed\n\n"
+    "- Failed task ❌\n"
+)
+
+
+class TestValidateMissionsStructure:
+    """validate_missions_structure() — read-only structural integrity check."""
+
+    def test_healthy_file_has_no_issues(self):
+        assert validate_missions_structure(HEALTHY_MISSIONS) == []
+
+    def test_empty_file_is_not_corrupt(self):
+        assert validate_missions_structure("") == []
+        assert validate_missions_structure("   \n") == []
+
+    def test_detects_glued_header(self):
+        # '## Done' glued directly to the preceding item — the production
+        # corruption mode from issue #2085.
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "## In Progress\n\n"
+            "- [project:koan] running\n"
+            "## Done\n\n"
+            "## Failed\n"
+        )
+        issues = validate_missions_structure(content)
+        assert any("glued" in i.lower() for i in issues)
+
+    def test_detects_missing_section(self):
+        content = "# Missions\n\n## Pending\n\n## In Progress\n\n## Done\n"
+        issues = validate_missions_structure(content)
+        assert any("Failed" in i for i in issues)
+
+    def test_detects_duplicate_section(self):
+        content = (
+            "# Missions\n\n## Pending\n\n## In Progress\n\n"
+            "## Done\n\n## Done\n\n## Failed\n"
+        )
+        issues = validate_missions_structure(content)
+        assert any("Duplicate" in i for i in issues)
+
+
+class TestRepairMissionsStructure:
+    """repair_missions_structure() — conservative, content-preserving self-heal."""
+
+    def test_healthy_file_round_trips_valid(self):
+        repaired = repair_missions_structure(HEALTHY_MISSIONS)
+        assert validate_missions_structure(repaired) == []
+
+    def test_repairs_glued_header_and_preserves_items(self):
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- Keep me pending\n\n"
+            "## In Progress\n\n"
+            "- [project:koan] running\n"
+            "## Done\n\n"
+            "## Failed\n"
+        )
+        assert validate_missions_structure(content)  # corrupt before
+        repaired = repair_missions_structure(content)
+        assert validate_missions_structure(repaired) == []
+        sections = parse_sections(repaired)
+        assert sections["pending"] == ["- Keep me pending"]
+        assert any("running" in i for i in sections["in_progress"])
+
+    def test_appends_missing_sections(self):
+        content = "# Missions\n\n## Pending\n\n- Task\n"
+        repaired = repair_missions_structure(content)
+        assert validate_missions_structure(repaired) == []
+        assert parse_sections(repaired)["pending"] == ["- Task"]
+
+    def test_empty_yields_skeleton(self):
+        repaired = repair_missions_structure("")
+        assert validate_missions_structure(repaired) == []
+
+    def test_preserves_non_canonical_ideas_section(self):
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n## In Progress\n\n## Done\n\n## Failed\n\n"
+            "## Ideas\n\n- A neat idea\n"
+        )
+        repaired = repair_missions_structure(content)
+        assert "## Ideas" in repaired
+        assert "A neat idea" in repaired
+
+
+class TestEnforceSizeBound:
+    """enforce_size_bound() — caps file line count by shedding old history."""
+
+    def _build(self, n_done):
+        done_items = "\n".join(f"- Done {i} ✅" for i in range(n_done))
+        return (
+            "# Missions\n\n"
+            "## Pending\n\n- keep pending\n\n"
+            "## In Progress\n\n"
+            "## Done\n"
+            f"{done_items}\n\n"
+            "## Failed\n\n- one fail ❌\n"
+        )
+
+    def test_under_cap_only_applies_keeps(self):
+        content = self._build(5)
+        result, pruned = enforce_size_bound(
+            content, max_lines=500, done_keep=50, failed_keep=30
+        )
+        assert pruned == 0
+        assert len(parse_sections(result)["done"]) == 5
+
+    def test_shrinks_below_max_lines(self):
+        content = self._build(200)
+        result, pruned = enforce_size_bound(
+            content, max_lines=40, done_keep=50, failed_keep=30
+        )
+        assert pruned > 0
+        assert len(result.splitlines()) <= 40
+        # Pending/In Progress preserved — only completed history shed.
+        assert parse_sections(result)["pending"] == ["- keep pending"]
+
+    def test_zero_max_lines_disables_hard_cap(self):
+        content = self._build(100)
+        result, pruned = enforce_size_bound(
+            content, max_lines=0, done_keep=50, failed_keep=30
+        )
+        # Only the configured keep applies; no further shrink loop.
+        assert len(parse_sections(result)["done"]) == 50
+        assert pruned == 50
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -3483,6 +3483,49 @@ class TestRepairMissionsStructure:
         assert body_block in repaired
         assert validate_missions_structure(repaired) == []
 
+    def test_h1_title_glued_to_first_section_not_corruption(self):
+        # '# Missions' directly above '## Pending' (no blank line) is the
+        # title, not a glued item — must not be flagged as corruption.
+        content = "# Missions\n## Pending\n\n## In Progress\n\n## Done\n\n## Failed\n"
+        assert validate_missions_structure(content) == []
+
+    def test_merges_duplicate_sections(self):
+        content = (
+            "# Missions\n\n## Pending\n\n- p1\n\n## In Progress\n\n"
+            "## Done\n\n- d1 ✅\n\n## Done\n\n- d2 ✅\n\n## Failed\n"
+        )
+        assert validate_missions_structure(content)  # duplicate flagged
+        repaired = repair_missions_structure(content)
+        assert validate_missions_structure(repaired) == []
+        done = parse_sections(repaired)["done"]
+        assert "- d1 ✅" in done
+        assert "- d2 ✅" in done
+
+    def test_rehomes_orphan_items_under_pending(self):
+        # Item line before any section header — orphan corruption.
+        content = (
+            "# Missions\n\n- orphan task\n\n## Pending\n\n- p1\n\n"
+            "## In Progress\n\n## Done\n\n## Failed\n"
+        )
+        assert validate_missions_structure(content)  # orphan flagged
+        repaired = repair_missions_structure(content)
+        assert validate_missions_structure(repaired) == []
+        pending = parse_sections(repaired)["pending"]
+        assert "- orphan task" in pending
+        assert "- p1" in pending
+
+    def test_repair_converges_on_second_pass(self):
+        # Repair must resolve everything validate flags as serious, so a
+        # second repair/validate round produces no further issues.
+        content = (
+            "# Missions\n- orphan\n## Pending\n\n- p1\n## In Progress\n\n"
+            "## Done\n\n## Done\n\n## Failed\n"
+        )
+        once = repair_missions_structure(content)
+        assert validate_missions_structure(once) == []
+        twice = repair_missions_structure(once)
+        assert once == twice
+
 
 class TestEnforceSizeBound:
     """enforce_size_bound() — caps file line count by shedding old history."""

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -3399,6 +3399,28 @@ class TestValidateMissionsStructure:
         issues = validate_missions_structure(content)
         assert any("Duplicate" in i for i in issues)
 
+    def test_items_under_non_canonical_section_not_flagged(self):
+        # Items under a non-canonical section (## Ideas) must not be
+        # reported as orphan corruption.
+        content = HEALTHY_MISSIONS + "\n## Ideas\n\n- A neat idea\n"
+        assert validate_missions_structure(content) == []
+
+    def test_fenced_headers_in_body_not_treated_as_structure(self):
+        # A mission body containing fenced markdown with ## / duplicate
+        # headers must not produce false glued/duplicate issues.
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- Document the sections\n"
+            "  ```\n"
+            "  ## Done\n"
+            "  ## Done\n"
+            "  some text\n"
+            "  ```\n\n"
+            "## In Progress\n\n## Done\n\n## Failed\n"
+        )
+        assert validate_missions_structure(content) == []
+
 
 class TestRepairMissionsStructure:
     """repair_missions_structure() — conservative, content-preserving self-heal."""
@@ -3443,6 +3465,23 @@ class TestRepairMissionsStructure:
         repaired = repair_missions_structure(content)
         assert "## Ideas" in repaired
         assert "A neat idea" in repaired
+
+    def test_does_not_mutate_fenced_mission_body(self):
+        # A glued ## header inside a fenced mission body must be left
+        # untouched — repair must not inject a blank line into the body.
+        body_block = "  ```\n  ## Done\n  ## Failed\n  ```"
+        content = (
+            "# Missions\n\n"
+            "## Pending\n\n"
+            "- Mission with fenced doc\n"
+            f"{body_block}\n\n"
+            "## In Progress\n\n## Done\n\n## Failed\n"
+        )
+        repaired = repair_missions_structure(content)
+        # The fenced block is preserved verbatim (no blank line injected
+        # before the fenced ## headers).
+        assert body_block in repaired
+        assert validate_missions_structure(repaired) == []
 
 
 class TestEnforceSizeBound:

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -364,15 +364,53 @@ class TestPruneMissionsDone:
         from app.startup_manager import prune_missions_done
         prune_missions_done(str(tmp_path))  # should not raise
 
-    def test_noop_when_few_done_items(self, tmp_path):
+    def test_no_pruning_when_few_done_items(self, tmp_path):
+        from app.startup_manager import prune_missions_done
+        from app.missions import parse_sections
+
+        missions = tmp_path / "missions.md"
+        # Incomplete file (no In Progress/Failed): items are preserved and
+        # missing canonical sections are silently healed, but no Done items
+        # are pruned since the count is under the keep threshold.
+        missions.write_text("# Missions\n\n## Pending\n\n## Done\n- Task 1\n- Task 2\n")
+
+        prune_missions_done(str(tmp_path))
+
+        sections = parse_sections(missions.read_text())
+        assert sections["done"] == ["- Task 1", "- Task 2"]
+
+    def test_silently_heals_missing_sections_without_backup(self, tmp_path):
         from app.startup_manager import prune_missions_done
 
         missions = tmp_path / "missions.md"
-        content = "# Missions\n\n## Pending\n\n## Done\n- Task 1\n- Task 2\n"
-        missions.write_text(content)
+        missions.write_text("# Missions\n\n## Pending\n\n## Done\n- Task 1\n")
 
         prune_missions_done(str(tmp_path))
-        assert missions.read_text() == content
+
+        content = missions.read_text()
+        assert "## In Progress" in content
+        assert "## Failed" in content
+        # Benign incomplete file → no corruption backup written.
+        assert not list(tmp_path.glob(".missions.md.bak-*"))
+
+    def test_backs_up_and_repairs_glued_header(self, tmp_path):
+        from app.startup_manager import prune_missions_done
+        from app.missions import validate_missions_structure
+
+        missions = tmp_path / "missions.md"
+        # '## Done' glued to the preceding In Progress item — real corruption.
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n## In Progress\n\n"
+            "- [project:koan] running\n## Done\n\n## Failed\n"
+        )
+
+        prune_missions_done(str(tmp_path))
+
+        content = missions.read_text()
+        assert validate_missions_structure(content) == []
+        assert "running" in content
+        # Genuine corruption → timestamped backup written.
+        assert list(tmp_path.glob(".missions.md.bak-*"))
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -440,6 +440,26 @@ class TestPruneMissionsDone:
         assert missions.read_text() == corrupt
         assert not list(tmp_path.glob(".missions.md.bak-*"))
 
+    def test_corrupt_file_not_renotified_on_second_pass(self, tmp_path):
+        from app.startup_manager import prune_missions_done
+        from app.missions import validate_missions_structure
+
+        missions = tmp_path / "missions.md"
+        # Orphan item + duplicate Done — corruption repair must fully resolve.
+        missions.write_text(
+            "# Missions\n- orphan task\n## Pending\n\n## In Progress\n\n"
+            "## Done\n\n## Done\n\n## Failed\n"
+        )
+
+        prune_missions_done(str(tmp_path))
+        first_backups = list(tmp_path.glob(".missions.md.bak-*"))
+        assert first_backups  # genuine corruption → backed up once
+        assert validate_missions_structure(missions.read_text()) == []
+
+        # Second pass over the now-healed file: no new corruption, no new backup.
+        prune_missions_done(str(tmp_path))
+        assert list(tmp_path.glob(".missions.md.bak-*")) == first_backups
+
     def test_old_backups_are_pruned(self, tmp_path):
         from app.startup_manager import _prune_old_missions_backups
 

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -412,6 +412,49 @@ class TestPruneMissionsDone:
         # Genuine corruption → timestamped backup written.
         assert list(tmp_path.glob(".missions.md.bak-*"))
 
+    def test_failed_backup_leaves_corrupt_file_untouched(self, tmp_path, monkeypatch):
+        from app.startup_manager import prune_missions_done
+
+        missions = tmp_path / "missions.md"
+        corrupt = (
+            "# Missions\n\n## Pending\n\n## In Progress\n\n"
+            "- [project:koan] running\n## Done\n\n## Failed\n"
+        )
+        missions.write_text(corrupt)
+
+        # Simulate the backup write failing.
+        import pathlib
+
+        orig_write_text = pathlib.Path.write_text
+
+        def _failing_write_text(self, *args, **kwargs):
+            if self.name.startswith(".missions.md.bak-"):
+                raise OSError("disk full")
+            return orig_write_text(self, *args, **kwargs)
+
+        monkeypatch.setattr(pathlib.Path, "write_text", _failing_write_text)
+
+        prune_missions_done(str(tmp_path))
+
+        # Destructive write skipped: the corrupt file is preserved as-is.
+        assert missions.read_text() == corrupt
+        assert not list(tmp_path.glob(".missions.md.bak-*"))
+
+    def test_old_backups_are_pruned(self, tmp_path):
+        from app.startup_manager import _prune_old_missions_backups
+
+        missions = tmp_path / "missions.md"
+        missions.write_text("# Missions\n")
+        for i in range(8):
+            (tmp_path / f".missions.md.bak-2026010{i}-000000").write_text("x")
+
+        _prune_old_missions_backups(missions, keep=5)
+
+        remaining = sorted(p.name for p in tmp_path.glob(".missions.md.bak-*"))
+        assert len(remaining) == 5
+        # Newest are kept.
+        assert remaining[-1] == ".missions.md.bak-20260107-000000"
+
 
 # ---------------------------------------------------------------------------
 # Test: cleanup_mission_history


### PR DESCRIPTION
## What
Add startup integrity validation, conservative self-heal, and configurable size bounds to `missions.md` (closes #2085).

## Why
`missions.md` is the single source of truth for the queue and is read/rewritten on every loop iteration. In production it grew gigantic and structurally corrupted (headers glued to items, hundreds of accumulated Done/Failed entries), silently degrading mission lifecycle with zombie In Progress entries. The file had no hard size bound and no startup integrity check — a single malformed write could degrade the whole loop with no surfaced error.

## How
- `validate_missions_structure()` — read-only invariant check (canonical sections present once, no header glued to a preceding item, no orphan items).
- `repair_missions_structure()` — content-preserving self-heal: restore blank lines around headers, append missing canonical sections. Never drops mission lines; Ideas and other non-canonical content preserved.
- `enforce_size_bound()` — prune Done/Failed to configured keeps, then progressively shed older completed history until under `max_lines`. Pending/In Progress are never touched.
- Startup `prune_missions_done` now validates first: incomplete files (e.g. fresh installs missing `## Failed`) are healed silently; genuine corruption is backed up to `instance/.missions.md.bak-<ts>` and announced via the outbox before repair. Post-mission pruning honours the same caps.
- New `missions:` config section (`done_keep`/`failed_keep`/`max_lines`), documented in `instance.example/config.yaml` and `docs/architecture/mission-lifecycle.md`.

Scope note: age-based purge and inline archive-to-file (issue items #2 and the archive variant of #1) were left out to keep this focused on the critical missing piece — startup integrity + a hard size cap. Worth a follow-up if completed-history retention windows are wanted.

## Testing
- 22 new tests across `test_missions.py` (validate/repair/enforce_size_bound) and `test_startup_manager.py` (silent heal vs backup+notify on real corruption). All pass.
- Full suite: pre-existing dashboard/pr_tracker failures are unrelated (confirmed failing on `main`); everything else green. Lint clean.
