### PR TITLE
fix(security): fail closed on inconclusive security review (#2183)

### DIFF
--- a/docs/operations/rest-api.md
+++ b/docs/operations/rest-api.md
@@ -276,6 +276,8 @@ Secret fields (keys containing `token`, `password`, `secret`, `api_key`) are rep
 | `days` | `30` | Lookback window, clamped to `[0, 365]` |
 | `project` | _(all)_ | Per-project metrics + trend; omit for global metrics with per-project trends |
 
+The global (no `project`) response includes `security_blocks_7d` — the count of auto-merge blocks recorded in `.security-audit.jsonl` over the last 7 days (see [Security Review](../security/security-review.md#audit-trail)).
+
 **GET /v1/logs** query params:
 
 | Param | Default | Description |

--- a/docs/security/security-review.md
+++ b/docs/security/security-review.md
@@ -12,7 +12,7 @@ When enabled, the security review runs as part of the post-mission pipeline, bet
 4. **Logs to journal** — all findings are recorded in the project's daily journal
 5. **Optionally blocks auto-merge** — when configured in blocking mode with a severity threshold
 
-The review is designed to be fail-open: if it encounters an error (git failure, config issue), auto-merge proceeds normally.
+The review **fails closed**: if it crashes, times out, or otherwise produces no verdict (git failure, misconfigured `project_path`, malformed diff), auto-merge is **blocked** rather than allowed. A crashed safety gate is indistinguishable from a passed one, so the conservative outcome is to block and alert the operator. The block reason and exception class are written to `.security-audit.jsonl` (see [Audit Trail](#audit-trail)) and a Telegram alert is sent so the underlying failure can be diagnosed.
 
 ## Configuration
 
@@ -144,6 +144,17 @@ Review results are written to the project's daily journal (`instance/journal/YYY
 - **Auto-merge blocked** by security review
 ```
 
+## Audit Trail
+
+Every completed review (approved or blocked) and every crashed review appends one JSON line to `instance/.security-audit.jsonl`. This makes the safety gate's behavior auditable after the fact — a crashed review is no longer indistinguishable from a passed one.
+
+```json
+{"ts": "2026-06-27T18:40:00", "project": "myapp", "risk_level": "high", "score": 9, "approved": false, "block_reason": "risk=high score=9 >= high", "variant_count": 0, "changed_files": ["src/auth.py"]}
+{"ts": "2026-06-27T18:41:10", "project": "myapp", "risk_level": "unknown", "score": 0, "approved": false, "block_reason": "review error", "variant_count": 0, "changed_files": [], "error_class": "CalledProcessError", "error_msg": "git diff failed"}
+```
+
+The `error_class` / `error_msg` fields are present only on the exception path, letting operators distinguish "review crashed on a malformed diff" from "review ran and blocked". `GET /v1/metrics` exposes a `security_blocks_7d` count derived from this file (see [REST API](../operations/rest-api.md)).
+
 ## Pipeline Integration
 
 The security review runs in the post-mission pipeline in `mission_runner.py`:
@@ -153,7 +164,7 @@ The security review runs in the post-mission pipeline in `mission_runner.py`:
 3. **Security review** ← here
 4. Auto-merge (skipped if security review blocks)
 
-If the review itself fails (exception), it logs the error and returns "pass" to avoid blocking the pipeline on review infrastructure issues.
+If the review itself fails (exception or pipeline timeout), it **fails closed**: the error is logged to `.security-audit.jsonl`, auto-merge is blocked, and a Telegram alert is sent. This prevents a crashed safety gate from silently promoting an unreviewed mission to auto-merge. There is intentionally **no config flag** to restore fail-open behavior.
 
 ## Variant Analysis
 

--- a/koan/app/api/routes_observability.py
+++ b/koan/app/api/routes_observability.py
@@ -76,6 +76,8 @@ def metrics():
     for proj, pdata in data.get("by_project", {}).items():
         if isinstance(pdata, dict):
             pdata["trend"] = compute_project_trend(instance, proj, days=days)
+    from app.security_review import count_security_blocks
+    data["security_blocks_7d"] = count_security_blocks(instance, days=7)
     return jsonify(data)
 
 

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -1122,6 +1122,28 @@ def _notify_pipeline_failures(
         _log_runner("error", f"Pipeline failure notification failed: {e}")
 
 
+def _notify_security_review_inconclusive(instance_dir: str, project_name: str) -> None:
+    """Alert the operator that a security review crashed/timed out and blocked merge.
+
+    Fail-closed means the operator must know *why* a mission did not auto-merge
+    so they can diagnose the underlying review failure (often a misconfigured
+    project_path or unavailable git diff). Best-effort; never raises.
+    """
+    try:
+        from app.utils import append_to_outbox
+        from app.notify import NotificationPriority
+
+        msg = (
+            f"🔒 [{project_name}] Security review was inconclusive "
+            f"(crashed or timed out) — auto-merge blocked. "
+            f"Check .security-audit.jsonl and logs for the cause."
+        )
+        outbox_path = Path(instance_dir) / "outbox.md"
+        append_to_outbox(outbox_path, msg + "\n", priority=NotificationPriority.WARNING)
+    except Exception as e:
+        _log_runner("error", f"Security review notification failed: {e}")
+
+
 # --- Pipeline timeout rate alert ---
 _TIMEOUT_ALERT_STATE_FILE = ".pipeline-timeout-alert.json"
 
@@ -1407,8 +1429,12 @@ def check_security_review(
 
         return _check(instance_dir, project_name, project_path)
     except Exception as e:
+        # Fail CLOSED: a crashed review must not silently promote a mission to
+        # auto-merge. The crash is audited in .security-audit.jsonl by
+        # security_review.check_security_review before the exception propagates.
+        _log_runner("error", f"Security review crashed → blocking auto-merge: {e}")
         print(f"[mission_runner] Security review failed: {e}", file=sys.stderr)
-        return True  # Don't block on failures
+        return False
 
 
 _PR_URL_RE = re.compile(r'https?://[^/]*github[^\s)]+/pull/\d+')
@@ -1887,7 +1913,16 @@ def run_post_mission(
                 pipeline_expired=_pipeline_expired,
             )
             if security_passed is None:
-                security_passed = True
+                # Fail CLOSED: run_step returns None on exception OR pipeline
+                # timeout. Either way the safety gate did not produce a verdict,
+                # so block auto-merge rather than promote an unreviewed mission.
+                security_passed = False
+                _log_runner(
+                    "error",
+                    "Security review produced no verdict (crash/timeout) "
+                    "→ blocking auto-merge",
+                )
+                _notify_security_review_inconclusive(instance_dir, project_name)
             result["security_review_passed"] = security_passed
 
             # Auto-merge check (respects quality gate + lint gate + verification + security review)

--- a/koan/app/security_review.py
+++ b/koan/app/security_review.py
@@ -733,6 +733,87 @@ def _write_journal_entry(
         print(f"[security_review] Journal write failed: {e}", file=sys.stderr)
 
 
+_AUDIT_LOG_NAME = ".security-audit.jsonl"
+
+
+def log_security_event(
+    instance_dir: str,
+    project_name: str,
+    result: Optional["SecurityReviewResult"],
+    *,
+    changed_files: Optional[List[str]] = None,
+    block_reason: str = "",
+    error_class: str = "",
+    error_msg: str = "",
+) -> None:
+    """Append a structured security-review outcome to ``.security-audit.jsonl``.
+
+    Written on every completed review (approved or blocked) and on the
+    exception path so a crashed review is auditable rather than invisible.
+    Best-effort: a write failure is logged to stderr and swallowed.
+    """
+    from datetime import datetime
+
+    changed = changed_files or []
+    entry = {
+        "ts": datetime.now().isoformat(timespec="seconds"),
+        "project": project_name,
+        "risk_level": result.risk_level if result else "unknown",
+        "score": result.score if result else 0,
+        "approved": bool(result.approved) if result else False,
+        "block_reason": block_reason,
+        "variant_count": len(result.variant_hits) if result else 0,
+        "changed_files": changed,
+    }
+    if error_class:
+        entry["error_class"] = error_class
+        entry["error_msg"] = error_msg[:500]
+    try:
+        from app.locked_file import locked_jsonl_append
+        locked_jsonl_append(Path(instance_dir) / _AUDIT_LOG_NAME, entry)
+    except OSError as e:
+        print(f"[security_review] Audit log write failed: {e}", file=sys.stderr)
+
+
+def count_security_blocks(instance_dir: str, days: int = 7) -> int:
+    """Count blocked (approved=False) security reviews in the last ``days``.
+
+    Reads ``.security-audit.jsonl``. Returns 0 when the file is absent or
+    unreadable — observability must never fail the request.
+    """
+    from datetime import datetime, timedelta
+
+    path = Path(instance_dir) / _AUDIT_LOG_NAME
+    if not path.exists():
+        return 0
+    cutoff = datetime.now() - timedelta(days=days)
+    count = 0
+    try:
+        from app.locked_file import locked_jsonl_read
+        for line in locked_jsonl_read(path):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = _json.loads(line)
+            except ValueError:
+                continue
+            if rec.get("approved", True):
+                continue
+            ts = rec.get("ts", "")
+            try:
+                when = datetime.fromisoformat(ts)
+            except (ValueError, TypeError):
+                # Undated entry: count it rather than silently drop a block.
+                count += 1
+                continue
+            if when >= cutoff:
+                count += 1
+    except OSError:
+        return 0
+    return count
+
+
 def check_security_review(
     instance_dir: str,
     project_name: str,
@@ -763,8 +844,37 @@ def check_security_review(
     merge_config = get_project_auto_merge(config, project_name)
     base_branch = merge_config.get("base_branch", "main")
 
+    changed_files: List[str] = []
+    try:
+        return _run_review(
+            instance_dir, project_name, project_path, base_branch,
+            sr_config, lambda files: changed_files.extend(files),
+        )
+    except Exception as e:
+        # Audit the crash so a failed review is distinguishable from a passed
+        # one. Re-raise: the caller (mission_runner) fails closed on exception.
+        log_security_event(
+            instance_dir, project_name, None,
+            changed_files=changed_files,
+            block_reason="review error",
+            error_class=type(e).__name__,
+            error_msg=str(e),
+        )
+        raise
+
+
+def _run_review(
+    instance_dir: str,
+    project_name: str,
+    project_path: str,
+    base_branch: str,
+    sr_config: dict,
+    record_files,
+) -> SecurityReviewResult:
+    """Core review logic. Wrapped by ``check_security_review`` for audit."""
     # Gather data
     changed_files = get_changed_files(project_path, base_branch)
+    record_files(changed_files)
     if not changed_files:
         return SecurityReviewResult(approved=True, risk_level="low", score=0)
 
@@ -820,11 +930,17 @@ def check_security_review(
             f"[security_review] Blocking auto-merge: "
             f"risk={risk_level} score={score} threshold={threshold}",
         )
-        return SecurityReviewResult(
+        blocked_result = SecurityReviewResult(
             approved=False, risk_level=risk_level, score=score,
             variant_patterns=variant_patterns,
             variant_hits=variant_hits,
         )
+        log_security_event(
+            instance_dir, project_name, blocked_result,
+            changed_files=changed_files,
+            block_reason=f"risk={risk_level} score={score} >= {threshold}",
+        )
+        return blocked_result
 
     if risk_level in ("high", "critical"):
         print(
@@ -832,8 +948,13 @@ def check_security_review(
             f"risk={risk_level} score={score} (non-blocking)",
         )
 
-    return SecurityReviewResult(
+    approved_result = SecurityReviewResult(
         approved=True, risk_level=risk_level, score=score,
         variant_patterns=variant_patterns,
         variant_hits=variant_hits,
     )
+    log_security_event(
+        instance_dir, project_name, approved_result,
+        changed_files=changed_files,
+    )
+    return approved_result

--- a/koan/tests/test_api_observability.py
+++ b/koan/tests/test_api_observability.py
@@ -39,6 +39,29 @@ def test_metrics_ok(client):
     assert "by_project" in r.get_json()
 
 
+def test_metrics_reports_security_blocks(tmp_path, monkeypatch):
+    """Global metrics expose security_blocks_7d sourced from .security-audit.jsonl."""
+    import json
+
+    monkeypatch.setenv("KOAN_API_TOKEN", "secret123")
+    instance = tmp_path / "instance"
+    instance.mkdir()
+    (tmp_path / "logs").mkdir()
+    audit = instance / ".security-audit.jsonl"
+    from datetime import datetime
+    now = datetime.now().isoformat(timespec="seconds")
+    audit.write_text(
+        json.dumps({"ts": now, "approved": False, "project": "p"}) + "\n"
+        + json.dumps({"ts": now, "approved": True, "project": "p"}) + "\n",
+        encoding="utf-8",
+    )
+    app = create_app(koan_root=tmp_path, instance_dir=instance)
+    app.config["TESTING"] = True
+    r = app.test_client().get("/v1/metrics?days=30", headers=_auth())
+    assert r.status_code == 200
+    assert r.get_json()["security_blocks_7d"] == 1
+
+
 def test_logs_ok(client):
     r = client.get("/v1/logs?source=run&limit=100", headers=_auth())
     assert r.status_code == 200

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -508,6 +508,36 @@ class TestRunPostMission:
         assert result["usage_updated"] is True
         assert result["quota_exhausted"] is False
 
+    @patch("app.mission_runner.commit_instance")
+    @patch("app.mission_runner.check_security_review", side_effect=Exception("review crashed"))
+    @patch("app.mission_runner.check_auto_merge", return_value="koan0/x")
+    @patch("app.mission_runner.trigger_reflection", return_value=False)
+    @patch("app.mission_runner.archive_pending", return_value=False)
+    @patch("app.quota_handler.handle_quota_exhaustion", return_value=None)
+    @patch("app.mission_runner.update_usage", return_value=True)
+    def test_security_review_crash_fails_closed(
+        self, mock_usage, mock_quota, mock_archive, mock_reflect,
+        mock_merge, mock_sec, mock_commit, tmp_path,
+    ):
+        """A crashed security review blocks auto-merge (fail-closed)."""
+        from app.mission_runner import run_post_mission
+
+        instance_dir = str(tmp_path / "instance")
+        os.makedirs(instance_dir, exist_ok=True)
+
+        result = run_post_mission(
+            instance_dir=instance_dir,
+            project_name="koan",
+            project_path=str(tmp_path),
+            run_num=1,
+            exit_code=0,
+            stdout_file="/tmp/out.json",
+            stderr_file="/tmp/err.txt",
+        )
+
+        assert result["security_review_passed"] is False
+        mock_merge.assert_not_called()
+
     @patch("app.mission_runner.check_auto_merge", return_value=None)
     @patch("app.mission_runner.trigger_reflection", return_value=False)
     @patch("app.mission_runner.archive_pending", return_value=False)

--- a/koan/tests/test_security_review.py
+++ b/koan/tests/test_security_review.py
@@ -731,10 +731,11 @@ class TestMissionRunnerIntegration:
         assert result is False
 
     @patch("app.security_review.check_security_review", side_effect=Exception("boom"))
-    def test_wrapper_returns_true_on_error(self, mock_check):
+    def test_wrapper_returns_false_on_error(self, mock_check):
+        """Fail CLOSED: a crashed review must block auto-merge, not promote it."""
         from app.mission_runner import check_security_review as wrapper
         result = wrapper("/instance", "myapp", "/tmp/myapp")
-        assert result is True  # Fail-open
+        assert result is False
 
 
 # ---------------------------------------------------------------------------
@@ -1507,3 +1508,99 @@ class TestFingerprintIsolation:
         keys_a = set(tracker_a.keys())
         keys_b = set(tracker_b.keys())
         assert keys_a != keys_b
+
+
+# ---------------------------------------------------------------------------
+# Security audit log (.security-audit.jsonl) — fail-closed observability
+# ---------------------------------------------------------------------------
+
+
+class TestSecurityAuditLog:
+    """log_security_event / count_security_blocks and review-path logging."""
+
+    def _read_audit(self, instance_dir):
+        import json
+        path = Path(instance_dir) / ".security-audit.jsonl"
+        if not path.exists():
+            return []
+        return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+    @patch("app.post_mission_reflection.write_to_journal")
+    @patch("app.security_review.get_changed_files")
+    @patch("app.security_review.get_diff_against_base")
+    @patch("app.projects_config.load_projects_config")
+    def test_completed_review_writes_audit_entry(
+        self, mock_config, mock_diff, mock_files, mock_journal, tmp_path
+    ):
+        """A completed (approved) review appends a structured audit entry."""
+        mock_config.return_value = {
+            "defaults": {"security_review": {"enabled": True, "blocking": True}},
+            "projects": {"myapp": {"path": "/tmp/myapp"}},
+        }
+        mock_files.return_value = ["src/main.py"]
+        mock_diff.return_value = "+x = 1"
+        check_security_review(str(tmp_path), "myapp", "/tmp/myapp")
+        entries = self._read_audit(str(tmp_path))
+        assert len(entries) == 1
+        assert entries[0]["approved"] is True
+        assert entries[0]["project"] == "myapp"
+        assert entries[0]["changed_files"] == ["src/main.py"]
+
+    @patch("app.post_mission_reflection.write_to_journal")
+    @patch("app.security_review.get_changed_files")
+    @patch("app.security_review.get_diff_against_base")
+    @patch("app.projects_config.load_projects_config")
+    def test_blocked_review_writes_audit_entry(
+        self, mock_config, mock_diff, mock_files, mock_journal, tmp_path
+    ):
+        """A blocked review records approved=False plus a block_reason."""
+        mock_config.return_value = {
+            "defaults": {"security_review": {
+                "enabled": True, "blocking": True, "severity_threshold": "high",
+            }},
+            "projects": {"myapp": {"path": "/tmp/myapp"}},
+        }
+        mock_files.return_value = [".env", "Dockerfile", "src/auth.py"] + [f"f{i}.py" for i in range(20)]
+        mock_diff.return_value = "\n".join([
+            "+eval(x)", "+os.system('cmd')", "+subprocess.run(x, shell=True)",
+        ])
+        check_security_review(str(tmp_path), "myapp", "/tmp/myapp")
+        entries = self._read_audit(str(tmp_path))
+        assert len(entries) == 1
+        assert entries[0]["approved"] is False
+        assert entries[0]["block_reason"]
+
+    @patch("app.post_mission_reflection.write_to_journal")
+    @patch("app.security_review.get_changed_files")
+    @patch("app.security_review.get_diff_against_base")
+    @patch("app.projects_config.load_projects_config")
+    def test_crashed_review_audits_error_and_reraises(
+        self, mock_config, mock_diff, mock_files, mock_journal, tmp_path
+    ):
+        """A crash during review records error_class and propagates the exception."""
+        mock_config.return_value = {
+            "defaults": {"security_review": {"enabled": True, "blocking": True}},
+            "projects": {"myapp": {"path": "/tmp/myapp"}},
+        }
+        mock_files.side_effect = RuntimeError("git diff exploded")
+        with pytest.raises(RuntimeError):
+            check_security_review(str(tmp_path), "myapp", "/tmp/myapp")
+        entries = self._read_audit(str(tmp_path))
+        assert len(entries) == 1
+        assert entries[0]["approved"] is False
+        assert entries[0]["error_class"] == "RuntimeError"
+        assert "exploded" in entries[0]["error_msg"]
+
+    def test_count_security_blocks_counts_recent_blocks_only(self, tmp_path):
+        from app.security_review import log_security_event, count_security_blocks
+
+        blocked = SecurityReviewResult(approved=False, risk_level="high", score=9)
+        approved = SecurityReviewResult(approved=True, risk_level="low", score=0)
+        log_security_event(str(tmp_path), "p", blocked, block_reason="x")
+        log_security_event(str(tmp_path), "p", blocked, block_reason="y")
+        log_security_event(str(tmp_path), "p", approved)
+        assert count_security_blocks(str(tmp_path), days=7) == 2
+
+    def test_count_security_blocks_missing_file_returns_zero(self, tmp_path):
+        from app.security_review import count_security_blocks
+        assert count_security_blocks(str(tmp_path), days=7) == 0


### PR DESCRIPTION
## What
Make the post-mission security review **fail closed** and write a structured audit trail. Closes #2183.

## Why
`mission_runner` mapped a `None` security-review verdict (raised exception *or* pipeline timeout) to `security_passed = True`, silently auto-merging an unreviewed mission — a trust-boundary inversion. The wrapper `check_security_review` had a second fail-open (`except: return True`). And `security_review.py` never logged to a structured trail, so blocks/crashes were invisible to the REST API audit surface ("Verifier Theater").

## How
- **Fail closed (two sites)**: wrapper `except` → `return False`; pipeline `None` verdict → `security_passed = False`, skip auto-merge, and send a Telegram alert (`_notify_security_review_inconclusive`) so the operator can diagnose the root cause.
- **Audit log**: `log_security_event()` appends every approved/blocked outcome — and every crash with `error_class`/`error_msg` — to `instance/.security-audit.jsonl` (via `locked_jsonl_append`). The core review body was split into `_run_review()` wrapped by a try/except that audits the crash before re-raising.
- **Observability**: `GET /v1/metrics` (global) now returns `security_blocks_7d` from `count_security_blocks()`.
- No config flag re-enables fail-open — intentional, per the issue.

## Testing
- New: crash/approve/block audit entries, `count_security_blocks` recency filter, pipeline fail-closed (`run_post_mission` skips auto-merge on review crash), `/v1/metrics` `security_blocks_7d`.
- Updated the one existing test that encoded the old fail-open contract to assert fail-closed.
- `make lint` clean; full suite green except a pre-existing `test_reset_parser` tzdata failure unrelated to this change.

---
🤖 Created by Kōan
