### PR TITLE
fix(rebase): stream codex output so review-feedback step survives idle watchdog

### DIFF
--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -86,6 +86,16 @@ a plan, executes it, and returns the result. Streaming skill calls use
 assistant response, so Kōan can show live activity without relying on
 Codex event shapes for the final answer.
 
+The git-pipeline steps that run through `run_claude_step` — notably the
+`/rebase` "apply review feedback" step and the CI-fix step — also request
+`--json` streaming. This matters for liveness: in plain-text mode Codex is
+silent during tool use, and these steps are guarded by an **idle watchdog**
+that kills the process when no output arrives for `rebase_review_idle_timeout`
+seconds (default 600). With `--json`, every event is a line of output that
+resets the watchdog on genuine progress, so a long-but-working feedback step
+on a large repo is no longer mistaken for a hang. The events are parsed back
+into clean final text (preferring `--output-last-message`).
+
 ### Execution Modes
 
 | Kōan Setting          | Codex Flag       | Behavior                        |

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -294,6 +294,8 @@ def run_claude(
     idle_timeout: Optional[int] = None,
     max_duration: Optional[int] = None,
     heartbeat_interval: Optional[int] = None,
+    use_stream_json: bool = False,
+    last_message_path: Optional[str] = None,
 ) -> dict:
     """Run a Claude Code CLI command, streaming stdout in real time.
 
@@ -318,6 +320,22 @@ def run_claude(
             marker to sys.stdout while the CLI is running. This keeps
             the parent process's LivenessWatchdog alive even when the
             CLI runs in print mode (no output during tool use).
+        use_stream_json: When True, the command was built with a
+            streaming JSONL output format (``--output-format stream-json``
+            for Claude, ``--json`` for codex/cline). Each JSONL event is
+            parsed and rendered as a short human-readable summary line.
+            Crucially, because *every* consumed stdout line resets the
+            inner idle watchdog, a provider that is silent during tool use
+            in plain-text mode (notably codex) now emits a steady stream
+            of per-event lines — so the idle watchdog tracks genuine
+            progress instead of spuriously firing. ``output`` is set to
+            the clean final assistant text (NOT raw JSONL), so callers that
+            parse the transcript (e.g. ``parse_commit_subject``) keep
+            working unchanged.
+        last_message_path: When set (stream-json + a provider that supports
+            ``--output-last-message``), the definitive final assistant text
+            is read from this file. The caller owns the file's lifecycle
+            (creation and cleanup).
 
     Returns:
         Dict with keys: success (bool), output (str), error (str).
@@ -349,11 +367,47 @@ def run_claude(
     if heartbeat_interval and heartbeat_interval > 0:
         heartbeat_thread = _start_heartbeat(proc, heartbeat_interval)
 
+    # When streaming JSONL, accumulate the final assistant text from parsed
+    # events so ``output`` stays clean text (raw JSONL never reaches callers).
+    # The summarized event line is what gets printed — feeding both the inner
+    # idle watchdog (every consumed line) and the parent run.py watchdog.
+    stream_text_chunks: List[str] = []
+    stream_final_result: Optional[str] = None
+    if use_stream_json:
+        from app.provider import (
+            _extract_assistant_text_chunks,
+            _extract_result_text,
+            _summarize_stream_event,
+        )
+
+        def on_line(line: str) -> None:
+            nonlocal stream_final_result
+            if not line:
+                return
+            try:
+                parsed = json.loads(line)
+            except (json.JSONDecodeError, ValueError):
+                parsed = None
+            if isinstance(parsed, dict):
+                print(_summarize_stream_event(parsed), flush=True)
+                stream_text_chunks.extend(_extract_assistant_text_chunks(parsed))
+                result_text = _extract_result_text(parsed)
+                if result_text is not None:
+                    stream_final_result = result_text
+            else:
+                # Stray non-JSON line (warning printed before the stream): keep
+                # it both on screen and as fallback text.
+                print(line, flush=True)
+                stream_text_chunks.append(line)
+    else:
+        def on_line(line: str) -> None:
+            print(line, flush=True)
+
     try:
         stream_result = stream_with_timeout(
             proc,
             timeout=timeout,
-            on_line=lambda line: print(line, flush=True),
+            on_line=on_line,
             idle_timeout=idle_timeout,
             max_duration=max_duration,
         )
@@ -362,8 +416,27 @@ def run_claude(
             heartbeat_thread.cancel()
         cleanup()
 
-    stdout_text = stream_result.stdout
+    raw_stdout = stream_result.stdout
     stderr_text = stream_result.stderr
+
+    if use_stream_json:
+        # Final-text precedence mirrors run_command_streaming: last-message
+        # file → result event → accumulated assistant chunks → raw stdout.
+        last_message_text = ""
+        if last_message_path:
+            import contextlib
+            with contextlib.suppress(OSError, UnicodeDecodeError):
+                last_message_text = Path(last_message_path).read_text()
+        if last_message_text.strip():
+            stdout_text = last_message_text
+        elif stream_final_result is not None:
+            stdout_text = stream_final_result
+        elif stream_text_chunks:
+            stdout_text = "\n".join(stream_text_chunks)
+        else:
+            stdout_text = raw_stdout
+    else:
+        stdout_text = raw_stdout
 
     if stream_result.timed_out:
         timeout_kind = getattr(stream_result, "timeout_kind", "")
@@ -683,13 +756,41 @@ def run_claude_step(
     if use_skill:
         tools.append("Skill")
 
+    # Opt into streaming JSONL output when the provider supports it. This is
+    # the fix for codex: in plain-text mode codex is silent during tool use, so
+    # the inner idle watchdog (no stdout line for idle_timeout seconds) kills a
+    # still-progressing step. With stream-json/--json every event is a stdout
+    # line that resets the watchdog on genuine progress. run_claude parses the
+    # events back into clean assistant text, so the downstream
+    # parse_commit_subject and change-summary logic is unaffected.
+    from app.provider import get_provider
+
+    provider = get_provider()
+    use_stream_json = provider.supports_stream_json()
+
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=tools,
         model=models["mission"],
         fallback=models["fallback"],
         max_turns=max_turns,
+        output_format="stream-json" if use_stream_json else "",
     )
+
+    # Last-message sidecar: lets run_claude recover the definitive final
+    # assistant text even if the stream is truncated. Caller owns the file —
+    # created here, removed in the finally below (fires on success/timeout/kill).
+    last_message_path: Optional[str] = None
+    if use_stream_json and provider.supports_last_message_file():
+        import tempfile
+
+        from app.utils import koan_tmp_dir
+
+        fd, last_message_path = tempfile.mkstemp(
+            prefix="koan-last-message-", suffix=".txt", dir=koan_tmp_dir(),
+        )
+        os.close(fd)
+        cmd = provider.add_last_message_file_args(cmd, last_message_path)
 
     from app.commit_conventions import parse_commit_subject
     from app.config import get_first_output_timeout
@@ -702,14 +803,23 @@ def run_claude_step(
     _fot = get_first_output_timeout()
     _heartbeat = max(60, _fot // 2) if _fot > 0 else 120
 
-    result = run_claude(
-        cmd,
-        project_path,
-        timeout=timeout,
-        idle_timeout=idle_timeout,
-        max_duration=max_duration,
-        heartbeat_interval=_heartbeat,
-    )
+    try:
+        result = run_claude(
+            cmd,
+            project_path,
+            timeout=timeout,
+            idle_timeout=idle_timeout,
+            max_duration=max_duration,
+            heartbeat_interval=_heartbeat,
+            use_stream_json=use_stream_json,
+            last_message_path=last_message_path,
+        )
+    finally:
+        if last_message_path:
+            import contextlib
+
+            with contextlib.suppress(OSError):
+                os.unlink(last_message_path)
     cleaned_output = strip_cli_noise(result.get("output", ""))
     if result["success"]:
         effective_msg = commit_msg

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -630,15 +630,31 @@ def run_rebase(
         from app.messaging_level import progress_notify
         notify_fn = progress_notify(log_category="rebase")
 
+    outcome_meta: Dict[str, str] = {}
     success, summary = _run_rebase_impl(
         owner, repo, pr_number, project_path,
         notify_fn=notify_fn, skill_dir=skill_dir, min_severity=min_severity,
+        outcome_meta=outcome_meta,
     )
 
     from app.messaging_level import notify_outcome
     pr_url = f"https://github.com/{owner}/{repo}/pull/{pr_number}"
     if success:
-        notify_outcome(f"✅ Rebased {pr_url}", notify_fn)
+        # A successful rebase that could NOT apply the reviewer's feedback is a
+        # partial success — surface it as a warning that always reaches chat
+        # (notify_outcome is not messaging.level-gated), so the dropped feedback
+        # is not mistaken for "done". The bare ✅ here is exactly why these were
+        # easy to miss.
+        feedback_unapplied = outcome_meta.get("feedback_unapplied")
+        if feedback_unapplied:
+            notify_outcome(
+                f"⚠️ Rebased {pr_url} — review feedback NOT applied "
+                f"({feedback_unapplied}); the reviewer comments still need "
+                "attention.",
+                notify_fn,
+            )
+        else:
+            notify_outcome(f"✅ Rebased {pr_url}", notify_fn)
     else:
         notify_outcome(f"❌ Rebase failed {pr_url}: {summary}", notify_fn)
     return success, summary
@@ -652,6 +668,7 @@ def _run_rebase_impl(
     notify_fn=None,
     skill_dir: Optional[Path] = None,
     min_severity: Optional[str] = None,
+    outcome_meta: Optional[Dict[str, str]] = None,
 ) -> Tuple[bool, str]:
     """Execute the rebase pipeline for a pull request.
 
