### PR TITLE
fix(commit_conventions): ticket-key regex matched lowercase tokens

### DIFF
--- a/koan/app/commit_conventions.py
+++ b/koan/app/commit_conventions.py
@@ -29,9 +29,12 @@ _CONVENTIONAL_RE = re.compile(
     r"(?:\([^)]+\))?!?:\s"
 )
 
-# Ticket/case reference patterns.
+# Ticket/case reference patterns. Ticket keys are uppercase by convention
+# (e.g. JIRA-123), so this is case-sensitive on purpose — IGNORECASE would
+# match lowercase hyphen-number tokens like "utf-8" or "python-3" and
+# misclassify a plain repo as ticket-style.
 _TICKET_RE = re.compile(
-    r"^[a-f0-9]+\s+.*?(?:Case\s+)?([A-Z][A-Z0-9_]+-\d+)", re.IGNORECASE
+    r"^[a-f0-9]+\s+.*?(?:Case\s+)?([A-Z][A-Z0-9_]+-\d+)"
 )
 
 # Matches file references in markdown: backtick-quoted paths or bare paths

--- a/koan/tests/test_commit_conventions.py
+++ b/koan/tests/test_commit_conventions.py
@@ -179,6 +179,23 @@ class TestInferCommitStyleFromHistory:
             result = _infer_commit_style_from_history(str(tmp_path), "HEAD")
         assert result == ""
 
+    def test_hyphenated_tokens_not_misread_as_tickets(self, tmp_path):
+        """Lowercase hyphen-number tokens (utf-8, python-3) must NOT count as
+        ticket references. The ticket-key pattern is uppercase-only by design;
+        a case-insensitive match would classify a plain repo as ticket-style
+        and inject bogus 'use ticket IDs' guidance into commit prompts.
+        """
+        log_lines = [
+            "abc1234 update to utf-8 everywhere",
+            "def5678 migrate to python-3 runtime",
+            "aaa9012 fix base64-decode helper",
+            "bbb3456 bump to v1-2 release",
+            "ccc7890 switch readme-2 layout",
+        ]
+        with patch("app.commit_conventions.subprocess.run", return_value=self._mock_git_log(log_lines)):
+            result = _infer_commit_style_from_history(str(tmp_path), "HEAD")
+        assert result == ""
+
     def test_git_error_returns_empty(self, tmp_path):
         mock_result = MagicMock()
         mock_result.returncode = 128


### PR DESCRIPTION
**What**: Make the commit-history ticket-reference detector case-sensitive.

**Why**: `_TICKET_RE` matched `[A-Z][A-Z0-9_]+-\d+` (uppercase JIRA-style keys) but carried `re.IGNORECASE`. That made ordinary lowercase hyphen-number tokens — `utf-8`, `python-3`, `v1-2`, `readme-2` — match as ticket keys. A repo using no tracker but with such subjects could cross the >50% threshold in `_infer_commit_style_from_history` and be classified as ticket-style, injecting bogus "this project references ticket/case IDs" guidance into commit prompts.

**How**: Dropped `re.IGNORECASE`. Ticket keys are uppercase by convention, and git short hashes (`[a-f0-9]+`) are lowercase hex, so the flag served no legitimate purpose. The conventional-commit check runs first and is unaffected.

**Testing**: Added `test_hyphenated_tokens_not_misread_as_tickets` (fails pre-fix, passes after). Full `test_commit_conventions.py` suite: 34 passed. `make lint` clean.
