### PR TITLE
fix(session_tracker): make 'blocked' outcome reachable

### DIFF
--- a/koan/app/session_tracker.py
+++ b/koan/app/session_tracker.py
@@ -52,6 +52,17 @@ _EMPTY_KEYWORDS = [
     "no changes needed",
 ]
 
+# Subset of _EMPTY_KEYWORDS that signal "blocked on external review" rather
+# than "nothing to do". These are scored via the dedicated blocked check in
+# classify_session(), NOT via empty_score — otherwise the canonical blocked
+# phrasing ("all work blocked. blocked on merge queue.") double-counts itself
+# into empty_score >= 3 and the "blocked" outcome becomes unreachable.
+_BLOCKED_KEYWORDS = (
+    "blocked on merge",
+    "merge queue",
+    "all work blocked",
+)
+
 # Strong productive signals — multi-word phrases that are unambiguous
 _STRONG_PRODUCTIVE = [
     "branch pushed",
@@ -110,19 +121,22 @@ def classify_session(journal_content: str, mission_title: str = "") -> str:
     if any(kw in lower for kw in _STRONG_PRODUCTIVE):
         return "productive"
 
-    # Count empty signals (multi-word phrases, low false positive rate)
-    empty_score = sum(1 for kw in _EMPTY_KEYWORDS if kw in lower)
+    # Count empty signals (multi-word phrases, low false positive rate).
+    # Blocked-trigger phrases are scored separately below, so a session that
+    # only signals "blocked" doesn't inflate empty_score and mask itself.
+    empty_score = sum(
+        1
+        for kw in _EMPTY_KEYWORDS
+        if kw in lower and kw not in _BLOCKED_KEYWORDS
+    )
 
-    # Strong empty overrides everything (including blocked keywords)
+    # Strong empty overrides everything: 3+ NON-blocked empty signals means the
+    # session was idle for reasons other than waiting on review.
     if empty_score >= 3:
         return "empty"
 
     # Blocked keywords with insufficient productive evidence → blocked
-    has_blocked = (
-        "blocked on merge" in lower
-        or "merge queue" in lower
-        or "all work blocked" in lower
-    )
+    has_blocked = any(kw in lower for kw in _BLOCKED_KEYWORDS)
     weak_productive = len(_WEAK_PRODUCTIVE_RE.findall(lower))
     if has_blocked and weak_productive < 1:
         return "blocked"

--- a/koan/tests/test_session_tracker.py
+++ b/koan/tests/test_session_tracker.py
@@ -512,6 +512,17 @@ class TestClassifySessionEdgeCases:
         content = "All branches pending. Blocked on merge reviews."
         assert classify_session(content) == "blocked"
 
+    def test_canonical_blocked_phrasing_is_blocked_not_empty(self):
+        """Regression: blocked-trigger phrases must not double-count into
+        empty_score. The canonical blocked journal repeats the same idea
+        ('all work blocked', 'blocked on merge queue') which previously
+        pushed empty_score >= 3 and misclassified the session as 'empty'."""
+        content = (
+            "All work blocked. Blocked on merge queue. "
+            "No actionable work this session."
+        )
+        assert classify_session(content) == "blocked"
+
     def test_blocked_with_weak_productive(self):
         """Blocked + weak productive signal → productive (implemented beats blocked)."""
         content = "Blocked on merge for old PRs, but implemented a new module."


### PR DESCRIPTION
**What**: Make the `blocked` session-outcome classification reachable for real blocked sessions.

**Why**: `classify_session()` defines three outcomes — productive / empty / blocked — feeding the daily metrics and the staleness warning the human sees. But "blocked" was effectively dead code: the three blocked-trigger phrases (`blocked on merge`, `merge queue`, `all work blocked`) were also members of `_EMPTY_KEYWORDS`. A canonically-phrased blocked journal restates the same idea ("All work blocked. Blocked on merge queue."), so those phrases *alone* pushed `empty_score >= 3` and the function returned `empty` before the blocked branch could run. The agent could never report "I'm stalled waiting on review" — the exact distinction that matters when the review queue is the bottleneck.

**How**: Extract the blocked phrases into `_BLOCKED_KEYWORDS` and exclude them from `empty_score`; they're now scored solely via the dedicated `has_blocked` check (also DRYs up the previously-duplicated literals). The documented "strong empty overrides blocked" intent is preserved — 3+ *non-blocked* empty signals still classify as `empty`.

**Testing**: Added a regression test for the canonical blocked phrasing (previously `empty`, now `blocked`). Full `test_session_tracker.py` suite passes (158 tests); `make lint` clean.
