### PR TITLE
fix(deep_research): suppress misleading boost tag on clamp-absorbed priority adjustment

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -502,10 +502,14 @@ class DeepResearch:
                 adjustment = boosts.get(category, 0)
                 if adjustment != 0:
                     old_prio = suggestion["priority"]
-                    suggestion["priority"] = max(1, min(3, old_prio + adjustment))
-                    if adjustment < 0:
+                    new_prio = max(1, min(3, old_prio + adjustment))
+                    suggestion["priority"] = new_prio
+                    # Only tag the reasoning when the clamp didn't absorb the
+                    # adjustment — a no-op boost on an already-top topic would
+                    # otherwise inject a misleading "(boosted)" into the agent prompt.
+                    if new_prio < old_prio:
                         suggestion["reasoning"] += " (boosted: this type of work gets merged quickly)"
-                    else:
+                    elif new_prio > old_prio:
                         suggestion["reasoning"] += " (deprioritized: this type of work tends to stay open)"
 
         # Sort by priority

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -1706,3 +1706,61 @@ class TestFileHotspots:
         assert len(hotspots) == 1
         assert "mission_runner.py" in hotspots[0]["topic"]
         assert hotspots[0]["priority"] == 2
+
+
+# ---------------------------------------------------------------------------
+# suggest_topics — PR-feedback priority adjustment
+# ---------------------------------------------------------------------------
+
+class TestFeedbackBoostTagging:
+    """A clamp-absorbed boost/demotion must not emit a misleading reasoning tag."""
+
+    def _research(self, env, priorities: str):
+        priorities_file = (
+            env["instance"] / "memory" / "projects" / env["project_name"] / "priorities.md"
+        )
+        priorities_file.write_text(priorities)
+        research = DeepResearch(env["instance"], env["project_name"], env["project_path"])
+        research._pending_prs = []
+        return research
+
+    def test_real_boost_tagged_clamped_boost_not(self, research_env):
+        """A priority-2 topic boosted to 1 gets the tag; an already-top
+        priority-1 topic whose -1 is absorbed by the clamp does not."""
+        research = self._research(
+            research_env,
+            "## Current Focus\n\n- Top focus item\n\n## Technical Debt\n\n- Debt item\n",
+        )
+        with patch.object(research, "get_open_issues", return_value=[]), \
+             patch.object(research, "get_recent_journal_topics", return_value=[]), \
+             patch.object(research, "_match_topic_to_category", return_value="other"), \
+             patch.object(research, "get_pr_feedback",
+                          return_value={"alignment_summary": "",
+                                        "category_boosts": {"other": -1}}):
+            topics = research.suggest_topics()
+
+        focus = next(t for t in topics if "Top focus item" in t["topic"])
+        debt = next(t for t in topics if "Debt item" in t["topic"])
+
+        # Clamp absorbed the boost on the already-top item: no misleading tag.
+        assert focus["priority"] == 1
+        assert "boosted" not in focus["reasoning"]
+        # Real boost on the debt item (2 -> 1): tag present.
+        assert debt["priority"] == 1
+        assert "boosted" in debt["reasoning"]
+
+    def test_clamped_demotion_not_tagged(self, research_env):
+        """A priority-3 strategic goal whose +1 is absorbed by the clamp
+        stays at 3 without a misleading '(deprioritized)' tag."""
+        research = self._research(research_env, "## Strategic Goals\n\n- Long-term goal\n")
+        with patch.object(research, "get_open_issues", return_value=[]), \
+             patch.object(research, "get_recent_journal_topics", return_value=[]), \
+             patch.object(research, "_match_topic_to_category", return_value="other"), \
+             patch.object(research, "get_pr_feedback",
+                          return_value={"alignment_summary": "",
+                                        "category_boosts": {"other": 1}}):
+            topics = research.suggest_topics()
+
+        goal = next(t for t in topics if "Long-term goal" in t["topic"])
+        assert goal["priority"] == 3
+        assert "deprioritized" not in goal["reasoning"]


### PR DESCRIPTION
**What**: Stop `deep_research` from tagging a topic as "(boosted)" / "(deprioritized)" when the priority clamp absorbed the adjustment and nothing actually changed.

**Why**: PR-merge feedback nudges topic priorities by ±1, clamped to `[1,3]`. The reasoning tag was appended based on the adjustment *sign* alone. So an already-top **priority-1** topic (e.g. a human "Current Focus" item) still received `(boosted: this type of work gets merged quickly)` even though the clamp left its priority untouched. That false "boosted" signal gets injected verbatim into the autonomous topic-selection prompt — directly in the "improve agent intelligence / topic selection" priority area. Symmetric issue for priority-3 items demoted by `+1`.

**How**: Compute `new_prio` first, set it, then emit the tag only when `new_prio != old_prio` (boosted if lower, deprioritized if higher). Clamp-absorbed adjustments now produce no tag.

**Testing**: `make test` on `test_deep_research.py` (84 passed). Added `TestFeedbackBoostTagging` with two behavior tests: a real 2→1 boost keeps its tag while a clamp-absorbed 1→1 boost drops it; a clamp-absorbed 3→3 demotion drops its tag. `make lint` clean.

*(Note: an Explore pass first flagged the boost message as sign-inverted — that was a false positive; `boosts[cat] = -1` is a boost because lower number = higher priority. The real defect is the clamp interaction.)*
