### PR TITLE
feat: real-time config sync with selective hot-reload (#2134)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -61,6 +61,7 @@ memory, or integration changes:
 - [PR Activity Reports](operations/pr-reports.md)
 - [Memory Watchdog](operations/memory-watchdog.md)
 - [Skill Evaluation Harness](operations/skill-evals.md) — golden-dataset evals for LLM skills (regression detection + improvement measurement)
+- [Real-time Config Sync](operations/config-sync.md)
 - [Messaging Level (bridge verbosity)](messaging/messaging-level.md)
 - [Design Decisions](design/decisions.md)
 

--- a/docs/operations/config-sync.md
+++ b/docs/operations/config-sync.md
@@ -1,0 +1,47 @@
+# Real-time config sync
+
+Kōan watches `instance/config.yaml` and `instance/projects.yaml` for changes
+and reflects them in the dashboard within ~2s (via the existing
+`/api/state/stream` SSE — no extra dependency or watcher thread).
+
+## Safe vs. restart-required
+
+- **Safe (hot, no restart):** `dashboard.nickname`, `tools.*`,
+  `automation_rules.*`, `messaging_level`, `verbose`. These are re-read per
+  use, so edits take effect immediately.
+- **Restart required:** `cli_provider`, `models`, anything in
+  `projects.yaml` (paths/providers), and any key not on the safe allowlist.
+
+The allowlist is closed: anything not explicitly listed is treated as
+restart-required, and `projects.yaml` is restart-required wholesale. This is
+deliberate — misclassifying an unsafe key as safe would silently run the agent
+on stale state. The allowlist lives in `config.py::_HOT_RELOAD_SAFE_KEYS`.
+
+## How it works
+
+The agent records a baseline snapshot at startup
+(`instance/.koan-config-baseline.json`). The dashboard diffs the current files
+against it:
+
+- Safe changes toast **"Settings updated"** and the badge stays green
+  **"Synced"**.
+- Unsafe changes turn the badge yellow **"Restart pending"** and show a
+  **"Restart required"** modal listing the changed keys.
+
+The restart only fires when the agent is **idle** (no in-flight mission). The
+modal's "Restart now" button posts to `POST /api/config/restart-if-idle`, which
+returns `409` when the agent is busy, guarding against lost work. After a real
+restart the baseline is rewritten, so the badge flips back to green.
+
+Because detection is folded into the existing 2s SSE tick, multiple rapid edits
+coalesce into a single emitted state — no separate debounce is needed.
+
+## Endpoints
+
+- `GET /api/config/sync` — non-SSE poll fallback returning the same status block.
+- `POST /api/config/restart-if-idle` — idle-gated restart (`200` when idle,
+  `409` when working).
+
+## Disabling
+
+Set `config_sync: { enabled: false }` in `config.yaml`.

--- a/docs/operations/config-sync.md
+++ b/docs/operations/config-sync.md
@@ -1,3 +1,12 @@
+---
+type: doc
+title: "Real-time Config Sync"
+description: "Documents real-time config sync: the dashboard reflects config.yaml/projects.yaml edits within ~2s over the existing SSE, classifying safe hot-reload keys vs restart-required changes and gating restarts on agent idleness."
+tags: [operations]
+created: 2026-07-17
+updated: 2026-07-17
+---
+
 # Real-time config sync
 
 Kōan watches `instance/config.yaml` and `instance/projects.yaml` for changes

--- a/docs/operations/index.md
+++ b/docs/operations/index.md
@@ -1,6 +1,7 @@
 # Operations
 
 * [Auto-Update](auto-update.md) - Describes Kōan's opt-in auto-update feature that checks for and pulls upstream commits, plus the always-on release-tag notification.
+* [Real-time Config Sync](config-sync.md) - Documents real-time config sync: the dashboard reflects config.yaml/projects.yaml edits within ~2s over the existing SSE, classifying safe hot-reload keys vs restart-required changes and gating restarts on agent idleness.
 * [Web Dashboard](dashboard.md) - Documents the local Flask web dashboard's architecture, blueprints, pages, passphrase gate, and design-system integration.
 * [Interactive launcher (make koan)](interactive-launcher.md) - Describes `make koan`, the TTY-gated interactive launcher and its textual terminal dashboard (tabs, toggles, keybindings).
 * [make logs formatting](log-formatting.md) - Documents the display-side [cli] log formatter (log_fmt.py) behind make logs, its glyph legend, tool-input previews, accumulating thinking dots, and the raw=1 escape hatch.

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -2319,8 +2319,19 @@ Run `make dashboard` to start a local web UI on port 5001. The dashboard provide
 - Mission queue management
 - Chat interface
 - Journal browsing
+- Real-time config sync
 
 The dashboard binds to `localhost` only — not accessible from the network.
+
+**Real-time config sync:** Edits to `instance/config.yaml` and
+`instance/projects.yaml` are reflected on the Config page within ~2s without a
+`make stop && make start` round-trip. Safe settings (`dashboard.nickname`,
+`tools.*`, `automation_rules.*`, `messaging_level`, `verbose`) are already
+re-read per use, so they toast "Settings updated" and stay live. Unsafe settings
+(`cli_provider`, `models`, anything in `projects.yaml`, and any other key) show a
+"Restart required" modal; the restart only runs when the agent is idle. Disable
+with `config_sync: { enabled: false }`. See
+[Real-time Config Sync](../operations/config-sync.md).
 
 ### Deployment
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -1285,3 +1285,14 @@ page_cache_reclaim:
 #       rtk: false          # never inject awareness for this project
 #                           # (e.g. its test runner emits JSON that rtk's
 #                           #  filter would clobber)
+
+# --- Real-time config sync (optional) ---
+# When the dashboard is running, edits to config.yaml / projects.yaml are
+# reflected in the UI within ~2s. Safe settings (dashboard.nickname, tools.*,
+# automation_rules.*, messaging_level, verbose) take effect immediately; unsafe
+# settings (cli_provider, models, anything in projects.yaml) show a
+# "Restart required" modal that only restarts when the agent is idle.
+# Set enabled: false to suppress the UI feedback entirely. Default: true.
+#
+# config_sync:
+#   enabled: true           # bool — show config-sync badge/toast/modal

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -937,6 +937,33 @@ def get_dashboard_nickname() -> str:
     return ""
 
 
+# Keys (dotted paths into config.yaml) that can be hot-reloaded without
+# restarting the agent. Anything NOT matching one of these is treated as
+# requiring a restart. A path matches if it equals an entry or is nested
+# under one (e.g. "tools.allowed" matches the "tools" entry).
+_HOT_RELOAD_SAFE_KEYS = frozenset({
+    "dashboard.nickname",
+    "tools",             # tools.chat / tools.mission re-read per mission
+    "automation_rules",  # whole section
+    "messaging_level",
+    "verbose",
+})
+
+
+def get_hot_reload_safe_keys() -> frozenset:
+    """Return the set of config.yaml dotted paths safe to hot-reload."""
+    return _HOT_RELOAD_SAFE_KEYS
+
+
+def is_config_sync_enabled() -> bool:
+    """Whether real-time config sync UI feedback is enabled (default True)."""
+    config = _load_config()
+    section = config.get("config_sync", {})
+    if not isinstance(section, dict):
+        return True
+    return bool(section.get("enabled", True))
+
+
 def is_api_enabled() -> bool:
     """Check if REST API is enabled for managed startup.
 

--- a/koan/app/config_sync.py
+++ b/koan/app/config_sync.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -19,6 +20,14 @@ from app import config as _config
 from app.utils import atomic_write
 
 BASELINE_FILE = ".koan-config-baseline.json"
+
+
+class _ConfigReadError(Exception):
+    """A config/baseline file exists on disk but could not be parsed.
+
+    Distinct from 'file absent' — a broken file must surface a restart-pending
+    state rather than being silently treated as empty/synced.
+    """
 
 
 def _config_path(koan_root: Path) -> Path:
@@ -35,8 +44,10 @@ def _read_yaml(path: Path) -> dict:
     try:
         with open(path, "r") as f:
             return yaml.safe_load(f) or {}
-    except (yaml.YAMLError, OSError):
-        return {}
+    except (yaml.YAMLError, OSError) as e:
+        # A malformed file parsed to {} would masquerade as "empty config",
+        # misclassifying the diff. Surface it so callers can report an error.
+        raise _ConfigReadError(f"{path.name}: {e}") from e
 
 
 def _flatten(data: Any, prefix: str = "") -> Dict[str, Any]:
@@ -60,7 +71,9 @@ def _snapshot(koan_root: Path) -> Dict[str, Dict[str, Any]]:
 def write_baseline(koan_root: Path) -> None:
     """Persist the current config as the post-restart baseline."""
     path = koan_root / "instance" / BASELINE_FILE
-    with contextlib.suppress(OSError):
+    # If config is broken at startup there is no meaningful baseline to
+    # snapshot; skip rather than crash the startup hook.
+    with contextlib.suppress(OSError, _ConfigReadError):
         atomic_write(path, json.dumps(_snapshot(koan_root)))
 
 
@@ -70,8 +83,10 @@ def _read_baseline(koan_root: Path) -> Optional[Dict[str, Dict[str, Any]]]:
         return None
     try:
         return json.loads(path.read_text())
-    except (json.JSONDecodeError, OSError):
-        return None
+    except (json.JSONDecodeError, OSError) as e:
+        # Corrupt baseline != absent baseline. Raise so compute_status reports
+        # restart-pending instead of a false "synced".
+        raise _ConfigReadError(f"{BASELINE_FILE}: {e}") from e
 
 
 def _is_safe(dotted: str) -> bool:
@@ -87,30 +102,42 @@ def _diff_keys(base: Dict[str, Any], cur: Dict[str, Any]) -> List[str]:
     return sorted(changed)
 
 
+def _synced_block() -> Dict[str, Any]:
+    return {
+        "synced": True,
+        "restart_pending": False,
+        "changed_safe_keys": [],
+        "changed_unsafe_keys": [],
+    }
+
+
 def compute_status(koan_root: Path) -> Dict[str, Any]:
     """Return the config-sync status block for the SSE payload / API."""
     koan_root = Path(koan_root)
 
     # Feature disabled -> suppress all UI feedback (badge/toast/modal).
     if not _config.is_config_sync_enabled():
-        return {
-            "synced": True,
-            "restart_pending": False,
-            "changed_safe_keys": [],
-            "changed_unsafe_keys": [],
-        }
+        return _synced_block()
 
-    baseline = _read_baseline(koan_root)
-    current = _snapshot(koan_root)
+    try:
+        baseline = _read_baseline(koan_root)
+        current = _snapshot(koan_root)
+    except _ConfigReadError as e:
+        # A corrupt baseline or unparseable config MUST NOT report "synced" —
+        # that would silently hide changes needing a restart, the exact failure
+        # the closed allowlist guards against. Surface a distinct error state.
+        print(f"[config_sync] {e}", file=sys.stderr)
+        return {
+            "synced": False,
+            "restart_pending": True,
+            "changed_safe_keys": [],
+            "changed_unsafe_keys": [f"<config read error: {e}>"],
+            "error": str(e),
+        }
 
     # No baseline (agent never recorded one) -> never block the UI.
     if baseline is None:
-        return {
-            "synced": True,
-            "restart_pending": False,
-            "changed_safe_keys": [],
-            "changed_unsafe_keys": [],
-        }
+        return _synced_block()
 
     safe_keys: List[str] = []
     unsafe_keys: List[str] = []

--- a/koan/app/config_sync.py
+++ b/koan/app/config_sync.py
@@ -90,6 +90,16 @@ def _diff_keys(base: Dict[str, Any], cur: Dict[str, Any]) -> List[str]:
 def compute_status(koan_root: Path) -> Dict[str, Any]:
     """Return the config-sync status block for the SSE payload / API."""
     koan_root = Path(koan_root)
+
+    # Feature disabled -> suppress all UI feedback (badge/toast/modal).
+    if not _config.is_config_sync_enabled():
+        return {
+            "synced": True,
+            "restart_pending": False,
+            "changed_safe_keys": [],
+            "changed_unsafe_keys": [],
+        }
+
     baseline = _read_baseline(koan_root)
     current = _snapshot(koan_root)
 

--- a/koan/app/config_sync.py
+++ b/koan/app/config_sync.py
@@ -8,7 +8,6 @@ safe (already live) vs unsafe (need a restart to take effect).
 """
 from __future__ import annotations
 
-import contextlib
 import json
 import sys
 from pathlib import Path
@@ -72,9 +71,13 @@ def write_baseline(koan_root: Path) -> None:
     """Persist the current config as the post-restart baseline."""
     path = koan_root / "instance" / BASELINE_FILE
     # If config is broken at startup there is no meaningful baseline to
-    # snapshot; skip rather than crash the startup hook.
-    with contextlib.suppress(OSError, _ConfigReadError):
+    # snapshot; skip rather than crash the startup hook. Log the failure so a
+    # persistent write problem (disk full, permissions) is observable — a
+    # missing baseline silently reports "synced", masking restart-pending state.
+    try:
         atomic_write(path, json.dumps(_snapshot(koan_root)))
+    except (OSError, _ConfigReadError) as e:
+        print(f"[config_sync] baseline write failed: {e}", file=sys.stderr)
 
 
 def _read_baseline(koan_root: Path) -> Optional[Dict[str, Dict[str, Any]]]:

--- a/koan/app/config_sync.py
+++ b/koan/app/config_sync.py
@@ -1,0 +1,124 @@
+"""Real-time config change classification for hot-reload vs restart-required.
+
+The backend already re-reads config per use (``utils.load_config`` has no
+cache; ``projects_config.load_projects_config`` self-invalidates on mtime),
+so this module does NOT reload anything. It snapshots config at agent
+startup (``write_baseline``) and later reports which on-disk changes are
+safe (already live) vs unsafe (need a restart to take effect).
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import yaml
+
+from app import config as _config
+from app.utils import atomic_write
+
+BASELINE_FILE = ".koan-config-baseline.json"
+
+
+def _config_path(koan_root: Path) -> Path:
+    return koan_root / "instance" / "config.yaml"
+
+
+def _projects_path(koan_root: Path) -> Path:
+    return koan_root / "instance" / "projects.yaml"
+
+
+def _read_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r") as f:
+            return yaml.safe_load(f) or {}
+    except (yaml.YAMLError, OSError):
+        return {}
+
+
+def _flatten(data: Any, prefix: str = "") -> Dict[str, Any]:
+    """Flatten a nested dict into dotted-path -> serialized scalar values."""
+    out: Dict[str, Any] = {}
+    if isinstance(data, dict):
+        for k, v in data.items():
+            out.update(_flatten(v, f"{prefix}.{k}" if prefix else str(k)))
+    else:
+        out[prefix] = json.dumps(data, sort_keys=True, default=str)
+    return out
+
+
+def _snapshot(koan_root: Path) -> Dict[str, Dict[str, Any]]:
+    return {
+        "config": _flatten(_read_yaml(_config_path(koan_root))),
+        "projects": _flatten(_read_yaml(_projects_path(koan_root))),
+    }
+
+
+def write_baseline(koan_root: Path) -> None:
+    """Persist the current config as the post-restart baseline."""
+    path = koan_root / "instance" / BASELINE_FILE
+    try:
+        atomic_write(path, json.dumps(_snapshot(koan_root)))
+    except OSError:
+        pass
+
+
+def _read_baseline(koan_root: Path) -> Optional[Dict[str, Dict[str, Any]]]:
+    path = koan_root / "instance" / BASELINE_FILE
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def _is_safe(dotted: str) -> bool:
+    safe = _config.get_hot_reload_safe_keys()
+    if dotted in safe:
+        return True
+    head = dotted.split(".", 1)[0]
+    return head in safe
+
+
+def _diff_keys(base: Dict[str, Any], cur: Dict[str, Any]) -> List[str]:
+    changed = []
+    for k in set(base) | set(cur):
+        if base.get(k) != cur.get(k):
+            changed.append(k)
+    return sorted(changed)
+
+
+def compute_status(koan_root: Path) -> Dict[str, Any]:
+    """Return the config-sync status block for the SSE payload / API."""
+    koan_root = Path(koan_root)
+    baseline = _read_baseline(koan_root)
+    current = _snapshot(koan_root)
+
+    # No baseline (agent never recorded one) -> never block the UI.
+    if baseline is None:
+        return {
+            "synced": True,
+            "restart_pending": False,
+            "changed_safe_keys": [],
+            "changed_unsafe_keys": [],
+        }
+
+    safe_keys: List[str] = []
+    unsafe_keys: List[str] = []
+
+    for ck in _diff_keys(baseline.get("config", {}), current["config"]):
+        (safe_keys if _is_safe(ck) else unsafe_keys).append(ck)
+
+    # projects.yaml: path/cli_provider/models are all unsafe -> wholesale.
+    for pk in _diff_keys(baseline.get("projects", {}), current["projects"]):
+        unsafe_keys.append(f"projects.yaml:{pk}")
+
+    return {
+        "synced": not safe_keys and not unsafe_keys,
+        "restart_pending": bool(unsafe_keys),
+        "changed_safe_keys": safe_keys,
+        "changed_unsafe_keys": unsafe_keys,
+    }

--- a/koan/app/config_sync.py
+++ b/koan/app/config_sync.py
@@ -8,6 +8,7 @@ safe (already live) vs unsafe (need a restart to take effect).
 """
 from __future__ import annotations
 
+import contextlib
 import json
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -59,10 +60,8 @@ def _snapshot(koan_root: Path) -> Dict[str, Dict[str, Any]]:
 def write_baseline(koan_root: Path) -> None:
     """Persist the current config as the post-restart baseline."""
     path = koan_root / "instance" / BASELINE_FILE
-    try:
+    with contextlib.suppress(OSError):
         atomic_write(path, json.dumps(_snapshot(koan_root)))
-    except OSError:
-        pass
 
 
 def _read_baseline(koan_root: Path) -> Optional[Dict[str, Dict[str, Any]]]:
@@ -84,10 +83,7 @@ def _is_safe(dotted: str) -> bool:
 
 
 def _diff_keys(base: Dict[str, Any], cur: Dict[str, Any]) -> List[str]:
-    changed = []
-    for k in set(base) | set(cur):
-        if base.get(k) != cur.get(k):
-            changed.append(k)
+    changed = [k for k in set(base) | set(cur) if base.get(k) != cur.get(k)]
     return sorted(changed)
 
 
@@ -113,8 +109,10 @@ def compute_status(koan_root: Path) -> Dict[str, Any]:
         (safe_keys if _is_safe(ck) else unsafe_keys).append(ck)
 
     # projects.yaml: path/cli_provider/models are all unsafe -> wholesale.
-    for pk in _diff_keys(baseline.get("projects", {}), current["projects"]):
-        unsafe_keys.append(f"projects.yaml:{pk}")
+    unsafe_keys.extend(
+        f"projects.yaml:{pk}"
+        for pk in _diff_keys(baseline.get("projects", {}), current["projects"])
+    )
 
     return {
         "synced": not safe_keys and not unsafe_keys,

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -112,6 +112,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "ci_check": _NESTED,
     "running_indicator": _NESTED,
     "verification": _NESTED,
+    "config_sync": _NESTED,
 }
 
 # Top-level keys that are recognized but deprecated: they still work (honored
@@ -317,6 +318,9 @@ SECTION_SCHEMAS: Dict[str, Dict[str, str]] = {
         "commit_status": "bool",
         "issue_label": "bool",
         "label_name": "str",
+    },
+    "config_sync": {
+        "enabled": "bool",
     },
 }
 

