### PR TITLE
Re-queue mission on verification failure

### DIFF
--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -126,12 +126,13 @@ limited number of times before regular failure handling and user notification.
 
 After a mission exits successfully, the RARV Verify phase
 (`mission_verifier.py`) checks that the work actually matches the mission title
-(meaningful changes, tests added, a PR created). When verification fails with
-**≥2** failed checks, `run_post_mission()` signals a re-queue and
-`_finalize_mission()` moves the mission back to **Pending** with a
-`[verify-failed: <summary>]` context tag instead of completing it. The single
-`>= 2` failure threshold avoids re-queueing on one borderline check, since the
-verifier uses the mission title as its spec.
+(meaningful changes, tests added, a PR created). When verification fails,
+`run_post_mission()` signals a re-queue and `_finalize_mission()` moves the
+mission back to **Pending** with a `[verify-failed: <summary>]` context tag
+instead of completing it. On a successful (exit 0) mission the only check that
+can FAIL is `check_diff_coherence` (an empty branch) — the other checks only
+PASS/WARN/SKIP — so a single failure is already a strong, unambiguous signal,
+and requiring two would make the re-queue unreachable.
 
 - The cap is `verification.max_requeue` in `config.yaml` (default **2**); `0`
   disables the verify re-queue entirely.

--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -134,6 +134,10 @@ can FAIL is `check_diff_coherence` (an empty branch) — the other checks only
 PASS/WARN/SKIP — so a single failure is already a strong, unambiguous signal,
 and requiring two would make the re-queue unreachable.
 
+- The re-queue is restricted to **code missions** (`_is_code_mission()`): an
+  empty branch is the *expected* outcome for an analysis / no-code mission, so
+  those complete normally regardless of `check_diff_coherence`. This avoids
+  re-running a no-code mission twice and emitting false failure notices.
 - The cap is `verification.max_requeue` in `config.yaml` (default **2**); `0`
   disables the verify re-queue entirely.
 - Re-queues use a dedicated `verify_count` sub-counter in

--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -122,6 +122,31 @@ Crash recovery moves stale In Progress work back to a safe state. Stagnation
 retries are tracked separately so a stuck provider session can be retried a
 limited number of times before regular failure handling and user notification.
 
+### Verification re-queue (verify-before-completion)
+
+After a mission exits successfully, the RARV Verify phase
+(`mission_verifier.py`) checks that the work actually matches the mission title
+(meaningful changes, tests added, a PR created). When verification fails with
+**≥2** failed checks, `run_post_mission()` signals a re-queue and
+`_finalize_mission()` moves the mission back to **Pending** with a
+`[verify-failed: <summary>]` context tag instead of completing it. The single
+`>= 2` failure threshold avoids re-queueing on one borderline check, since the
+verifier uses the mission title as its spec.
+
+- The cap is `verification.max_requeue` in `config.yaml` (default **2**); `0`
+  disables the verify re-queue entirely.
+- Re-queues use a dedicated `verify_count` sub-counter in
+  `instance/.mission-retries.json`, isolated from the stagnation `count` and
+  crash-recovery `crash_count`, but still feeding the shared `total_attempts`
+  so the `max_total_retries` ceiling applies across all retry systems.
+- The `[verify-failed: …]` tag is stripped by `canonical_mission_key()`, so the
+  counter stays attached to the same logical mission across cycles, and the tag
+  never stacks (a prior tag is replaced on re-queue).
+- At the cap (or when `max_total_retries` is hit), the mission **completes
+  normally (Done)** — the auto-merge gate (`verify_blocking`) already kept the
+  draft PR out of `main`, so a human reviews the draft rather than the work
+  being marked Failed. Each re-queue sends a Telegram notification.
+
 ## File Integrity And Size Bounds
 
 `missions.md` is on the hot path of every loop iteration, so a malformed write

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -301,6 +301,18 @@ skill_timeout: 7200
 #   sample_lines: 50
 #   max_retry_on_stagnation: 3
 
+# Verify-before-completion — re-queue a mission when post-mission verification
+# fails. After a mission exits successfully, the RARV Verify phase checks that
+# the work matches the mission title (meaningful changes, tests, a PR). When it
+# fails with >=2 failed checks, the mission is moved back to Pending with a
+# ``[verify-failed: <summary>]`` context tag and re-tried, instead of landing as
+# a draft PR a human must reject. ``max_requeue`` caps how many times this
+# happens (default 2); at the cap the mission completes (Done) so a human
+# reviews the draft (auto-merge stays blocked regardless). Set
+# ``max_requeue: 0`` to disable the verify re-queue entirely.
+# verification:
+#   max_requeue: 2
+
 # Crash and error recovery — how the agent loop tolerates failures.
 # ``max_consecutive_errors`` is the number of iteration failures before
 # the loop enters pause mode. ``max_main_crashes`` is the number of

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -304,7 +304,8 @@ skill_timeout: 7200
 # Verify-before-completion — re-queue a mission when post-mission verification
 # fails. After a mission exits successfully, the RARV Verify phase checks that
 # the work matches the mission title (meaningful changes, tests, a PR). When it
-# fails with >=2 failed checks, the mission is moved back to Pending with a
+# fails (an empty branch is the signal on a successful exit), the mission is
+# moved back to Pending with a
 # ``[verify-failed: <summary>]`` context tag and re-tried, instead of landing as
 # a draft PR a human must reject. ``max_requeue`` caps how many times this
 # happens (default 2); at the cap the mission completes (Done) so a human

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1892,9 +1892,13 @@ def get_verify_requeue_max() -> int:
     cfg = _load_config() or {}
     raw = (cfg.get("verification") or {}).get("max_requeue", 2)
     try:
-        return max(0, int(raw))
+        value = int(raw)
     except (TypeError, ValueError):
         return 2
+    # A negative value is a config mistake, not "disable" — clamp it to the
+    # default rather than to 0 (which would silently turn the re-queue off).
+    # ``0`` is the explicit, documented way to disable.
+    return value if value >= 0 else 2
 
 
 def get_autonomous_health_config() -> dict:

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1880,6 +1880,23 @@ def get_stagnation_config(project_name: str = "") -> dict:
     }
 
 
