### PR TITLE
docs: document /checkup skill in references

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -90,6 +90,7 @@ Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <com
 | `/ask <comment-url>` | `/question` | Ask a question about a PR/issue — posts AI reply to GitHub | Yes |
 | `/reviewrebase <PR>` | `/rr` | Review then rebase a PR (combo: /review → /rebase) | Yes |
 | `/planimplement <issue>` | `/planimp`, `/planimpl`, `/planit`, `/plandoit` | Plan then implement an issue (combo: /plan → /implement) | Yes |
+| `/checkup` | `/checkprs` | Health-check all open PRs across projects — auto-queues `/rebase` on conflicts, `/check` on CI failures | — |
 | `/branches [project]` | `/br`, `/prs` | List koan branches + open PRs with merge order | — |
 | `/orphans <project>` | `/orphan` | Recover orphan branches — rebase onto main + draft PR | — |
 | `/done [project]` | `/merged` | List PRs merged in the last 24 hours | — |

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -773,6 +773,17 @@ After completion, Kōan posts a structured comment on the PR with these sections
 - `/branches koan` — Show branches for a specific project
 </details>
 
+**`/checkup`** — Health-check every open PR you authored across all projects. For each PR with merge conflicts it queues a `/rebase`; for each with failing CI it queues a `/check`. Results are deduplicated against already-queued missions and skipped when a PR is unchanged since the last checkup.
+
+- **Usage:** `/checkup`
+- **Aliases:** `/checkprs`
+
+<details>
+<summary>Use cases</summary>
+
+- `/checkup` — Sweep all open PRs and auto-queue fixes for conflicts and CI failures
+</details>
+
 **`/orphans`** — Recover orphan branches by rebasing onto the default branch and creating draft PRs.
 
 - **Usage:** `/orphans <project_name>`
@@ -2242,6 +2253,7 @@ All commands at a glance. **Tier:** B = Beginner, I = Intermediate, P = Power Us
 | `/recreate <PR>` | `/rc` | I | Re-implement a PR from scratch |
 | `/pr <PR>` | — | I | Review and update a GitHub PR |
 | `/branches [project]` | `/br`, `/prs` | B | List koan branches + PRs with merge order |
+| `/checkup` | `/checkprs` | B | Health-check all open PRs — auto-queue /rebase + /check |
 | `/orphans <project>` | `/orphan` | B | Recover orphan branches — rebase + draft PR |
 | `/check <url>` | `/inspect` | I | Run project health checks on a PR/issue |
 | `/check_need <url>` | `/need`, `/needs` | I | Analyze if a PR/issue is still needed |


### PR DESCRIPTION
**What:** Document the `/checkup` core skill in the two canonical user references.

**Why:** `/checkup` (PR health check across all projects) shipped in `koan/skills/core/checkup/` but was missing from `docs/users/skills.md` and `docs/users/user-manual.md`. The CLAUDE.md convention requires every core skill to appear in both — an undocumented skill is invisible to users. The other 88 core skills are all present; this one slipped through.

**How:** Added `/checkup` to the PR Management table in `skills.md`, plus a body entry (next to `/branches`) and a quick-reference appendix row in the user manual. Wording derived from reading the handler + `pr_checkup.run_checkup`: scans the bot's open PRs, auto-queues `/rebase` on merge conflicts and `/check` on CI failures, with dedup and unchanged-PR skipping.

**Testing:** Docs-only, no code change. Verified `/checkup` now resolves in both files and the appendix; confirmed it was the only core skill absent from the references (the other two flagged by a name scan — `planimplement`, `reviewrebase` — were already present under their primary command names).
