### PR TITLE
Gate config-driven dashboard launch behind Railway passphrase

### DIFF
--- a/docs/setup/railway.md
+++ b/docs/setup/railway.md
@@ -76,6 +76,13 @@ If `KOAN_DASHBOARD_PWD` is **unset on Railway, the dashboard refuses to start**
 `KOAN_DEPLOY` is not `railway`, the gate is inert and the dashboard behaves as
 the local-only tool it has always been.
 
+This gate is enforced on **both** launch paths through a single helper
+(`railway.dashboard_allowed()`): the supervisord `dashboard` program
+(`docker/dashboard-supervised.sh`) and the config-driven launcher
+(`pid_manager.start_all`, triggered by `dashboard.enabled: true` in
+`config.yaml`). With the passphrase unset on Railway, only `run` + `awake`
+launch, exposing the minimal worker footprint.
+
 `make koan` either **attaches** to the already-running daemon (status/logs/
 dashboard), or runs the onboarding **wizard** on an empty volume. Because the
 volume is made writable at boot, config edits (`instance/config.yaml`,

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -429,8 +429,15 @@ def _is_api_enabled() -> bool:
 
 
 def _is_dashboard_enabled() -> bool:
-    """Check if dashboard is enabled in config.yaml."""
+    """Check if dashboard is enabled in config.yaml and allowed by the deploy gate.
+
+    On Railway the dashboard is publicly exposed, so it must not launch without
+    KOAN_DASHBOARD_PWD — see ``railway.dashboard_allowed`` (the shared gate also
+    enforced by ``docker/dashboard-supervised.sh``)."""
     try:
+        from app.railway import dashboard_allowed
+        if not dashboard_allowed():
+            return False
         from app.config import is_dashboard_enabled
         return is_dashboard_enabled()
     except (ImportError, OSError, ValueError):

--- a/koan/app/railway.py
+++ b/koan/app/railway.py
@@ -19,6 +19,20 @@ def is_railway() -> bool:
     return os.environ.get("KOAN_DEPLOY", "").strip().lower() == "railway"
 
 
+def dashboard_allowed() -> bool:
+    """Whether launching the web dashboard is permitted by the deploy gate.
+
+    On a Railway deploy the dashboard binds to 0.0.0.0 and is exposed publicly,
+    so it MUST be passphrase-gated: refuse to launch unless KOAN_DASHBOARD_PWD
+    is set. Off Railway there is no public exposure, so config gating alone
+    decides. Single source of truth for the passphrase gate shared between the
+    config-driven launch path (``pid_manager.start_all``) and the supervised
+    dashboard launcher (``docker/dashboard-supervised.sh``)."""
+    if is_railway() and not os.environ.get("KOAN_DASHBOARD_PWD", "").strip():
+        return False
+    return True
+
+
 def resolve_gh_token() -> str:
     """Resolve the effective GitHub token for Kōan's git/gh operations.
 

--- a/koan/docker/dashboard-supervised.sh
+++ b/koan/docker/dashboard-supervised.sh
@@ -15,7 +15,9 @@ if [ "${KOAN_DEPLOY:-}" != "railway" ]; then
     exec sleep infinity
 fi
 
-if [ -z "${KOAN_DASHBOARD_PWD:-}" ]; then
+# Shared passphrase gate (railway.dashboard_allowed) — single source of truth
+# with the config-driven launch path (pid_manager.start_all).
+if ! python3 -c "import sys; from app.railway import dashboard_allowed; sys.exit(0 if dashboard_allowed() else 1)"; then
     echo "[dashboard] refusing to start: KOAN_DASHBOARD_PWD is not set." >&2
     echo "[dashboard] Set a passphrase to expose the dashboard on Railway." >&2
     exec sleep infinity

--- a/koan/tests/test_pid_manager.py
+++ b/koan/tests/test_pid_manager.py
@@ -2018,6 +2018,20 @@ class TestDashboardConfig:
         with patch("app.config._load_config", return_value={"dashboard": {"enabled": True}}):
             assert _is_dashboard_enabled()
 
+    def test_is_dashboard_enabled_blocked_on_railway_without_pwd(self, monkeypatch):
+        """On Railway without KOAN_DASHBOARD_PWD, the config path must not enable it."""
+        monkeypatch.setenv("KOAN_DEPLOY", "railway")
+        monkeypatch.delenv("KOAN_DASHBOARD_PWD", raising=False)
+        with patch("app.config._load_config", return_value={"dashboard": {"enabled": True}}):
+            assert not _is_dashboard_enabled()
+
+    def test_is_dashboard_enabled_allowed_on_railway_with_pwd(self, monkeypatch):
+        """On Railway with KOAN_DASHBOARD_PWD set, config enablement is honored."""
+        monkeypatch.setenv("KOAN_DEPLOY", "railway")
+        monkeypatch.setenv("KOAN_DASHBOARD_PWD", "secret")
+        with patch("app.config._load_config", return_value={"dashboard": {"enabled": True}}):
+            assert _is_dashboard_enabled()
+
     def test_get_status_processes_excludes_dashboard_by_default(self, tmp_path):
         """status processes should NOT include dashboard when disabled."""
         with patch("app.pid_manager._detect_provider", return_value="claude"), \

--- a/koan/tests/test_railway.py
+++ b/koan/tests/test_railway.py
@@ -86,6 +86,36 @@ def test_is_railway(monkeypatch):
     assert railway.is_railway() is False
 
 
+# --- dashboard_allowed gate (#2174) -----------------------------------------
+
+def test_dashboard_allowed_off_railway(monkeypatch):
+    """Off Railway, the dashboard is always allowed regardless of passphrase."""
+    monkeypatch.delenv("KOAN_DEPLOY", raising=False)
+    monkeypatch.delenv("KOAN_DASHBOARD_PWD", raising=False)
+    assert railway.dashboard_allowed() is True
+
+
+def test_dashboard_allowed_railway_with_pwd(monkeypatch):
+    """On Railway with a passphrase set, the dashboard is allowed."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.setenv("KOAN_DASHBOARD_PWD", "secret")
+    assert railway.dashboard_allowed() is True
+
+
+def test_dashboard_allowed_railway_without_pwd(monkeypatch):
+    """On Railway without a passphrase, the dashboard must be refused."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.delenv("KOAN_DASHBOARD_PWD", raising=False)
+    assert railway.dashboard_allowed() is False
+
+
+def test_dashboard_allowed_railway_blank_pwd(monkeypatch):
+    """A blank/whitespace passphrase counts as unset."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.setenv("KOAN_DASHBOARD_PWD", "   ")
+    assert railway.dashboard_allowed() is False
+
+
 # --- has_instance / env path ------------------------------------------------
 
 def test_has_instance_true_via_env(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

On `KOAN_DEPLOY=railway` the web dashboard binds to a public host and must be passphrase-gated, but `start_all()` launched it from `dashboard.enabled: true` in `config.yaml` with no railway/passphrase gate — so a fresh Railway restart exposed it. This adds a single shared gate honored by both launch paths.

Closes https://github.com/Anantys-oss/koan/issues/2174

## Changes

- Add `railway.dashboard_allowed()` — single source of truth: refuses the dashboard on Railway unless `KOAN_DASHBOARD_PWD` is set (inert off Railway).
- Route the config-driven path (`pid_manager._is_dashboard_enabled`) and the supervised launcher (`docker/dashboard-supervised.sh`) through the helper.
- With the passphrase unset on Railway, only `run` + `awake` launch (minimal worker footprint).
- Docs (`docs/setup/railway.md`) note both paths share the gate.

## Test plan

- New tests in `test_railway.py` (`dashboard_allowed` on/off Railway, with/without/blank pwd) and `test_pid_manager.py` (config path blocked/allowed on Railway).
- `make lint` clean; `test_railway.py`, `test_pid_manager.py`, `test_config.py` pass (415).

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=69905536)_