+def get_verify_requeue_max() -> int:
+    """Max times a mission is re-queued on verification failure (default 2).
+
+    Read from ``verification.max_requeue`` in ``config.yaml``. When a mission
+    exits successfully but post-mission verification reports failures, it is
+    re-queued to Pending with a ``[verify-failed: …]`` context tag up to this
+    many times before completing normally for human review. ``0`` disables the
+    verify-failure re-queue entirely.
+    """
+    cfg = _load_config() or {}
+    raw = (cfg.get("verification") or {}).get("max_requeue", 2)
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return 2
+
+
 def get_autonomous_health_config() -> dict:
     """Get autonomous health diagnostic configuration.
 

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -111,6 +111,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "optimizations": _NESTED,
     "ci_check": _NESTED,
     "running_indicator": _NESTED,
+    "verification": _NESTED,
 }
 
 # Top-level keys that are recognized but deprecated: they still work (honored
@@ -257,6 +258,9 @@ SECTION_SCHEMAS: Dict[str, Dict[str, str]] = {
         "abort_after_cycles": "int",
         "sample_lines": "int",
         "max_retry_on_stagnation": "int",
+    },
+    "verification": {
+        "max_requeue": "int",
     },
     "branch_cleanup": {
         "enabled": "bool",

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -1610,8 +1610,9 @@ def _run_iteration(
 
         # Complete/fail mission in missions.md after quota handling has had a
         # chance to requeue transient quota failures.
+        _mission_requeued = False
         if original_mission_title:
-            _run._finalize_mission(
+            _mission_requeued = _run._finalize_mission(
                 instance, original_mission_title, project_name, claude_exit,
                 verify_requeue=bool(post_result.get("verify_requeue")),
                 verify_summary=post_result.get("verify_failure_summary", ""),
@@ -1645,14 +1646,17 @@ def _run_iteration(
             except Exception as e:
                 print(f"[run] plugin cleanup error: {e}", file=sys.stderr)
 
-    # Report result — always notify on completion (success or failure)
-    if claude_exit == 0:
-        log("mission", f"Run {run_num}/{max_runs} — [{project_name}] completed successfully")
-    _run._notify_mission_end(
-        instance, project_name, run_num, max_runs,
-        claude_exit, mission_title,
-        pr_url=_completion_pr_url,
-    )
+    # Report result — always notify on completion (success or failure), unless
+    # _finalize_mission re-queued the mission to Pending instead of completing
+    # it (verify-failure or stagnation retry already sent its own notification).
+    if not _mission_requeued:
+        if claude_exit == 0:
+            log("mission", f"Run {run_num}/{max_runs} — [{project_name}] completed successfully")
+        _run._notify_mission_end(
+            instance, project_name, run_num, max_runs,
+            claude_exit, mission_title,
+            pr_url=_completion_pr_url,
+        )
 
     # Commit instance
     _run._commit_instance(instance)

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -1562,6 +1562,9 @@ def _run_iteration(
         # PR URL captured during post-mission processing (before pending.md is
         # deleted) so the concise completion line can attach it afterward.
         _completion_pr_url = ""
+        # Initialized before the try so the verify-requeue flags below are always
+        # safe to read even if run_post_mission raises.
+        post_result = {}
         try:
             from app.mission_runner import run_post_mission
             from app.restart_manager import RESTART_EXIT_CODE
@@ -1608,7 +1611,11 @@ def _run_iteration(
         # Complete/fail mission in missions.md after quota handling has had a
         # chance to requeue transient quota failures.
         if original_mission_title:
-            _run._finalize_mission(instance, original_mission_title, project_name, claude_exit)
+            _run._finalize_mission(
+                instance, original_mission_title, project_name, claude_exit,
+                verify_requeue=bool(post_result.get("verify_requeue")),
+                verify_summary=post_result.get("verify_failure_summary", ""),
+            )
 
         # --- Clean up checkpoint after mission finalization ---
         # Delete on both success and failure to prevent orphaned checkpoint files.

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -1086,6 +1086,22 @@ def _is_lint_blocking(
         return False
 
 
+def _apply_verify_requeue_signal(result: dict, verify_result) -> None:
+    """Flag a verify-failure re-queue when ≥2 checks failed (false-positive guard).
+
+    Sets ``result["verify_requeue"]`` and ``result["verify_failure_summary"]``
+    so ``_finalize_mission`` can move the mission back to Pending instead of
+    completing it. The ≥2-failure threshold avoids re-queueing on a single
+    borderline check (verification uses the mission title as its spec). This
+    only *signals*; the lifecycle transition happens in ``_finalize_mission``.
+    """
+    failures = verify_result.failures
+    if not verify_result.passed and len(failures) >= 2:
+        summary = "; ".join(c.message for c in failures)[:300] or verify_result.summary
+        result["verify_requeue"] = True
+        result["verify_failure_summary"] = summary
+
+
 def _run_mission_verification(
     project_path: str,
     mission_title: str,
@@ -1975,6 +1991,7 @@ def run_post_mission(
                     "warnings": len(verify_result.warnings),
                     "failures": len(verify_result.failures),
                 }
+                _apply_verify_requeue_signal(result, verify_result)
 
             # Quality pipeline (scan, tests, branch hygiene, PR enrichment)
             _report("running quality pipeline")

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -1087,16 +1087,18 @@ def _is_lint_blocking(
 
 
 def _apply_verify_requeue_signal(result: dict, verify_result) -> None:
-    """Flag a verify-failure re-queue when ≥2 checks failed (false-positive guard).
+    """Flag a verify-failure re-queue when verification failed on a successful exit.
 
     Sets ``result["verify_requeue"]`` and ``result["verify_failure_summary"]``
     so ``_finalize_mission`` can move the mission back to Pending instead of
-    completing it. The ≥2-failure threshold avoids re-queueing on a single
-    borderline check (verification uses the mission title as its spec). This
-    only *signals*; the lifecycle transition happens in ``_finalize_mission``.
+    completing it. On a successful (exit 0) mission the only check that can
+    FAIL is ``check_diff_coherence`` (an empty branch), so a single failure is
+    already a strong, unambiguous signal — requiring two would make the
+    re-queue unreachable. This only *signals*; the lifecycle transition happens
+    in ``_finalize_mission``.
     """
     failures = verify_result.failures