@@ -819,6 +836,7 @@ def _run_rebase_impl(
     # ── Step 4: Analyze review comments and apply changes ──────────────
     change_summary = ""
     feedback_status = ""
+    feedback_reason = ""
     if _has_review_feedback(context):
         severity_hint = ""
         if min_severity and min_severity != "suggestion":
@@ -873,6 +891,9 @@ def _run_rebase_impl(
                 f"Review feedback timed out on `{branch}`{suffix}; "
                 "pushing the clean rebase without feedback edits."
             )
+            feedback_reason = "the feedback step timed out"
+            if outcome_meta is not None:
+                outcome_meta["feedback_unapplied"] = "timed out"
         if feedback_status == "feedback_quota":
             # Provider quota is exhausted — no point pushing a half-applied
             # review, and the loop should back off until quota resets.
@@ -897,6 +918,9 @@ def _run_rebase_impl(
                 f"Could not apply review feedback on `{branch}`{suffix}; "
                 "pushing the rebase without feedback changes."
             )
+            feedback_reason = "the feedback step errored"
+            if outcome_meta is not None:
+                outcome_meta["feedback_unapplied"] = "step errored"
 
         # Claude may switch branches during feedback — ensure we're still
         # on the expected branch before pushing.
@@ -980,6 +1004,7 @@ def _run_rebase_impl(
         ci_section=ci_section,
         change_summary=change_summary,
         feedback_failed=feedback_status in ("feedback_timeout", "feedback_failed"),
+        feedback_reason=feedback_reason,
     )
 
     try:
@@ -2196,13 +2221,17 @@ def _build_rebase_comment(
     ci_section: str = "",
     change_summary: str = "",
     feedback_failed: bool = False,
+    feedback_reason: str = "",
 ) -> str:
     """Build a structured markdown comment summarizing the rebase.
 
     ``feedback_failed`` is supplied by the caller from the structured
     feedback status (``feedback_timeout`` / ``feedback_failed``) rather than
     inferred from log prose, so a reworded log line cannot silently revert
-    the summary to "Simple rebase".
+    the summary to "Simple rebase". ``feedback_reason`` carries a short
+    human-readable cause (e.g. "the feedback step timed out") that is surfaced
+    in a prominent, non-collapsed warning callout so the dropped feedback is
+    obvious instead of being buried in the collapsed Actions section.
 
     Sections:
     1. Summary — rebase type (simple vs. with adjustments) + one-liner
@@ -2244,6 +2273,17 @@ def _build_rebase_comment(
 
     parts = [f"## {rebase_type}\n"]
     parts.append(f"{summary_line}\n")
+
+    # Prominent, non-collapsed warning so dropped reviewer feedback is
+    # impossible to miss (the cause otherwise hides in the <details> block).
+    if feedback_failed:
+        reason = feedback_reason.strip() or "the feedback step did not complete"
+        parts.append(
+            "> [!WARNING]\n"
+            f"> **Review feedback was NOT applied** — {reason}. The reviewer "
+            "comments above still need to be addressed: re-run `/rebase` or "
+            "apply them manually.\n"
+        )
 
     # ── 2. Changes ──────────────────────────────────────────────────
     # Only include when there are meaningful changes beyond rebasing

--- a/koan/tests/test_claude_step.py
+++ b/koan/tests/test_claude_step.py
@@ -4,6 +4,7 @@ Tests _run_git, truncate_text, _rebase_onto_target, run_claude,
 commit_if_changes, and run_claude_step.
 """
 
+import json
 import subprocess
 from unittest.mock import MagicMock, call, patch
 
@@ -657,6 +658,99 @@ class TestRunClaude:
         assert result["success"] is True
 
 
+class TestRunClaudeStreamJson:
+    """run_claude(use_stream_json=True) parses JSONL events into clean text.
+
+    Each event is one stdout line, so the inner idle watchdog resets on
+    genuine per-event progress (the codex silent-tool-use fix), while the
+    returned ``output`` is the final assistant text — not raw JSONL.
+    """
+
+    @staticmethod
+    def _jsonl(*events):
+        return [json.dumps(e) + "\n" for e in events]
+
+    @patch("app.claude_step.popen_cli")
+    def test_result_event_is_clean_output(self, mock_popen):
+        lines = self._jsonl(
+            {"type": "system", "subtype": "init", "model": "gpt-5.5"},
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Read"},
+            ]}},
+            {"type": "result", "subtype": "success",
+             "result": "COMMIT_SUBJECT: fix the thing\n\nApplied the fix."},
+        )
+        proc = _fake_proc(lines, returncode=0)
+        mock_popen.return_value = (proc, lambda: None)
+        result = run_claude(
+            ["claude", "-p", "x"], "/project", use_stream_json=True,
+        )
+        assert result["success"] is True
+        # Clean final text, not raw JSONL.
+        assert result["output"] == (
+            "COMMIT_SUBJECT: fix the thing\n\nApplied the fix."
+        )
+        assert '"type"' not in result["output"]
+
+    @patch("app.claude_step.popen_cli")
+    def test_summarized_events_printed_not_raw_json(self, mock_popen, capsys):
+        lines = self._jsonl(
+            {"type": "assistant", "message": {"content": [
+                {"type": "tool_use", "name": "Grep"},
+            ]}},
+            {"type": "result", "subtype": "success", "result": "done"},
+        )
+        proc = _fake_proc(lines, returncode=0)
+        mock_popen.return_value = (proc, lambda: None)
+        run_claude(["claude", "-p", "x"], "/project", use_stream_json=True)
+        captured = capsys.readouterr()
+        # Human-readable summaries are printed (these reset the idle watchdog),
+        # not the raw JSON lines.
+        assert "[cli]" in captured.out
+        assert "tool_use: Grep" in captured.out
+        assert '{"type"' not in captured.out
+
+    @patch("app.claude_step.popen_cli")
+    def test_falls_back_to_assistant_chunks_without_result(self, mock_popen):
+        """If the stream dies before a result event, accumulated assistant
+        text is still returned instead of empty/raw JSONL."""
+        lines = self._jsonl(
+            {"type": "assistant", "message": {"content": [
+                {"type": "text", "text": "partial answer"},
+            ]}},
+        )
+        proc = _fake_proc(lines, returncode=0)
+        mock_popen.return_value = (proc, lambda: None)
+        result = run_claude(
+            ["claude", "-p", "x"], "/project", use_stream_json=True,
+        )
+        assert result["output"] == "partial answer"
+
+    @patch("app.claude_step.popen_cli")
+    def test_last_message_file_takes_precedence(self, mock_popen, tmp_path):
+        last_msg = tmp_path / "last.txt"
+        last_msg.write_text("definitive final text")
+        lines = self._jsonl(
+            {"type": "result", "subtype": "success", "result": "streamed text"},
+        )
+        proc = _fake_proc(lines, returncode=0)
+        mock_popen.return_value = (proc, lambda: None)
+        result = run_claude(
+            ["claude", "-p", "x"], "/project",
+            use_stream_json=True, last_message_path=str(last_msg),
+        )
+        # File content wins over the result event.
+        assert result["output"] == "definitive final text"
+
+    @patch("app.claude_step.popen_cli")
+    def test_plain_text_path_unchanged(self, mock_popen):
+        """Default (use_stream_json=False) is byte-for-byte the old behavior."""
+        proc = _fake_proc(["plain line one\n", "plain line two\n"], returncode=0)
+        mock_popen.return_value = (proc, lambda: None)
+        result = run_claude(["claude", "-p", "x"], "/project")
+        assert result["output"] == "plain line one\nplain line two"
+
+
 # ---------- commit_if_changes ----------
 
 
