### PR TITLE
fix(event_scheduler): tz-aware run_at crashes tick() (poison pill)

### DIFF
--- a/koan/app/event_scheduler.py
+++ b/koan/app/event_scheduler.py
@@ -72,6 +72,12 @@ def tick(instance_dir: str) -> List[str]:
             run_at = datetime.fromisoformat(run_at_str)
         except ValueError:
             continue
+        # ISO strings may carry a 'Z' or offset (tz-aware); 'now' is naive-local.
+        # Comparing the two raises TypeError, which would crash the tick and leave
+        # the file un-archived — poisoning every subsequent iteration. Normalize
+        # any aware value to the equivalent naive local wall-clock.
+        if run_at.tzinfo is not None:
+            run_at = run_at.astimezone().replace(tzinfo=None)
 
         if run_at > now:
             continue
@@ -111,9 +117,15 @@ def parse_at_arg(arg: str, now: Optional[datetime] = None) -> Optional[datetime]
 
     # ISO datetime
     try:
-        return datetime.fromisoformat(arg)
+        dt = datetime.fromisoformat(arg)
     except ValueError:
         pass
+    else:
+        # Stored events are naive-local (write_event_file drops tzinfo). Convert an
+        # aware input to local wall-clock so the offset is honored, not discarded.
+        if dt.tzinfo is not None:
+            dt = dt.astimezone().replace(tzinfo=None)
+        return dt
 
     # HH:MM
     m = _HHMM_RE.match(arg)

--- a/koan/tests/test_event_scheduler.py
+++ b/koan/tests/test_event_scheduler.py
@@ -180,6 +180,58 @@ class TestTick:
         mock_insert.assert_not_called()
         assert result == []
 
+    def test_past_due_event_with_utc_z_suffix_processed(self, tmp_path):
+        """An overdue event whose run_at carries a 'Z' (UTC) suffix is processed,
+        not crashed on. ``datetime.fromisoformat`` returns a tz-aware value for a
+        'Z'-suffixed string; comparing it against a naive ``now`` raises TypeError.
+        Such an event file would otherwise never be archived and poison every
+        subsequent tick.
+        """
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        # Far in the past, expressed as a UTC instant with explicit 'Z'.
+        (events_dir / "z.json").write_text(
+            json.dumps({"type": "once", "run_at": "2020-01-01T00:00:00Z",
+                        "mission": "Z-suffixed mission"}),
+            encoding="utf-8",
+        )
+
+        missions_path = tmp_path / "missions.md"
+        missions_path.write_text("## Pending\n\n## In Progress\n\n## Done\n")
+
+        with patch("app.event_scheduler.insert_pending_mission", return_value=True) as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_called_once()
+        assert result == ["Z-suffixed mission"]
+        # File must be archived so it is not reprocessed (poison-pill guard).
+        assert not (events_dir / "z.json").exists()
+        assert (events_dir / "archive" / "z.json").exists()
+
+    def test_future_event_with_offset_not_inserted(self, tmp_path):
+        """A future event with an explicit timezone offset is compared correctly
+        and not inserted (no crash on naive-vs-aware comparison).
+        """
+        events_dir = tmp_path / "events"
+        events_dir.mkdir()
+        # 2 hours in the future expressed in UTC; well ahead of local now regardless
+        # of host offset, padded so even a +14h zone stays in the future.
+        future = datetime.now() + timedelta(hours=20)
+        (events_dir / "f.json").write_text(
+            json.dumps({"type": "once",
+                        "run_at": future.strftime("%Y-%m-%dT%H:%M:%S") + "+00:00",
+                        "mission": "Future offset mission"}),
+            encoding="utf-8",
+        )
+
+        with patch("app.event_scheduler.insert_pending_mission") as mock_insert:
+            from app.event_scheduler import tick
+            result = tick(str(tmp_path))
+
+        mock_insert.assert_not_called()
+        assert result == []
+
 
 # ---------------------------------------------------------------------------
 # parse_at_arg() — natural-language time parsing for /at command


### PR DESCRIPTION
**What:** Normalize timezone-aware `run_at` values to naive-local in `event_scheduler` so a scheduled-event file with a `Z` suffix or UTC offset no longer crashes the tick.

**Why:** `datetime.fromisoformat` (Python 3.11+) returns a *tz-aware* datetime for an ISO string ending in `Z` or carrying an offset — both standard ISO 8601 forms. `tick()` then compares it against a naive `now`, raising `TypeError: can't compare offset-naive and offset-aware datetimes`. The call site (`iteration_manager.py:1423`) only catches `(ImportError, OSError)`, so the `TypeError` propagates. Worse, the crash happens *before* the file is archived, so the offending event is re-read and re-crashes on **every** iteration — a poison pill that silently halts the whole event scheduler until a human deletes the file. Any externally- or hand-created event file with a `Z`/offset timestamp triggers it.

**How:** After parsing, convert any aware value to the equivalent naive local wall-clock (`.astimezone().replace(tzinfo=None)`) at both boundaries:
- `tick()` — kills the poison pill regardless of how the file was created.
- `parse_at_arg()` ISO branch — so `/at 2026-04-25T09:00:00Z` honors the offset instead of `write_event_file` silently dropping tzinfo and mislabeling the wall-clock.

**Testing:** Two new PoC tests committed *before* the fix (they fail with the exact `TypeError` against the prior commit): a past-due `Z`-suffixed event is now processed and archived; a future offset event is compared correctly and not inserted. Full `test_event_scheduler.py` (24) passes; lint clean. (One unrelated pre-existing failure, `test_reset_parser::test_us_timezone`, is environmental — missing `US/Eastern` tzdata key — not touched here.)
