### PR TITLE
Never start ollama serve unless provider is exactly ollama (#2172)

### DIFF
--- a/docs/setup/railway.md
+++ b/docs/setup/railway.md
@@ -61,6 +61,13 @@ On every boot, `KOAN_DEPLOY=railway` makes the entrypoint:
   program). On Railway the dashboard is the primary UI; on every other deploy
   the program stays idle. The port is overridable via `KOAN_DASHBOARD_PORT`
   (falls back to `PORT`, then `5000`).
+- **Refuse to start `ollama serve`.** The hosted profile defaults to the Claude
+  provider, and `ollama serve` is the single largest idle RAM consumer in the
+  stack. Even if the resolved provider is `ollama`, the launcher refuses to
+  start the bundled `ollama serve` unless you explicitly set
+  `KOAN_ALLOW_OLLAMA=1`. On every deploy (Railway or not) `ollama serve` is
+  also never started when the resolved provider is anything other than
+  `ollama`.
 
 ## Dashboard passphrase (`KOAN_DASHBOARD_PWD`)
 
@@ -97,6 +104,7 @@ service variables are set.
 | Git prompts for a username | No token set — set `KOAN_GH_TOKEN` (or `GH_TOKEN`). |
 | PRs/commits authored by the operator, not the bot | Railway injected its own `GH_TOKEN`; set `KOAN_GH_TOKEN` to the bot token (it overrides `GH_TOKEN`). |
 | No projects after a redeploy | Put config in `instance/projects.yaml`, not the repo root. |
+| `ollama serve` not starting (intended) | Hosted profile refuses it to save RAM. Set provider to `ollama` **and** `KOAN_ALLOW_OLLAMA=1` to run it on Railway. |
 
 ## Local / dev installs
 

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -348,14 +348,75 @@ def start_runner(
     )
 
 