@@ -1018,6 +1112,77 @@ class TestIsHookRejection:
 
 
 # ---------- run_claude_step ----------
+
+
+class TestRunClaudeStepStreaming:
+    """run_claude_step opts into stream-json when the provider supports it,
+    so codex (silent in plain-text mode) emits per-event lines that keep the
+    inner idle watchdog alive. See the codex /rebase feedback-timeout fix."""
+
+    def _fake_provider(self, *, stream_json, last_message):
+        provider = MagicMock()
+        provider.supports_stream_json.return_value = stream_json
+        provider.supports_last_message_file.return_value = last_message
+        provider.add_last_message_file_args.side_effect = (
+            lambda cmd, path: [*cmd[:-1], "--output-last-message", path, cmd[-1]]
+        )
+        return provider
+
+    @patch("app.provider.get_provider")
+    @patch("app.claude_step.commit_if_changes", return_value=False)
+    @patch("app.claude_step.run_claude")
+    @patch("app.claude_step.build_full_command", return_value=["codex", "exec", "p"])
+    @patch(
+        "app.claude_step.get_model_config",
+        return_value={"mission": "gpt-5.5", "fallback": "gpt-5.5", "chat": "", "lightweight": "", "review_mode": ""},
+    )
+    def test_codex_like_provider_requests_streaming_and_cleans_tempfile(
+        self, mock_config, mock_flags, mock_claude, mock_commit, mock_provider,
+    ):
+        mock_provider.return_value = self._fake_provider(
+            stream_json=True, last_message=True,
+        )
+        mock_claude.return_value = {"success": True, "output": "ok", "error": ""}
+        run_claude_step(
+            prompt="apply feedback", project_path="/project",
+            commit_msg="rebase: apply", success_label="ok", failure_label="no",
+            actions_log=[],
+        )
+        # build_full_command asked for stream-json output.
+        assert mock_flags.call_args.kwargs["output_format"] == "stream-json"
+        # run_claude told to parse events, with a last-message sidecar path.
+        ck = mock_claude.call_args.kwargs
+        assert ck["use_stream_json"] is True
+        last_path = ck["last_message_path"]
+        assert last_path
+        # Caller-owned temp file is cleaned up after the run.
+        import os as _os
+        assert not _os.path.exists(last_path)
+
+    @patch("app.provider.get_provider")
+    @patch("app.claude_step.commit_if_changes", return_value=False)
+    @patch("app.claude_step.run_claude")
+    @patch("app.claude_step.build_full_command", return_value=["copilot", "-p", "x"])
+    @patch(
+        "app.claude_step.get_model_config",
+        return_value={"mission": "", "fallback": "", "chat": "", "lightweight": "", "review_mode": ""},
+    )
+    def test_nonstreaming_provider_keeps_plain_text(
+        self, mock_config, mock_flags, mock_claude, mock_commit, mock_provider,
+    ):
+        mock_provider.return_value = self._fake_provider(
+            stream_json=False, last_message=False,
+        )
+        mock_claude.return_value = {"success": True, "output": "ok", "error": ""}
+        run_claude_step(
+            prompt="x", project_path="/project",
+            commit_msg="m", success_label="ok", failure_label="no",
+            actions_log=[],
+        )
+        assert mock_flags.call_args.kwargs["output_format"] == ""
+        ck = mock_claude.call_args.kwargs
+        assert ck["use_stream_json"] is False
+        assert ck["last_message_path"] is None
 
 
 class TestRunClaudeStep:

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -609,6 +609,35 @@ class TestBuildRebaseComment:
         assert "review feedback could not be applied automatically" in result
         assert "## Rebase with requested adjustments" not in result
 
