### PR TITLE
ci: simplify reviewer assignment loop

### DIFF
--- a/.github/workflows/request-review.yml
+++ b/.github/workflows/request-review.yml
@@ -14,12 +14,11 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const bot = 'Koan-Bot';
-            const fallbackBot = 'Father-Koan';
+            const bots = ['Koan-Bot', 'Father-Koan'];
             const author = context.payload.pull_request.user.login;
-            let commented = false;
 
-            if (author !== bot) {
+            for (const bot of bots) {
+              if (bot === author) continue;
               try {
                 await github.rest.pulls.requestReviewers({
                   owner: context.repo.owner,
@@ -27,17 +26,6 @@ jobs:
                   pull_number: context.issue.number,
                   reviewers: [bot]
                 });
-                commented = true;
-              } catch (e) {}
-            }
-
-            if (!commented) {
-              try {
-                await github.rest.pulls.requestReviewers({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  pull_number: context.issue.number,
-                  reviewers: [fallbackBot]
-                });
+                break;
               } catch (e) {}
             }


### PR DESCRIPTION
## Summary

Refactors the request-review workflow to collapse the duplicated try/catch blocks into a single ordered loop that requests the first available reviewer and stops on success.

- Iterates over an ordered bot list, skipping the PR author.
- Requests the first reachable reviewer and breaks on success.
- Preserves the existing bot priority (`Koan-Bot` primary, `Father-Koan` fallback).

## Test plan

- [ ] Open a PR and confirm `Koan-Bot` is requested as a reviewer.
- [ ] Confirm a PR authored by `Koan-Bot` falls back to `Father-Koan`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)