### PR TITLE
feat(systemd): add systemd-user service-manager mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,21 +51,35 @@ endif
 
 # --- service manager detection ---
 # Default: foreground processes via pid_manager (no service manager)
-# Set KOAN_SERVICE_MANAGER=systemd or KOAN_SERVICE_MANAGER=launchd in .env to opt in
+# Set KOAN_SERVICE_MANAGER=systemd | systemd-user | launchd in .env to opt in.
+#   systemd      — system service in /etc/systemd/system (needs sudo)
+#   systemd-user — per-user service in ~/.config/systemd/user (no sudo; uses linger)
+#   launchd      — macOS LaunchAgents
 IS_LINUX := $(shell [ "$$(uname -s)" = "Linux" ] && echo 1)
 IS_MAC := $(shell [ "$$(uname -s)" = "Darwin" ] && echo 1)
 ifeq ($(KOAN_SERVICE_MANAGER),systemd)
   USE_SYSTEMD := 1
+  USE_SYSTEMD_USER :=
+  USE_LAUNCHD :=
+else ifeq ($(KOAN_SERVICE_MANAGER),systemd-user)
+  USE_SYSTEMD :=
+  USE_SYSTEMD_USER := 1
   USE_LAUNCHD :=
 else ifeq ($(KOAN_SERVICE_MANAGER),launchd)
   USE_SYSTEMD :=
+  USE_SYSTEMD_USER :=
   USE_LAUNCHD := 1
 else
   USE_SYSTEMD :=
+  USE_SYSTEMD_USER :=
   USE_LAUNCHD :=
 endif
 SERVICE_INSTALLED = $(shell [ -f /etc/systemd/system/koan.service ] && echo 1)
+USER_SERVICE_INSTALLED = $(shell [ -f ~/.config/systemd/user/koan.service ] && echo 1)
 LAUNCHD_INSTALLED = $(shell [ -f ~/Library/LaunchAgents/com.koan.run.plist ] && echo 1)
+# Bus-safe `systemctl --user` prefix: works from a normal login AND via `sudo -niu`
+# (where XDG_RUNTIME_DIR/DBUS_SESSION_BUS_ADDRESS are unset). Linger keeps /run/user/<uid> alive.
+SYSTEMCTL_USER = XDG_RUNTIME_DIR="$${XDG_RUNTIME_DIR:-/run/user/$$(id -u)}" DBUS_SESSION_BUS_ADDRESS="$${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$$(id -u)/bus}" systemctl --user
 
 setup: $(VENV)/.installed
 
@@ -170,6 +184,26 @@ stop:
 
 status:
 	@sudo systemctl status koan koan-awake --no-pager || true
+
+else ifeq ($(USE_SYSTEMD_USER),1)
+
+start: setup
+	@if [ -n "$$SSH_AUTH_SOCK" ]; then \
+		ln -sf "$$SSH_AUTH_SOCK" "$(PWD)/.ssh-agent-sock"; \
+		echo "✓ SSH agent socket forwarded"; \
+	fi
+	@if [ -z "$(USER_SERVICE_INSTALLED)" ]; then \
+		echo "→ systemd (user) detected — installing Kōan user service (one-time setup)..."; \
+		bash koan/systemd/install-user-service.sh "$(PWD)" "$(PWD)/$(PYTHON)"; \
+	fi
+	@$(SYSTEMCTL_USER) start koan.service
+	@echo "✓ Kōan started via systemd --user"
+
+stop:
+	@$(SYSTEMCTL_USER) stop koan.service koan-awake.service 2>/dev/null || true
+
+status:
+	@$(SYSTEMCTL_USER) status koan.service koan-awake.service --no-pager || true
 
 else ifeq ($(USE_LAUNCHD),1)
 

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ export
 .PHONY: awake run errand-run errand-awake dashboard koan api api-token webhook
 .PHONY: ollama logs ssh-forward
 .PHONY: install-systemctl-service uninstall-systemctl-service
+.PHONY: install-user-service uninstall-user-service
 .PHONY: install-launchd-service uninstall-launchd-service
 .PHONY: docker-setup docker-pull-up docker-up docker-down docker-logs docker-test docker-auth docker-gh-auth
 
