### PR TITLE
fix(reset_parser): convert naive now to reset tz, don't relabel

### DIFF
--- a/koan/app/reset_parser.py
+++ b/koan/app/reset_parser.py
@@ -65,8 +65,11 @@ def parse_reset_time(text: str, now: Optional[datetime] = None) -> Tuple[Optiona
     except (KeyError, ValueError):
         tz = ZoneInfo("Europe/Paris")
 
-    # Parse the time component
-    now_tz = now.astimezone(tz) if now.tzinfo else now.replace(tzinfo=tz)
+    # Parse the time component. astimezone(tz) converts in both cases: an
+    # aware `now` is shifted into `tz`, and a naive `now` (the production path
+    # via datetime.now()) is presumed system-local and converted — never
+    # relabeled, which would wrongly assume the host runs in `tz`.
+    now_tz = now.astimezone(tz)
 
     # Pattern: "10am" or "5pm" (today or next occurrence)
     time_only = re.match(r'^(\d{1,2})\s*(am|pm)$', reset_str, re.IGNORECASE)

--- a/koan/tests/test_reset_parser.py
+++ b/koan/tests/test_reset_parser.py
@@ -684,3 +684,51 @@ class TestCLIMainBlock:
             with pytest.raises(SystemExit) as exc_info:
                 run_module("app.reset_parser", run_name="__main__")
             assert exc_info.value.code == 1
+
+
+# ---------------------------------------------------------------------------
+# Naive `now` is presumed system-local and must be CONVERTED to the reset
+# timezone, not relabeled. Regression for non-Paris hosts (e.g. UTC servers).
+# ---------------------------------------------------------------------------
+
+
+class TestNaiveNowSystemLocal:
+    """When `now` is naive it represents the host's local clock.
+
+    Production always calls parse_reset_time() with now=None, yielding a naive
+    datetime.now() in the host's local timezone. The parser must convert that
+    instant into the reset timezone before deciding today-vs-tomorrow. Relabeling
+    (replace(tzinfo=tz)) silently assumes the host runs in the reset timezone,
+    which is false on the typical UTC server — and produces a reset time off by
+    the UTC offset, flipping the day near boundaries.
+    """
+
+    def test_naive_now_on_utc_host_converts_to_paris(self):
+        """UTC host at 09:30 == 10:30 Paris (CET); 'resets 10am' is tomorrow.
+
+        Pre-fix the naive branch relabeled 09:30 as Paris time, so 10am looked
+        still-upcoming today — pointing auto-resume at a reset that already
+        passed in real Paris time, hammering the still-exhausted quota.
+        """
+        import os
+        import time
+        from app.reset_parser import parse_reset_time
+
+        old_tz = os.environ.get("TZ")
+        os.environ["TZ"] = "UTC"
+        time.tzset()
+        try:
+            # Naive: presumed system-local (UTC). Feb → CET (UTC+1) in Paris.
+            now = datetime(2026, 2, 4, 9, 30, 0)
+            ts, _ = parse_reset_time("resets 10am (Europe/Paris)", now=now)
+            assert ts is not None
+            reset_dt = datetime.fromtimestamp(ts, tz=ZoneInfo("Europe/Paris"))
+            # Real Paris time is 10:30 > 10:00, so the next 10am is tomorrow.
+            assert reset_dt.day == 5
+            assert reset_dt.hour == 10
+        finally:
+            if old_tz is None:
+                os.environ.pop("TZ", None)
+            else:
+                os.environ["TZ"] = old_tz
+            time.tzset()


### PR DESCRIPTION
**What**: Convert a naive `now` to the reset timezone instead of relabeling it, in `reset_parser.parse_reset_time`.

**Why**: Production (`quota_handler.parse_reset_time` → `reset_parser`) always calls with `now=None`, yielding a naive `datetime.now()` in the host's local clock. The old naive branch did `now.replace(tzinfo=tz)`, which *tags* the host wall-clock as if it were the reset timezone (default Europe/Paris). On any host not running in that timezone — the typical UTC server / Railway deploy — the computed reset instant is off by the UTC offset, and the today-vs-tomorrow decision flips near boundaries. Concretely: a UTC host at 09:30 (= 10:30 Paris, CET) parsing "resets 10am (Europe/Paris)" returned *today* 10am — already in the past — instead of *tomorrow*. That points quota auto-resume at a reset that hasn't actually happened, hammering the still-exhausted quota.

**How**: `now.astimezone(tz)` handles both cases — an aware `now` is shifted into `tz`, and a naive `now` is presumed system-local (Python semantics) and converted. The ternary collapses to one call. No behavior change on hosts whose local tz already equals the reset tz (naive→relabel was a no-op there), so existing Paris-based tests are unaffected.

**Testing**: Added a regression test that pins `TZ=UTC` and asserts the conversion (committed first, fails against the prior code, passes after). Full `test_reset_parser.py` suite green (58 passed). Note: `test_us_timezone` fails in this sandbox due to missing `US/Eastern` tzdata — pre-existing on `main`, unrelated to this change. `make lint` clean.