-    if not verify_result.passed and len(failures) >= 2:
+    if not verify_result.passed and failures:
         summary = "; ".join(c.message for c in failures)[:300] or verify_result.summary
         result["verify_requeue"] = True
         result["verify_failure_summary"] = summary

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -1086,7 +1086,7 @@ def _is_lint_blocking(
         return False
 
 
-def _apply_verify_requeue_signal(result: dict, verify_result) -> None:
+def _apply_verify_requeue_signal(result: dict, verify_result, mission_title: str = "") -> None:
     """Flag a verify-failure re-queue when verification failed on a successful exit.
 
     Sets ``result["verify_requeue"]`` and ``result["verify_failure_summary"]``
@@ -1096,7 +1096,16 @@ def _apply_verify_requeue_signal(result: dict, verify_result) -> None:
     already a strong, unambiguous signal — requiring two would make the
     re-queue unreachable. This only *signals*; the lifecycle transition happens
     in ``_finalize_mission``.
+
+    Restricted to code missions: an empty branch is the *expected* outcome for
+    an analysis / no-code mission, not a failure, so re-queueing one would
+    re-run it needlessly and emit false failure notices. Non-code missions are
+    left to complete normally regardless of ``check_diff_coherence``.
     """
+    from app.mission_verifier import _is_code_mission
+
+    if not _is_code_mission(mission_title):
+        return
     failures = verify_result.failures
     if not verify_result.passed and failures:
         summary = "; ".join(c.message for c in failures)[:300] or verify_result.summary
@@ -1993,7 +2002,7 @@ def run_post_mission(
                     "warnings": len(verify_result.warnings),
                     "failures": len(verify_result.failures),
                 }
-                _apply_verify_requeue_signal(result, verify_result)
+                _apply_verify_requeue_signal(result, verify_result, mission_title)
 
             # Quality pipeline (scan, tests, branch hygiene, PR enrichment)
             _report("running quality pipeline")

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -197,7 +197,12 @@ _CANONICAL_KEY_STRIP_RE = re.compile(
     r"|\s*[✅❌]\s*\([^)]*\)"       # ✅/❌ (completed-timestamp)
     r"|\s*\[r:\d+\]"                # [r:N] crash-recovery counter
     r"|\s*\[complexity:[^\]]*\]"    # [complexity:X] classifier tag
+    r"|\s*\[verify-failed:[^\]]*\]" # [verify-failed: …] context tag
 )
+
+# Standalone matcher for the verify-failed context tag, used by requeue_mission
+# to drop a prior tag before appending a fresh one (so cycles don't stack tags).
+_VERIFY_FAILED_TAG_RE = re.compile(r"\s*\[verify-failed:[^\]]*\]")
 
 
 def canonical_mission_key(text: str) -> str:
@@ -1316,7 +1321,7 @@ def fail_mission(content: str, mission_text: str, cause_tag: str = "") -> str:
     return fail_mission_checked(content, mission_text, cause_tag=cause_tag)[0]
 
 
-def requeue_mission(content: str, mission_text: str) -> str:
+def requeue_mission(content: str, mission_text: str, append_tag: str = "") -> str:
     """Move a mission from In Progress (or Failed) back to Pending.
 
     Used when an error is recoverable (e.g. re-login, quota reset)
@@ -1358,6 +1363,11 @@ def requeue_mission(content: str, mission_text: str) -> str:
     display = _QUEUED_PATTERN.sub("", display).strip()
     display = _STARTED_PATTERN.sub("", display).strip()
     display = _COMPLETED_PATTERN.sub("", display).strip()
+
+    if append_tag:
+        # Drop any prior verify-failed tag so repeated cycles don't stack tags.
+        display = _VERIFY_FAILED_TAG_RE.sub("", display).strip()
+        display = f"{display} {append_tag.strip()}".strip()
 
     entry = f"- {display}"
 

--- a/koan/app/missions.py
+++ b/koan/app/missions.py
@@ -197,12 +197,14 @@ _CANONICAL_KEY_STRIP_RE = re.compile(
     r"|\s*[✅❌]\s*\([^)]*\)"       # ✅/❌ (completed-timestamp)
     r"|\s*\[r:\d+\]"                # [r:N] crash-recovery counter
     r"|\s*\[complexity:[^\]]*\]"    # [complexity:X] classifier tag
-    r"|\s*\[verify-failed:[^\]]*\]" # [verify-failed: …] context tag
+    r"|\s*\[verify-failed:?[^\]]*\]" # [verify-failed] or [verify-failed: …] tag
 )
 
 # Standalone matcher for the verify-failed context tag, used by requeue_mission
 # to drop a prior tag before appending a fresh one (so cycles don't stack tags).
-_VERIFY_FAILED_TAG_RE = re.compile(r"\s*\[verify-failed:[^\]]*\]")
+# The colon is optional so it also matches the bare "[verify-failed]" fallback
+# used when no summary text is available.
+_VERIFY_FAILED_TAG_RE = re.compile(r"\s*\[verify-failed:?[^\]]*\]")
 
 
 def canonical_mission_key(text: str) -> str:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2956,22 +2956,37 @@ def _prune_missions_history(instance: str) -> None:
         log("error", f"Missions history pruning failed: {e}")
 
 
-def _requeue_mission_in_file(instance: str, mission_title: str):
-    """Move mission from In Progress back to Pending via locked write."""
+def _requeue_mission_in_file(instance: str, mission_title: str, append_tag: str = ""):
+    """Move mission from In Progress back to Pending via locked write.
+
+    When *append_tag* is set, it is appended to the re-queued mission text (a
+    prior ``[verify-failed: …]`` tag is replaced rather than stacked).
+    """
     try:
         from app.missions import requeue_mission
         from app.utils import modify_missions_file
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
             return
-        modify_missions_file(missions_path, lambda c: requeue_mission(c, mission_title))
+        modify_missions_file(
+            missions_path,
+            lambda c: requeue_mission(c, mission_title, append_tag=append_tag),
+        )
     except Exception as e:
         log("error", f"Could not requeue mission in missions.md: {e}")
 
 
-def _finalize_mission(instance: str, mission_title: str, project_name: str,
-                      exit_code: int, *, failure_reason: Optional[str] = None,
-                      failure_detail: Optional[str] = None):
+def _finalize_mission(
+    instance: str,
+    mission_title: str,
+    project_name: str,
+    exit_code: int,
+    *,
+    failure_reason: Optional[str] = None,
+    failure_detail: Optional[str] = None,
+    verify_requeue: bool = False,
+    verify_summary: str = "",
+):
     """Complete or fail a mission and record execution history.
 
     When the last mission was killed by the stagnation monitor, the
@@ -2997,6 +3012,45 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str,
     if failed and _last_mission_stagnated.is_set():
         stagnated = True
         _last_mission_stagnated.clear()
+
+    # Verify-failure re-queue (exit 0, but post-mission verification said the
+    # mission did not actually do what its title implies). Runs before the
+    # success-path counter clear so a re-queued mission keeps its retry state.
+    if verify_requeue and exit_code == 0 and not stagnated:
+        from app.config import get_stagnation_config, get_verify_requeue_max
+        from app.stagnation_monitor import (
+            get_total_attempts,
+            get_verify_count,
+            increment_verify_count,
+        )
+
+        max_verify = get_verify_requeue_max()
+        max_total = get_stagnation_config(project_name)["max_total_retries"]
+        already = get_verify_count(instance, mission_title)
+        total = get_total_attempts(instance, mission_title)
+        total_cap_hit = max_total > 0 and total >= max_total
+        if max_verify > 0 and already < max_verify and not total_cap_hit:
+            new_count = increment_verify_count(instance, mission_title)
+            tag = (
+                f"[verify-failed: {verify_summary[:120]}]"
+                if verify_summary else "[verify-failed]"
+            )
+            log("koan", (
+                f"Verify re-queue {new_count}/{max_verify} — "
+                f"requeueing mission: {mission_title[:60]}"
+            ))
+            _requeue_mission_in_file(instance, mission_title, append_tag=tag)
+            _notify_verify_requeue(
+                mission_title, project_name, new_count, max_verify, verify_summary,
+            )
+            try:
+                from app.mission_history import record_execution
+                record_execution(instance, mission_title, project_name, exit_code)
+            except (OSError, ValueError) as e:
+                log("error", f"Mission history recording error: {e}")
+            return
+        # Cap reached → fall through to normal completion (Done). verify_blocking
+        # already prevented auto-merge, so a human reviews the draft PR.
 
     if stagnated:
         from app.config import get_stagnation_config
@@ -3171,6 +3225,28 @@ def _notify_stagnation_retry(
         send_telegram(message, priority=NotificationPriority.WARNING)
     except Exception as e:
         log("error", f"Stagnation retry notification failed: {e}")
+
+
+def _notify_verify_requeue(
+    mission_title: str,
+    project_name: str,
+    attempt: int,
+    max_attempts: int,
+    summary: str = "",
+) -> None:
+    """Send a Telegram message announcing a verification-failure requeue."""
+    try:
+        from app.notify import NotificationPriority, send_telegram
+        prefix = f"[{project_name}] " if project_name else ""
+        message = (
+            f"🔁 {prefix}Verification failed — re-queueing for attempt "
+            f"{attempt}/{max_attempts}.\n\nMission: {mission_title[:120]}"
+        )
+        if summary:
+            message += f"\n\nWhat failed: {summary[:200]}"
+        send_telegram(message, priority=NotificationPriority.WARNING)
+    except Exception as e:
+        log("error", f"Verify re-queue notification failed: {e}")
 
 
 def _get_koan_branch(koan_root: str) -> str:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2956,24 +2956,30 @@ def _prune_missions_history(instance: str) -> None:
         log("error", f"Missions history pruning failed: {e}")
 
 
-def _requeue_mission_in_file(instance: str, mission_title: str, append_tag: str = ""):
+def _requeue_mission_in_file(instance: str, mission_title: str, append_tag: str = "") -> bool:
     """Move mission from In Progress back to Pending via locked write.
 
     When *append_tag* is set, it is appended to the re-queued mission text (a
     prior ``[verify-failed: …]`` tag is replaced rather than stacked).
+
+    Returns ``True`` when the write succeeded, ``False`` otherwise. Callers that
+    bump retry counters / notify on a re-queue must check this so they do not
+    report a re-queue that never landed (leaving the mission stuck In Progress).
     """
     try:
         from app.missions import requeue_mission
         from app.utils import modify_missions_file
         missions_path = Path(instance, "missions.md")
         if not missions_path.exists():
-            return
+            return False
         modify_missions_file(
             missions_path,
             lambda c: requeue_mission(c, mission_title, append_tag=append_tag),
         )
+        return True
     except Exception as e:
         log("error", f"Could not requeue mission in missions.md: {e}")
+        return False
 
 
 def _finalize_mission(
@@ -3030,27 +3036,41 @@ def _finalize_mission(
         total = get_total_attempts(instance, mission_title)
         total_cap_hit = max_total > 0 and total >= max_total
         if max_verify > 0 and already < max_verify and not total_cap_hit:
+            # Persist the counter first. If it can't be written, do NOT re-queue:
+            # the on-disk count would stay below the cap and the mission could be
+            # re-queued unboundedly. Fall through to normal completion instead.
             new_count = increment_verify_count(instance, mission_title)
-            tag = (
-                f"[verify-failed: {verify_summary[:120]}]"
-                if verify_summary else "[verify-failed]"
-            )
-            log("koan", (
-                f"Verify re-queue {new_count}/{max_verify} — "
-                f"requeueing mission: {mission_title[:60]}"
-            ))
-            _requeue_mission_in_file(instance, mission_title, append_tag=tag)
-            _notify_verify_requeue(
-                mission_title, project_name, new_count, max_verify, verify_summary,
-            )
-            try:
-                from app.mission_history import record_execution
-                record_execution(instance, mission_title, project_name, exit_code)
-            except (OSError, ValueError) as e:
-                log("error", f"Mission history recording error: {e}")
-            return
-        # Cap reached → fall through to normal completion (Done). verify_blocking
-        # already prevented auto-merge, so a human reviews the draft PR.
+            if new_count < 0:
+                log("error", "Verify re-queue aborted: could not persist counter")
+            else:
+                # Brackets in the summary would corrupt the [verify-failed: …]
+                # tag (the strip regex stops at the first ]); neutralize them.
+                safe_summary = verify_summary.replace("[", "(").replace("]", ")")
+                tag = (
+                    f"[verify-failed: {safe_summary[:120]}]"
+                    if safe_summary else "[verify-failed]"
+                )
+                # Only announce / record the re-queue once the missions.md write
+                # is confirmed, so the user is never told a re-queue landed when
+                # the mission is actually still stuck In Progress.
+                if _requeue_mission_in_file(instance, mission_title, append_tag=tag):
+                    log("koan", (
+                        f"Verify re-queue {new_count}/{max_verify} — "
+                        f"requeueing mission: {mission_title[:60]}"
+                    ))
+                    _notify_verify_requeue(
+                        mission_title, project_name, new_count, max_verify, verify_summary,
+                    )
+                    try:
+                        from app.mission_history import record_execution
+                        record_execution(instance, mission_title, project_name, exit_code)
+                    except (OSError, ValueError) as e:
+                        log("error", f"Mission history recording error: {e}")
+                    return
+                log("error", "Verify re-queue write failed; completing normally")
+        # Cap reached (or re-queue could not be applied) → fall through to normal
+        # completion (Done). verify_blocking already prevented auto-merge, so a
+        # human reviews the draft PR.
 
     if stagnated:
         from app.config import get_stagnation_config

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2992,7 +2992,7 @@ def _finalize_mission(
     failure_detail: Optional[str] = None,
     verify_requeue: bool = False,
     verify_summary: str = "",
-):
+) -> bool:
     """Complete or fail a mission and record execution history.
 
     When the last mission was killed by the stagnation monitor, the
@@ -3011,6 +3011,11 @@ def _finalize_mission(
     On success, all retry counters are cleared. On failure (stagnation
     cap or crash) the counters are left intact for diagnostic visibility
     while the mission remains in Failed state.
+
+    Returns ``True`` when the mission was re-queued to Pending (verify-failure
+    or stagnation retry) instead of being completed/failed — callers must
+    treat this as "not actually finished" and skip end-of-mission notifications
+    that announce completion.
     """
     failed = exit_code != 0
     cause_tag = ""
@@ -3066,7 +3071,7 @@ def _finalize_mission(
                         record_execution(instance, mission_title, project_name, exit_code)
                     except (OSError, ValueError) as e:
                         log("error", f"Mission history recording error: {e}")
-                    return
+                    return True
                 log("error", "Verify re-queue write failed; completing normally")
         # Cap reached (or re-queue could not be applied) → fall through to normal
         # completion (Done). verify_blocking already prevented auto-merge, so a
@@ -3113,7 +3118,7 @@ def _finalize_mission(
                 record_execution(instance, mission_title, project_name, exit_code)
             except (OSError, ValueError) as e:
                 log("error", f"Mission history recording error: {e}")
-            return
+            return True
 
         # Retry cap reached (or retries disabled): mark Failed with cause tag.
         # Counter is preserved — cleared when the human retries the mission.
@@ -3195,6 +3200,7 @@ def _finalize_mission(
         record_execution(instance, mission_title, project_name, exit_code)
     except (OSError, ValueError) as e:
         log("error", f"Mission history recording error: {e}")
+    return False
 
 
 def _notify_stagnation(

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2370,7 +2370,11 @@ def _handle_auth_error(
 ) -> None:
     """Requeue mission, enter auth pause, and notify on auth failure."""
     log("error", f"{provider_label} is logged out — requeueing mission to Pending")
-    _requeue_mission_in_file(instance, mission_title)
+    if not _requeue_mission_in_file(instance, mission_title):
+        # Surface a dropped write: the pause still fires (provider is genuinely
+        # logged out) but the mission stays In Progress, contradicting the
+        # "moved back to Pending" notice below.
+        log("error", "Auth re-queue write failed — mission may still be In Progress")
     from app.pause_manager import create_pause
     create_pause(koan_root, "auth")
     _notify(instance, (
@@ -2398,7 +2402,10 @@ def _handle_quota_error(
     ``stdout_file``/``stderr_file`` (regular mission path).
     """
     log("quota", "API quota exhausted — requeueing mission to Pending")
-    _requeue_mission_in_file(instance, mission_title)
+    if not _requeue_mission_in_file(instance, mission_title):
+        # Surface a dropped write: the quota pause still fires but the mission
+        # stays In Progress, contradicting the "moved back to Pending" notice.
+        log("error", "Quota re-queue write failed — mission may still be In Progress")
     from app.quota_handler import handle_quota_exhaustion, QUOTA_CHECK_UNRELIABLE
     quota_result = handle_quota_exhaustion(
         koan_root=koan_root,
@@ -3108,17 +3115,23 @@ def _finalize_mission(
                 f"Stagnation retry {new_count}/{max_retry} ({pattern}) — "
                 f"requeueing mission: {mission_title[:60]}"
             ))
-            _requeue_mission_in_file(instance, mission_title)
-            _notify_stagnation_retry(
-                mission_title, project_name, new_count, max_retry,
-                pattern_type=pattern, pattern_excerpt=excerpt,
-            )
-            try:
-                from app.mission_history import record_execution
-                record_execution(instance, mission_title, project_name, exit_code)
-            except (OSError, ValueError) as e:
-                log("error", f"Mission history recording error: {e}")
-            return True
+            # Only announce / record the retry once the missions.md write is
+            # confirmed, so the user is never told a re-queue landed while the
+            # mission is actually still stuck In Progress. On write failure,
+            # fall through to the Failed path below rather than silently losing
+            # the mission.
+            if _requeue_mission_in_file(instance, mission_title):
+                _notify_stagnation_retry(
+                    mission_title, project_name, new_count, max_retry,
+                    pattern_type=pattern, pattern_excerpt=excerpt,
+                )
+                try:
+                    from app.mission_history import record_execution
+                    record_execution(instance, mission_title, project_name, exit_code)
+                except (OSError, ValueError) as e:
+                    log("error", f"Mission history recording error: {e}")
+                return True
+            log("error", "Stagnation re-queue write failed; marking mission Failed")
 
         # Retry cap reached (or retries disabled): mark Failed with cause tag.
         # Counter is preserved — cleared when the human retries the mission.

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -550,12 +550,24 @@ def get_verify_count(instance_dir: str, mission_title: str) -> int:
     path = _retry_tracker_path(instance_dir)
     data = locked_json_read(path, default={})
     if not isinstance(data, dict):
+        # A corrupt tracker silently reads as 0 (never-requeued), which would
+        # reset the verify budget — surface it instead of masking it.
+        print(
+            f"[stagnation_monitor] verify tracker not a dict "
+            f"({type(data).__name__}); treating verify_count as 0",
+            file=sys.stderr,
+        )
         return 0
     raw = data.get(_mission_key(mission_title), {})
     if isinstance(raw, dict):
         try:
             return max(0, int(raw.get("verify_count", 0)))
         except (TypeError, ValueError):
+            print(
+                f"[stagnation_monitor] unparseable verify_count "
+                f"{raw.get('verify_count')!r}; treating as 0",
+                file=sys.stderr,
+            )
             return 0
     return 0
 

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -567,7 +567,10 @@ def increment_verify_count(instance_dir: str, mission_title: str) -> int:
     per-system verify cap and the combined max_total_retries cap remain
     effective. Preserves sibling sub-counters (count, crash_count).
 
-    Returns the new verify_count value.
+    Returns the new verify_count value, or ``-1`` if the tracker could not be
+    persisted — callers MUST treat a negative return as "not incremented" and
+    skip the re-queue, otherwise the on-disk count stays below the cap and the
+    mission could be re-queued unboundedly.
     """
     path = _retry_tracker_path(instance_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -601,7 +604,7 @@ def increment_verify_count(instance_dir: str, mission_title: str) -> int:
         return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
     except OSError as e:
         print(f"[stagnation_monitor] verify tracker save error: {e}", file=sys.stderr)
-        return 1
+        return -1
 
 
 def seed_crash_count(instance_dir: str, mission_title: str, seed_value: int) -> None:

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -540,6 +540,70 @@ def increment_crash_count(instance_dir: str, mission_title: str) -> int:
     return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
 
 
+def get_verify_count(instance_dir: str, mission_title: str) -> int:
+    """Return how many times *mission_title* has been verify-failure requeued.
+
+    Tracks only verification-failure requeues (verify-before-completion), not
+    stagnation or crash-recovery requeues. Used to decide when to stop
+    re-queueing and let the mission complete for human review.
+    """
+    path = _retry_tracker_path(instance_dir)
+    data = locked_json_read(path, default={})
+    if not isinstance(data, dict):
+        return 0
+    raw = data.get(_mission_key(mission_title), {})
+    if isinstance(raw, dict):
+        try:
+            return max(0, int(raw.get("verify_count", 0)))
+        except (TypeError, ValueError):
+            return 0
+    return 0
+
+
+def increment_verify_count(instance_dir: str, mission_title: str) -> int:
+    """Increment both verify_count and total_attempts for *mission_title*.
+
+    Called by the verify-before-completion re-queue path so that both the
+    per-system verify cap and the combined max_total_retries cap remain
+    effective. Preserves sibling sub-counters (count, crash_count).
+
+    Returns the new verify_count value.
+    """
+    path = _retry_tracker_path(instance_dir)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    key = _mission_key(mission_title)
+
+    def _mutate(data: dict) -> int:
+        _prune_tracker(data)
+        existing = data.get(key, {})
+        if isinstance(existing, dict):
+            total = max(0, int(existing.get("total_attempts", 0)))
+            verify = max(0, int(existing.get("verify_count", 0)))
+            new_verify = verify + 1
+            new_total = total + 1
+            data[key] = {
+                **existing,
+                "verify_count": new_verify,
+                "total_attempts": new_total,
+                "updated_at": time.time(),
+            }
+        else:
+            new_verify = 1
+            data[key] = {
+                "count": _extract_count(existing),
+                "verify_count": 1,
+                "total_attempts": 1,
+                "updated_at": time.time(),
+            }
+        return new_verify
+
+    try:
+        return locked_json_modify(path, _mutate, default_factory=dict, validator=_validate_tracker)
+    except OSError as e:
+        print(f"[stagnation_monitor] verify tracker save error: {e}", file=sys.stderr)
+        return 1
+
+
 def seed_crash_count(instance_dir: str, mission_title: str, seed_value: int) -> None:
     """Set crash_count to at least *seed_value* without changing total_attempts.
 

--- a/koan/app/stagnation_monitor.py
+++ b/koan/app/stagnation_monitor.py
@@ -42,6 +42,7 @@ from pathlib import Path
 from typing import Callable, Optional
 
 from app.locked_file import locked_json_modify, locked_json_read
+from app.run_log import log
 
 
 # Default configuration — overridable via config.yaml stagnation: section.
@@ -551,11 +552,13 @@ def get_verify_count(instance_dir: str, mission_title: str) -> int:
     data = locked_json_read(path, default={})
     if not isinstance(data, dict):
         # A corrupt tracker silently reads as 0 (never-requeued), which would
-        # reset the verify budget — surface it instead of masking it.
-        print(
-            f"[stagnation_monitor] verify tracker not a dict "
-            f"({type(data).__name__}); treating verify_count as 0",
-            file=sys.stderr,
+        # reset the verify budget. Unlike increment_verify_count's -1 sentinel,
+        # callers here can't distinguish "genuinely 0" from "corrupt, treated
+        # as 0" — route through the structured log so operators see it.
+        log(
+            "error",
+            f"verify tracker not a dict ({type(data).__name__}); "
+            f"treating verify_count as 0",
         )
         return 0
     raw = data.get(_mission_key(mission_title), {})
@@ -563,10 +566,10 @@ def get_verify_count(instance_dir: str, mission_title: str) -> int:
         try:
             return max(0, int(raw.get("verify_count", 0)))
         except (TypeError, ValueError):
-            print(
-                f"[stagnation_monitor] unparseable verify_count "
-                f"{raw.get('verify_count')!r}; treating as 0",
-                file=sys.stderr,
+            log(
+                "error",
+                f"unparseable verify_count {raw.get('verify_count')!r}; "
+                f"treating as 0",
             )
             return 0
     return 0

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -2623,11 +2623,13 @@ class TestGetVerifyRequeueMax:
         with _mock_config({"verification": {"max_requeue": 0}}):
             assert get_verify_requeue_max() == 0
 
-    def test_negative_clamps_to_zero(self):
+    def test_negative_is_config_error_not_disable(self):
         from app.config import get_verify_requeue_max
 
+        # A negative value is a mistake, not "disable" — returning the default
+        # keeps the re-queue on instead of silently clamping to 0 (disabled).
         with _mock_config({"verification": {"max_requeue": -5}}):
-            assert get_verify_requeue_max() == 0
+            assert get_verify_requeue_max() == 2
 
     def test_non_numeric_falls_back_to_default(self):
         from app.config import get_verify_requeue_max

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -2599,3 +2599,38 @@ class TestMigratedConfigFunctionsIgnoreBareFalse:
         with _mock_config({"private_review_gate": False}), \
              patch("app.config._load_project_overrides", return_value={}):
             assert get_private_review_gate_config()["enabled"] is False
+
+
+# --- get_verify_requeue_max ---
+
+
+class TestGetVerifyRequeueMax:
+    def test_default(self):
+        from app.config import get_verify_requeue_max
+
+        with _mock_config({}):
+            assert get_verify_requeue_max() == 2
+
+    def test_override(self):
+        from app.config import get_verify_requeue_max
+
+        with _mock_config({"verification": {"max_requeue": 1}}):
+            assert get_verify_requeue_max() == 1
+
+    def test_zero_disables(self):
+        from app.config import get_verify_requeue_max
+
+        with _mock_config({"verification": {"max_requeue": 0}}):
+            assert get_verify_requeue_max() == 0
+
+    def test_negative_clamps_to_zero(self):
+        from app.config import get_verify_requeue_max
+
+        with _mock_config({"verification": {"max_requeue": -5}}):
+            assert get_verify_requeue_max() == 0
+
+    def test_non_numeric_falls_back_to_default(self):
+        from app.config import get_verify_requeue_max
+
+        with _mock_config({"verification": {"max_requeue": "lots"}}):
+            assert get_verify_requeue_max() == 2

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -4081,3 +4081,44 @@ class TestSkillOutcomeCapture:
         )
 
         assert result["success"] is True
+
+
+class TestApplyVerifyRequeueSignal:
+    """_apply_verify_requeue_signal flags re-queue only for failed ≥2-failure results."""
+
+    @staticmethod
+    def _fail(n):
+        from app.mission_verifier import Check, CheckStatus
+        return Check(name=f"c{n}", status=CheckStatus.FAIL, message=f"failure {n}")
+
+    def test_two_failures_set_verify_requeue(self):
+        from app.mission_verifier import VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(
+            passed=False,
+            checks=[self._fail(1), self._fail(2)],
+            summary="2 checks failed",
+        )
+        result = {}
+        _apply_verify_requeue_signal(result, vr)
+        assert result["verify_requeue"] is True
+        assert "failure 1" in result["verify_failure_summary"]
+
+    def test_single_failure_does_not_requeue(self):
+        from app.mission_verifier import VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(passed=False, checks=[self._fail(1)], summary="1 check failed")
+        result = {}
+        _apply_verify_requeue_signal(result, vr)
+        assert result.get("verify_requeue") is not True
+
+    def test_passed_result_does_not_requeue(self):
+        from app.mission_verifier import VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(passed=True, checks=[], summary="ok")
+        result = {}
+        _apply_verify_requeue_signal(result, vr)
+        assert result.get("verify_requeue") is not True

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -4084,7 +4084,11 @@ class TestSkillOutcomeCapture:
 
 
 class TestApplyVerifyRequeueSignal:
-    """_apply_verify_requeue_signal flags re-queue whenever verification fails."""
+    """_apply_verify_requeue_signal flags re-queue when a code mission fails."""
+
+    # A code-mission title (contains "fix", no analysis keyword) so the signal
+    # is not short-circuited by the _is_code_mission gate.
+    CODE_TITLE = "Fix the parser"
 
     @staticmethod
     def _fail(n):
@@ -4107,7 +4111,7 @@ class TestApplyVerifyRequeueSignal:
             summary="1 failure(s)",
         )
         result = {}
-        _apply_verify_requeue_signal(result, vr)
+        _apply_verify_requeue_signal(result, vr, self.CODE_TITLE)
         assert result["verify_requeue"] is True
         assert "no changes" in result["verify_failure_summary"]
 
@@ -4121,7 +4125,7 @@ class TestApplyVerifyRequeueSignal:
             summary="2 checks failed",
         )
         result = {}
-        _apply_verify_requeue_signal(result, vr)
+        _apply_verify_requeue_signal(result, vr, self.CODE_TITLE)
         assert result["verify_requeue"] is True
         assert "failure 1" in result["verify_failure_summary"]
 
@@ -4131,5 +4135,43 @@ class TestApplyVerifyRequeueSignal:
 
         vr = VerifyResult(passed=True, checks=[], summary="ok")
         result = {}
-        _apply_verify_requeue_signal(result, vr)
+        _apply_verify_requeue_signal(result, vr, self.CODE_TITLE)
+        assert result.get("verify_requeue") is not True
+
+    def test_analysis_mission_does_not_requeue(self):
+        """An empty branch is the expected outcome for an analysis / no-code
+        mission, so a failed verification must NOT re-queue it."""
+        from app.mission_verifier import Check, CheckStatus, VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(
+            passed=False,
+            checks=[Check(
+                name="diff_coherence",
+                status=CheckStatus.FAIL,
+                message="Branch has no changes compared to base",
+            )],
+            summary="1 failure(s)",
+        )
+        result = {}
+        _apply_verify_requeue_signal(result, vr, "Investigate the flaky test")
+        assert result.get("verify_requeue") is not True
+
+    def test_empty_title_does_not_requeue(self):
+        """An unclassifiable (empty) title is treated as non-code — do not
+        re-queue on an empty branch."""
+        from app.mission_verifier import Check, CheckStatus, VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(
+            passed=False,
+            checks=[Check(
+                name="diff_coherence",
+                status=CheckStatus.FAIL,
+                message="Branch has no changes compared to base",
+            )],
+            summary="1 failure(s)",
+        )
+        result = {}
+        _apply_verify_requeue_signal(result, vr, "")
         assert result.get("verify_requeue") is not True

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -4084,14 +4084,34 @@ class TestSkillOutcomeCapture:
 
 
 class TestApplyVerifyRequeueSignal:
-    """_apply_verify_requeue_signal flags re-queue only for failed ≥2-failure results."""
+    """_apply_verify_requeue_signal flags re-queue whenever verification fails."""
 
     @staticmethod
     def _fail(n):
         from app.mission_verifier import Check, CheckStatus
         return Check(name=f"c{n}", status=CheckStatus.FAIL, message=f"failure {n}")
 
-    def test_two_failures_set_verify_requeue(self):
+    def test_single_reachable_failure_sets_verify_requeue(self):
+        """On a successful exit only check_diff_coherence can FAIL — that single,
+        realistic failure must trigger a re-queue (a >=2 threshold was unreachable)."""
+        from app.mission_verifier import Check, CheckStatus, VerifyResult
+        from app.mission_runner import _apply_verify_requeue_signal
+
+        vr = VerifyResult(
+            passed=False,
+            checks=[Check(
+                name="diff_coherence",
+                status=CheckStatus.FAIL,
+                message="Branch has no changes compared to base",
+            )],
+            summary="1 failure(s)",
+        )
+        result = {}
+        _apply_verify_requeue_signal(result, vr)
+        assert result["verify_requeue"] is True
+        assert "no changes" in result["verify_failure_summary"]
+
+    def test_multiple_failures_set_verify_requeue(self):
         from app.mission_verifier import VerifyResult
         from app.mission_runner import _apply_verify_requeue_signal
 
@@ -4104,15 +4124,6 @@ class TestApplyVerifyRequeueSignal:
         _apply_verify_requeue_signal(result, vr)
         assert result["verify_requeue"] is True
         assert "failure 1" in result["verify_failure_summary"]
-
-    def test_single_failure_does_not_requeue(self):
-        from app.mission_verifier import VerifyResult
-        from app.mission_runner import _apply_verify_requeue_signal
-
-        vr = VerifyResult(passed=False, checks=[self._fail(1)], summary="1 check failed")
-        result = {}
-        _apply_verify_requeue_signal(result, vr)
-        assert result.get("verify_requeue") is not True
 
     def test_passed_result_does_not_requeue(self):
         from app.mission_verifier import VerifyResult

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -1837,6 +1837,24 @@ class TestRequeueMission:
         assert sections["pending"][0].count("[verify-failed:") == 1
         assert "[verify-failed: still no PR]" in sections["pending"][0]
 
+    def test_requeue_bare_verify_tag_does_not_stack(self):
+        """A prior bare `[verify-failed]` (no colon, from an empty-summary
+        fallback) must also be replaced rather than stacked."""
+        content = (
+            "## Pending\n\n"
+            "## In Progress\n\n"
+            "- Fix the parser [verify-failed] ▶(2026-06-27T11:00)\n"
+        )
+        result = requeue_mission(
+            content,
+            "Fix the parser [verify-failed]",
+            append_tag="[verify-failed: now has a summary]",
+        )
+        sections = parse_sections(result)
+        assert len(sections["pending"]) == 1
+        assert sections["pending"][0].count("[verify-failed") == 1
+        assert "[verify-failed: now has a summary]" in sections["pending"][0]
+
 
 # ---------------------------------------------------------------------------
 # canonical_mission_key — verify-failed tag stability
@@ -1849,6 +1867,11 @@ class TestCanonicalKeyVerifyFailed:
             "Fix the parser [verify-failed: no tests added; PR missing] "
             "[project:my-toolkit]"
         )
+        assert canonical_mission_key(tagged) == canonical_mission_key(base)
+
+    def test_canonical_key_strips_bare_verify_failed_tag(self):
+        base = "Fix the parser [project:my-toolkit]"
+        tagged = "Fix the parser [verify-failed] [project:my-toolkit]"
         assert canonical_mission_key(tagged) == canonical_mission_key(base)
 
 

--- a/koan/tests/test_missions.py
+++ b/koan/tests/test_missions.py
@@ -1806,6 +1806,51 @@ class TestRequeueMission:
         assert "⏳" not in sections["pending"][0]
         assert "Do something" in sections["pending"][0]
 
+    def test_requeue_appends_verify_tag(self):
+        content = (
+            "## Pending\n\n"
+            "## In Progress\n\n"
+            "- Fix the parser ▶(2026-06-27T10:00)\n"
+        )
+        result = requeue_mission(
+            content, "Fix the parser", append_tag="[verify-failed: no tests; no PR]",
+        )
+        sections = parse_sections(result)
+        assert len(sections["pending"]) == 1
+        assert "[verify-failed: no tests; no PR]" in sections["pending"][0]
+        assert "▶" not in sections["pending"][0]
+
+    def test_requeue_verify_tag_does_not_stack(self):
+        """A prior verify-failed tag is replaced, not accumulated."""
+        content = (
+            "## Pending\n\n"
+            "## In Progress\n\n"
+            "- Fix the parser [verify-failed: no tests; no PR] ▶(2026-06-27T11:00)\n"
+        )
+        result = requeue_mission(
+            content,
+            "Fix the parser [verify-failed: no tests; no PR]",
+            append_tag="[verify-failed: still no PR]",
+        )
+        sections = parse_sections(result)
+        assert len(sections["pending"]) == 1
+        assert sections["pending"][0].count("[verify-failed:") == 1
+        assert "[verify-failed: still no PR]" in sections["pending"][0]
+
+
+# ---------------------------------------------------------------------------
+# canonical_mission_key — verify-failed tag stability
+# ---------------------------------------------------------------------------
+
+class TestCanonicalKeyVerifyFailed:
+    def test_canonical_key_strips_verify_failed_tag(self):
+        base = "Fix the parser [project:my-toolkit]"
+        tagged = (
+            "Fix the parser [verify-failed: no tests added; PR missing] "
+            "[project:my-toolkit]"
+        )
+        assert canonical_mission_key(tagged) == canonical_mission_key(base)
+
 
 # ---------------------------------------------------------------------------
 # parse_sections — failed section

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -8617,6 +8617,7 @@ class TestClassifyTrustStdout:
         quota.assert_not_called()
 
 
+
 class TestMemoryWatchdog:
     def test_build_memory_monitor_disabled_returns_none(self):
         from app import run
@@ -8664,3 +8665,56 @@ class TestMemoryWatchdog:
             with pytest.raises(SystemExit) as exc:
                 run._handle_memory_restart(str(tmp_path), "test-instance", mon, count=3)
         assert exc.value.code == RESTART_EXIT_CODE
+
+
+class TestFinalizeVerifyRequeue:
+    """_finalize_mission re-queues verify-failed missions under cap, completes at cap."""
+
+    def test_verify_requeue_does_not_complete(self, tmp_path):
+        from app import run
+
+        inst = str(tmp_path)
+        title = "Implement feature Z"
+        with patch.object(run, "_update_mission_in_file") as complete, \
+             patch.object(run, "_requeue_mission_in_file") as requeue, \
+             patch.object(run, "_notify_verify_requeue") as notify, \
+             patch("app.config.get_verify_requeue_max", return_value=2):
+            run._finalize_mission(
+                inst, title, "my-toolkit", 0,
+                verify_requeue=True, verify_summary="no tests; no PR",
+            )
+        complete.assert_not_called()        # did NOT fall through to completion
+        requeue.assert_called_once()
+        notify.assert_called_once()
+        # The re-queue carries the verify-failed context tag.
+        assert "verify-failed" in requeue.call_args.kwargs["append_tag"]
+
+    def test_verify_requeue_completes_at_cap(self, tmp_path):
+        from app import run
+        from app import stagnation_monitor as sm
+
+        inst = str(tmp_path)
+        title = "Implement feature Z"
+        sm.increment_verify_count(inst, title)
+        sm.increment_verify_count(inst, title)   # at cap (2)
+        with patch.object(run, "_update_mission_in_file") as complete, \
+             patch.object(run, "_requeue_mission_in_file") as requeue, \
+             patch.object(run, "_notify_verify_requeue"), \
+             patch("app.config.get_verify_requeue_max", return_value=2):
+            run._finalize_mission(
+                inst, title, "my-toolkit", 0,
+                verify_requeue=True, verify_summary="no tests; no PR",
+            )
+        complete.assert_called_once()        # falls through to normal completion (Done)
+        requeue.assert_not_called()
+
+    def test_no_verify_requeue_completes_normally(self, tmp_path):
+        from app import run
+
+        inst = str(tmp_path)
+        title = "Implement feature Z"
+        with patch.object(run, "_update_mission_in_file") as complete, \
+             patch.object(run, "_requeue_mission_in_file") as requeue:
+            run._finalize_mission(inst, title, "my-toolkit", 0)
+        complete.assert_called_once()
+        requeue.assert_not_called()

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -7929,7 +7929,9 @@ class TestRunIterationPaths:
                 return_value=(False, plan.get("mission_title", ""))
             ),
             "_start_mission_in_file": MagicMock(return_value=True),
-            "_finalize_mission": MagicMock(),
+            # False = "completed, not re-queued" (the common case here) so the
+            # default doesn't suppress the _notify_mission_end call below.
+            "_finalize_mission": MagicMock(return_value=False),
             "_notify": MagicMock(),
             "_notify_mission_end": MagicMock(),
             "_commit_instance": MagicMock(),
@@ -8065,6 +8067,20 @@ class TestRunIterationPaths:
             mocks["run_claude_task"].assert_called_once()
             mocks["_finalize_mission"].assert_called_once()
             mocks["_notify_mission_end"].assert_called_once()
+            assert result is True
+
+    def test_verify_requeue_skips_completion_notification(self, tmp_path):
+        """When _finalize_mission re-queues (verify-failure), the completion
+        notification must be suppressed — it already sent its own re-queue
+        notice, and a "completed" message would contradict missions.md state."""
+        plan = self._make_plan("mission", mission_title="implement feature X")
+        with self._patched_iteration(
+            tmp_path, plan,
+            _finalize_mission=MagicMock(return_value=True),
+        ) as mocks:
+            result = self._call(tmp_path)
+            mocks["_finalize_mission"].assert_called_once()
+            mocks["_notify_mission_end"].assert_not_called()
             assert result is True
 
     # --- start_mission transition failure aborts run ---
@@ -8679,7 +8695,7 @@ class TestFinalizeVerifyRequeue:
              patch.object(run, "_requeue_mission_in_file") as requeue, \
              patch.object(run, "_notify_verify_requeue") as notify, \
              patch("app.config.get_verify_requeue_max", return_value=2):
-            run._finalize_mission(
+            result = run._finalize_mission(
                 inst, title, "my-toolkit", 0,
                 verify_requeue=True, verify_summary="no tests; no PR",
             )
@@ -8688,6 +8704,8 @@ class TestFinalizeVerifyRequeue:
         notify.assert_called_once()
         # The re-queue carries the verify-failed context tag.
         assert "verify-failed" in requeue.call_args.kwargs["append_tag"]
+        # Callers (mission_executor) key off this to skip the completion notice.
+        assert result is True
 
     def test_verify_requeue_completes_at_cap(self, tmp_path):
         from app import run
@@ -8715,8 +8733,9 @@ class TestFinalizeVerifyRequeue:
         title = "Implement feature Z"
         with patch.object(run, "_update_mission_in_file") as complete, \
              patch.object(run, "_requeue_mission_in_file") as requeue:
-            run._finalize_mission(inst, title, "my-toolkit", 0)
+            result = run._finalize_mission(inst, title, "my-toolkit", 0)
         complete.assert_called_once()
+        assert result is False
 
     def test_verify_requeue_aborts_when_counter_not_persisted(self, tmp_path):
         """If the counter can't be persisted (-1), skip the re-queue and complete

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -8717,4 +8717,43 @@ class TestFinalizeVerifyRequeue:
              patch.object(run, "_requeue_mission_in_file") as requeue:
             run._finalize_mission(inst, title, "my-toolkit", 0)
         complete.assert_called_once()
+
+    def test_verify_requeue_aborts_when_counter_not_persisted(self, tmp_path):
+        """If the counter can't be persisted (-1), skip the re-queue and complete
+        normally — never re-queue without bumping the on-disk count (unbounded loop)."""
+        from app import run
+
+        inst = str(tmp_path)
+        title = "Implement feature Z"
+        with patch.object(run, "_update_mission_in_file") as complete, \
+             patch.object(run, "_requeue_mission_in_file") as requeue, \
+             patch.object(run, "_notify_verify_requeue") as notify, \
+             patch("app.stagnation_monitor.increment_verify_count", return_value=-1), \
+             patch("app.config.get_verify_requeue_max", return_value=2):
+            run._finalize_mission(
+                inst, title, "my-toolkit", 0,
+                verify_requeue=True, verify_summary="no tests; no PR",
+            )
+        requeue.assert_not_called()
+        notify.assert_not_called()
+        complete.assert_called_once()        # falls through to normal completion
+
+    def test_verify_requeue_completes_when_write_fails(self, tmp_path):
+        """If the missions.md re-queue write fails, do not notify — complete normally
+        instead of telling the user a re-queue landed while it is stuck In Progress."""
+        from app import run
+
+        inst = str(tmp_path)
+        title = "Implement feature Z"
+        with patch.object(run, "_update_mission_in_file") as complete, \
+             patch.object(run, "_requeue_mission_in_file", return_value=False) as requeue, \
+             patch.object(run, "_notify_verify_requeue") as notify, \
+             patch("app.config.get_verify_requeue_max", return_value=2):
+            run._finalize_mission(
+                inst, title, "my-toolkit", 0,
+                verify_requeue=True, verify_summary="no tests; no PR",
+            )
+        requeue.assert_called_once()
+        notify.assert_not_called()
+        complete.assert_called_once()        # falls through to normal completion
         requeue.assert_not_called()

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -173,7 +173,7 @@ class TestFinalizeRunningIndicator:
                             lambda i, t: 0)
         monkeypatch.setattr("app.stagnation_monitor.increment_retry_count",
                             lambda *a, **k: 1)
-        monkeypatch.setattr(run, "_requeue_mission_in_file", lambda *a, **k: None)
+        monkeypatch.setattr(run, "_requeue_mission_in_file", lambda *a, **k: True)
         monkeypatch.setattr(run, "_notify_stagnation_retry", lambda *a, **k: None)
         monkeypatch.setattr("app.mission_history.record_execution",
                             lambda *a, **k: None)

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -8756,4 +8756,3 @@ class TestFinalizeVerifyRequeue:
         requeue.assert_called_once()
         notify.assert_not_called()
         complete.assert_called_once()        # falls through to normal completion
-        requeue.assert_not_called()

--- a/koan/tests/test_stagnation_monitor.py
+++ b/koan/tests/test_stagnation_monitor.py
@@ -20,8 +20,10 @@ from app.stagnation_monitor import (
     get_retry_count,
     get_retry_info,
     get_total_attempts,
+    get_verify_count,
     increment_crash_count,
     increment_retry_count,
+    increment_verify_count,
 )
 
 
@@ -779,6 +781,46 @@ class TestCrashCount:
         # crash_count should be preserved
         assert get_crash_count(d, "mission B") == 2
         assert get_total_attempts(d, "mission B") == 2
+
+
+class TestVerifyCount:
+    """Tests for verify_count tracking — separate from stagnation/crash counts."""
+
+    def test_get_verify_count_returns_zero_for_unknown(self, tmp_path):
+        assert get_verify_count(str(tmp_path), "unseen mission") == 0
+
+    def test_verify_count_increments_and_feeds_total(self, tmp_path):
+        d = str(tmp_path)
+        title = "Implement feature X"
+        assert get_verify_count(d, title) == 0
+        assert increment_verify_count(d, title) == 1
+        assert increment_verify_count(d, title) == 2
+        assert get_verify_count(d, title) == 2
+        assert get_total_attempts(d, title) == 2
+
+    def test_verify_count_independent_of_stagnation(self, tmp_path):
+        d = str(tmp_path)
+        title = "Implement feature Y"
+        increment_retry_count(d, title)          # stagnation
+        increment_verify_count(d, title)         # verify
+        assert get_retry_count(d, title) == 1
+        assert get_verify_count(d, title) == 1
+        assert get_total_attempts(d, title) == 2
+
+    def test_verify_count_preserves_crash_count(self, tmp_path):
+        d = str(tmp_path)
+        title = "Implement feature Z"
+        increment_crash_count(d, title)
+        increment_verify_count(d, title)
+        assert get_crash_count(d, title) == 1
+        assert get_verify_count(d, title) == 1
+        assert get_total_attempts(d, title) == 2
+
+    def test_verify_count_key_stable_across_lifecycle_markers(self, tmp_path):
+        d = str(tmp_path)
+        increment_verify_count(d, "- Fix the bug [verify-failed: no PR]")
+        assert get_verify_count(d, "- Fix the bug") == 1
+        assert get_verify_count(d, "- Fix the bug [verify-failed: still no PR]") == 1
 
 
 class TestClassifyStagnationEdgeCases:


### PR DESCRIPTION
**What**: Mission re-queues to Pending when post-mission verification fails on successful exit.

**Why**: Prevents silent completion of missions that exit successfully but fail to accomplish their title (empty branch scenario).

**How**:
- New `verify_count` sub-counter in `.mission-retries.json`, isolated from stagnation/crash counters
- `verification.max_requeue` config option (default 2; 0 disables)
- Signal from `run_post_mission()` flows to `_finalize_mission()` for lifecycle transition
- [verify-failed: …] context tag appended (prior tag replaced on re-cycle)
- Capped at max attempts; completes (Done) at cap for human review of draft
- `verify_blocking` auto-merge gate remains effective

Closes #1996