@@ -315,6 +316,16 @@ uninstall-systemctl-service:
 	@if [ -z "$(IS_LINUX)" ]; then echo "Error: systemd is only available on Linux." >&2; exit 1; fi
 	@if [ -z "$(USE_SYSTEMD)" ]; then echo "Error: systemctl not found." >&2; exit 1; fi
 	sudo bash koan/systemd/uninstall-service.sh
+
+install-user-service: setup
+	@if [ -z "$(IS_LINUX)" ]; then echo "Error: systemd is only available on Linux." >&2; exit 1; fi
+	@command -v systemctl >/dev/null 2>&1 || (echo "Error: systemctl not found. systemd is required." >&2; exit 1)
+	bash koan/systemd/install-user-service.sh "$(PWD)" "$(PWD)/$(PYTHON)"
+
+uninstall-user-service:
+	@if [ -z "$(IS_LINUX)" ]; then echo "Error: systemd is only available on Linux." >&2; exit 1; fi
+	@command -v systemctl >/dev/null 2>&1 || (echo "Error: systemctl not found." >&2; exit 1)
+	bash koan/systemd/uninstall-user-service.sh $(if $(disable-linger),--disable-linger,)
 
 install-launchd-service: setup
 	@if [ -z "$(IS_MAC)" ]; then echo "Error: launchd is only available on macOS." >&2; exit 1; fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -38,7 +38,7 @@ memory, or integration changes:
 ## Directory Map
 
 - `users/` - user manual, onboarding, and command references.
-- `setup/` - installation and host runtime setup (see [Deploy on Railway](setup/railway.md)).
+- `setup/` - installation and host runtime setup (see [Deploy on Railway](setup/railway.md), [systemd `--user` service](setup/systemd-user.md), [launchd service](setup/launchd.md)).
 - `providers/` - CLI and local model provider setup and behavior.
 - `messaging/` - messaging and issue-tracker integration setup.
 - `operations/` - maintenance, troubleshooting, self-update, and optional operational tools (dashboard, REST API, auto-update, RTK).