+    def test_feedback_failed_renders_prominent_warning_callout(self):
+        # The reason must be surfaced in a non-collapsed warning callout (not
+        # only buried inside the <details> Actions block), and appear before it.
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            [
+                "Rebased onto origin/main",
+                "Review feedback timed out; restored clean rebased state and continuing with rebase-only push",
+            ],
+            {"title": "Fix bug", "review_comments": "please fix the typo"},
+            feedback_failed=True,
+            feedback_reason="the feedback step timed out",
+        )
+        assert "[!WARNING]" in result
+        assert "Review feedback was NOT applied" in result
+        assert "the feedback step timed out" in result
+        # Callout comes before the collapsed Actions section.
+        assert result.index("[!WARNING]") < result.index("<details>")
+
+    def test_feedback_failed_warning_has_default_reason(self):
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main"],
+            {"title": "Fix bug"},
+            feedback_failed=True,
+        )
+        assert "[!WARNING]" in result
+        assert "Review feedback was NOT applied" in result
+
     def test_feedback_failure_label_drives_summary_not_log_prose(self):
         # Detection comes from the structured status the caller passes, not
         # from substring-matching log lines.  A failure marker left in the
@@ -1410,6 +1439,32 @@ class TestRunRebase:
             )
             assert success is True
             assert "Rebased" in summary