--- a/koan/app/dashboard/chat.py
+++ b/koan/app/dashboard/chat.py
@@ -297,6 +297,10 @@ def api_state_stream():
         # Mutable container for mtime-based forecast caching
         burn_rate_mtime = [0.0]
         forecast_cache = [{**_EMPTY_FORECAST}]
+        # Mutable container for mtime-based config-sync caching
+        config_mtime = [0.0]
+        config_sync_cache = [{"synced": True, "restart_pending": False,
+                              "changed_safe_keys": [], "changed_unsafe_keys": []}]
 
         while True:
             try:
@@ -335,6 +339,21 @@ def api_state_stream():
                     burn_rate_mtime[0] = br_mtime
                     forecast_cache[0] = stats_svc.build_forecast()
                 agent_state["forecast"] = forecast_cache[0]
+                # Add config-sync status (mtime-gated on config files + baseline)
+                try:
+                    from app import config_sync as _cs
+                    newest = 0.0
+                    for p in (state.INSTANCE_DIR / "config.yaml",
+                              state.INSTANCE_DIR / "projects.yaml",
+                              state.INSTANCE_DIR / _cs.BASELINE_FILE):
+                        if p.exists():
+                            newest = max(newest, p.stat().st_mtime)
+                    if newest != config_mtime[0]:
+                        config_mtime[0] = newest
+                        config_sync_cache[0] = _cs.compute_status(state.KOAN_ROOT)
+                except (OSError, ImportError) as e:
+                    print(f"[dashboard] config_sync error: {e}", file=sys.stderr)
+                agent_state["config_sync"] = config_sync_cache[0]
                 state_json = json.dumps(agent_state, sort_keys=True)
                 if state_json != last_json:
                     last_json = state_json

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -34,9 +34,7 @@ from app.recurring import (
 config_bp = Blueprint("config", __name__)
 
 
-# ---------------------------------------------------------------------------
 # Config page
-# ---------------------------------------------------------------------------
 
 @config_bp.route("/config")
 def config_page():
@@ -102,16 +100,12 @@ def api_config_sync():
 
 @config_bp.route("/api/config/restart-if-idle", methods=["POST"])
 def api_config_restart_if_idle():
-    """Restart the agent only when it is idle (no in-flight mission)."""
+    """Restart the agent only when idle (no in-flight mission); 409 if busy."""
     import sys
-
     agent_state = stats_svc.get_agent_state()
     if agent_state.get("state") != "idle":
-        return jsonify({
-            "ok": False,
-            "error": "agent_busy",
-            "state": agent_state.get("state"),
-        }), 409
+        return jsonify({"ok": False, "error": "agent_busy",
+                        "state": agent_state.get("state")}), 409
     from app.restart_manager import request_restart
     try:
         request_restart(str(state.KOAN_ROOT))
@@ -144,9 +138,7 @@ def api_nickname_set():
     return jsonify({"ok": True, "nickname": nickname})
 
 
-# ---------------------------------------------------------------------------
 # Automation rules
-# ---------------------------------------------------------------------------
 
 @config_bp.route("/rules")
 def rules_page():
@@ -218,9 +210,7 @@ def api_rules_delete(rule_id):
     return jsonify({"ok": True})
 
 
-# ---------------------------------------------------------------------------
 # Recurring tasks
-# ---------------------------------------------------------------------------
 
 @config_bp.route("/recurring")
 def recurring_page():

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -102,9 +102,8 @@ def api_config_sync():
 def api_config_restart_if_idle():
     """Restart the agent only when idle (no in-flight mission); 409 if busy."""
     import sys
+    # Only an in-flight mission ("working") blocks a restart; idle/sleeping/paused/stopped are safe.
     agent_state = stats_svc.get_agent_state()
-    # Only an in-flight mission ("working") blocks a restart. The normal
-    # between-runs states (idle, sleeping, paused, stopped) are all safe.
     if agent_state.get("state") == "working":
         return jsonify({"ok": False, "error": "agent_busy",
                         "state": agent_state.get("state")}), 409

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -17,6 +17,7 @@ from app.automation_rules import (
 from app.dashboard import state
 from app.dashboard_service import journal as journal_svc
 from app.dashboard_service import missions as missions_svc
+from app.dashboard_service import stats as stats_svc
 from app.dashboard_service import validate_yaml
 from app.recurring import (
     _locked_modify as _recurring_locked_modify,
@@ -90,6 +91,34 @@ def api_config_restart():
     except Exception as e:
         print(f"[dashboard] restart signal failed: {e}", file=sys.stderr)
         return jsonify({"ok": False, "error": "Failed to send restart signal"}), 500
+
+
+@config_bp.route("/api/config/sync", methods=["GET"])
+def api_config_sync():
+    """Non-SSE poll fallback for config-sync status."""
+    from app import config_sync
+    return jsonify(config_sync.compute_status(state.KOAN_ROOT))
+
+
+@config_bp.route("/api/config/restart-if-idle", methods=["POST"])
+def api_config_restart_if_idle():
+    """Restart the agent only when it is idle (no in-flight mission)."""
+    import sys
+
+    agent_state = stats_svc.get_agent_state()
+    if agent_state.get("state") != "idle":
+        return jsonify({
+            "ok": False,
+            "error": "agent_busy",
+            "state": agent_state.get("state"),
+        }), 409
+    from app.restart_manager import request_restart
+    try:
+        request_restart(str(state.KOAN_ROOT))
+    except Exception as e:
+        print(f"[dashboard] restart-if-idle failed: {e}", file=sys.stderr)
+        return jsonify({"ok": False, "error": "restart_failed"}), 500
+    return jsonify({"ok": True, "status": "restart_signaled"})
 
 
 @config_bp.route("/api/nickname", methods=["GET"])

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -102,9 +102,20 @@ def api_config_sync():
 def api_config_restart_if_idle():
     """Restart the agent only when idle (no in-flight mission); 409 if busy."""
     import sys
-    # Only an in-flight mission ("working") blocks a restart; idle/sleeping/paused/stopped are safe.
+    from app.active_mission import is_mission_active
+    # Authoritative in-flight check: the ``.koan-active`` provider-liveness
+    # signal, NOT the derived ``.koan-status`` string (which flips to a stale
+    # "idle" after 5 min, so a mission running longer would be misclassified
+    # idle and the restart would drop in-flight work). Also treat error_recovery
+    # and a stale status writer as busy — err on the side of not restarting.
     agent_state = stats_svc.get_agent_state()
-    if agent_state.get("state") == "working":
+    label = (agent_state.get("label") or "").lower()
+    busy = (
+        is_mission_active(state.KOAN_ROOT)
+        or agent_state.get("state") in ("working", "error_recovery")
+        or "stale" in label
+    )
+    if busy:
         return jsonify({"ok": False, "error": "agent_busy",
                         "state": agent_state.get("state")}), 409
     from app.restart_manager import request_restart

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -3,6 +3,8 @@
 NOTE: this module is ``app.dashboard.config`` — it must never shadow the global
 ``app.config``. All references to the global config use absolute imports.
 """
+import sys
+
 from flask import Blueprint, jsonify, render_template, request
 
 from app.automation_rules import (
@@ -33,8 +35,6 @@ from app.recurring import (
 
 config_bp = Blueprint("config", __name__)
 
-
-# Config page
 
 @config_bp.route("/config")
 def config_page():
@@ -80,8 +80,6 @@ def api_config_save(target: str):
 @config_bp.route("/api/config/restart", methods=["POST"])
 def api_config_restart():
     """Signal the agent loop to restart."""
-    import sys
-
     from app.restart_manager import request_restart
     try:
         request_restart(str(state.KOAN_ROOT))
@@ -101,20 +99,15 @@ def api_config_sync():
 @config_bp.route("/api/config/restart-if-idle", methods=["POST"])
 def api_config_restart_if_idle():
     """Restart the agent only when idle (no in-flight mission); 409 if busy."""
-    import sys
     from app.active_mission import is_mission_active
-    # Authoritative in-flight check: the ``.koan-active`` provider-liveness
-    # signal, NOT the derived ``.koan-status`` string (which flips to a stale
-    # "idle" after 5 min, so a mission running longer would be misclassified
-    # idle and the restart would drop in-flight work). Also treat error_recovery
-    # and a stale status writer as busy — err on the side of not restarting.
+    # Authoritative in-flight check via ``.koan-active`` (the derived ``.koan-status``
+    # goes stale "idle" after 5 min, so a longer mission would be misclassified and the
+    # restart would drop in-flight work). error_recovery / a stale writer also count busy.
     agent_state = stats_svc.get_agent_state()
     label = (agent_state.get("label") or "").lower()
-    busy = (
-        is_mission_active(state.KOAN_ROOT)
-        or agent_state.get("state") in ("working", "error_recovery")
-        or "stale" in label
-    )
+    busy = (is_mission_active(state.KOAN_ROOT)
+            or agent_state.get("state") in ("working", "error_recovery")
+            or "stale" in label)
     if busy:
         return jsonify({"ok": False, "error": "agent_busy",
                         "state": agent_state.get("state")}), 409
@@ -149,8 +142,6 @@ def api_nickname_set():
     update_config_yaml(config_path, ["dashboard", "nickname"], nickname)
     return jsonify({"ok": True, "nickname": nickname})
 
-
-# Automation rules
 
 @config_bp.route("/rules")
 def rules_page():
@@ -221,8 +212,6 @@ def api_rules_delete(rule_id):
         return jsonify({"error": "Rule not found"}), 404
     return jsonify({"ok": True})
 
-
-# Recurring tasks
 
 @config_bp.route("/recurring")
 def recurring_page():

--- a/koan/app/dashboard/config.py
+++ b/koan/app/dashboard/config.py
@@ -103,7 +103,9 @@ def api_config_restart_if_idle():
     """Restart the agent only when idle (no in-flight mission); 409 if busy."""
     import sys
     agent_state = stats_svc.get_agent_state()
-    if agent_state.get("state") != "idle":
+    # Only an in-flight mission ("working") blocks a restart. The normal
+    # between-runs states (idle, sleeping, paused, stopped) are all safe.
+    if agent_state.get("state") == "working":
         return jsonify({"ok": False, "error": "agent_busy",
                         "state": agent_state.get("state")}), 409
     from app.restart_manager import request_restart

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -512,6 +512,17 @@ def check_health(koan_root: str, max_age: int = 120):
     check_and_alert(koan_root, max_age=max_age)
 
 
+def write_config_baseline(koan_root: str):
+    """Snapshot config.yaml/projects.yaml as the post-restart baseline.
+
+    Lets the dashboard distinguish hot-reloadable (safe) edits from those
+    needing a restart. Re-runs on every (re)start so "restart pending"
+    clears once the agent has actually reloaded.
+    """
+    from app import config_sync
+    config_sync.write_baseline(Path(koan_root))
+
+
 def check_self_reflection(instance: str):
     """Trigger periodic self-reflection if due and enabled in config.
 
@@ -819,6 +830,7 @@ def run_startup(koan_root: str, instance: str, projects: list):
         from app.utils import reap_stale_mission_tmp_dirs
         _safe_run("Stale mission tmp sweep", reap_stale_mission_tmp_dirs)
         _safe_run("Health check", check_health, koan_root)
+        _safe_run("Config baseline", write_config_baseline, koan_root)
 
     with protected_phase("Self-reflection check"):
         _safe_run("Self-reflection check", check_self_reflection, instance)

--- a/koan/static/js/dashboard.js
+++ b/koan/static/js/dashboard.js
@@ -69,6 +69,9 @@
                 if (data.status) {
                     updateFavicon(data.status);
                 }
+                if (data.config_sync) {
+                    handleConfigSync(data.config_sync);
+                }
             } catch (ex) {}
         };
         src.onerror = function () {
@@ -78,8 +81,71 @@
         };
     }
 