--- a/docs/setup/systemd-user.md
+++ b/docs/setup/systemd-user.md
@@ -1,0 +1,140 @@
+# Running as a systemd `--user` Service (Linux, no root)
+
+Kōan can run as a per-user **systemd** service on Linux — automatic restart on
+failure, boot-time startup, and **no `sudo`** required for day-to-day operation.
+This is the recommended Linux deployment when you don't want (or can't have) a
+root-owned system service.
+
+## Service manager modes
+
+`make start/stop/status` delegate to a service manager selected by the
+`KOAN_SERVICE_MANAGER` variable (read from `.env`):
+
+| `KOAN_SERVICE_MANAGER` | Where units live | Privileges | Platform |
+|------------------------|------------------|-----------|----------|
+| _(unset, default)_ | — (foreground PID manager) | none | any |
+| `systemd` | `/etc/systemd/system` | needs `sudo` | Linux |
+| `systemd-user` | `~/.config/systemd/user` | no root (uses linger) | Linux |
+| `launchd` | `~/Library/LaunchAgents` | no root | macOS |
+
+To opt in, add to your `.env`:
+
+```bash
+KOAN_SERVICE_MANAGER=systemd-user
+```
+
+## Quick Setup
+
+```bash
+make install-user-service   # One-time: render units + enable linger + enable services
+make start                  # Start via systemctl --user
+```
+
+Or simply run `make start` with `KOAN_SERVICE_MANAGER=systemd-user` set — it
+auto-installs the user service on first run.
+
+## What It Does
+
+The install (`koan/systemd/install-user-service.sh`) creates two units in
+`~/.config/systemd/user/`:
+
+| Unit | Process | Description |
+|------|---------|-------------|
+| `koan.service` | `run.py` | Agent loop (missions, execution, reflection) |
+| `koan-awake.service` | `awake.py` | Messaging bridge (Telegram/Slack) |
+
+Both are `Restart=on-failure` with `RestartSec=10` and `WantedBy=default.target`
+so they start when the user manager comes up. `koan.service` `Requires`/`BindsTo`
+`koan-awake.service`, so the bridge and loop start and stop together.
+
+### Linger (boot persistence)
+
+A user manager normally exists only while you have an active login session. To
+keep Kōan running after you log out — and to start it at boot with **no login at
+all** — the installer enables **lingering**:
+
+```bash
+loginctl enable-linger <user>
+```
+
+If that fails (it can require privileges on locked-down hosts), the installer
+prints the exact `sudo loginctl enable-linger <user>` command to run once.
+
+### PATH preservation (important)
+
+Unlike the system installer (`app/systemd_service.py`), the `--user` installer
+**keeps** `~/.npm-global/bin` and `~/.local/bin` on the service `PATH`. These hold
+the `claude` CLI and the `ocgo` helper used by the provider wrapper; without them
+provider calls fail with `ocgo/claude not found`. This is intentional — do not
+sanitize the user-service PATH the way the system service does.
+
+## How `make start/stop/status` Work
+
+With `KOAN_SERVICE_MANAGER=systemd-user`, the Makefile drives `systemctl --user`
+through a bus-safe prefix that works both from a normal login **and** via
+`sudo -niu <user>` (where `XDG_RUNTIME_DIR` / `DBUS_SESSION_BUS_ADDRESS` are
+unset). Linger keeps `/run/user/<uid>` alive so the bus is reachable.
+
+| Command | Action |
+|---------|--------|
+| `make start` | `systemctl --user start koan.service` (auto-installs on first run) |
+| `make stop` | `systemctl --user stop koan.service koan-awake.service` |
+| `make status` | `systemctl --user status koan.service koan-awake.service` |
+| `make restart` | `make stop` + `make start` |
+
+## Viewing Logs
+
+Units write to `logs/run.log` and `logs/awake.log` (via `StandardOutput`/
+`StandardError=append:`):
+
+```bash
+make logs            # watch live
+tail -f logs/run.log
+```
+
+`journalctl --user -u koan.service` also works.
+
+## SSH Agent Forwarding
+
+If you use SSH git remotes, `make start` forwards your SSH agent socket so the
+managed processes can reach it (`SSH_AUTH_SOCK=<koan_root>/.ssh-agent-sock` in the
+unit). See [ssh-setup.md](ssh-setup.md) for details.
+
+## Uninstalling
+
+```bash
+make uninstall-user-service                  # stop, disable, remove units
+make uninstall-user-service disable-linger=1 # also run loginctl disable-linger
+```
+
+This stops and disables both units, removes them from `~/.config/systemd/user/`,
+and reloads the user daemon. Lingering is left in place unless you pass
+`disable-linger=1`. After uninstalling, unset `KOAN_SERVICE_MANAGER` (or set it
+back to the default) and `make start` uses the Python PID manager again.
+
+## Troubleshooting
+
+### `Failed to connect to bus: No such file or directory`
+
+The user bus socket (`/run/user/<uid>/bus`) isn't up yet. On a fresh host where
+linger was just enabled, logind starts `user@<uid>.service` asynchronously — the
+installer already waits for the socket before its first `--user` call. If you hit
+this manually, ensure linger is enabled (`loginctl show-user <user>` →
+`Linger=yes`) and that `/run/user/<uid>` exists, then retry.
+
+### Services don't start at boot
+
+Confirm linger is on:
+
+```bash
+loginctl show-user "$(id -un)" | grep Linger   # expect Linger=yes
+```
+
+If it shows `Linger=no`, run `sudo loginctl enable-linger "$(id -un)"`.
+
+### Provider call fails with `ocgo/claude not found`
+
+The service `PATH` is missing the user bin dirs. Confirm `~/.npm-global/bin` and
+`~/.local/bin` are present in the `Environment=PATH=` line of
+`~/.config/systemd/user/koan.service`, then `systemctl --user daemon-reload` and
+restart.

