### PR TITLE
fix(session_tracker): drift label uses calendar day, not elapsed hours

### DIFF
--- a/koan/app/session_tracker.py
+++ b/koan/app/session_tracker.py
@@ -734,7 +734,9 @@ def get_drift_summary(
     # Parse the timestamp for display
     try:
         dt = datetime.fromisoformat(ts)
-        days_ago = (datetime.now() - dt).days
+        # Calendar-day difference, not elapsed 24h periods: a session at
+        # 23:59 viewed at 00:30 next day is "yesterday", not "today".
+        days_ago = (datetime.now().date() - dt.date()).days
         if days_ago == 0:
             time_desc = "today"
         elif days_ago == 1:

--- a/koan/tests/test_session_tracker.py
+++ b/koan/tests/test_session_tracker.py
@@ -846,6 +846,30 @@ class TestGetDriftSummary:
         record_outcome(tracker_env, "koan", "deep", 10, "branch pushed")
         assert get_drift_summary(tracker_env, "koan", "") == ""
 
+    @patch("app.session_tracker.subprocess.run")
+    @patch("app.session_tracker._count_commits_since", return_value=5)
+    @patch("app.session_tracker.get_last_session_timestamp")
+    @patch("app.session_tracker.datetime")
+    def test_label_uses_calendar_day_not_elapsed_hours(
+        self, mock_dt, mock_ts, mock_count, mock_run, tracker_env
+    ):
+        """A session late on day N, viewed early on day N+1, is 'yesterday'.
+
+        The prior code used ``(now - dt).days`` which counts elapsed 24h
+        periods: a 31-minute gap across midnight yields 0 → mislabelled
+        'today'. The label tracks calendar dates, so it must read 'yesterday'.
+        """
+        from datetime import datetime as real_dt
+
+        mock_ts.return_value = "2026-06-28T23:59:30"
+        mock_dt.now.return_value = real_dt(2026, 6, 29, 0, 30, 0)
+        mock_dt.fromisoformat.side_effect = real_dt.fromisoformat
+        mock_run.return_value = type("R", (), {"returncode": 0, "stdout": ""})()
+
+        summary = get_drift_summary(tracker_env, "koan", "/path")
+        assert "yesterday" in summary
+        assert "today" not in summary
+
 
 # --- classify_mission_type ---
 


### PR DESCRIPTION
**What**: Fix the today/yesterday drift label in `get_drift_summary()` to track calendar days.

**Why**: The label used `(datetime.now() - dt).days`, which counts elapsed 24h periods, not calendar days. A session recorded at 23:59 and viewed at 00:30 the next morning is 31 minutes ago → `.days == 0` → the prompt says drift landed "today" when it was calendar-yesterday. This is the same assumption-coherent class as recent tz fixes: existing tests passed because none crossed a midnight boundary.

**How**: Compare `.date()` values instead of the raw timedelta. Single-line change; the comment explains the boundary case.

**Testing**: Added `test_label_uses_calendar_day_not_elapsed_hours` (committed first, failing against the old code) that freezes `now` to 00:30 with a 23:59 stored timestamp and asserts "yesterday". Full `test_session_tracker.py` (159 tests) green; `make lint` clean.
