### PR TITLE
fix(ci_dispatch): bound log-snippet truncation against tiny/negative max_bytes

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1898,7 +1898,7 @@ Kōan can automatically create fix missions when CI fails on its own PRs. When e
 ci_dispatch:
   enabled: true              # Master switch (default: false)
   cooldown_minutes: 30       # Min time between checks per project (default: 30)
-  log_snippet_bytes: 4096    # Max CI log snippet in mission text (default: 4096)
+  log_snippet_bytes: 4096    # Max CI log snippet in mission text (default: 4096, floored at 64)
   tracker_max_age_days: 30   # Prune dedup entries older than this (default: 30)
 ```
 

--- a/koan/app/ci_dispatch.py
+++ b/koan/app/ci_dispatch.py
@@ -31,7 +31,11 @@ log = logging.getLogger(__name__)
 _DEFAULT_ENABLED = False
 _DEFAULT_COOLDOWN_MINUTES = 30
 _DEFAULT_LOG_SNIPPET_BYTES = 4096
+# Floor for a meaningful snippet; guards against a misconfigured (tiny/negative)
+# log_snippet_bytes that would otherwise break truncation slicing.
+_MIN_LOG_SNIPPET_BYTES = 64
 _DEFAULT_TRACKER_MAX_AGE_DAYS = 30
+_TRUNCATION_MARKER = "\n...(truncated)"
 
 
 def _get_ci_dispatch_config() -> dict:
@@ -42,7 +46,10 @@ def _get_ci_dispatch_config() -> dict:
         return {
             "enabled": bool(cd.get("enabled", _DEFAULT_ENABLED)),
             "cooldown_minutes": int(cd.get("cooldown_minutes", _DEFAULT_COOLDOWN_MINUTES)),
-            "log_snippet_bytes": int(cd.get("log_snippet_bytes", _DEFAULT_LOG_SNIPPET_BYTES)),
+            "log_snippet_bytes": max(
+                _MIN_LOG_SNIPPET_BYTES,
+                int(cd.get("log_snippet_bytes", _DEFAULT_LOG_SNIPPET_BYTES)),
+            ),
             "tracker_max_age_days": int(cd.get("tracker_max_age_days", _DEFAULT_TRACKER_MAX_AGE_DAYS)),
         }
     except (ImportError, OSError, ValueError):
@@ -230,7 +237,8 @@ def fetch_check_run_log_snippet(
 
     result = "\n".join(parts)
     if len(result) > max_bytes:
-        result = result[:max_bytes - 20] + "\n...(truncated)"
+        keep = max(0, max_bytes - len(_TRUNCATION_MARKER))
+        result = result[:keep] + _TRUNCATION_MARKER
     return result
 
 

--- a/koan/tests/test_ci_dispatch.py
+++ b/koan/tests/test_ci_dispatch.py
@@ -134,9 +134,44 @@ class TestFetchCheckRunLogSnippet:
         assert len(result) <= 100
         assert "truncated" in result
 
+    @patch("app.ci_dispatch.run_gh")
+    def test_tiny_max_bytes_never_returns_more_than_input(self, mock_gh):
+        """A tiny max_bytes must not inflate the snippet.
+
+        Previously `result[:max_bytes - 20]` produced a NEGATIVE slice index
+        when max_bytes < 20, so it returned all-but-the-last-N bytes of the
+        original content — i.e. far MORE than the caller asked for. The
+        truncation must never yield a string longer than the source.
+        """
+        source = "y" * 500
+        mock_gh.return_value = json.dumps({"summary": source, "text": "", "annotations": []})
+        result = fetch_check_run_log_snippet("owner/repo", 1, max_bytes=10)
+        assert len(result) <= len(source)
+        assert "y" * 100 not in result
+
     @patch("app.ci_dispatch.run_gh", side_effect=RuntimeError("err"))
     def test_returns_empty_on_error(self, _gh):
         assert fetch_check_run_log_snippet("owner/repo", 1) == ""
+
+
+class TestCiDispatchConfigBounds:
+    @patch("app.utils.load_config")
+    def test_log_snippet_bytes_floored(self, mock_load):
+        from app.ci_dispatch import _get_ci_dispatch_config, _MIN_LOG_SNIPPET_BYTES
+        mock_load.return_value = {"ci_dispatch": {"log_snippet_bytes": 5}}
+        assert _get_ci_dispatch_config()["log_snippet_bytes"] == _MIN_LOG_SNIPPET_BYTES
+
+    @patch("app.utils.load_config")
+    def test_log_snippet_bytes_negative_floored(self, mock_load):
+        from app.ci_dispatch import _get_ci_dispatch_config, _MIN_LOG_SNIPPET_BYTES
+        mock_load.return_value = {"ci_dispatch": {"log_snippet_bytes": -100}}
+        assert _get_ci_dispatch_config()["log_snippet_bytes"] == _MIN_LOG_SNIPPET_BYTES
+
+    @patch("app.utils.load_config")
+    def test_log_snippet_bytes_sane_value_preserved(self, mock_load):
+        from app.ci_dispatch import _get_ci_dispatch_config
+        mock_load.return_value = {"ci_dispatch": {"log_snippet_bytes": 2048}}
+        assert _get_ci_dispatch_config()["log_snippet_bytes"] == 2048
 
 
 class TestCheckAndDispatchCiFixes:


### PR DESCRIPTION
## What
Bound CI log-snippet truncation so a tiny or negative `log_snippet_bytes` can no longer return *more* content than requested.

## Why
`fetch_check_run_log_snippet` truncated with `result[:max_bytes - 20]`. When `log_snippet_bytes` is set below 20 (or negative), `max_bytes - 20` is a negative index, so the slice returns all-but-the-last-N bytes of the source — the opposite of truncation. There was also no floor on the config value, so the bound could be silently broken by a misconfiguration.

## How
- Truncate with `keep = max(0, max_bytes - len(marker))`, using a named `_TRUNCATION_MARKER` constant (the marker is 15 chars; the old `-20` was a loose magic number).
- Floor `log_snippet_bytes` to `_MIN_LOG_SNIPPET_BYTES = 64` when reading config, so an absurd value can't reach the slice.

## Testing
- New behavioral test proves the bug: `max_bytes=10` against a 500-char payload no longer inflates the snippet (fails on pre-fix source).
- New config-floor tests for tiny/negative/sane values.
- Full `test_ci_dispatch.py` suite: 33 passed. Lint clean.