--- a/koan/systemd/install-user-service.sh
+++ b/koan/systemd/install-user-service.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Install Kōan systemd --user services (no root).
+# Usage: ./install-user-service.sh <koan_root> <python_path>
+#
+# Counterpart to install-service.sh, but installs per-user units under
+# ~/.config/systemd/user and drives them with `systemctl --user` (no sudo).
+# Enables lingering so the services start at boot without an active login.
+set -euo pipefail
+
+KOAN_ROOT="${1:?Usage: $0 <koan_root> <python_path>}"
+PYTHON="${2:?Usage: $0 <koan_root> <python_path>}"
+
+# --- Validations ---
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Error: systemd services are only supported on Linux." >&2
+    exit 1
+fi
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "Error: systemctl not found. systemd is required." >&2
+    exit 1
+fi
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Error: run as your normal user, not root (these are --user units)." >&2
+    exit 1
+fi
+
+# Resolve to absolute paths
+KOAN_ROOT="$(cd "$KOAN_ROOT" && pwd)"
+PYTHON="$(cd "$(dirname "$PYTHON")" && pwd)/$(basename "$PYTHON")"
+
+if [ ! -f "$KOAN_ROOT/koan/app/run.py" ]; then
+    echo "Error: $KOAN_ROOT does not look like a Kōan installation." >&2
+    exit 1
+fi
+if [ ! -x "$PYTHON" ]; then
+    echo "Error: Python binary not found or not executable: $PYTHON" >&2
+    exit 1
+fi
+
+# Service PATH. Unlike the system installer's sanitizer (app/systemd_service.py),
+# KEEP the user bin dirs: ~/.npm-global/bin (claude CLI) and ~/.local/bin (ocgo)
+# are required by the oc-claude provider wrapper — without them the provider call
+# fails with 'ocgo/claude not found'.
+SVC_PATH="$HOME/.npm-global/bin:$HOME/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
+UNIT_DIR="$HOME/.config/systemd/user"
+mkdir -p "$UNIT_DIR"
+mkdir -p "$KOAN_ROOT/logs"
+
+# write_unit <filename> <exec-arg> <description> <logfile> <extra-unit-lines>
+write_unit() {
+    local file="$UNIT_DIR/$1"
+    cat > "$file" <<UNIT
+[Unit]
+Description=$3
+After=network-online.target
+Wants=network-online.target
+$5
+
+[Service]
+Type=simple
+WorkingDirectory=$KOAN_ROOT/koan
+EnvironmentFile=$KOAN_ROOT/.env
+Environment=KOAN_ROOT=$KOAN_ROOT
+Environment=PYTHONPATH=$KOAN_ROOT/koan
+Environment=PATH=$SVC_PATH
+Environment=SSH_AUTH_SOCK=$KOAN_ROOT/.ssh-agent-sock
+ExecStart=$PYTHON $2
+Restart=on-failure
+RestartSec=10
+StandardOutput=append:$KOAN_ROOT/logs/$4
+StandardError=append:$KOAN_ROOT/logs/$4
+
+[Install]
+WantedBy=default.target
+UNIT
+    echo "  wrote $file"
+}
+
+write_unit "koan-awake.service" "app/awake.py" "Kōan Communication Bridge (user)" "awake.log" \
+    "PartOf=koan.service"
+write_unit "koan.service" "app/run.py" "Kōan Agent Loop (user)" "run.log" \
+    "Requires=koan-awake.service
+BindsTo=koan-awake.service
+After=koan-awake.service"
+
+# Enable lingering so the user manager (and these services) start at boot
+# without an active login session.
+if ! loginctl show-user "$(id -un)" 2>/dev/null | grep -q '^Linger=yes'; then
+    if loginctl enable-linger "$(id -un)" 2>/dev/null; then
+        echo "→ Enabled lingering for $(id -un)"
+    else
+        echo "⚠ Could not enable lingering (needs privileges). Run once:" >&2
+        echo "    sudo loginctl enable-linger $(id -un)" >&2
+    fi
+fi
+
+# Reach the user bus even when invoked without a login session (e.g. sudo -niu).
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+
+systemctl --user daemon-reload
+systemctl --user enable koan.service koan-awake.service
+
+echo "✓ Kōan systemd --user services installed and enabled."
+echo "  Start with: make start   (requires KOAN_SERVICE_MANAGER=systemd-user in .env)"
+echo "  Or directly: systemctl --user start koan.service"

