### PR TITLE
perf(deep_research): cache open-issue and pr-feedback fetches

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -94,6 +94,8 @@ class DeepResearch:
         self.project_path = project_path
         self.memory_dir = instance_dir / "memory" / "projects" / project_name
         self._pending_prs: list[dict] | None = None
+        self._pr_feedback: dict | None = None
+        self._open_issues: dict[int, list[dict]] = {}
 
     def get_priorities(self) -> dict:
         """Parse priorities.md into structured data."""
@@ -147,7 +149,13 @@ class DeepResearch:
         }
 
     def get_open_issues(self, limit: int = 10) -> list[dict]:
-        """Fetch open GitHub issues for the project."""
+        """Fetch open GitHub issues for the project.
+
+        Results are cached per ``limit`` for the lifetime of this instance to
+        avoid redundant gh calls when suggest_topics and to_json both ask.
+        """
+        if limit in self._open_issues:
+            return self._open_issues[limit]
         try:
             from app.github import run_gh
             output = run_gh(
@@ -157,10 +165,11 @@ class DeepResearch:
                 "--json", "number,title,labels,createdAt",
                 cwd=self.project_path,
             )
-            return json.loads(output)
+            self._open_issues[limit] = json.loads(output)
         except Exception as e:
             print(f"[deep_research] Issue fetch failed: {e}", file=sys.stderr)
-            return []
+            self._open_issues[limit] = []
+        return self._open_issues[limit]
 
     def get_pending_prs(self) -> list[dict]:
         """Fetch open PRs that might need attention.
@@ -296,18 +305,25 @@ class DeepResearch:
             Dict with keys:
             - alignment_summary: str (formatted for prompt)
             - category_boosts: dict (category → priority adjustment)
+
+        Cached for the lifetime of this instance: get_alignment_summary and
+        get_category_boost both shell out (git + gh), and suggest_topics plus
+        format_for_agent/to_json each request the feedback once.
         """
+        if self._pr_feedback is not None:
+            return self._pr_feedback
         try:
             from app.pr_feedback import get_alignment_summary, get_category_boost
             summary = get_alignment_summary(str(self.project_path))
             boosts = get_category_boost(str(self.project_path))
-            return {
+            self._pr_feedback = {
                 "alignment_summary": summary,
                 "category_boosts": boosts,
             }
         except Exception as e:
             print(f"[deep_research] PR feedback failed: {e}", file=sys.stderr)
-            return {"alignment_summary": "", "category_boosts": {}}
+            self._pr_feedback = {"alignment_summary": "", "category_boosts": {}}
+        return self._pr_feedback
 
     def _match_topic_to_category(self, topic: str) -> str:
         """Best-effort match a topic string to a PR work category.

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -267,6 +267,39 @@ class TestGitHubIntegration:
             assert len(result) == 1
             assert result[0]["headRefName"] == "koan/fix-typo"
 
+    def test_get_open_issues_cached_per_limit(self, research_env):
+        """Repeated calls with the same limit hit gh once; a new limit refetches."""
+        with patch("app.github.run_gh", return_value="[]") as mock_gh:
+            research = DeepResearch(
+                research_env["instance"],
+                research_env["project_name"],
+                research_env["project_path"],
+            )
+
+            research.get_open_issues()
+            research.get_open_issues()
+            assert mock_gh.call_count == 1  # second call served from cache
+
+            research.get_open_issues(limit=3)
+            assert mock_gh.call_count == 2  # distinct limit refetches
+
+    def test_get_pr_feedback_cached(self, research_env):
+        """Repeated calls reuse the cached feedback instead of reshelling out."""
+        with patch("app.pr_feedback.get_alignment_summary", return_value="x") as mock_sum, \
+                patch("app.pr_feedback.get_category_boost", return_value={"fix": -1}) as mock_boost:
+            research = DeepResearch(
+                research_env["instance"],
+                research_env["project_name"],
+                research_env["project_path"],
+            )
+
+            first = research.get_pr_feedback()
+            second = research.get_pr_feedback()
+
+            assert first == second == {"alignment_summary": "x", "category_boosts": {"fix": -1}}
+            assert mock_sum.call_count == 1
+            assert mock_boost.call_count == 1
+
 
 class TestJournalAnalysis:
     """Tests for recent journal topic extraction."""


### PR DESCRIPTION
## What
Cache `get_open_issues` and `get_pr_feedback` in `DeepResearch` so each underlying fetch runs once per analysis run.

## Why
`get_pending_prs` was already memoized per-instance, but its two sibling fetchers were not. Both shell out — `get_open_issues` via `gh issue list`, `get_pr_feedback` via `pr_feedback` (git + `gh pr list --limit 1000`) — and each is invoked twice per run: once inside `suggest_topics()` and again in `format_for_agent()` / `to_json()`. On the autonomous DEEP-mode hot path that doubles the network/subprocess cost, and two independent `gh` snapshots could disagree mid-run, letting the topic ranking and the prompt's "In-Flight Work" list reason over different states.

## How
Extended the existing per-instance cache pattern (the one already used for `_pending_prs`):
- `get_open_issues` caches by `limit` in a dict, preserving the param contract (a distinct limit refetches).
- `get_pr_feedback` caches its single result.

No behavior change beyond fetch count and snapshot consistency.

## Testing
`make test` on `test_deep_research.py` (86 passed) + 2 new tests asserting the underlying fetch runs once across repeated calls and that a distinct issue `limit` refetches. `make lint` clean.