+    /* ----- Config-sync badge / toast / restart modal (config page only) ----- */
+    var _lastSyncKey = null;
+
+    function handleConfigSync(cs) {
+        var badge = document.getElementById('config-sync-badge');
+        if (badge) {
+            badge.hidden = false;
+            badge.setAttribute('data-state', cs.restart_pending ? 'pending' : 'synced');
+            var label = badge.querySelector('.label');
+            if (label) label.textContent = cs.restart_pending ? 'Restart pending' : 'Synced';
+        }
+        var key = JSON.stringify([cs.changed_safe_keys, cs.changed_unsafe_keys]);
+        if (key === _lastSyncKey) return;       // only act on transitions
+        _lastSyncKey = key;
+
+        if (cs.changed_safe_keys && cs.changed_safe_keys.length) {
+            showToast('Settings updated');
+        }
+        if (cs.restart_pending) {
+            showRestartModal(cs.changed_unsafe_keys || []);
+        }
+    }
+
+    function showRestartModal(keys) {
+        var modal = document.getElementById('config-restart-modal');
+        if (!modal) return;
+        var list = document.getElementById('config-restart-keys');
+        if (list) {
+            list.innerHTML = '';
+            keys.forEach(function (k) {
+                var li = document.createElement('li');
+                li.textContent = k;
+                list.appendChild(li);
+            });
+        }
+        modal.hidden = false;
+    }
+
+    function showToast(msg) {
+        if (window.koanToast) { window.koanToast(msg); return; }
+        console.log('[config]', msg);
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         connectAttentionSSE();
+
+        var now = document.getElementById('config-restart-now');
+        var dismiss = document.getElementById('config-restart-dismiss');
+        var modal = document.getElementById('config-restart-modal');
+        if (now) {
+            now.addEventListener('click', function () {
+                fetch('/api/config/restart-if-idle', { method: 'POST' })
+                    .then(function (r) {
+                        if (r.status === 409) {
+                            var busy = document.getElementById('config-restart-busy');
+                            if (busy) busy.hidden = false;
+                            return;
+                        }
+                        if (modal) modal.hidden = true;
+                    });
+            });
+        }
+        if (dismiss && modal) {
+            dismiss.addEventListener('click', function () { modal.hidden = true; });
+        }
     });
 })();
 

