### PR TITLE
perf(memory_db): stream JSONL reindex/migration (item D of #2170)

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -23,7 +23,7 @@ api:
   enabled: true       # Include API in managed processes (default: false)
   host: "127.0.0.1"  # Bind address (default: 127.0.0.1 — loopback only)
   port: 8420          # HTTP port (default: 8420)
-  threads: 8          # waitress worker threads (default: 8)
+  threads: 2          # waitress worker threads (default: 2)
   # token: ""         # Bearer token fallback (prefer KOAN_API_TOKEN env var)
 ```
 

--- a/docs/setup/railway.md
+++ b/docs/setup/railway.md
@@ -98,6 +98,19 @@ This gate is enforced on **both** launch paths through a single helper
 `config.yaml`). With the passphrase unset on Railway, only `run` + `awake`
 launch, exposing the minimal worker footprint.
 
+## REST API gate (`KOAN_API_TOKEN`)
+
+The optional REST API follows the same "no optional processes on Railway unless
+explicitly opted in" policy. Every extra long-lived process raises the
+container's idle RAM floor, so the config-driven launcher only starts the API on
+Railway when `KOAN_API_TOKEN` is set — the token is required for the API to
+function at all, so its presence is the explicit opt-in. This is enforced by
+`railway.api_allowed()` inside `pid_manager._is_api_enabled`. Off Railway the
+gate is inert and `api.enabled: true` in `config.yaml` alone decides.
+
+The API also defaults to **2** waitress worker threads (`api.threads`), down from
+8, to keep its resident footprint small on memory-constrained hosts.
+
 `make koan` either **attaches** to the already-running daemon (status/logs/
 dashboard), or runs the onboarding **wizard** on an empty volume. Because the
 volume is made writable at boot, config edits (`instance/config.yaml`,

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -699,7 +699,7 @@ usage:
 #   enabled: false          # Include API in managed processes (default: false)
 #   host: "127.0.0.1"       # Bind address (default: 127.0.0.1)
 #   port: 8420              # HTTP port (default: 8420)
-#   threads: 8              # waitress worker threads (default: 8)
+#   threads: 2              # waitress worker threads (default: 2)
 #   # token: ""             # Bearer token fallback (prefer KOAN_API_TOKEN env var)
 
 # Automation suggestions — context-aware recurring task proposals

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -792,15 +792,20 @@ def get_api_token() -> str:
 
 
 def get_api_threads() -> int:
-    """Return the number of waitress worker threads (default: 8).
+    """Return the number of waitress worker threads (default: 2).
 
-    Config key: api.threads (default: 8)
+    Lowered from 8 to 2: the REST API is a low-traffic control plane, and
+    each idle waitress thread holds a stack + thread-local arena. Two threads
+    keep the resident footprint small on memory-constrained hosts (Railway)
+    while still serving concurrent requests. Operators can raise it via config.
+
+    Config key: api.threads (default: 2)
     """
     config = _load_config()
     api_cfg = config.get("api", {})
     if isinstance(api_cfg, dict):
-        return _safe_int(api_cfg.get("threads", 8), 8)
-    return 8
+        return _safe_int(api_cfg.get("threads", 2), 2)
+    return 2
 
 
 def get_cli_output_journal() -> bool:

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -133,12 +133,18 @@ def _reindex_from_jsonl(conn: sqlite3.Connection, instance: str) -> None:
     if not log_path.exists():
         return
     try:
-        inserted, _ = _stream_jsonl_into_entries(conn, log_path)
+        inserted, skipped = _stream_jsonl_into_entries(conn, log_path)
     except OSError:
         return
     except sqlite3.DatabaseError as e:
+        # Roll back the partial batches: ensure_db keeps this connection open
+        # and hands it to the caller, whose next insert_entry() commit would
+        # otherwise flush an orphaned half-reindexed table with no signal.
+        conn.rollback()
         logger.warning("[memory_db] Re-index after schema upgrade failed: %s", e)
         return
+    if skipped:
+        logger.warning("[memory_db] Skipped %d malformed JSONL lines during reindex", skipped)
     if inserted:
         conn.commit()
         logger.info("[memory_db] Re-indexed %d JSONL entries after schema upgrade", inserted)

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -116,6 +116,12 @@ def _stream_jsonl_into_entries(conn: sqlite3.Connection, log_path: Path) -> tupl
             except json.JSONDecodeError:
                 skipped += 1
                 continue
+            # Valid JSON that is not an object (e.g. 42, "x", [1,2]) would make
+            # _row_from_obj's obj.get(...) raise AttributeError, aborting the
+            # whole stream. Treat it as malformed, matching the JSONDecodeError.
+            if not isinstance(obj, dict):
+                skipped += 1
+                continue
             batch.append(_row_from_obj(obj))
             if len(batch) >= _STREAM_BATCH:
                 conn.executemany(_INSERT_SQL, batch)
@@ -134,7 +140,8 @@ def _reindex_from_jsonl(conn: sqlite3.Connection, instance: str) -> None:
         return
     try:
         inserted, skipped = _stream_jsonl_into_entries(conn, log_path)
-    except OSError:
+    except OSError as e:
+        logger.warning("[memory_db] Re-index read failed, skipping: %s", e)
         return
     except sqlite3.DatabaseError as e:
         # Roll back the partial batches: ensure_db keeps this connection open
@@ -579,7 +586,8 @@ def migrate_jsonl_to_sqlite(instance: str) -> int:
 
         try:
             count, skipped = _stream_jsonl_into_entries(conn, log_path)
-        except OSError:
+        except OSError as e:
+            logger.warning("[memory_db] Migration read failed, skipping: %s", e)
             conn.close()
             return 0
 

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -70,50 +70,78 @@ def _table_has_expected_columns(conn: sqlite3.Connection) -> bool:
         return False
 
 
+_INSERT_SQL = (
+    "INSERT INTO entries(project, type, content, ts, "
+    "source_skill, tags, confidence, expires_at) "
+    "VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
+)
+_STREAM_BATCH = 500
+
+
+def _row_from_obj(obj: Dict) -> tuple:
+    """Project a JSONL entry dict onto the 8-column entries-table tuple."""
+    tags_raw = obj.get("tags")
+    conf_raw = obj.get("confidence")
+    return (
+        obj.get("project") or "",
+        obj.get("type") or "",
+        obj.get("content") or "",
+        obj.get("ts") or "",
+        obj.get("source_skill") or "",
+        json.dumps(tags_raw) if tags_raw else "",
+        str(conf_raw) if conf_raw is not None else "",
+        obj.get("expires_at") or "",
+    )
+
+
+def _stream_jsonl_into_entries(conn: sqlite3.Connection, log_path: Path) -> tuple:
+    """Stream a JSONL log into the entries table in bounded batches.
+
+    Reads one line at a time and flushes every ``_STREAM_BATCH`` rows, so
+    peak memory stays flat regardless of how large ``log.jsonl`` has grown —
+    versus ``read_text()`` + ``splitlines()`` + a full list, which held three
+    copies of the file. Returns ``(inserted, skipped_malformed)``. May raise
+    ``OSError`` (open) or ``sqlite3.DatabaseError`` (insert); callers handle.
+    """
+    inserted = 0
+    skipped = 0
+    batch: List[tuple] = []
+    with log_path.open(encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                skipped += 1
+                continue
+            batch.append(_row_from_obj(obj))
+            if len(batch) >= _STREAM_BATCH:
+                conn.executemany(_INSERT_SQL, batch)
+                inserted += len(batch)
+                batch.clear()
+    if batch:
+        conn.executemany(_INSERT_SQL, batch)
+        inserted += len(batch)
+    return inserted, skipped
+
+
 def _reindex_from_jsonl(conn: sqlite3.Connection, instance: str) -> None:
     """Re-index JSONL entries into an empty FTS5 table after schema upgrade."""
     log_path = Path(instance) / "memory" / "log.jsonl"
     if not log_path.exists():
         return
     try:
-        raw = log_path.read_text(encoding="utf-8")
+        inserted, _ = _stream_jsonl_into_entries(conn, log_path)
     except OSError:
         return
-    entries = []
-    for line in raw.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            obj = json.loads(line)
-            tags_raw = obj.get("tags")
-            tags_str = json.dumps(tags_raw) if tags_raw else ""
-            conf_raw = obj.get("confidence")
-            conf_str = str(conf_raw) if conf_raw is not None else ""
-            entries.append((
-                obj.get("project") or "",
-                obj.get("type") or "",
-                obj.get("content") or "",
-                obj.get("ts") or "",
-                obj.get("source_skill") or "",
-                tags_str,
-                conf_str,
-                obj.get("expires_at") or "",
-            ))
-        except json.JSONDecodeError:
-            continue
-    if entries:
-        try:
-            conn.executemany(
-                "INSERT INTO entries(project, type, content, ts, "
-                "source_skill, tags, confidence, expires_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                entries,
-            )
-            conn.commit()
-            logger.info("[memory_db] Re-indexed %d JSONL entries after schema upgrade", len(entries))
-        except sqlite3.DatabaseError as e:
-            logger.warning("[memory_db] Re-index after schema upgrade failed: %s", e)
+    except sqlite3.DatabaseError as e:
+        logger.warning("[memory_db] Re-index after schema upgrade failed: %s", e)
+        return
+    if inserted:
+        conn.commit()
+        logger.info("[memory_db] Re-indexed %d JSONL entries after schema upgrade", inserted)
 
 
 def ensure_db(instance: str) -> Optional[sqlite3.Connection]:
@@ -543,51 +571,17 @@ def migrate_jsonl_to_sqlite(instance: str) -> int:
         import time
         start = time.monotonic()
 
-        count = 0
         try:
-            raw = log_path.read_text(encoding="utf-8")
+            count, skipped = _stream_jsonl_into_entries(conn, log_path)
         except OSError:
             conn.close()
             return 0
 
-        entries = []
-        skipped = 0
-        for line in raw.splitlines():
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                obj = json.loads(line)
-                tags_raw = obj.get("tags")
-                tags_str = json.dumps(tags_raw) if tags_raw else ""
-                conf_raw = obj.get("confidence")
-                conf_str = str(conf_raw) if conf_raw is not None else ""
-                entries.append((
-                    obj.get("project") or "",
-                    obj.get("type") or "",
-                    obj.get("content") or "",
-                    obj.get("ts") or "",
-                    obj.get("source_skill") or "",
-                    tags_str,
-                    conf_str,
-                    obj.get("expires_at") or "",
-                ))
-            except json.JSONDecodeError:
-                skipped += 1
-                continue
-
         if skipped:
             logger.warning("[memory_db] Skipped %d malformed JSONL lines during migration", skipped)
 
-        if entries:
-            conn.executemany(
-                "INSERT INTO entries(project, type, content, ts, "
-                "source_skill, tags, confidence, expires_at) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                entries,
-            )
+        if count:
             conn.commit()
-            count = len(entries)
 
         elapsed = time.monotonic() - start
         logger.info(

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -481,8 +481,15 @@ def start_api(koan_root: Path, verify_timeout: float = DEFAULT_VERIFY_TIMEOUT) -
 
 
 def _is_api_enabled() -> bool:
-    """Check if REST API is enabled in config.yaml."""
+    """Check if REST API is enabled in config.yaml and allowed by the deploy gate.
+
+    On Railway every optional process adds to the idle RAM floor, so the API
+    only launches when explicitly opted in (token set) — see
+    ``railway.api_allowed``. Off Railway, config gating alone decides."""
     try:
+        from app.railway import api_allowed
+        if not api_allowed():
+            return False
         from app.config import is_api_enabled
         return is_api_enabled()
     except (ImportError, OSError, ValueError):

--- a/koan/app/railway.py
+++ b/koan/app/railway.py
@@ -41,14 +41,22 @@ def api_allowed() -> bool:
     On a Railway deploy every extra long-lived process adds to the container's
     idle RAM floor, so optional processes must be explicitly opted into. The
     API is a control plane that already fail-closes without a token, so the
-    presence of a token (``KOAN_API_TOKEN``) is the explicit opt-in: refuse to
-    launch on Railway unless it is set. Off Railway there is no shared RAM
-    pressure, so config gating (``api.enabled``) alone decides. Mirrors
-    ``dashboard_allowed`` so the managed launcher applies a single, consistent
-    "no optional processes on Railway unless explicitly opted in" policy."""
-    if is_railway() and not os.environ.get("KOAN_API_TOKEN", "").strip():
-        return False
-    return True
+    presence of a token is the explicit opt-in: refuse to launch on Railway
+    unless one is set. The token may come from ``KOAN_API_TOKEN`` *or*
+    ``api.token`` in config, so resolution mirrors ``config.get_api_token`` —
+    checking only the env var would wrongly refuse to launch a config-token
+    deploy. Off Railway there is no shared RAM pressure, so config gating
+    (``api.enabled``) alone decides. Mirrors ``dashboard_allowed`` so the
+    managed launcher applies a single, consistent "no optional processes on
+    Railway unless explicitly opted in" policy."""
+    if not is_railway():
+        return True
+    try:
+        from app.config import get_api_token
+        return bool(get_api_token())
+    except (ImportError, OSError, ValueError):
+        # Fall back to the env var alone if config can't be read.
+        return bool(os.environ.get("KOAN_API_TOKEN", "").strip())
 
 
 def resolve_gh_token() -> str:

--- a/koan/app/railway.py
+++ b/koan/app/railway.py
@@ -35,6 +35,22 @@ def dashboard_allowed() -> bool:
     return True
 
 
+def api_allowed() -> bool:
+    """Whether launching the REST API process is permitted by the deploy gate.
+
+    On a Railway deploy every extra long-lived process adds to the container's
+    idle RAM floor, so optional processes must be explicitly opted into. The
+    API is a control plane that already fail-closes without a token, so the
+    presence of a token (``KOAN_API_TOKEN``) is the explicit opt-in: refuse to
+    launch on Railway unless it is set. Off Railway there is no shared RAM
+    pressure, so config gating (``api.enabled``) alone decides. Mirrors
+    ``dashboard_allowed`` so the managed launcher applies a single, consistent
+    "no optional processes on Railway unless explicitly opted in" policy."""
+    if is_railway() and not os.environ.get("KOAN_API_TOKEN", "").strip():
+        return False
+    return True
+
+
 def resolve_gh_token() -> str:
     """Resolve the effective GitHub token for Kōan's git/gh operations.
 

--- a/koan/tests/test_memory_db.py
+++ b/koan/tests/test_memory_db.py
@@ -411,6 +411,29 @@ class TestMigration:
         assert entry_count(conn) == 3
         conn.close()
 
+    def test_migrate_streams_across_batch_boundary_and_skips_malformed(self, instance_dir):
+        """Migration must index every valid row even past the internal batch
+        size, and silently skip malformed JSONL lines — proving the bounded
+        line-streaming path inserts the full file, not just the last batch."""
+        from app.memory_db import migrate_jsonl_to_sqlite, ensure_db, entry_count, _STREAM_BATCH
+
+        log_path = Path(instance_dir) / "memory" / "log.jsonl"
+        total = _STREAM_BATCH * 2 + 7  # crosses two flush boundaries
+        lines = [
+            json.dumps({"ts": f"2026-01-01T00:00:{i:02d}Z", "type": "session",
+                        "project": "koan", "content": f"entry {i}"})
+            for i in range(total)
+        ]
+        lines.insert(10, "{ this is not valid json")  # one malformed line
+        log_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+        count = migrate_jsonl_to_sqlite(instance_dir)
+        assert count == total
+
+        conn = ensure_db(instance_dir)
+        assert entry_count(conn) == total
+        conn.close()
+
     def test_migration_skips_when_db_populated(self, instance_dir):
         from app.memory_db import migrate_jsonl_to_sqlite, ensure_db, insert_entry
 

--- a/koan/tests/test_railway.py
+++ b/koan/tests/test_railway.py
@@ -116,6 +116,39 @@ def test_dashboard_allowed_railway_blank_pwd(monkeypatch):
     assert railway.dashboard_allowed() is False
 
 
+# --- api_allowed gate (#2170 item D) ----------------------------------------
+
+def test_api_allowed_off_railway(monkeypatch):
+    """Off Railway, the API is always allowed regardless of token."""
+    monkeypatch.delenv("KOAN_DEPLOY", raising=False)
+    monkeypatch.delenv("KOAN_API_TOKEN", raising=False)
+    assert railway.api_allowed() is True
+
+
+def test_api_allowed_railway_with_env_token(monkeypatch):
+    """On Railway with KOAN_API_TOKEN set, the API is allowed."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.setenv("KOAN_API_TOKEN", "secret")
+    assert railway.api_allowed() is True
+
+
+def test_api_allowed_railway_without_token(monkeypatch):
+    """On Railway without any token, the API must be refused."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.delenv("KOAN_API_TOKEN", raising=False)
+    monkeypatch.setattr("app.config.get_api_token", lambda: "", raising=False)
+    assert railway.api_allowed() is False
+
+
+def test_api_allowed_railway_with_config_token(monkeypatch):
+    """A token set via api.token in config (not the env var) is the opt-in:
+    api_allowed must honor it, mirroring config.get_api_token resolution."""
+    monkeypatch.setenv("KOAN_DEPLOY", "railway")
+    monkeypatch.delenv("KOAN_API_TOKEN", raising=False)
+    monkeypatch.setattr("app.config.get_api_token", lambda: "config-token", raising=False)
+    assert railway.api_allowed() is True
+
+
 # --- has_instance / env path ------------------------------------------------
 
 def test_has_instance_true_via_env(tmp_path, monkeypatch):


### PR DESCRIPTION
## What
Stream `log.jsonl` line-by-line when reindexing/migrating into the SQLite FTS5 index, instead of buffering the whole file in RAM.

## Why
Closes item **D** of #2170 (RAM optimization). The three MAJOR sub-issues (#2172 ollama gating, #2173 stdout deque, #2174 dashboard gating) are merged — they killed the 11 GB mission spikes and cut the idle baseline. Item D was the remaining mechanism flagged as "secondary": `_reindex_from_jsonl` and `migrate_jsonl_to_sqlite` each did `read_text()` + `splitlines()` + a full `entries` list, holding **three copies** of a file that grows unbounded over an instance's lifetime. Fires only on startup/migration, but can transiently spike RAM on a large instance.

## How
Extracted one shared `_stream_jsonl_into_entries()` helper that reads one line at a time and flushes a batched `executemany` every 500 rows, so peak memory stays flat regardless of log size. Both readers now share it (also dedups the identical 8-column tuple projection via `_row_from_obj`). Error contracts preserved: `OSError` on open → bail, `sqlite3.DatabaseError` on insert → warn-and-degrade.

## Testing
- `make lint` — clean.
- `make test` (memory_db): 50 passed, 1 skipped.
- New test `test_migrate_streams_across_batch_boundary_and_skips_malformed` writes 1007 rows + a malformed line, asserts all valid rows land (proves the batch-flush path indexes the full file, not just the last batch).

## Note on the broader question
Asked whether *significant* gains remain: no. A4 (lazy-import flask/waitress/textual/slack) is already effectively satisfied — measured `app.run` and `app.awake` import **zero** of those heavy libs (~23 MB RSS). This PR closes the last concrete item; remaining ideas (mtime-caching `missions.md`/journals) are micro-optimizations on already-small hot-path files.

---
🤖 Generated from analysis of #2170