+
+    @patch("app.rebase_pr._run_rebase_impl")
+    @patch("app.messaging_level.notify_outcome")
+    def test_outcome_warns_when_feedback_unapplied(self, mock_outcome, mock_impl):
+        """A rebase that succeeds but drops feedback must surface a warning
+        outcome (not a green check) so the dropped feedback is noticed."""
+        def impl(*args, **kwargs):
+            kwargs["outcome_meta"]["feedback_unapplied"] = "timed out"
+            return True, "PR #42 rebased."
+        mock_impl.side_effect = impl
+        run_rebase("o", "r", "42", "/p", notify_fn=MagicMock())
+        msg = mock_outcome.call_args.args[0]
+        assert "⚠️" in msg
+        assert "feedback NOT applied" in msg
+        assert "timed out" in msg
+
+    @patch("app.rebase_pr._run_rebase_impl")
+    @patch("app.messaging_level.notify_outcome")
+    def test_outcome_green_check_when_feedback_ok(self, mock_outcome, mock_impl):
+        def impl(*args, **kwargs):
+            return True, "PR #42 rebased."
+        mock_impl.side_effect = impl
+        run_rebase("o", "r", "42", "/p", notify_fn=MagicMock())
+        msg = mock_outcome.call_args.args[0]
+        assert msg.startswith("✅")
+        assert "NOT applied" not in msg
 
     @patch("app.rebase_pr.fetch_pr_context")
     def test_fetch_failure(self, mock_ctx):


