### PR TITLE
feat(provider): support relative KOAN_CLAUDE_CLI_PATH

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -9,12 +9,14 @@ Each wrapper is a `claude`-compatible executable. Point Koan at one with:
 
 ```bash
 # .env
-KOAN_CLAUDE_CLI_PATH=/absolute/path/to/koan/bin/<wrapper>
+KOAN_CLAUDE_CLI_PATH=bin/<wrapper>
 ```
 
-Koan's `ClaudeProvider` reads `KOAN_CLAUDE_CLI_PATH` (see
-`koan/app/provider/claude.py`) and invokes it exactly like the real `claude`
-CLI, e.g. `-p "<prompt>" --model <name> --output-format json --verbose …`.
+The path may be **relative to `KOAN_ROOT`** (recommended — keeps the config
+portable across installs/copies) or absolute. Koan's `ClaudeProvider` reads
+`KOAN_CLAUDE_CLI_PATH` (see `koan/app/provider/claude.py`), resolves a relative
+value against `KOAN_ROOT`, and invokes it exactly like the real `claude` CLI,
+e.g. `-p "<prompt>" --model <name> --output-format json --verbose …`.
 
 ## The contract every wrapper must honor
 

--- a/bin/zai-claude
+++ b/bin/zai-claude
@@ -77,21 +77,29 @@ args=()
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --model)
-            args+=("--model" "$(map_model "${2:-}")")
+            # Emit only when a value follows; drop a bare trailing --model
+            # so we never forward an empty --model "" (Koan always supplies one).
+            if [[ $# -ge 2 ]]; then
+                args+=("--model" "$(map_model "$2")")
+            fi
             shift
             [[ $# -gt 0 ]] && shift
             ;;
         --model=*)
-            args+=("--model=$(map_model "${1#--model=}")")
+            val="${1#--model=}"
+            [[ -n "$val" ]] && args+=("--model=$(map_model "$val")")
             shift
             ;;
         --fallback-model)
-            args+=("--fallback-model" "$(map_model "${2:-}")")
+            if [[ $# -ge 2 ]]; then
+                args+=("--fallback-model" "$(map_model "$2")")
+            fi
             shift
             [[ $# -gt 0 ]] && shift
             ;;
         --fallback-model=*)
-            args+=("--fallback-model=$(map_model "${1#--fallback-model=}")")
+            val="${1#--fallback-model=}"
+            [[ -n "$val" ]] && args+=("--fallback-model=$(map_model "$val")")
             shift
             ;;
         *)

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -125,11 +125,15 @@ You can point Koan at a custom Claude-compatible binary instead of the
 default `claude` command. Set `KOAN_CLAUDE_CLI_PATH` in your `.env`:
 
 ```bash
-KOAN_CLAUDE_CLI_PATH=/path/to/my-claude-wrapper
+KOAN_CLAUDE_CLI_PATH=bin/my-claude-wrapper   # relative to KOAN_ROOT (portable)
+# or
+KOAN_CLAUDE_CLI_PATH=/path/to/my-claude-wrapper   # absolute
 ```
 
-The custom binary must accept the same CLI interface as `claude`
-(e.g., `my-wrapper --model <model> -p "prompt"`). This is useful for:
+A relative value is resolved against `KOAN_ROOT`, so the config stays portable
+across installs/copies without a hard-coded path. The custom binary must
+accept the same CLI interface as `claude` (e.g., `my-wrapper --model <model>
+-p "prompt"`). This is useful for:
 
 - Using a custom `ANTHROPIC_BASE_URL` via a wrapper script
 - Adding default arguments or environment variables

--- a/docs/providers/zai.md
+++ b/docs/providers/zai.md
@@ -64,13 +64,18 @@ and never commit it.
 
 ## Wire Koan to the wrapper
 
-Point `KOAN_CLAUDE_CLI_PATH` at the committed wrapper in your `.env`:
+Point `KOAN_CLAUDE_CLI_PATH` at the committed wrapper in your `.env`. A path
+**relative to `KOAN_ROOT`** is recommended — it keeps the config portable
+across installs, copies, and machines (no hard-coded absolute path):
 
 ```bash
-KOAN_CLAUDE_CLI_PATH=/absolute/path/to/koan/bin/zai-claude
+KOAN_CLAUDE_CLI_PATH=bin/zai-claude
 ```
 
-The wrapper is resolved by the Claude provider (see
+The Claude provider resolves a relative value against `KOAN_ROOT`, so this
+finds `bin/zai-claude` inside your Koan checkout regardless of where it lives.
+An absolute path still works if you prefer it. The wrapper is resolved by the
+Claude provider (see
 [claude.md → Custom CLI Binary](claude.md#advanced-configuration)). No other
 Koan config changes are required.
 
@@ -134,41 +139,42 @@ ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.8
 These feed both the `--model` translation and the `ANTHROPIC_DEFAULT_*_MODEL`
 exports, so Claude Code's internal tier selection stays consistent.
 
-### Concurrency — tune the lightweight tier for headroom
+### Concurrency
 
 Z.ai enforces per-model concurrency caps (see the rate-limits page on your
-API-key dashboard). The defaults the wrapper ships with land on opposite
-sides of that (values are plan-dependent — confirm on your dashboard):
+API-key dashboard; values are plan-dependent). The shipped defaults both sit
+at the high end of the scale, so out-of-the-box throughput is balanced:
 
 | Tier | GLM model | Typical concurrency |
 |------|-----------|---------------------|
-| `haiku` (lightweight) | `glm-4.5` | low (~2) |
+| `haiku` (lightweight) | `glm-4.5` | high (~10) |
 | `sonnet` / `opus` (mission) | `glm-5.2[1m]` | high (~10) |
 
-The **lightweight tier is the bottleneck**: Claude Code reaches for it on
-background / small calls, so under load it trips `429` first. A single Kōan
-instance rarely exceeds a couple of concurrent lightweight calls, so the
-default is fine until you run multiple instances or parallel subagents.
+Kōan's agent loop is single-threaded (one mission, one `claude` subprocess at
+a time), so a single instance rarely stresses even a modest concurrency cap.
+You only need to think about it if you run **multiple Kōan instances** or
+**parallel subagents** against the same key.
 
-To raise headroom, point `haiku` at a higher-concurrency **text** model:
+If you do retune a tier, keep two things in mind:
+
+- Prefer a **text** model, not a `V` variant (e.g. `glm-4.6V`). The `V` means
+  vision/multimodal; the lightweight tier (formatting, mission picking,
+  contemplation — all text-only) never sends images, so a vision model just
+  adds cost and latency. `glm-4.5` is a good text choice; `glm-5.1` if you'd
+  trade cost for a smarter lightweight model.
+- Lower-tier "flash"/"air" variants (e.g. `glm-4.7-Flash`) trade concurrency
+  for price — check your dashboard's cap before swapping them in.
 
 ```bash
-# .env — glm-4.5 is a text model with a high concurrency cap (~10)
-ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-4.5
+# .env — override any tier (here, a smarter lightweight model)
+ANTHROPIC_DEFAULT_HAIKU_MODEL=glm-5.1
 ```
-
-Pick a **text** model here, not a `V` variant (e.g. `glm-4.6V`) — the `V`
-means vision/multimodal, and the lightweight tier (formatting, mission
-picking, contemplation — all text-only) never sends images, so you'd pay for
-capability and latency you don't use. Good text picks at a high concurrency
-cap: `glm-4.5` (default choice), or `glm-5.1` if you'd trade cost for a
-smarter lightweight model.
 
 ## Environment reference
 
 | Variable | Default | Purpose |
 |----------|---------|---------|
-| `KOAN_CLAUDE_CLI_PATH` | — | Set to the wrapper path in `.env` to activate it. |
+| `KOAN_CLAUDE_CLI_PATH` | — | Path to the wrapper in `.env`. Relative (e.g. `bin/zai-claude`) resolves against `KOAN_ROOT`; absolute works too. |
 | `KOAN_ZAI_KEY` | — | Z.ai API key value (highest priority). |
 | `$KOAN_ROOT/.zai.key` | — | Fallback key file (read when `KOAN_ZAI_KEY` is unset). |
 | `KOAN_ZAI_CLAUDE_BIN` | `claude` | The backend binary to `exec`. Override if your `claude` lives elsewhere. |

--- a/koan/app/provider/claude.py
+++ b/koan/app/provider/claude.py
@@ -12,7 +12,20 @@ class ClaudeProvider(CLIProvider):
     name = "claude"
 
     def binary(self) -> str:
-        return os.environ.get("KOAN_CLAUDE_CLI_PATH", "").strip() or "claude"
+        raw = os.environ.get("KOAN_CLAUDE_CLI_PATH", "").strip()
+        if not raw:
+            return "claude"
+        # Absolute path → as-is. Bare command name (no directory component)
+        # → leave for PATH lookup. Relative path → resolve against KOAN_ROOT
+        # so .env config is portable across installs/copies. Note the process
+        # CWD is KOAN_ROOT/koan (Makefile runs `cd koan`), not KOAN_ROOT, so a
+        # naive relative path would resolve to the wrong place.
+        if os.path.isabs(raw) or not os.path.dirname(raw):
+            return raw
+        root = os.environ.get("KOAN_ROOT", "").strip()
+        if root:
+            return os.path.normpath(os.path.join(root, raw))
+        return raw
 
     def supports_session_resume(self) -> bool:
         return True

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -97,6 +97,37 @@ class TestClaudeProvider:
         assert cmd[0] == "/opt/bin/claude-proxy"
         assert cmd[1:] == ["-p", "hello"]
 
+    def test_binary_relative_path_resolved_against_koan_root(self, monkeypatch):
+        # Portable .env form: a relative path is joined to KOAN_ROOT.
+        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "bin/zai-claude")
+        monkeypatch.setenv("KOAN_ROOT", "/home/user/koan")
+        assert self.provider.binary() == "/home/user/koan/bin/zai-claude"
+
+    def test_binary_relative_path_normalizes(self, monkeypatch):
+        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "./bin/zai-claude")
+        monkeypatch.setenv("KOAN_ROOT", "/home/user/koan/")
+        assert self.provider.binary() == "/home/user/koan/bin/zai-claude"
+
+    def test_binary_relative_path_without_koan_root_returns_raw(self, monkeypatch):
+        # Graceful fallback: no KOAN_ROOT → return the path unchanged (CWD/PATH).
+        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "bin/zai-claude")
+        monkeypatch.delenv("KOAN_ROOT", raising=False)
+        assert self.provider.binary() == "bin/zai-claude"
+
+    def test_binary_bare_command_name_not_joined(self, monkeypatch):
+        # A bare name (no directory component) stays a PATH lookup, even with
+        # KOAN_ROOT set — it must not be silently re-rooted.
+        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "my-wrapper")
+        monkeypatch.setenv("KOAN_ROOT", "/home/user/koan")
+        assert self.provider.binary() == "my-wrapper"
+
+    def test_binary_relative_path_flows_into_build_command(self, monkeypatch):
+        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "bin/zai-claude")
+        monkeypatch.setenv("KOAN_ROOT", "/srv/koan")
+        cmd = self.provider.build_command(prompt="hello")
+        assert cmd[0] == "/srv/koan/bin/zai-claude"
+        assert cmd[1:] == ["-p", "hello"]
+
     def test_name(self):
         assert self.provider.name == "claude"
 

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -31,6 +31,7 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 | `__init__.build_full_command()` | Assembles the provider-specific argv. |
 | `__init__.get_provider_display()` / `get_cli_binary_name()` | Display helpers. `get_provider_display()` returns `"<name>"` or `"<name> (<binary>)"` when `KOAN_CLAUDE_CLI_PATH` points at a different binary. Single source of truth for the provider line shown by the startup banner and `/status`. |
 | Provider resolution | Order: `KOAN_CLI_PROVIDER` env (fallback `CLI_PROVIDER`) → `projects.yaml`/`config.yaml` → default. Centralized in `utils.get_cli_provider_env()`. |
+| `ClaudeProvider.binary()` | Resolves `KOAN_CLAUDE_CLI_PATH`: absolute → as-is; relative → `normpath(join(KOAN_ROOT, …))`; bare name (no directory component) → PATH lookup; unset/empty → `"claude"`. Rooted at `KOAN_ROOT` (not CWD) because the agent runs from `KOAN_ROOT/koan`. |
 
 ## Invariants
 
@@ -38,6 +39,12 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
   lock lives under `koan_tmp_dir()` (per-uid), not a fixed `/tmp` path.
 - **Provider resolution has a fixed precedence** (env → config → default). New
   resolution inputs slot into that order; do not add parallel resolution paths.
+- **`KOAN_CLAUDE_CLI_PATH` relative paths root at `KOAN_ROOT`, not CWD.** The
+  agent runs from `KOAN_ROOT/koan` (the Makefile does `cd koan`), so a naive
+  relative path would resolve to the wrong place. Joining against `KOAN_ROOT`
+  in `binary()` is what makes the portable `.env` form work; a future
+  simplification that re-targets the join at CWD silently breaks every such
+  setup. Bare command names stay PATH lookups and are never re-rooted.
 - **Tool-name vocabularies differ per provider.** Copilot maps its own names; the
   abstraction must translate, not leak provider-specific tool names upward.
 - **Quota/usage extraction is provider-specific.** Claude exposes usage in


### PR DESCRIPTION
## What

`ClaudeProvider.binary()` now resolves a **relative** `KOAN_CLAUDE_CLI_PATH` against `KOAN_ROOT`, so `.env` config is portable across installs, copies, and machines — no more hard-coded absolute wrapper path:

```bash
# .env — works on any install, no /Users/... path
KOAN_CLAUDE_CLI_PATH=bin/zai-claude
```

Absolute paths pass through unchanged, and a bare command name (no directory component) still resolves via `PATH`, so all existing behavior is preserved.

## Why

Customers activating a wrapper (`bin/zai-claude`, `bin/oc-claude`, `bin/ollama-claude`) had to hard-code an absolute path that breaks the moment the checkout is moved or copied. This makes the config portable.

- The join is against `KOAN_ROOT` specifically because the Makefile runs `cd koan`, leaving the process CWD at `KOAN_ROOT/koan` — a naive relative path would resolve to the wrong place.
- The `${KOAN_ROOT}/bin/zai-claude` form was considered and **rejected**: Kōan's custom `load_dotenv()` (`utils.py`) does no `${VAR}` interpolation (`python-dotenv` is not a dependency), so the value would stay literal and the exec would fail. Resolution in `binary()` is the targeted, backward-compatible fix.

## Also addresses the review on #2223

- **`docs/providers/zai.md` — Concurrency section rewritten.** The shipped haiku default (`glm-4.5`) and mission default (`glm-5.2[1m]`) both sit at ~10 concurrent, so the prior narrative (haiku is the bottleneck at ~2, "raise headroom by setting `glm-4.5`") was stale and the advice was a no-op. Now documents the balanced defaults + single-threaded loop, with the genuinely useful "use text models, avoid `V` variants" guidance retained.
- **`bin/zai-claude` — drop empty model args.** A trailing/empty `--model` / `--fallback-model` is now dropped instead of forwarding an empty value (defensive; Koan always supplies a value).

## Tests

5 new cases in `koan/tests/test_cli_provider.py`:
- relative + `KOAN_ROOT` → joined absolute
- `./`-prefixed + trailing-slash `KOAN_ROOT` → normalized
- relative + `KOAN_ROOT` unset → raw passthrough (graceful fallback)
- bare command name → unchanged (PATH lookup, **not** re-rooted)
- resolved path propagates into `build_command` as `cmd[0]`

Existing `test_binary*` (absolute paths) and `test_status_skill.py` (`/status` still shows `claude (zai-claude)` for a relative path) pass unchanged.

## Verification

- `make lint` — clean
- `pytest koan/tests/test_cli_provider.py` — all pass
- `pytest koan/tests/test_status_skill.py` — 105 pass
- Direct `ClaudeProvider().binary()` smoke across all 5 resolution paths
- `bin/zai-claude` arg-translation probe: trailing `--model` / `--model=` / `--fallback-model` correctly dropped; normal tier mapping intact