### PR TITLE
fix(review_dispatch): invalid gh api --limit broke comment fetch

### DIFF
--- a/koan/app/review_comment_dispatch.py
+++ b/koan/app/review_comment_dispatch.py
@@ -117,8 +117,8 @@ def fetch_unresolved_review_comments(
     results: List[dict] = []
     try:
         raw = run_gh(
-            "api", f"repos/{full_repo}/pulls/{pr_number}/comments",
-            "--limit", "100", "--jq",
+            "api", f"repos/{full_repo}/pulls/{pr_number}/comments?per_page=100",
+            "--jq",
             r'.[] | {id: .id, user: .user.login, body: .body, path: .path, user_type: .user.type}',
             timeout=15,
         )
@@ -161,8 +161,8 @@ def fetch_review_body_comments(
     results: List[dict] = []
     try:
         raw = run_gh(
-            "api", f"repos/{full_repo}/pulls/{pr_number}/reviews",
-            "--limit", "100", "--jq",
+            "api", f"repos/{full_repo}/pulls/{pr_number}/reviews?per_page=100",
+            "--jq",
             r'.[] | {id: .id, user: .user.login, body: .body, state: .state, user_type: .user.type}',
             timeout=15,
         )

--- a/koan/tests/test_review_comment_dispatch.py
+++ b/koan/tests/test_review_comment_dispatch.py
@@ -188,6 +188,24 @@ class TestFetchUnresolvedReviewComments:
 
         assert fetch_unresolved_review_comments("owner/repo", 1) == []
 
+    @patch("app.review_comment_dispatch.run_gh", return_value="")
+    def test_gh_api_invocation_has_no_invalid_limit_flag(self, mock_gh):
+        """`gh api` rejects --limit; pagination must use the per_page query param.
+
+        Regression: passing `--limit 100` to `gh api` made every fetch exit
+        non-zero, so run_gh raised, the comments list came back empty, and the
+        whole review-dispatch feature silently never fired. Pin the invocation
+        so the page size travels in the endpoint, not an unsupported flag.
+        """
+        from app.review_comment_dispatch import fetch_unresolved_review_comments
+
+        fetch_unresolved_review_comments("owner/repo", 1)
+        args = mock_gh.call_args.args
+        assert "--limit" not in args
+        endpoint = args[1]
+        assert endpoint.startswith("repos/owner/repo/pulls/1/comments")
+        assert "per_page=100" in endpoint
+
 
 class TestFetchReviewBodyComments:
     """fetch_review_body_comments filters approvals and empty bodies."""
@@ -220,6 +238,18 @@ class TestFetchReviewBodyComments:
         comments = fetch_review_body_comments("owner/repo", 1, bot_username="mybot")
 
         assert comments == [{"id": 21, "user": "alice", "body": "needs tests"}]
+
+    @patch("app.review_comment_dispatch.run_gh", return_value="")
+    def test_gh_api_invocation_has_no_invalid_limit_flag(self, mock_gh):
+        """`gh api` rejects --limit; the reviews fetch must page via per_page."""
+        from app.review_comment_dispatch import fetch_review_body_comments
+
+        fetch_review_body_comments("owner/repo", 1)
+        args = mock_gh.call_args.args
+        assert "--limit" not in args
+        endpoint = args[1]
+        assert endpoint.startswith("repos/owner/repo/pulls/1/reviews")
+        assert "per_page=100" in endpoint
 
 
 class TestReviewDispatchConfigHelpers:


### PR DESCRIPTION
## What
Fix `review_comment_dispatch` so it actually fetches review comments — it was passing an invalid `--limit` flag to `gh api`.

## Why
`gh api` has no `--limit` flag (that belongs to `gh pr/issue list`). Both fetch helpers passed `--limit 100`, so every call exited non-zero. `run_gh` raised `RuntimeError`, the helpers caught it and returned `[]`, so `all_comments` was always empty. The opt-in `review_dispatch` feature therefore **never dispatched a mission**. Worse: an empty result makes `check_and_dispatch_review_comments` *delete* the PR's tracker entry, so it also churned state.

Confirmed against the real CLI: `gh api …/comments --limit 100` → `unknown flag: --limit`, exit 1.

## How
Page size now rides as a `per_page=100` query param on the endpoint (`…/comments?per_page=100`), which `gh api` accepts. One-line change at each of the two fetch sites; no behavioral contract change.

## Testing
- Verified the failing flag and the working `per_page` form against live `gh`.
- Added two regression tests pinning the `gh api` invocation (no `--limit`, `per_page` in endpoint). The existing tests mocked `run_gh`, which is exactly why the dead flag was invisible.
- Full module suite: 42 passed. `make lint` clean.