### PR DESCRIPTION
The /rebase "apply review feedback" step (and the CI-fix step) run via run_claude_step, which built its command without an output format. Under cli_provider: codex the CLI then runs in buffered plain-text mode and is silent during tool use, so the inner idle watchdog (rebase_review_idle_timeout, default 600s) — which only resets on a child stdout line — killed a still-progressing step. The rebase then fell back to a rebase-only push, so a reviewer's comment looked ignored (observed on a real PR where the only trace was a buried "Timeout (idle 600s)" line). Claude survived because its plain-text mode dribbles enough output; codex does not.

Root-cause fix: run_claude_step now opts into stream-json/--json when the provider supports it. run_claude grows a use_stream_json mode that parses each JSONL event (reusing the provider event helpers), printing a short summary per event — so every event resets the idle watchdog on genuine progress — while returning clean final assistant text (last-message file → result event → accumulated chunks), keeping parse_commit_subject and change-summary intact. The plain-text path is unchanged for providers without stream-json support.

Visibility: a successful rebase that could not apply feedback no longer emits a bare green "Rebased" outcome. run_rebase now emits a "⚠️ … review feedback NOT applied (reason)" outcome (always reaches chat), and the PR comment carries a prominent, non-collapsed [!WARNING] callout naming the cause instead of burying it in the collapsed Actions block.

Tests cover stream-json parsing/precedence, the plain-text path staying unchanged, the streaming opt-in + temp-file cleanup, the warning callout, and the warning outcome. Docs updated (docs/providers/codex.md).