--- a/koan/systemd/install-user-service.sh
+++ b/koan/systemd/install-user-service.sh
@@ -53,8 +53,6 @@ write_unit() {
     cat > "$file" <<UNIT
 [Unit]
 Description=$3
-After=network-online.target
-Wants=network-online.target
 $5
 
 [Service]
@@ -98,6 +96,17 @@ fi
 # Reach the user bus even when invoked without a login session (e.g. sudo -niu).
 export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
 export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+
+# On a fresh no-session host (sudo -niu, linger just enabled), logind spins up
+# user@<uid>.service asynchronously — enable-linger returns before the user
+# manager's bus socket is listening. Wait for it so the first `--user` call
+# below doesn't fail with "Failed to connect to bus" and abort under set -e.
+for _ in $(seq 1 40); do
+    if [ -S "$XDG_RUNTIME_DIR/bus" ] && systemctl --user show-environment >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.25
+done
 
 systemctl --user daemon-reload
 systemctl --user enable koan.service koan-awake.service

--- a/koan/systemd/uninstall-user-service.sh
+++ b/koan/systemd/uninstall-user-service.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Uninstall Kōan systemd --user services (no root).
+# Usage: ./uninstall-user-service.sh
+#
+# Counterpart to uninstall-service.sh, but removes the per-user units under
+# ~/.config/systemd/user and drives them with `systemctl --user` (no sudo).
+# Leaves lingering in place by default; pass --disable-linger to also turn it off.
+set -euo pipefail
+
+if [ "$(uname -s)" != "Linux" ]; then
+    echo "Error: systemd services are only supported on Linux." >&2
+    exit 1
+fi
+if ! command -v systemctl >/dev/null 2>&1; then
+    echo "Error: systemctl not found." >&2
+    exit 1
+fi
+if [ "$(id -u)" -eq 0 ]; then
+    echo "Error: run as your normal user, not root (these are --user units)." >&2
+    exit 1
+fi
+
+# Reach the user bus even when invoked without a login session (e.g. sudo -niu).
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+export DBUS_SESSION_BUS_ADDRESS="${DBUS_SESSION_BUS_ADDRESS:-unix:path=/run/user/$(id -u)/bus}"
+
+UNIT_DIR="$HOME/.config/systemd/user"
+SERVICES="koan.service koan-awake.service"
+
+for svc in $SERVICES; do
+    if [ -f "$UNIT_DIR/$svc" ]; then
+        echo "→ Stopping $svc"
+        systemctl --user stop "$svc" 2>/dev/null || true
+        echo "→ Disabling $svc"
+        systemctl --user disable "$svc" 2>/dev/null || true
+        echo "→ Removing $svc"
+        rm -f "$UNIT_DIR/$svc"
+    else
+        echo "  $svc not installed, skipping"
+    fi
+done
+
+echo "→ Reloading user systemd daemon"
+systemctl --user daemon-reload 2>/dev/null || true
+
+if [ "${1:-}" = "--disable-linger" ]; then
+    if loginctl disable-linger "$(id -un)" 2>/dev/null; then
+        echo "→ Disabled lingering for $(id -un)"
+    else
+        echo "⚠ Could not disable lingering (needs privileges). Run once:" >&2
+        echo "    sudo loginctl disable-linger $(id -un)" >&2
+    fi
+fi
+
+echo "✓ Kōan systemd --user services removed."


### PR DESCRIPTION
Add KOAN_SERVICE_MANAGER=systemd-user so `make start/stop/status/restart`
drive a per-user service via `systemctl --user` instead of daemonizing
through pid_manager. Previously `make restart` would stop a systemd-managed
instance and relaunch koan as a detached login-session process that dies on
logout/reboot.

- Makefile: new systemd-user branch mirroring the systemd/launchd ones, a
  file-based USER_SERVICE_INSTALLED probe, and a bus-safe SYSTEMCTL_USER
  prefix that falls back to /run/user/<uid> when XDG_RUNTIME_DIR is unset
  (e.g. under `sudo -niu`).
- koan/systemd/install-user-service.sh: writes ~/.config/systemd/user units
  (no sudo), enables linger for boot persistence, daemon-reload + enable.
  Unlike the system installer's PATH sanitizer it preserves ~/.npm-global/bin
  and ~/.local/bin (needed by the oc-claude provider wrapper).

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