-def start_ollama(koan_root: Path, verify_timeout: float = OLLAMA_VERIFY_TIMEOUT) -> tuple:
+def _ollama_railway_opt_in() -> bool:
+    """True when the operator explicitly allows ollama serve on a hosted deploy.
+
+    ``ollama serve`` is the single largest idle RAM consumer in the stack, so on
+    a Railway (hosted single-container) deploy — whose profile defaults to the
+    Claude provider — it is refused unless ``KOAN_ALLOW_OLLAMA`` opts in.
+    """
+    return os.environ.get("KOAN_ALLOW_OLLAMA", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _ollama_start_allowed(koan_root: Path, provider: Optional[str] = None) -> tuple:
+    """Decide whether ``ollama serve`` may be started on this deploy.
+
+    Returns ``(allowed: bool, reason: str)``. ``reason`` is empty when allowed.
+
+    ``ollama serve`` must never launch unless the resolved CLI provider is
+    exactly ``"ollama"`` — it is the largest idle memory consumer and is pure
+    wasted footprint on a Claude/Copilot deploy (#2172). On Railway the hosted
+    profile defaults to Claude, so even an ``ollama`` provider is refused unless
+    ``KOAN_ALLOW_OLLAMA`` explicitly opts in.
+
+    When ``provider`` is None it is resolved via :func:`_detect_provider`.
+    Callers that deliberately want ollama (e.g. ``make ollama``) pass
+    ``provider="ollama"`` to assert that intent.
+    """
+    if provider is None:
+        provider = _detect_provider(koan_root)
+    if not _needs_ollama(provider):
+        return False, (
+            f"provider is '{provider}', not 'ollama' — skipping ollama serve "
+            "(saves idle RAM)"
+        )
+    try:
+        from app.railway import is_railway
+        railway = is_railway()
+    except (ImportError, OSError, ValueError):
+        railway = False
+    if railway and not _ollama_railway_opt_in():
+        return False, (
+            "Railway deploy defaults to the Claude provider — refusing to start "
+            "ollama serve. Set KOAN_ALLOW_OLLAMA=1 to override."
+        )
+    return True, ""
+
+
+def start_ollama(
+    koan_root: Path,
+    verify_timeout: float = OLLAMA_VERIFY_TIMEOUT,
+    provider: Optional[str] = None,
+) -> tuple:
     """Start ollama serve as a detached subprocess.
 
-    Checks that ollama binary is available, not already running,
-    then launches it in the background with a tracked PID file.
+    Refuses to launch unless :func:`_ollama_start_allowed` permits it — this is
+    the single chokepoint that guarantees ``ollama serve`` (the largest idle RAM
+    consumer) never starts on a non-ollama deploy or an opt-out Railway deploy
+    (#2172). Then checks that the ollama binary is available and not already
+    running, and launches it in the background with a tracked PID file.
+
+    ``provider`` lets a caller assert the resolved/intended provider; when None
+    it is detected from env/config.
 
     Returns (success: bool, message: str).
     """
+    allowed, reason = _ollama_start_allowed(koan_root, provider)
+    if not allowed:
+        return False, reason
+
     pid = check_pidfile(koan_root, "ollama")
     if pid:
         return False, f"ollama already running (PID {pid})"
@@ -614,18 +675,29 @@ def start_all(koan_root: Path, provider: str = None, show_banner: bool = True) -
     if provider is None:
         provider = _detect_provider(koan_root)
 
+    # Log the resolved provider so a mis-set env/config (which would otherwise
+    # silently launch ollama serve) is visible at startup (#2172).
+    print(f"[pid_manager] resolved CLI provider: {provider}", file=sys.stderr)
+
     # Display startup banner before launching processes
     if show_banner:
         _show_startup_banner(koan_root, provider)
 
     results = {}
 
-    # 1. Start ollama serve if needed
-    if _needs_ollama(provider):
-        ok, msg = start_ollama(koan_root)
+    # 1. Start ollama serve only when the resolved provider needs it AND the
+    #    deploy permits it (never on a Claude deploy; not on Railway unless
+    #    explicitly opted in). ollama serve is the largest idle RAM consumer.
+    allowed, reason = _ollama_start_allowed(koan_root, provider)
+    if allowed:
+        ok, msg = start_ollama(koan_root, provider=provider)
         results["ollama"] = (ok, msg)
         if ok:
             time.sleep(1)
+    elif _needs_ollama(provider):
+        # Provider is ollama but the deploy guard refused (e.g. Railway without
+        # opt-in). Log the reason — this is intentional, not a launch failure.
+        print(f"[pid_manager] {reason}", file=sys.stderr)
 
     # 2. Start awake (Telegram bridge)
     ok, msg = start_awake(koan_root)
@@ -852,7 +924,9 @@ if __name__ == "__main__":
 
     if action == "start-ollama":
         root = Path(sys.argv[2])
-        ok, msg = start_ollama(root)
+        # Explicit operator command — assert ollama intent (the Railway guard in
+        # start_ollama still applies). Auto paths use the resolved provider.
+        ok, msg = start_ollama(root, provider="ollama")
         print(f"  {msg}")
         sys.exit(0 if ok else 1)
 

--- a/koan/tests/test_pid_manager.py
+++ b/koan/tests/test_pid_manager.py
@@ -44,6 +44,17 @@ from app.pid_manager import (
 pytestmark = pytest.mark.slow
 
 
+@pytest.fixture(autouse=True)
+def _isolate_deploy_env(monkeypatch):
+    """Clear ambient deploy env so ollama gating tests are deterministic.
+
+    The host may set KOAN_DEPLOY=railway (which refuses ollama serve) or
+    KOAN_ALLOW_OLLAMA; tests that exercise those paths set them explicitly.
+    """
+    monkeypatch.delenv("KOAN_DEPLOY", raising=False)
+    monkeypatch.delenv("KOAN_ALLOW_OLLAMA", raising=False)
+
+
 # ---------------------------------------------------------------------------
 # _pidfile_path
 # ---------------------------------------------------------------------------
@@ -1017,13 +1028,13 @@ class TestStartOllama:
         pidfile = tmp_path / ".koan-pid-ollama"
         pidfile.write_text(str(os.getpid()))
 
-        ok, msg = start_ollama(tmp_path)
+        ok, msg = start_ollama(tmp_path, provider="ollama")
         assert ok is False
         assert "already running" in msg
 
     def test_returns_error_when_binary_not_found(self, tmp_path):
         with patch("app.pid_manager.shutil.which", return_value=None):
-            ok, msg = start_ollama(tmp_path)
+            ok, msg = start_ollama(tmp_path, provider="ollama")
 
         assert ok is False
         assert "not found in PATH" in msg
@@ -1035,7 +1046,7 @@ class TestStartOllama:
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch("app.pid_manager._is_process_alive", return_value=True):
-            ok, msg = start_ollama(tmp_path, verify_timeout=0.5)
+            ok, msg = start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
 
         assert ok is True
         assert "54321" in msg
@@ -1051,7 +1062,7 @@ class TestStartOllama:
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", return_value=mock_proc), \
              patch("app.pid_manager._is_process_alive", return_value=True):
-            start_ollama(tmp_path, verify_timeout=0.5)
+            start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
 
         pidfile = tmp_path / ".koan-pid-ollama"
         assert pidfile.exists()
@@ -1060,7 +1071,7 @@ class TestStartOllama:
     def test_returns_failure_on_popen_exception(self, tmp_path):
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", side_effect=OSError("Permission denied")):
-            ok, msg = start_ollama(tmp_path)
+            ok, msg = start_ollama(tmp_path, provider="ollama")
 
         assert ok is False
         assert "Failed to launch ollama" in msg
@@ -1072,7 +1083,7 @@ class TestStartOllama:
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", return_value=mock_proc), \
              patch("app.pid_manager._is_process_alive", return_value=False):
-            ok, msg = start_ollama(tmp_path, verify_timeout=0.5)
+            ok, msg = start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
 
         assert ok is False
         assert "exited immediately" in msg
@@ -1085,11 +1096,50 @@ class TestStartOllama:
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", return_value=mock_proc), \
              patch("app.pid_manager._is_process_alive", return_value=False):
-            ok, msg = start_ollama(tmp_path, verify_timeout=0.5)
+            ok, msg = start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
 
         assert ok is False
         pidfile = tmp_path / ".koan-pid-ollama"
         assert not pidfile.exists(), "Stale PID file should be removed after failed launch"
+
+    # --- provider/deploy gating (#2172) ---
+
+    def test_refuses_when_provider_not_ollama(self, tmp_path):
+        """ollama serve must never start on a non-ollama deploy."""
+        with patch("app.pid_manager.subprocess.Popen") as mock_popen:
+            ok, msg = start_ollama(tmp_path, provider="claude")
+        assert ok is False
+        assert "not 'ollama'" in msg
+        mock_popen.assert_not_called()
+
+    def test_refuses_auto_detected_claude(self, tmp_path):
+        """With no provider arg, a claude-resolving deploy refuses ollama."""
+        with patch("app.pid_manager._detect_provider", return_value="claude"), \
+             patch("app.pid_manager.subprocess.Popen") as mock_popen:
+            ok, msg = start_ollama(tmp_path)
+        assert ok is False
+        mock_popen.assert_not_called()
+
+    def test_refuses_on_railway_without_opt_in(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_DEPLOY", "railway")
+        monkeypatch.delenv("KOAN_ALLOW_OLLAMA", raising=False)
+        with patch("app.pid_manager.subprocess.Popen") as mock_popen:
+            ok, msg = start_ollama(tmp_path, provider="ollama")
+        assert ok is False
+        assert "Railway" in msg
+        mock_popen.assert_not_called()
+
+    def test_railway_opt_in_allows_ollama(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("KOAN_DEPLOY", "railway")
+        monkeypatch.setenv("KOAN_ALLOW_OLLAMA", "1")
+        mock_proc = MagicMock()
+        mock_proc.pid = 777
+        with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
+             patch("app.pid_manager.subprocess.Popen", return_value=mock_proc), \
+             patch("app.pid_manager._is_process_alive", return_value=True):
+            ok, msg = start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
+        assert ok is True
+        assert "777" in msg
 
 
 # ---------------------------------------------------------------------------
@@ -1556,7 +1606,7 @@ class TestStarterLogFiles:
         with patch("app.pid_manager.shutil.which", return_value="/usr/local/bin/ollama"), \
              patch("app.pid_manager.subprocess.Popen", return_value=mock_proc) as mock_popen, \
              patch("app.pid_manager._is_process_alive", return_value=True):
-            start_ollama(tmp_path, verify_timeout=0.5)
+            start_ollama(tmp_path, verify_timeout=0.5, provider="ollama")
 
         call_args = mock_popen.call_args
         stdout_arg = call_args[1]["stdout"]


### PR DESCRIPTION
## Summary

`ollama serve` is the single largest idle RAM consumer in the stack and was the only ungated launch primitive — once `start_ollama()` was reached it launched unconditionally, relying entirely on the caller's gate. This adds a single chokepoint so it never starts unless the resolved provider is exactly `ollama`, and refuses on Railway unless explicitly opted in.

Closes https://github.com/Anantys-oss/koan/issues/2172

## Changes

- Add `_ollama_start_allowed()` inside `start_ollama()`: refuses unless the resolved provider is exactly `ollama`, and refuses on `KOAN_DEPLOY=railway` unless `KOAN_ALLOW_OLLAMA` opts in (hosted profile defaults to Claude).
- `start_all()` logs the resolved CLI provider at startup so a mis-set env/config is visible, and gates ollama through the helper (Railway refusal surfaced as an intentional skip, not a launch failure).
- `start_ollama()` gains a `provider` param; explicit operator paths (`make ollama`, CLI `start-ollama`) assert `provider="ollama"` while the Railway guard still applies; auto paths pass the resolved provider.
- Audited every launch path: `start_all`, `start_stack`/`make ollama`, CLI `start-ollama`, docker entrypoint + supervisord (latter two never start ollama).
- Document the gating in `docs/setup/railway.md`.

## Test plan

- New gating tests in `test_pid_manager.py` (provider≠ollama refused, auto-detected claude refused, Railway refused without opt-in, Railway allowed with opt-in).
- Autouse fixture isolates ambient `KOAN_DEPLOY` so launch-mechanics tests stay deterministic.
- `pytest test_pid_manager.py test_railway.py test_koan_cli.py` → 230 passed; `make lint` clean.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(provider claude · model claude-opus-4-8 · HEAD=79696511)_
