### PR TITLE
perf(run): stream skill-dispatch stdout to disk, not RAM (#2173)

### DIFF
--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -126,3 +126,27 @@ path because they depend on git prep and specialised post-mission handling.
 
 Single-slot installations (`max_parallel_sessions: 1`, the default) skip all
 parallel logic with zero overhead.
+
+## CLI stdout memory model
+
+Claude/skill CLI output can reach hundreds of MB per mission, multiplied per
+concurrent session when `max_parallel_sessions > 1`. To keep peak RAM bounded,
+no path holds the full transcript in a Python list while the mission runs:
+
+- **Main mission path** (`run_claude_task`): the child's stdout is wired
+  straight to a temp file (`subprocess.Popen(stdout=out_f)`); no Python-side
+  line list is ever built. Downstream consumers (`run_post_mission`, token
+  parsing, PR-URL extraction) read that file.
+- **Skill-dispatch path** (`_run_skill_mission`): each line is streamed via
+  `_pump_skill_stdout` to the same on-disk capture and to `pending.md` (for
+  `/live`) as it arrives; only a 200-line tail deque is kept in RAM for timeout
+  diagnostics. The full transcript is read back from disk once, at
+  end-of-mission, when a caller needs it (`_extract_pr_url`, the `— skipping`
+  check, error classification).
+- **Provider stream runner** (`run_command_streaming`): the error/max-turns
+  accumulator (`raw_lines`) is a bounded `deque`; the assistant-text
+  accumulator (`text_lines`) is the actual return value and is intentionally
+  unbounded so long sessions never silently lose output.
+
+Operators running on constrained hosts (e.g. Railway) should also pin
+`max_parallel_sessions: 1` so per-session cost is not multiplied.

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -27,6 +27,7 @@ import re
 import subprocess
 import sys
 import tempfile
+from collections import deque
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -870,7 +871,13 @@ def run_command_streaming(
 
     from app.cli_exec import popen_cli
 
-    raw_lines: List[str] = []  # for error reporting (full transcript)
+    # raw_lines is scanned only for error/max-turns detection, never returned,
+    # so a bounded tail is safe and caps RAM on long provider streams. 2000 is
+    # deliberately generous so terminal _format_cli_error context and the
+    # non-stream-json max-turns regex fallback keep working.
+    raw_lines = deque(maxlen=2000)  # for error reporting (terminal lines)
+    # text_lines IS the fallback return value when no result event arrives —
+    # it must stay unbounded or long sessions would silently lose output.
     text_lines: List[str] = []  # fallback return value when no result event
     final_result: Optional[str] = None
     usage_snapshot: Optional[Dict[str, Any]] = None

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -31,6 +31,7 @@ import tempfile
 import threading
 import time
 import traceback
+from collections import deque
 from pathlib import Path
 from typing import List, Optional, Tuple
 
@@ -2648,6 +2649,41 @@ def _restore_koan_branch(koan_root: str, expected_branch: str):
             log("error", f"Failed to restore koan branch: {e}")
 
 
+def _pump_skill_stdout(stdout, *, out_fh, pending_fh, tail, liveness=None):
+    """Stream a skill subprocess's stdout to disk line-by-line.
+
+    Each line is written to *out_fh* (the per-mission stdout capture that
+    run_post_mission reads) and mirrored to *pending_fh* (pending.md, for
+    ``/live``). Only a bounded *tail* deque is retained in RAM, so a verbose
+    skill session cannot accumulate the full transcript in memory.
+
+    Returns the still-open *pending_fh*, or ``None`` if a write error disabled
+    the pending sink (out_fh writes continue regardless).
+    """
+    for line in stdout:
+        if liveness is not None:
+            liveness.heartbeat()
+        stripped = line.rstrip("\n")
+        tail.append(stripped)
+        print(stripped)
+        out_fh.write(f"{stripped}\n")
+        if pending_fh is not None:
+            try:
+                pending_fh.write(f"{stripped}\n")
+                pending_fh.flush()
+            except OSError:
+                pending_fh = None
+    return pending_fh
+
+
+def _read_back_or_tail(stdout_file, tail):
+    """Read the on-disk transcript; fall back to the in-RAM tail on error."""
+    try:
+        return Path(stdout_file).read_text(errors="replace")
+    except OSError:
+        return "\n".join(tail)
+
+
 def _run_skill_mission(
     skill_cmd: list,
     koan_root: str,
@@ -2689,7 +2725,7 @@ def _run_skill_mission(
 
     debug_log(f"[run] skill exec: cmd={' '.join(skill_cmd)}")
     debug_log(f"[run] skill exec: cwd={koan_pkg_dir} timeout={skill_timeout}s")
-    stdout_lines = []
+    tail = deque(maxlen=200)
     proc = None
 
     # Create temp files for post-mission processing up front.
@@ -2718,6 +2754,7 @@ def _run_skill_mission(
     if _mission_model_key:
         skill_env["KOAN_MISSION_MODEL_KEY"] = _mission_model_key
     stderr_fh = None
+    out_fh = None
     try:
         stderr_fh = open(stderr_file, "w")
         proc = subprocess.Popen(
@@ -2755,26 +2792,20 @@ def _run_skill_mission(
                 ),
             ).start()
 
-        # Stream stdout line-by-line, appending each to pending.md
-        # so /live shows real-time progress.
+        # Stream stdout line-by-line into stdout_file (the post-mission
+        # source) and pending.md (/live), keeping only a bounded tail in RAM
+        # so a verbose skill session cannot buffer the whole transcript.
         pending_fh = None
         try:
             pending_fh = open(pending_path, "a")
         except OSError as e:
             debug_log(f"[run] cannot open pending.md for streaming: {e}")
+        out_fh = open(stdout_file, "w")
         try:
-            for line in proc.stdout:
-                if liveness is not None:
-                    liveness.heartbeat()
-                stripped = line.rstrip("\n")
-                stdout_lines.append(stripped)
-                print(stripped)
-                if pending_fh is not None:
-                    try:
-                        pending_fh.write(f"{stripped}\n")
-                        pending_fh.flush()
-                    except OSError:
-                        pending_fh = None
+            pending_fh = _pump_skill_stdout(
+                proc.stdout, out_fh=out_fh, pending_fh=pending_fh,
+                tail=tail, liveness=liveness,
+            )
         finally:
             if pending_fh is not None:
                 pending_fh.close()
@@ -2784,11 +2815,12 @@ def _run_skill_mission(
 
         proc.wait(timeout=30)
         if watchdog.fired or (liveness and liveness.fired):
+            out_fh.close()
+            out_fh = None
             raise subprocess.TimeoutExpired(skill_cmd, skill_timeout)
         exit_code = proc.returncode
-        skill_stdout = "\n".join(stdout_lines)
         # Provider stream mode can persist token usage to a sidecar file.
-        # Append that JSON payload to stdout capture so token_parser can
+        # Append that JSON payload to the on-disk capture so token_parser can
         # account for skill-dispatch sessions in run_post_mission.
         with suppress_logged(log, "warning", "Skill stream usage read failed", OSError, json.JSONDecodeError):
             raw_usage = Path(stream_usage_file).read_text().strip()
@@ -2796,10 +2828,14 @@ def _run_skill_mission(
                 usage_payload = json.loads(raw_usage)
                 if isinstance(usage_payload, dict):
                     usage_json = json.dumps(usage_payload, separators=(",", ":"))
-                    if skill_stdout:
-                        skill_stdout = f"{skill_stdout}\n{usage_json}"
-                    else:
-                        skill_stdout = usage_json
+                    out_fh.write(f"{usage_json}\n")
+        out_fh.flush()
+        out_fh.close()
+        out_fh = None
+        # Full transcript is genuinely needed by the caller (_extract_pr_url,
+        # the "— skipping" check, error classification): read it back from
+        # disk once instead of holding every line in RAM for the whole run.
+        skill_stdout = _read_back_or_tail(stdout_file, tail)
         # Read stderr from file after process exits.
         stderr_fh.close()
         stderr_fh = None
@@ -2828,7 +2864,7 @@ def _run_skill_mission(
         debug_log(f"[run] skill exec: TIMEOUT ({timeout_kind}: {timeout_val}s)")
         # Log last lines of captured output so the journal shows *where*
         # the run stalled, not just that it timed out.
-        tail_lines = stdout_lines[-20:] if stdout_lines else []
+        tail_lines = list(tail)[-20:]
         if tail_lines:
             tail_preview = "\n".join(tail_lines)
             log("info", f"Last output before timeout:\n{tail_preview}")
@@ -2842,7 +2878,10 @@ def _run_skill_mission(
             if _timeout_stderr:
                 debug_log(f"[run] timeout stderr:\n{_timeout_stderr[:2000]}")
         exit_code = 1
-        skill_stdout = "\n".join(stdout_lines)
+        if out_fh is not None:
+            with suppress_logged(log, "debug", "Skill stdout flush failed", OSError):
+                out_fh.flush()
+        skill_stdout = _read_back_or_tail(stdout_file, tail)
         skill_stderr = ""
     except Exception as e:
         if proc is not None:
@@ -2850,9 +2889,15 @@ def _run_skill_mission(
         log("error", f"Skill runner failed: {e}\n{traceback.format_exc()}")
         debug_log(f"[run] skill exec: EXCEPTION {e}")
         exit_code = 1
-        skill_stdout = "\n".join(stdout_lines)
+        if out_fh is not None:
+            with suppress_logged(log, "debug", "Skill stdout flush failed", OSError):
+                out_fh.flush()
+        skill_stdout = _read_back_or_tail(stdout_file, tail)
         skill_stderr = ""
     finally:
+        if out_fh is not None:
+            with suppress_logged(log, "debug", "Skill stdout file close failed", OSError):
+                out_fh.close()
         if proc is not None and proc.stdout is not None:
             with suppress_logged(log, "debug", "Skill proc stdout close failed", OSError):
                 proc.stdout.close()
@@ -2876,9 +2921,8 @@ def _run_skill_mission(
         "quota_info": None,
     }
     try:
-        with open(stdout_file, 'wb') as f:
-            f.write(skill_stdout.encode('utf-8'))
-
+        # stdout_file is already populated by _pump_skill_stdout (plus the
+        # usage-JSON line); no re-write from the in-memory string is needed.
         _skill_prefix = f"Run {run_num}"
         set_status(koan_root, f"{_skill_prefix} — finalizing")
         from app.mission_runner import run_post_mission

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2679,7 +2679,7 @@ def _pump_skill_stdout(stdout, *, out_fh, pending_fh, tail, liveness=None):
 def _read_back_or_tail(stdout_file, tail):
     """Read the on-disk transcript; fall back to the in-RAM tail on error."""
     try:
-        return Path(stdout_file).read_text(errors="replace")
+        return Path(stdout_file).read_text(encoding="utf-8", errors="replace")
     except OSError:
         return "\n".join(tail)
 
@@ -2800,7 +2800,7 @@ def _run_skill_mission(
             pending_fh = open(pending_path, "a")
         except OSError as e:
             debug_log(f"[run] cannot open pending.md for streaming: {e}")
-        out_fh = open(stdout_file, "w")
+        out_fh = open(stdout_file, "w", encoding="utf-8")
         try:
             pending_fh = _pump_skill_stdout(
                 proc.stdout, out_fh=out_fh, pending_fh=pending_fh,

--- a/koan/tests/test_cli_exec.py
+++ b/koan/tests/test_cli_exec.py
@@ -530,6 +530,18 @@ class TestStreamWithTimeout:
         assert result.stderr == ""
         assert result.timed_out is False
 
+    def test_returns_full_stdout_not_just_tail(self):
+        # 500 lines of output; the returned result must contain all of them,
+        # proving the result accumulator is intentionally unbounded (guards
+        # against an over-eager future cap — see #2173).
+        lines = [f"{i}\n" for i in range(500)]
+        proc = _fake_proc(lines, returncode=0)
+        result = stream_with_timeout(proc, timeout=30)
+        out = result.stdout.splitlines()
+        assert out[0] == "0"
+        assert out[-1] == "499"
+        assert len(out) == 500
+
     def test_forwards_each_line_to_callback(self):
         proc = _fake_proc(["one\n", "two\n", "three\n"], returncode=0)
         seen = []

--- a/koan/tests/test_skill_stdout_streaming.py
+++ b/koan/tests/test_skill_stdout_streaming.py
@@ -1,0 +1,59 @@
+"""Unit tests for the skill-dispatch stdout streaming pump.
+
+Verifies that ``_pump_skill_stdout`` streams every line to disk while keeping
+only a bounded tail in RAM, so a verbose skill session cannot buffer the full
+transcript in memory (issue #2173).
+"""
+import io
+import os
+from collections import deque
+
+os.environ.setdefault("KOAN_ROOT", "/tmp/test-koan")
+
+from app.run import _pump_skill_stdout
+
+
+def test_pump_writes_all_lines_to_both_sinks():
+    lines = [f"line {i}\n" for i in range(5)]
+    out_fh = io.StringIO()
+    pending_fh = io.StringIO()
+    tail = deque(maxlen=200)
+
+    result_pending = _pump_skill_stdout(
+        iter(lines), out_fh=out_fh, pending_fh=pending_fh, tail=tail
+    )
+
+    assert out_fh.getvalue() == "".join(f"line {i}\n" for i in range(5))
+    assert pending_fh.getvalue() == "".join(f"line {i}\n" for i in range(5))
+    assert list(tail) == [f"line {i}" for i in range(5)]
+    assert result_pending is pending_fh
+
+
+def test_pump_tail_is_bounded():
+    lines = [f"{i}\n" for i in range(1000)]
+    out_fh = io.StringIO()
+    tail = deque(maxlen=200)
+
+    _pump_skill_stdout(iter(lines), out_fh=out_fh, pending_fh=None, tail=tail)
+
+    # Full transcript on disk, only the last 200 lines kept in RAM.
+    assert out_fh.getvalue().count("\n") == 1000
+    assert len(tail) == 200
+    assert list(tail)[-1] == "999"
+    assert list(tail)[0] == "800"
+
+
+def test_pump_disables_pending_on_write_error_but_keeps_out_fh():
+    class _Broken(io.StringIO):
+        def write(self, *_):
+            raise OSError("disk full")
+
+    out_fh = io.StringIO()
+    tail = deque(maxlen=200)
+    result_pending = _pump_skill_stdout(
+        iter(["a\n", "b\n"]), out_fh=out_fh, pending_fh=_Broken(), tail=tail
+    )
+
+    assert result_pending is None            # pending sink disabled
+    assert out_fh.getvalue() == "a\nb\n"     # stdout_file write unaffected
+    assert list(tail) == ["a", "b"]


### PR DESCRIPTION
## Summary

`_run_skill_mission` buffered every skill-runner stdout line into an unbounded Python list and then built a second full copy with `"\n".join(...)` — even though every line was already streamed to `pending.md` and the joined string already written to `stdout_file`. For verbose skill sessions this peaked at hundreds of MB, multiplied per concurrent session. This streams each line straight to disk during the loop, keeps only a 200-line `deque` tail in RAM, and reads the transcript back from disk once when a caller genuinely needs it.

Closes https://github.com/Anantys-oss/koan/issues/2173

## Changes

- `run.py`: add `_pump_skill_stdout()` + `_read_back_or_tail()`; rewrite `_run_skill_mission` to stream stdout to `stdout_file` + bounded tail; drop the `stdout_lines` list and all three `"\n".join()` copies; append usage-JSON to `stdout_file`; drop the now-redundant post-loop file write.
- `provider/__init__.py`: bound `raw_lines` (error/max-turns detection only) with `deque(maxlen=2000)`; document why `text_lines` (the return value) stays unbounded.
- Tests: `test_skill_stdout_streaming.py` (pump streams to both sinks, bounds tail, survives pending-write failure); `test_cli_exec.py` regression guarding the streaming result accumulator stays full.
- Docs: `daemon.md` "CLI stdout memory model" subsection.

## Test plan

- `pytest tests/test_skill_stdout_streaming.py tests/test_cli_exec.py tests/test_run.py` — pass
- `pytest -k "provider or skill or mission_exec"` — 4182 pass
- `make lint` — clean
- Confirmed `grep stdout_lines koan/app/run.py` returns nothing

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=0fe77ccd)_
