### PR TITLE
fix(outbox): prevent duplicate delivery on truncation failure

### DIFF
--- a/koan/app/outbox_manager.py
+++ b/koan/app/outbox_manager.py
@@ -5,6 +5,7 @@ Encapsulates all outbox state (thread, lock, staging file) in a class
 instead of module-level globals.
 """
 
+import contextlib
 import fcntl
 import re
 import subprocess
@@ -153,6 +154,14 @@ class OutboxManager:
                     fcntl.flock(f, fcntl.LOCK_UN)
         except Exception as e:
             log("error", f"Outbox read error: {e}")
+            # If truncation failed after staging was written, the outbox still
+            # holds the content. Drop the staging copy so the next flush's
+            # recover_staged() doesn't re-queue it on top — that would deliver
+            # the same message twice. If the outbox WAS cleared (truncate ran,
+            # a later step failed), keep staging so recovery can resend.
+            with contextlib.suppress(OSError):
+                if staging.exists() and self._outbox_file.read_text().strip():
+                    staging.unlink(missing_ok=True)
             return
 
         if not content:

--- a/koan/tests/test_outbox_manager.py
+++ b/koan/tests/test_outbox_manager.py
@@ -307,6 +307,63 @@ class TestFlush:
 
         assert staging_existed == [True]
 
+    @patch("app.outbox_manager.log")
+    def test_flush_truncate_failure_does_not_duplicate(self, mock_log, outbox_env):
+        """A failed truncation must not cause the message to be sent twice.
+
+        Bug: in phase 1, ``atomic_write(staging)`` succeeds and then
+        ``f.truncate()`` raises (e.g. transient I/O error). The outbox file
+        still holds the content AND staging holds a copy. On the next flush,
+        ``recover_staged()`` re-queues the staged copy on top of the
+        un-cleared outbox content, so the same message is delivered twice.
+        """
+        mgr, outbox_file, _ = outbox_env
+        outbox_file.write_text("hello world")
+
+        real_open = open
+
+        class _NoTruncateFile:
+            """Proxy that delegates everything to a real file but fails on
+            truncate(), simulating a transient I/O error mid-clear."""
+
+            def __init__(self, real):
+                self._real = real
+
+            def truncate(self, *a):
+                raise OSError("disk full")
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def __enter__(self):
+                self._real.__enter__()
+                return self
+
+            def __exit__(self, *a):
+                return self._real.__exit__(*a)
+
+        def faulty_open(*args, **kwargs):
+            return _NoTruncateFile(real_open(*args, **kwargs))
+
+        # First flush: truncation fails after staging is written.
+        with patch("app.outbox_manager.open", faulty_open, create=True):
+            mgr.flush()
+
+        # Subsequent flushes: count how many times the content is sent.
+        sent = []
+        with patch("app.outbox_manager.scan_and_log",
+                   return_value=MagicMock(blocked=False)), \
+             patch("app.outbox_manager.send_telegram",
+                   side_effect=lambda msg, **kw: sent.append(msg) or True), \
+             patch.object(mgr, "_format_message", side_effect=lambda c: c), \
+             patch.object(mgr, "_expand_github_refs", side_effect=lambda f, c: f), \
+             patch("app.outbox_manager.save_conversation_message"), \
+             patch.object(mgr, "_get_last_message_id", return_value=0):
+            mgr.flush()
+            mgr.flush()
+
+        assert "".join(sent).count("hello world") == 1
+
 
 class TestFlushAsync:
     """Background thread management."""


### PR DESCRIPTION
**What**: Prevent duplicate Telegram delivery when the outbox truncation fails mid-flush.

**Why**: `OutboxManager.flush()` phase 1 writes content to a staging file (`atomic_write`) and *then* truncates the outbox. If `f.truncate()` raises a transient I/O error, the outbox keeps its content while staging holds a copy. The next flush's `recover_staged()` re-queues the staged copy on top of the un-cleared outbox → the same message is sent twice. The existing in-code comment already flags duplicate delivery as a known production pain; this closes one concrete path to it.

**How**: In the phase-1 `except` handler, if the outbox file still has content, delete the staging copy — the outbox is the intact source of truth, so recovery would only duplicate. If the outbox *was* cleared (truncate ran, a later step failed), staging is kept so `recover_staged()` resends exactly once. `atomic_write` is already fully atomic, so the staging file is never partial.

**Testing**: Added `test_flush_truncate_failure_does_not_duplicate` — injects an `OSError` on `truncate()` via an open() proxy, then asserts the message is delivered exactly once across subsequent flushes. Committed failing first (proves duplication: "hello worldhello world"), passing after the fix. Full `test_outbox_manager.py` (39 tests) green, lint clean.