--- a/koan/static/js/dashboard.js
+++ b/koan/static/js/dashboard.js
@@ -72,7 +72,9 @@
                 if (data.config_sync) {
                     handleConfigSync(data.config_sync);
                 }
-            } catch (ex) {}
+            } catch (ex) {
+                console.error('[dashboard] state stream handler error', ex);
+            }
         };
         src.onerror = function () {
             src.close();
@@ -132,14 +134,32 @@
         var modal = document.getElementById('config-restart-modal');
         if (now) {
             now.addEventListener('click', function () {
+                var busy = document.getElementById('config-restart-busy');
                 fetch('/api/config/restart-if-idle', { method: 'POST' })
                     .then(function (r) {
                         if (r.status === 409) {
-                            var busy = document.getElementById('config-restart-busy');
-                            if (busy) busy.hidden = false;
+                            if (busy) {
+                                busy.textContent = 'Agent is busy — try again when it is idle.';
+                                busy.hidden = false;
+                            }
                             return;
                         }
+                        if (!r.ok) {
+                            if (busy) {
+                                busy.textContent = 'Restart failed — check the agent logs.';
+                                busy.hidden = false;
+                            }
+                            return;
+                        }
+                        // Only dismiss on a 2xx (restart actually signaled).
                         if (modal) modal.hidden = true;
+                    })
+                    .catch(function (ex) {
+                        console.error('[config] restart request failed', ex);
+                        if (busy) {
+                            busy.textContent = 'Restart request failed — check your connection.';
+                            busy.hidden = false;
+                        }
                     });
             });
         }

--- a/koan/templates/dashboard/config.html
+++ b/koan/templates/dashboard/config.html
@@ -2,7 +2,28 @@
 {% block title_suffix %} — Config{% endblock %}
 {% block page_title %}Config{% endblock %}
 {% block content %}
-<p class="k-body-sm k-text-muted k-mb-4">View and edit instance configuration files.</p>
+<div class="k-row k-gap-2 k-mb-4" style="align-items:center;">
+    <p class="k-body-sm k-text-muted" style="margin:0;">View and edit instance configuration files.</p>
+    <span id="config-sync-badge" class="k-badge" data-state="synced" hidden>
+        <span class="dot"></span><span class="label">Synced</span>
+    </span>
+</div>
+
+<!-- Restart-required modal (shown by dashboard.js when an unsafe change is detected) -->
+<div id="config-restart-modal" class="k-modal" hidden>
+    <div class="k-modal__body">
+        <h3>Restart required</h3>
+        <p>Some changed settings need a restart to take effect:</p>
+        <ul id="config-restart-keys"></ul>
+        <p id="config-restart-busy" class="k-text-muted" hidden>
+            Agent is busy — try again when it is idle.
+        </p>
+        <div class="k-row k-gap-2">
+            <button id="config-restart-now" class="k-btn k-btn--primary k-btn--sm">Restart now</button>
+            <button id="config-restart-dismiss" class="k-btn k-btn--ghost k-btn--sm">Later</button>
+        </div>
+    </div>
+</div>
 
 <!-- Tab bar -->
 <div style="display:flex; align-items:flex-end; justify-content:space-between; margin-bottom:1rem;">

--- a/koan/tests/test_config_sync.py
+++ b/koan/tests/test_config_sync.py
@@ -1,0 +1,70 @@
+import yaml
+from pathlib import Path
+
+import pytest
+
+from app import config_sync
+
+
+@pytest.fixture
+def koan_root(tmp_path):
+    (tmp_path / "instance").mkdir()
+    return tmp_path
+
+
+def _write_config(koan_root: Path, data: dict):
+    (koan_root / "instance" / "config.yaml").write_text(yaml.safe_dump(data))
+
+
+def test_synced_when_baseline_matches(koan_root):
+    _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
+    config_sync.write_baseline(koan_root)
+    status = config_sync.compute_status(koan_root)
+    assert status["synced"] is True
+    assert status["restart_pending"] is False
+    assert status["changed_safe_keys"] == []
+    assert status["changed_unsafe_keys"] == []
+
+
+def test_safe_change_is_hot_not_restart(koan_root):
+    _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
+    config_sync.write_baseline(koan_root)
+    _write_config(koan_root, {"dashboard": {"nickname": "Newname"}})
+    status = config_sync.compute_status(koan_root)
+    assert status["restart_pending"] is False
+    assert "dashboard.nickname" in status["changed_safe_keys"]
+    assert status["changed_unsafe_keys"] == []
+
+
+def test_unsafe_change_sets_restart_pending(koan_root):
+    _write_config(koan_root, {"cli_provider": "claude"})
+    config_sync.write_baseline(koan_root)
+    _write_config(koan_root, {"cli_provider": "copilot"})
+    status = config_sync.compute_status(koan_root)
+    assert status["restart_pending"] is True
+    assert "cli_provider" in status["changed_unsafe_keys"]
+
+
+def test_projects_yaml_change_is_unsafe(koan_root):
+    pj = koan_root / "instance" / "projects.yaml"
+    pj.write_text(yaml.safe_dump({"projects": {"a": {"path": "/x"}}}))
+    config_sync.write_baseline(koan_root)
+    pj.write_text(yaml.safe_dump({"projects": {"a": {"path": "/y"}}}))
+    status = config_sync.compute_status(koan_root)
+    assert status["restart_pending"] is True
+    assert any(k.startswith("projects.yaml") for k in status["changed_unsafe_keys"])
+
+
+def test_unknown_key_defaults_to_unsafe(koan_root):
+    _write_config(koan_root, {})
+    config_sync.write_baseline(koan_root)
+    _write_config(koan_root, {"some_new_section": {"x": 1}})
+    status = config_sync.compute_status(koan_root)
+    assert status["restart_pending"] is True
+
+
+def test_missing_baseline_reports_synced(koan_root):
+    # No baseline written yet -> never block; treat as synced.
+    _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
+    status = config_sync.compute_status(koan_root)
+    assert status["synced"] is True

--- a/koan/tests/test_config_sync.py
+++ b/koan/tests/test_config_sync.py
@@ -70,6 +70,28 @@ def test_missing_baseline_reports_synced(koan_root):
     assert status["synced"] is True
 
 
+def test_corrupt_baseline_reports_restart_pending(koan_root):
+    # A corrupt (existing but unparseable) baseline must NOT report synced --
+    # that would silently hide changes needing a restart.
+    _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
+    (koan_root / "instance" / config_sync.BASELINE_FILE).write_text("{not json")
+    status = config_sync.compute_status(koan_root)
+    assert status["synced"] is False
+    assert status["restart_pending"] is True
+    assert "error" in status
+
+
+def test_malformed_config_reports_restart_pending(koan_root):
+    # A malformed config.yaml must surface an error state, not parse to {}.
+    _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
+    config_sync.write_baseline(koan_root)
+    (koan_root / "instance" / "config.yaml").write_text("key: [unclosed\n")
+    status = config_sync.compute_status(koan_root)
+    assert status["synced"] is False
+    assert status["restart_pending"] is True
+    assert "error" in status
+
+
 def test_disabled_flag_suppresses_status(koan_root, monkeypatch):
     # An unsafe change would normally set restart_pending, but the disable
     # flag must suppress all UI feedback.

--- a/koan/tests/test_config_sync.py
+++ b/koan/tests/test_config_sync.py
@@ -68,3 +68,17 @@ def test_missing_baseline_reports_synced(koan_root):
     _write_config(koan_root, {"dashboard": {"nickname": "Koan"}})
     status = config_sync.compute_status(koan_root)
     assert status["synced"] is True
+
+
+def test_disabled_flag_suppresses_status(koan_root, monkeypatch):
+    # An unsafe change would normally set restart_pending, but the disable
+    # flag must suppress all UI feedback.
+    _write_config(koan_root, {"cli_provider": "claude"})
+    config_sync.write_baseline(koan_root)
+    _write_config(koan_root, {"cli_provider": "copilot"})
+    monkeypatch.setattr(config_sync._config, "is_config_sync_enabled",
+                        lambda: False)
+    status = config_sync.compute_status(koan_root)
+    assert status["synced"] is True
+    assert status["restart_pending"] is False
+    assert status["changed_unsafe_keys"] == []

--- a/koan/tests/test_config_validator.py
+++ b/koan/tests/test_config_validator.py
@@ -1059,3 +1059,9 @@ class TestPreflightCacheMinutesKey:
         warnings = validate_config({"preflight_cache_minutes": "ten"})
         assert len(warnings) == 1
         assert "should be int" in warnings[0][1]
+
+
+class TestConfigSyncSection:
+    def test_config_sync_section_valid(self):
+        errors = validate_config({"config_sync": {"enabled": True}})
+        assert not errors  # well-formed section produces no errors

--- a/koan/tests/test_dashboard_config.py
+++ b/koan/tests/test_dashboard_config.py
@@ -33,3 +33,13 @@ def test_restart_if_idle_restarts_when_idle():
         resp = _client().post("/api/config/restart-if-idle")
     assert resp.status_code == 200
     req.assert_called_once()
+
+
+def test_restart_if_idle_restarts_when_sleeping():
+    # "sleeping" is the normal between-runs state and must allow a restart.
+    with patch("app.dashboard.config.stats_svc.get_agent_state",
+               return_value={"state": "sleeping"}), \
+         patch("app.restart_manager.request_restart") as req:
+        resp = _client().post("/api/config/restart-if-idle")
+    assert resp.status_code == 200
+    req.assert_called_once()

--- a/koan/tests/test_dashboard_config.py
+++ b/koan/tests/test_dashboard_config.py
@@ -1,0 +1,35 @@
+from unittest.mock import patch
+
+from app.dashboard import app as dashboard_app
+
+
+def _client():
+    dashboard_app.config["TESTING"] = True
+    return dashboard_app.test_client()
+
+
+def test_config_sync_endpoint_returns_status():
+    fake = {"synced": True, "restart_pending": False,
+            "changed_safe_keys": [], "changed_unsafe_keys": []}
+    with patch("app.config_sync.compute_status", return_value=fake):
+        resp = _client().get("/api/config/sync")
+    assert resp.status_code == 200
+    assert resp.get_json()["restart_pending"] is False
+
+
+def test_restart_if_idle_blocks_when_working():
+    with patch("app.dashboard.config.stats_svc.get_agent_state",
+               return_value={"state": "working"}), \
+         patch("app.restart_manager.request_restart") as req:
+        resp = _client().post("/api/config/restart-if-idle")
+    assert resp.status_code == 409
+    req.assert_not_called()
+
+
+def test_restart_if_idle_restarts_when_idle():
+    with patch("app.dashboard.config.stats_svc.get_agent_state",
+               return_value={"state": "idle"}), \
+         patch("app.restart_manager.request_restart") as req:
+        resp = _client().post("/api/config/restart-if-idle")
+    assert resp.status_code == 200
+    req.assert_called_once()

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -45,6 +45,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 
 ### Operations
 - [`operations/auto-update.md`](docs/operations/auto-update.md) — Describes Kōan's opt-in auto-update feature that checks for and pulls upstream commits, plus the always-on release-tag notification.
+- [`operations/config-sync.md`](docs/operations/config-sync.md) — Documents real-time config sync: the dashboard reflects config.yaml/projects.yaml edits within ~2s over the existing SSE, classifying safe hot-reload keys vs restart-required changes and gating restarts on agent idleness.
 - [`operations/dashboard.md`](docs/operations/dashboard.md) — Documents the local Flask web dashboard's architecture, blueprints, pages, passphrase gate, design-system integration, and structured `/progress` mission timeline.
 - [`operations/interactive-launcher.md`](docs/operations/interactive-launcher.md) — Describes `make koan`, the TTY-gated interactive launcher and its textual terminal dashboard (tabs, toggles, keybindings).
 - [`operations/log-formatting.md`](docs/operations/log-formatting.md) — Documents the display-side `[cli]` log formatter (log_fmt.py) behind `make logs` and the shared `classify_cli` grammar used by the dashboard `/progress` timeline.


### PR DESCRIPTION
## Summary

Adds real-time config sync between `config.yaml`/`projects.yaml` on disk and the running dashboard, eliminating the `make stop && make start` round-trip for safe settings. The backend already re-reads config per use, so this adds three thin layers: a pure change classifier, a `config_sync` block folded into the existing `/api/state/stream` SSE, and a dashboard badge/toast/restart-modal — no new dependency, no watcher thread.

Closes https://github.com/Anantys-oss/koan/issues/2134

## Changes

- New `app/config_sync.py`: startup baseline snapshot + safe/unsafe change classification (unknown keys and `projects.yaml` default to unsafe).
- `config.py`: `_HOT_RELOAD_SAFE_KEYS` allowlist + `get_hot_reload_safe_keys()` / `is_config_sync_enabled()`.
- `startup_manager.py`: writes `instance/.koan-config-baseline.json` at every (re)start so "restart pending" clears after a real restart.
- `dashboard/chat.py`: mtime-gated `config_sync` block on each SSE payload (~2s detection).
- `dashboard/config.py`: `GET /api/config/sync` (poll fallback) + `POST /api/config/restart-if-idle` (409 when busy).
- `dashboard.js` + `config.html`: live badge, "Settings updated" toast, idle-gated "Restart required" modal.
- `config_validator.py`: register `config_sync` in both `CONFIG_SCHEMA` and `SECTION_SCHEMAS`.
- Docs: `docs/operations/config-sync.md`, user-manual note, example config key.

## Test plan

- `test_config_sync.py` (classification matrix), `test_dashboard_config.py` (endpoints), `test_config_validator.py` (schema) — all green.
- Full suite: 17634 passed (1 preexisting env-only `ZoneInfoNotFoundError` failure unrelated to this change), `make lint` clean.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(HEAD=39b598a6)_
