### PR TITLE
fix(pr_review_learning): paginate review/comment fetches (#2185)

### DIFF
--- a/koan/app/pr_review_learning.py
+++ b/koan/app/pr_review_learning.py
@@ -147,9 +147,12 @@ def _fetch_gh_jsonl(
     """
     try:
         from app.github import run_gh
+        # --paginate follows GitHub's Link headers so PRs with >30 reviews or
+        # comments aren't silently truncated at the default page size. gh runs
+        # --jq per page, so the JSONL output concatenates cleanly across pages.
         raw = run_gh(
-            "api", endpoint, "--jq", jq_filter,
-            cwd=project_path, timeout=10,
+            "api", endpoint, "--paginate", "--jq", jq_filter,
+            cwd=project_path, timeout=30,
         )
         if not raw.strip():
             return []


### PR DESCRIPTION
## What
Add `--paginate` to the shared GitHub fetch helper in `pr_review_learning.py` so PR review data isn't capped at 30 items.

## Why
`_fetch_gh_jsonl()` called `gh api` without `--paginate`. GitHub's REST API returns at most 30 items per page by default, so on PRs with many reviews/comments the reviews, review comments, and issue comments were silently truncated. The PR-review learning pipeline then extracted lessons from an incomplete feedback set without any signal that data was missing. This is the pagination half of #2185.

## How
- One change in the shared helper fixes all three fetchers (reviews, review comments, issue comments).
- `gh` applies `--jq` per response page, so the JSONL output concatenates cleanly across pages — same pattern already used in `review_runner.py` and `rebase_pr.py`.
- Bumped the per-call timeout from 10s → 30s since multi-page fetches issue sequential requests.

## Testing
`make lint` clean; `test_pr_review_learning.py` + `test_pr_review.py` (176 tests) green.

No PoC test added: the truncation lives at the `gh` CLI boundary. Mocking `run_gh` can't reproduce real pagination — a unit test would only assert the flag is present, which is exactly the false-confidence trap of the assumption-coherent bug class. Verified by matching the established `--paginate`+`--jq` usage elsewhere.
