### PR TITLE
feat(bin): add zai-claude wrapper for Z.ai GLM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ koan/htmlcov/
 # Environment & secrets
 .env
 .envrc
+.zai.key
 
 # OS
 .DS_Store

--- a/bin/README.md
+++ b/bin/README.md
@@ -39,6 +39,7 @@ CLI, e.g. `-p "<prompt>" --model <name> --output-format json --verbose …`.
 |---------|---------|-------------|
 | `oc-claude` | OpenCode Go (via `ocgo` proxy) | [docs/providers/opencode.md](../docs/providers/opencode.md) |
 | `ollama-claude` | Local Ollama (via `ollama launch claude`) | [docs/providers/ollama-wrapper.md](../docs/providers/ollama-wrapper.md) |
+| `zai-claude` | Z.ai / GLM (real `claude` + Z.ai endpoint) | [docs/providers/zai.md](../docs/providers/zai.md) |
 
 ## Adding a new flavor
 

--- a/bin/zai-claude
+++ b/bin/zai-claude
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+#
+# zai-claude — run the Claude CLI against a Z.ai (GLM) subscription.
+#
+# Koan invokes this as a drop-in `claude` replacement when
+#   KOAN_CLAUDE_CLI_PATH=/path/to/koan/bin/zai-claude
+# is set. Koan passes a Claude-style argument vector, e.g.:
+#   -p "<prompt>" --model <name> --output-format json --verbose ...
+#
+# Unlike bin/oc-claude and bin/ollama-claude (which re-dispatch through a
+# proxy/launcher), the backend here IS the real `claude` binary. So this
+# wrapper sets the Z.ai endpoint + auth via env vars and execs `claude`
+# directly — Claude Code's own tier machinery does the work.
+#
+# Model handling — the "keep Koan config unchanged" story:
+#   Koan emits Anthropic tier names from `models:` (haiku / sonnet / opus).
+#   This wrapper translates those to Z.ai GLM model ids on --model and
+#   --fallback-model, and exports ANTHROPIC_DEFAULT_*_MODEL so Claude Code's
+#   internal tier selection also resolves to GLM. A customer's Koan config
+#   therefore stays identical to a standard Claude setup — switching to Z.ai
+#   is just pointing KOAN_CLAUDE_CLI_PATH here.
+#
+#   Any value that is NOT a tier alias (a real Z.ai model id like glm-5.2[1m]
+#   or glm-4.5) passes through unchanged, so customers may also name GLM models
+#   directly in config.yaml.
+#
+# Model mapping (each overridable via its ANTHROPIC_DEFAULT_*_MODEL env var):
+#   haiku  -> glm-4.5
+#   sonnet -> glm-5.2[1m]
+#   opus   -> glm-5.2[1m]
+#
+# Z.ai key resolution order:
+#   1. $KOAN_ZAI_KEY          (key value, e.g. from .env)
+#   2. $KOAN_ROOT/.zai.key    (file contents, newline-trimmed)
+#
+# Prerequisites: the Claude Code CLI installed and on PATH.
+# See docs/providers/zai.md.
+
+set -euo pipefail
+
+# --- Z.ai model tiers (single source of truth; env-overridable) --------------
+ZAI_HAIKU="${ANTHROPIC_DEFAULT_HAIKU_MODEL:-glm-4.5}"
+ZAI_SONNET="${ANTHROPIC_DEFAULT_SONNET_MODEL:-glm-5.2[1m]}"
+ZAI_OPUS="${ANTHROPIC_DEFAULT_OPUS_MODEL:-glm-5.2[1m]}"
+
+# --- resolve the Z.ai API key ------------------------------------------------
+ZAI_KEY=""
+if [[ -n "${KOAN_ZAI_KEY:-}" ]]; then
+    ZAI_KEY="$KOAN_ZAI_KEY"
+elif [[ -n "${KOAN_ROOT:-}" && -r "$KOAN_ROOT/.zai.key" ]]; then
+    ZAI_KEY="$(tr -d '\r\n' < "$KOAN_ROOT/.zai.key")"
+else
+    echo "zai-claude: no Z.ai key found." >&2
+    echo "zai-claude: set KOAN_ZAI_KEY in your .env, or create \$KOAN_ROOT/.zai.key" >&2
+    echo "zai-claude: see docs/providers/zai.md" >&2
+    exit 1
+fi
+
+if [[ -z "$ZAI_KEY" ]]; then
+    echo "zai-claude: Z.ai key is empty (KOAN_ZAI_KEY / \$KOAN_ROOT/.zai.key)." >&2
+    exit 1
+fi
+
+# --- map a Koan tier name to a Z.ai model id; real ids pass through ----------
+map_model() {
+    case "$1" in
+        haiku)  printf '%s' "$ZAI_HAIKU" ;;
+        sonnet) printf '%s' "$ZAI_SONNET" ;;
+        opus)   printf '%s' "$ZAI_OPUS" ;;
+        *)      printf '%s' "$1" ;;
+    esac
+}
+
+# --- rewrite the arg vector: translate --model / --fallback-model ------------
+args=()
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)
+            args+=("--model" "$(map_model "${2:-}")")
+            shift
+            [[ $# -gt 0 ]] && shift
+            ;;
+        --model=*)
+            args+=("--model=$(map_model "${1#--model=}")")
+            shift
+            ;;
+        --fallback-model)
+            args+=("--fallback-model" "$(map_model "${2:-}")")
+            shift
+            [[ $# -gt 0 ]] && shift
+            ;;
+        --fallback-model=*)
+            args+=("--fallback-model=$(map_model "${1#--fallback-model=}")")
+            shift
+            ;;
+        *)
+            args+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# --- resolve the backend binary ----------------------------------------------
+ZAI_CLAUDE_BIN="${KOAN_ZAI_CLAUDE_BIN:-claude}"
+if ! command -v "$ZAI_CLAUDE_BIN" >/dev/null 2>&1; then
+    echo "zai-claude: '$ZAI_CLAUDE_BIN' not found on PATH." >&2
+    echo "zai-claude: set KOAN_ZAI_CLAUDE_BIN, or install the Claude Code CLI (npm i -g @anthropic-ai/claude-code)." >&2
+    echo "zai-claude: see docs/providers/claude.md" >&2
+    exit 127
+fi
+
+# --- export Z.ai env and exec ------------------------------------------------
+export ANTHROPIC_AUTH_TOKEN="$ZAI_KEY"
+export ANTHROPIC_BASE_URL="${ANTHROPIC_BASE_URL:-https://api.z.ai/api/anthropic}"
+export API_TIMEOUT_MS="${API_TIMEOUT_MS:-9000000}"
+export CLAUDE_CODE_AUTO_COMPACT_WINDOW="${CLAUDE_CODE_AUTO_COMPACT_WINDOW:-1000000}"
+export ANTHROPIC_DEFAULT_HAIKU_MODEL="$ZAI_HAIKU"
+export ANTHROPIC_DEFAULT_SONNET_MODEL="$ZAI_SONNET"
+export ANTHROPIC_DEFAULT_OPUS_MODEL="$ZAI_OPUS"
+
+# "${args[@]+...}" guards against set -u on bash 3.2 when args is empty.
+exec "$ZAI_CLAUDE_BIN" "${args[@]+"${args[@]}"}"

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ to operate Koan. Most non-trivial changes update both.
 - [User Manual](users/user-manual.md) - daily use, workflows, and command guide.
 - [Onboarding](users/onboarding.md) - first-run setup and configuration flow.
 - [Skills Reference](users/skills.md) - built-in command reference.
-- [Provider Setup](providers/) - Claude, Cline, Codex, Copilot, and Ollama Launch (local models) providers; plus [OpenRouter via the Claude CLI](providers/openrouter.md), [OpenCode Go via the Claude CLI](providers/opencode.md), and [Local Ollama via the Claude CLI](providers/ollama-wrapper.md).
+- [Provider Setup](providers/) - Claude, Cline, Codex, Copilot, and Ollama Launch (local models) providers; plus [OpenRouter via the Claude CLI](providers/openrouter.md), [OpenCode Go via the Claude CLI](providers/opencode.md), [Local Ollama via the Claude CLI](providers/ollama-wrapper.md), and [Z.ai (GLM) via the Claude CLI](providers/zai.md).
 - [Messaging Setup](messaging/) - Telegram, Slack, Matrix, Discord, GitHub, and Jira.
 - [Troubleshooting](operations/troubleshooting.md) - common issues and how to fix them.
 

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -153,6 +153,11 @@ When a custom path is set, `/status` shows the binary name next to the provider
 > `bin/ollama-claude`, that routes the Claude CLI through
 > `ollama launch claude`. Set `KOAN_CLAUDE_CLI_PATH` to that script.
 
+> **Using a Z.ai (GLM) subscription?** See [zai.md](zai.md) — it ships a
+> ready-made wrapper, `bin/zai-claude`, that points the Claude CLI at Z.ai's
+> Anthropic-compatible endpoint and maps Koan's model tiers (`haiku`/`sonnet`/
+> `opus`) to GLM models. Set `KOAN_CLAUDE_CLI_PATH` to that script.
+
 ### MCP (Model Context Protocol) Servers
 
 Claude Code supports MCP servers for extended capabilities (browser,

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -1,0 +1,220 @@
+# Z.ai (GLM) via the Claude CLI
+
+Run Koan's **default Claude provider** against a
+[Z.ai](https://z.ai) subscription (GLM models) — without changing any Koan
+code. Koan keeps invoking the Claude CLI; a committed wrapper, `bin/zai-claude`,
+points that invocation at Z.ai's Anthropic-compatible endpoint and maps Koan's
+model tiers to GLM models.
+
+> Same mechanism as [OpenCode Go via the Claude CLI](opencode.md) and
+> [Local Ollama via the Claude CLI](ollama-wrapper.md): a thin wrapper binary
+> set via `KOAN_CLAUDE_CLI_PATH`. `cli_provider` stays `claude`.
+
+Unlike those two wrappers, the backend here **is** the real `claude` binary —
+there is no proxy or launcher in between. The wrapper only sets the Z.ai
+endpoint/auth via env vars and translates model tiers, then `exec`s `claude`.
+
+## Architecture
+
+```
+run.py ──spawn──> bin/zai-claude   (KOAN_CLAUDE_CLI_PATH)
+                     │  loads Z.ai key, maps --model tiers -> GLM, exports env
+                     ▼
+                  claude <args>   (the real Claude Code CLI, on PATH)
+                     │  ANTHROPIC_BASE_URL=api.z.ai  +  ANTHROPIC_AUTH_TOKEN
+                     ▼
+                  Z.ai ──> glm-4.5 / glm-5.2[1m] / ...
+```
+
+## Prerequisites
+
+1. **A Z.ai account + API key** (from the Z.ai console).
+
+2. **The Claude Code CLI installed and on PATH** — the wrapper execs the real
+   `claude` binary, it does not bundle one:
+
+   ```bash
+   npm install -g @anthropic-ai/claude-code
+   claude --version
+   ```
+
+## Provide the Z.ai key
+
+The wrapper resolves the key in this order:
+
+1. `$KOAN_ZAI_KEY` — the key value, read from `.env` (recommended).
+2. `$KOAN_ROOT/.zai.key` — a file at the root of your Kōan instance containing
+   just the key (whitespace/newlines are trimmed).
+
+Put one of these in your `.env`:
+
+```bash
+KOAN_ZAI_KEY=sk-zai-...               # option A: key value
+```
+
+…or create the file:
+
+```bash
+printf 'sk-zai-...\n' > "$KOAN_ROOT/.zai.key"
+chmod 600 "$KOAN_ROOT/.zai.key"
+```
+
+`.zai.key` is gitignored (see `.gitignore`) — but treat it like any other secret
+and never commit it.
+
+## Wire Koan to the wrapper
+
+Point `KOAN_CLAUDE_CLI_PATH` at the committed wrapper in your `.env`:
+
+```bash
+KOAN_CLAUDE_CLI_PATH=/absolute/path/to/koan/bin/zai-claude
+```
+
+The wrapper is resolved by the Claude provider (see
+[claude.md → Custom CLI Binary](claude.md#advanced-configuration)). No other
+Koan config changes are required.
+
+## Model selection — your config does not change
+
+This is the key simplification: **keep using Anthropic tier names** in your Koan
+config exactly as you would for a normal Claude subscription. The wrapper maps
+each tier to a Z.ai GLM model:
+
+| Koan tier (`--model`) | Z.ai model |
+|-----------------------|------------|
+| `haiku`               | `glm-4.5`  |
+| `sonnet`              | `glm-5.2[1m]` |
+| `opus`                | `glm-5.2[1m]` |
+
+So your existing `config.yaml` works as-is:
+
+```yaml
+# config.yaml — identical to a standard Claude setup
+models:
+  default:
+    mission: ""          # -> glm-5.2[1m]  (empty = default = sonnet tier)
+    lightweight: "haiku" # -> glm-4.5      (cheap calls)
+    fallback: "sonnet"   # -> glm-5.2[1m]
+```
+
+And per-project overrides in `projects.yaml` keep using tiers too:
+
+```yaml
+projects:
+  heavy-repo:
+    path: "/path/to/heavy-repo"
+    models:
+      mission: "opus"        # -> glm-5.2[1m]
+      review_mode: "sonnet"  # -> glm-5.2[1m]
+```
+
+**Naming GLM models directly** also works: any `--model` value that is *not* a
+tier alias (`haiku`/`sonnet`/`opus`) passes through unchanged. So this is
+equally valid:
+
+```yaml
+models:
+  claude:
+    mission: "glm-5.2[1m]"
+    lightweight: "glm-4.5"
+    fallback: "glm-5.2[1m]"
+```
+
+### Overriding the tier → model mapping
+
+Each tier is overridable via its `ANTHROPIC_DEFAULT_*_MODEL` env var (set in
+`.env`). Useful when Z.ai ships a new model and you want to test it without
+editing the wrapper:
+
+```bash
+ANTHROPIC_DEFAULT_SONNET_MODEL=glm-6.0
+ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.8
+```
+
+These feed both the `--model` translation and the `ANTHROPIC_DEFAULT_*_MODEL`
+exports, so Claude Code's internal tier selection stays consistent.
+
+### Concurrency — tune the lightweight tier for headroom
+
+Z.ai enforces per-model concurrency caps (see the rate-limits page on your
+API-key dashboard). The defaults the wrapper ships with land on opposite
+sides of that (values are plan-dependent — confirm on your dashboard):
+
+| Tier | GLM model | Typical concurrency |
+|------|-----------|---------------------|
+| `haiku` (lightweight) | `glm-4.5` | low (~2) |
+| `sonnet` / `opus` (mission) | `glm-5.2[1m]` | high (~10) |
+
+The **lightweight tier is the bottleneck**: Claude Code reaches for it on
+background / small calls, so under load it trips `429` first. A single Kōan
+instance rarely exceeds a couple of concurrent lightweight calls, so the
+default is fine until you run multiple instances or parallel subagents.
+
+To raise headroom, point `haiku` at a higher-concurrency **text** model:
+
+```bash
+# .env — glm-4.5 is a text model with a high concurrency cap (~10)
+ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.5
+```
+
+Pick a **text** model here, not a `V` variant (e.g. `glm-4.6V`) — the `V`
+means vision/multimodal, and the lightweight tier (formatting, mission
+picking, contemplation — all text-only) never sends images, so you'd pay for
+capability and latency you don't use. Good text picks at a high concurrency
+cap: `glm-4.5` (default choice), or `glm-5.1` if you'd trade cost for a
+smarter lightweight model.
+
+## Environment reference
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `KOAN_CLAUDE_CLI_PATH` | — | Set to the wrapper path in `.env` to activate it. |
+| `KOAN_ZAI_KEY` | — | Z.ai API key value (highest priority). |
+| `$KOAN_ROOT/.zai.key` | — | Fallback key file (read when `KOAN_ZAI_KEY` is unset). |
+| `KOAN_ZAI_CLAUDE_BIN` | `claude` | The backend binary to `exec`. Override if your `claude` lives elsewhere. |
+| `ANTHROPIC_BASE_URL` | `https://api.z.ai/api/anthropic` | Z.ai endpoint. Override only for a mirror/proxy. |
+| `API_TIMEOUT_MS` | `9000000` (150 min) | Long per-request timeout for big missions. |
+| `CLAUDE_CODE_AUTO_COMPACT_WINDOW` | `1000000` | Raised auto-compact window. |
+| `ANTHROPIC_DEFAULT_HAIKU/SONNET/OPUS_MODEL` | `glm-4.5` / `glm-5.2[1m]` / `glm-5.2[1m]` | Override any tier's GLM model. |
+
+## Caveats
+
+- **`claude` must stay on PATH.** If the CLI is missing, every mission fails
+  fast — the wrapper exits `127` with a `claude`-not-found message that Kōan
+  surfaces as a real error. (The wrapper resolves the *real* `claude` binary on
+  PATH; it is not named `claude` itself, so there is no recursion.)
+- **Interactive shell functions are irrelevant here.** If you have a personal
+  `claude-zai` / `claude-full` shell function for interactive use, it is *not*
+  loaded in Kōan's non-interactive subprocess — the wrapper always finds the
+  real `claude` binary.
+- **Cost figures are Anthropic-priced.** Token *counts* survive, but any
+  reported `cost_usd` is computed against Anthropic pricing and is approximate
+  at best for GLM models. Treat cost numbers as unreliable here.
+- **Re-apply exec bit after clone if needed.** Git preserves `+x`, but a
+  restrictive umask may strip it: `chmod +x bin/zai-claude`.
+
+## Verify
+
+1. **Arg translation only (no API call, no quota spent)** — point the wrapper
+   at a printer to confirm the tier mapping and env exports:
+
+   ```bash
+   cat > /tmp/zai-probe.sh <<'EOF'
+   #!/usr/bin/env bash
+   echo "ARGS: $*"
+   echo "AUTH: ${ANTHROPIC_AUTH_TOKEN:+set}"
+   echo "URL: $ANTHROPIC_BASE_URL"
+   echo "HAIKU: $ANTHROPIC_DEFAULT_HAIKU_MODEL  SONNET: $ANTHROPIC_DEFAULT_SONNET_MODEL"
+   EOF
+   chmod +x /tmp/zai-probe.sh
+
+   KOAN_ZAI_KEY=test KOAN_ZAI_CLAUDE_BIN=/tmp/zai-probe.sh \
+     ./bin/zai-claude --model haiku --fallback-model sonnet -p "hi"
+   # expect: ARGS: --model glm-4.5 --fallback-model glm-5.2[1m] -p hi
+   ```
+
+   `--model glm-5.2[1m]` (a real model id) should pass through unchanged.
+
+2. **End-to-end in Kōan** — with `KOAN_CLAUDE_CLI_PATH` set and a valid key,
+   queue a trivial mission and watch `make logs` confirm it reaches **Done**.
+   `/status` shows the provider as `claude (zai-claude)`.

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -491,6 +491,9 @@ models:
   #   fallback: "sonnet"       # Fallback when primary is overloaded
   #   review_mode: "sonnet"    # Override model for REVIEW mode
   #   reflect: "sonnet"        # Model for review reflection pass
+  #
+  # Z.ai (GLM): no change needed here — bin/zai-claude maps these tier names
+  # (haiku/sonnet/opus) to GLM models. See docs/providers/zai.md.
 
   # Codex (OpenAI) provider overrides (uncomment to customize):
   # codex:


### PR DESCRIPTION
Add a community CLI wrapper that runs Koan's default Claude provider
against a Z.ai (GLM) subscription, selected via the existing
KOAN_CLAUDE_CLI_PATH mechanism — no Python or provider changes.

Unlike bin/oc-claude and bin/ollama-claude, the backend here is the
real `claude` binary. The wrapper loads the Z.ai key (KOAN_ZAI_KEY env
var, else \$KOAN_ROOT/.zai.key), exports the Z.ai endpoint and auth,
and maps Koan's Anthropic tier names to GLM models so a customer's
config.yaml stays identical to a standard Claude setup:

  haiku  -> glm-4.5 (for concurrency limits)
  sonnet -> glm-5.2[1m]
  opus   -> glm-5.2[1m]

Real Z.ai model ids pass through unchanged, and each tier is
overridable via ANTHROPIC_DEFAULT_*_MODEL. The wrapper execs the real
`claude` on PATH (not named `claude`, so no recursion); the model
versions are defined once and feed both the --model translation and the
exported tier env vars.

Also adds docs/providers/zai.md, cross-references in bin/README.md,
docs/providers/claude.md and docs/README.md, an instance.example
config.yaml note, and gitignores .zai.key.
