### PR TITLE
feat(memory): RSS watchdog with self-restart and tracemalloc diagnostics (#2232)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -38,6 +38,7 @@ memory, or integration changes:
 - [GitHub And Trackers](architecture/github-and-trackers.md)
 - [GitHub Webhooks](messaging/github-webhooks.md)
 - [PR Activity Reports](operations/pr-reports.md)
+- [Memory Watchdog](operations/memory-watchdog.md)
 - [Messaging Level (bridge verbosity)](messaging/messaging-level.md)
 - [Design Decisions](design/decisions.md)
 

--- a/docs/operations/memory-watchdog.md
+++ b/docs/operations/memory-watchdog.md
@@ -52,13 +52,27 @@ memory overhead — enable it only while investigating, then turn it off.
 ## Observability
 
 `GET /api/health` on the dashboard includes a `memory` block with current
-`rss_mb`, the configured `threshold_mb`, `watchdog_enabled`, and `source`.
+`rss_mb`, `threshold_mb`, `watchdog_enabled`, and `source`.
 The dashboard runs in its own process, so it resolves the agent loop's (`run`)
 PID and reports *that* process's RSS (`source: "agent_loop"`) — the watchdog's
 actual subject. If the run PID can't be resolved (agent loop not running) it
 falls back to the dashboard's own RSS (`source: "self"`).
 
+`watchdog_enabled`/`threshold_mb` reflect the *runtime* decision, not raw
+config. The agent loop writes its actual enabled/disabled state (and reason) to
+`instance/.memory-watchdog-status.json` at startup, and the health endpoint
+reads that. So a watchdog that config-enables but startup-disables itself
+(unreadable baseline, or `threshold_mb` ≤ baseline RSS) correctly reports
+`watchdog_enabled: false` — the dashboard never falsely advertises protection.
+Only when no runtime status file exists does it fall back to raw config.
+
 If reading the config fails, the block sets `config_error: true` and reports
 `watchdog_enabled`/`threshold_mb` as `null` rather than a plausible-looking
 disabled state — so consumers can tell a real failure from an intentional
-disable.
+disable. A read failure that takes down the whole snapshot returns the same
+`config_error: true` shape from the endpoint itself, not a bare `error` object.
+
+A mid-session RSS read failure (`read_rss_mb` returns `0.0`, meaning "unknown")
+does **not** reset the overage counter — treating unknown as below-threshold
+would silently disable protection. The counter is held and the failure is
+logged to stderr once.

--- a/docs/operations/memory-watchdog.md
+++ b/docs/operations/memory-watchdog.md
@@ -1,0 +1,46 @@
+# Memory watchdog (#2232)
+
+Kōan's RSS grows over multi-day runs. The watchdog samples RSS each loop
+iteration and, after a sustained overage, restarts the agent loop *between
+missions* to reclaim memory back to the ~400 MB baseline. Restarts use the
+existing `RESTART_EXIT_CODE` re-exec path, so no mission is ever interrupted.
+
+## Enable (config.yaml)
+
+```yaml
+memory_monitor:
+  enabled: true
+  threshold_mb: 1200          # restart when RSS stays at/above this
+  sustained_samples: 3        # consecutive over-threshold loop iterations required
+  min_runs_before_restart: 1  # don't restart before completing N runs this session
+  tracemalloc: false          # set true to diagnose the leak source
+```
+
+Defaults: disabled, `threshold_mb: 1200`, `sustained_samples: 3`,
+`min_runs_before_restart: 1`, `tracemalloc: false`.
+
+## How it works
+
+RSS is read from `/proc/self/status` (`VmRSS`, current RSS) with a
+`resource.getrusage` fallback — no new dependency. Sampling happens once per
+loop iteration, at the loop top, never mid-mission. After RSS stays at or above
+`threshold_mb` for `sustained_samples` consecutive iterations (and at least
+`min_runs_before_restart` runs have completed this session), the loop logs,
+journals, notifies via Telegram, and exits with `RESTART_EXIT_CODE` (`42`).
+
+## Diagnosing the leak
+
+With `tracemalloc: true`, each restart appends a record to
+`instance/.memory-restarts.jsonl` containing the top allocation sites:
+
+```bash
+jq '.top_allocations' instance/.memory-restarts.jsonl | tail
+```
+
+Recurring sites across restarts point at the leak. tracemalloc adds CPU and
+memory overhead — enable it only while investigating, then turn it off.
+
+## Observability
+
+`GET /api/health` on the dashboard includes a `memory` block with current
+`rss_mb`, the configured `threshold_mb`, and `watchdog_enabled`.

--- a/docs/operations/memory-watchdog.md
+++ b/docs/operations/memory-watchdog.md
@@ -19,6 +19,9 @@ memory_monitor:
 Defaults: disabled, `threshold_mb: 1200`, `sustained_samples: 3`,
 `min_runs_before_restart: 1`, `tracemalloc: false`.
 
+All knobs are read once at agent-loop startup and frozen for the session — a
+live config edit takes effect on the next restart, consistently for every knob.
+
 ## How it works
 
 RSS is read from `/proc/self/status` (`VmRSS`, current RSS) with a
@@ -43,4 +46,8 @@ memory overhead — enable it only while investigating, then turn it off.
 ## Observability
 
 `GET /api/health` on the dashboard includes a `memory` block with current
-`rss_mb`, the configured `threshold_mb`, and `watchdog_enabled`.
+`rss_mb`, the configured `threshold_mb`, `watchdog_enabled`, and `source`.
+The dashboard runs in its own process, so it resolves the agent loop's (`run`)
+PID and reports *that* process's RSS (`source: "agent_loop"`) — the watchdog's
+actual subject. If the run PID can't be resolved (agent loop not running) it
+falls back to the dashboard's own RSS (`source: "self"`).

--- a/docs/operations/memory-watchdog.md
+++ b/docs/operations/memory-watchdog.md
@@ -22,10 +22,16 @@ Defaults: disabled, `threshold_mb: 1200`, `sustained_samples: 3`,
 All knobs are read once at agent-loop startup and frozen for the session — a
 live config edit takes effect on the next restart, consistently for every knob.
 
+If `threshold_mb` is at or below the agent loop's baseline RSS at startup, the
+watchdog disables itself for the session (and logs why) instead of restart-looping
+forever. Raise `threshold_mb` above baseline to re-enable it.
+
 ## How it works
 
 RSS is read from `/proc/self/status` (`VmRSS`, current RSS) with a
-`resource.getrusage` fallback — no new dependency. Sampling happens once per
+`resource.getrusage` fallback — no new dependency. The fallback is peak (not
+current) RSS and its units are platform-dependent (KB on Linux, bytes on
+macOS/BSD), so it is scaled per-platform. Sampling happens once per
 loop iteration, at the loop top, never mid-mission. After RSS stays at or above
 `threshold_mb` for `sustained_samples` consecutive iterations (and at least
 `min_runs_before_restart` runs have completed this session), the loop logs,
@@ -51,3 +57,8 @@ The dashboard runs in its own process, so it resolves the agent loop's (`run`)
 PID and reports *that* process's RSS (`source: "agent_loop"`) — the watchdog's
 actual subject. If the run PID can't be resolved (agent loop not running) it
 falls back to the dashboard's own RSS (`source: "self"`).
+
+If reading the config fails, the block sets `config_error: true` and reports
+`watchdog_enabled`/`threshold_mb` as `null` rather than a plausible-looking
+disabled state — so consumers can tell a real failure from an intentional
+disable.

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -722,6 +722,15 @@ auto_update:
   check_interval: 10      # Check every N iterations (default: 10)
   notify: true            # Notify on Telegram before/after update (default: true)
 
+# Memory watchdog (#2232): restart the agent loop to reclaim RSS after a
+# sustained overage. Restarts happen only between missions. Disabled by default.
+memory_monitor:
+  enabled: false            # Master switch (default: false)
+  threshold_mb: 1200        # Restart when RSS stays at/above this (MB)
+  sustained_samples: 3      # Consecutive over-threshold loop iterations required
+  min_runs_before_restart: 1  # Don't restart before completing N runs this session
+  tracemalloc: false        # Opt-in: capture top allocation sites at restart (adds overhead)
+
 # CI check: master switch for the entire CI monitoring pipeline.
 # Controls queue draining, auto-dispatch of fix missions, CI enqueue
 # after rebase, and the /ci_check skill command. Disable to save tokens

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -534,6 +534,27 @@ def _safe_int(value, default: int) -> int:
         return default
 
 
+def get_memory_monitor_config() -> dict:
+    """Memory watchdog config (#2232). Disabled by default.
+
+    Uses the module-local _safe_int (defined above) to coerce string YAML
+    values; never raises on bad input.
+    """
+    config = _load_config()
+    section = config.get("memory_monitor", {})
+    if not isinstance(section, dict):
+        section = {}
+    return {
+        "enabled": bool(section.get("enabled", False)),
+        "threshold_mb": _safe_int(section.get("threshold_mb", 1200), 1200),
+        "sustained_samples": _safe_int(section.get("sustained_samples", 3), 3),
+        "tracemalloc": bool(section.get("tracemalloc", False)),
+        "min_runs_before_restart": _safe_int(
+            section.get("min_runs_before_restart", 1), 1
+        ),
+    }
+
+
 def get_start_on_pause() -> bool:
     """Check if start_on_pause is enabled in config.yaml.
 

--- a/koan/app/dashboard/core.py
+++ b/koan/app/dashboard/core.py
@@ -226,8 +226,13 @@ def api_health():
     run_health = _check_process_alive(state.KOAN_ROOT, "run")
     awake_health = _check_process_alive(state.KOAN_ROOT, "awake")
 
-    from app.memory_monitor import get_memory_status
-    memory = get_memory_status(state.KOAN_ROOT)
+    # Isolate the health endpoint from memory-status failures: a broken
+    # snapshot must not take down liveness reporting.
+    try:
+        from app.memory_monitor import get_memory_status
+        memory = get_memory_status(state.KOAN_ROOT)
+    except Exception as exc:  # pragma: no cover - defensive
+        memory = {"error": str(exc)}
 
     return jsonify({
         "disk": disk,

--- a/koan/app/dashboard/core.py
+++ b/koan/app/dashboard/core.py
@@ -232,7 +232,16 @@ def api_health():
         from app.memory_monitor import get_memory_status
         memory = get_memory_status(state.KOAN_ROOT)
     except Exception as exc:  # pragma: no cover - defensive
-        memory = {"error": str(exc)}
+        # Return a schema-consistent block, not a bare {"error": ...}: a missing
+        # watchdog_enabled reads as falsy and is indistinguishable from an
+        # intentionally-disabled watchdog. Flag the failure explicitly.
+        memory = {
+            "config_error": True,
+            "watchdog_enabled": None,
+            "threshold_mb": None,
+            "source": "unknown",
+            "error": str(exc),
+        }
 
     return jsonify({
         "disk": disk,

--- a/koan/app/dashboard/core.py
+++ b/koan/app/dashboard/core.py
@@ -227,7 +227,7 @@ def api_health():
     awake_health = _check_process_alive(state.KOAN_ROOT, "awake")
 
     from app.memory_monitor import get_memory_status
-    memory = get_memory_status()
+    memory = get_memory_status(state.KOAN_ROOT)
 
     return jsonify({
         "disk": disk,

--- a/koan/app/dashboard/core.py
+++ b/koan/app/dashboard/core.py
@@ -226,4 +226,12 @@ def api_health():
     run_health = _check_process_alive(state.KOAN_ROOT, "run")
     awake_health = _check_process_alive(state.KOAN_ROOT, "awake")
 
-    return jsonify({"disk": disk, "run": run_health, "awake": awake_health})
+    from app.memory_monitor import get_memory_status
+    memory = get_memory_status()
+
+    return jsonify({
+        "disk": disk,
+        "run": run_health,
+        "awake": awake_health,
+        "memory": memory,
+    })

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -14,9 +14,10 @@ def read_rss_mb(pid: int | None = None) -> float:
     """Resident set size in MB for a process (current process by default).
 
     Prefers /proc/<pid>/status VmRSS (current RSS, decreases when freed).
-    Falls back to resource.ru_maxrss (peak; KB on Linux) only for the current
-    process when /proc is unavailable (e.g. non-Linux). Returns 0.0 if neither
-    is readable.
+    Falls back to resource.ru_maxrss (peak, not current) only for the current
+    process when /proc is unavailable (e.g. non-Linux). ru_maxrss units are
+    platform-dependent: KB on Linux, bytes on macOS/BSD — scaled accordingly.
+    Returns 0.0 if neither source is readable.
     """
     target = "self" if pid is None else str(pid)
     try:
@@ -31,7 +32,11 @@ def read_rss_mb(pid: int | None = None) -> float:
         return 0.0
     try:
         import resource
-        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+        maxrss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # ru_maxrss is bytes on macOS/BSD, kilobytes on Linux.
+        if sys.platform == "darwin" or "bsd" in sys.platform:
+            return maxrss / (1024.0 * 1024.0)
+        return maxrss / 1024.0
     except Exception as exc:  # pragma: no cover - platform dependent
         print(f"[memory_monitor] read_rss_mb fallback failed: {exc}", file=sys.stderr)
         return 0.0
@@ -52,6 +57,7 @@ class MemoryMonitor:
         self.sustained_samples = max(1, int(sustained_samples))
         self.min_runs_before_restart = int(min_runs_before_restart)
         self.tracemalloc_enabled = bool(tracemalloc_enabled)
+        self.tracemalloc_error: str | None = None
         self._tracemalloc_frames = int(tracemalloc_frames)
         self._over_count = 0
         self._last_rss_mb = 0.0
@@ -64,6 +70,9 @@ class MemoryMonitor:
             if not tracemalloc.is_tracing():
                 tracemalloc.start(self._tracemalloc_frames)
         except Exception as exc:  # pragma: no cover - defensive
+            # Record the failure so callers can surface "diagnostics broken"
+            # distinctly from "diagnostics intentionally off".
+            self.tracemalloc_error = str(exc)
             print(f"[memory_monitor] tracemalloc start failed: {exc}", file=sys.stderr)
             self.tracemalloc_enabled = False
 
@@ -142,17 +151,23 @@ def get_memory_status(koan_root=None) -> dict:
         rss = read_rss_mb()
         source = "self"
 
+    config_error = False
     try:
         from app.config import get_memory_monitor_config
         conf = get_memory_monitor_config()
         threshold = conf.get("threshold_mb", 0)
-        enabled = conf.get("enabled", False)
+        enabled = bool(conf.get("enabled", False))
     except Exception as exc:  # pragma: no cover - defensive
         print(f"get_memory_status: config read failed: {exc}", file=sys.stderr)
-        threshold, enabled = 0, False
-    return {
+        # Don't fabricate a plausible "disabled" state; flag the failure so
+        # consumers can distinguish it from an intentionally-off watchdog.
+        threshold, enabled, config_error = None, None, True
+    status = {
         "rss_mb": round(rss, 1),
         "threshold_mb": threshold,
-        "watchdog_enabled": bool(enabled),
+        "watchdog_enabled": enabled,
         "source": source,
     }
+    if config_error:
+        status["config_error"] = True
+    return status

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -126,7 +126,8 @@ def get_memory_status(koan_root=None) -> dict:
         try:
             from app.utils import KOAN_ROOT
             koan_root = KOAN_ROOT
-        except Exception:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"get_memory_status: KOAN_ROOT import failed: {exc}", file=sys.stderr)
             koan_root = None
 
     run_pid = _read_run_pid(koan_root) if koan_root is not None else None

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -27,7 +27,8 @@ def read_rss_mb() -> float:
     try:
         import resource
         return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
-    except Exception:  # pragma: no cover - platform dependent
+    except Exception as exc:  # pragma: no cover - platform dependent
+        print(f"[memory_monitor] read_rss_mb fallback failed: {exc}", file=sys.stderr)
         return 0.0
 
 
@@ -55,7 +56,8 @@ class MemoryMonitor:
             import tracemalloc
             if not tracemalloc.is_tracing():
                 tracemalloc.start(self._tracemalloc_frames)
-        except Exception:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"[memory_monitor] tracemalloc start failed: {exc}", file=sys.stderr)
             self.tracemalloc_enabled = False
 
     @property
@@ -89,7 +91,8 @@ class MemoryMonitor:
                 f"{s.traceback[0]}: {s.size / 1024 / 1024:.1f} MiB ({s.count} blocks)"
                 for s in stats
             ]
-        except Exception:  # pragma: no cover - defensive
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"[memory_monitor] top_allocations failed: {exc}", file=sys.stderr)
             return []
 
 

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -10,20 +10,25 @@ from __future__ import annotations
 import sys
 
 
-def read_rss_mb() -> float:
-    """Current resident set size in MB.
+def read_rss_mb(pid: int | None = None) -> float:
+    """Resident set size in MB for a process (current process by default).
 
-    Prefers /proc/self/status VmRSS (current RSS, decreases when freed).
-    Falls back to resource.ru_maxrss (peak; KB on Linux) when /proc is
-    unavailable (e.g. non-Linux). Returns 0.0 if neither is readable.
+    Prefers /proc/<pid>/status VmRSS (current RSS, decreases when freed).
+    Falls back to resource.ru_maxrss (peak; KB on Linux) only for the current
+    process when /proc is unavailable (e.g. non-Linux). Returns 0.0 if neither
+    is readable.
     """
+    target = "self" if pid is None else str(pid)
     try:
-        with open("/proc/self/status", "r", encoding="utf-8") as f:
+        with open(f"/proc/{target}/status", "r", encoding="utf-8") as f:
             for line in f:
                 if line.startswith("VmRSS:"):
                     return int(line.split()[1]) / 1024.0
     except (OSError, ValueError, IndexError):
         pass
+    if pid is not None:
+        # Cannot use ru_maxrss for another process; report unknown.
+        return 0.0
     try:
         import resource
         return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
@@ -41,9 +46,11 @@ class MemoryMonitor:
         sustained_samples: int,
         tracemalloc_enabled: bool = False,
         tracemalloc_frames: int = 10,
+        min_runs_before_restart: int = 1,
     ) -> None:
         self.threshold_mb = int(threshold_mb)
         self.sustained_samples = max(1, int(sustained_samples))
+        self.min_runs_before_restart = int(min_runs_before_restart)
         self.tracemalloc_enabled = bool(tracemalloc_enabled)
         self._tracemalloc_frames = int(tracemalloc_frames)
         self._over_count = 0
@@ -96,9 +103,44 @@ class MemoryMonitor:
             return []
 
 
-def get_memory_status() -> dict:
-    """Lightweight memory snapshot for observability endpoints."""
-    rss = read_rss_mb()
+def _read_run_pid(koan_root) -> int | None:
+    """Resolve the agent-loop ('run') process PID from its pid file."""
+    try:
+        from app.signals import pid_file
+        from pathlib import Path
+        pid_path = Path(koan_root) / pid_file("run")
+        return int(pid_path.read_text().strip())
+    except (OSError, ValueError, ImportError):
+        return None
+
+
+def get_memory_status(koan_root=None) -> dict:
+    """Lightweight memory snapshot for observability endpoints.
+
+    Reports the *agent loop's* RSS (the watchdog's subject), not the caller's.
+    The dashboard runs in a separate process, so it resolves the 'run' PID and
+    reads that process's RSS. Falls back to the current process only when the
+    run PID cannot be resolved (e.g. agent loop not running).
+    """
+    if koan_root is None:
+        try:
+            from app.utils import KOAN_ROOT
+            koan_root = KOAN_ROOT
+        except Exception:  # pragma: no cover - defensive
+            koan_root = None
+
+    run_pid = _read_run_pid(koan_root) if koan_root is not None else None
+    if run_pid is not None:
+        rss = read_rss_mb(run_pid)
+        source = "agent_loop"
+        if rss <= 0:
+            # PID stale or /proc unreadable; fall back to this process.
+            rss = read_rss_mb()
+            source = "self"
+    else:
+        rss = read_rss_mb()
+        source = "self"
+
     try:
         from app.config import get_memory_monitor_config
         conf = get_memory_monitor_config()
@@ -111,4 +153,5 @@ def get_memory_status() -> dict:
         "rss_mb": round(rss, 1),
         "threshold_mb": threshold,
         "watchdog_enabled": bool(enabled),
+        "source": source,
     }

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -1,0 +1,111 @@
+"""Process memory watchdog (#2232).
+
+Samples current RSS each agent-loop iteration. After RSS stays above a
+configurable threshold for N consecutive samples, the caller restarts the
+process (via RESTART_EXIT_CODE re-exec) to reclaim memory back to baseline.
+Optional tracemalloc mode captures top allocation sites for diagnosis.
+"""
+from __future__ import annotations
+
+import sys
+
+
+def read_rss_mb() -> float:
+    """Current resident set size in MB.
+
+    Prefers /proc/self/status VmRSS (current RSS, decreases when freed).
+    Falls back to resource.ru_maxrss (peak; KB on Linux) when /proc is
+    unavailable (e.g. non-Linux). Returns 0.0 if neither is readable.
+    """
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as f:
+            for line in f:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) / 1024.0
+    except (OSError, ValueError, IndexError):
+        pass
+    try:
+        import resource
+        return resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024.0
+    except Exception:  # pragma: no cover - platform dependent
+        return 0.0
+
+
+class MemoryMonitor:
+    """Tracks RSS overage and signals when a restart is warranted."""
+
+    def __init__(
+        self,
+        threshold_mb: int,
+        sustained_samples: int,
+        tracemalloc_enabled: bool = False,
+        tracemalloc_frames: int = 10,
+    ) -> None:
+        self.threshold_mb = int(threshold_mb)
+        self.sustained_samples = max(1, int(sustained_samples))
+        self.tracemalloc_enabled = bool(tracemalloc_enabled)
+        self._tracemalloc_frames = int(tracemalloc_frames)
+        self._over_count = 0
+        self._last_rss_mb = 0.0
+        if self.tracemalloc_enabled:
+            self._start_tracemalloc()
+
+    def _start_tracemalloc(self) -> None:
+        try:
+            import tracemalloc
+            if not tracemalloc.is_tracing():
+                tracemalloc.start(self._tracemalloc_frames)
+        except Exception:  # pragma: no cover - defensive
+            self.tracemalloc_enabled = False
+
+    @property
+    def last_rss_mb(self) -> float:
+        return self._last_rss_mb
+
+    def reset(self) -> None:
+        self._over_count = 0
+
+    def sample(self) -> bool:
+        """Record current RSS; return True if a restart is warranted."""
+        rss = read_rss_mb()
+        self._last_rss_mb = rss
+        if self.threshold_mb > 0 and rss >= self.threshold_mb:
+            self._over_count += 1
+        else:
+            self._over_count = 0
+        return self._over_count >= self.sustained_samples
+
+    def top_allocations(self, limit: int = 10) -> list[str]:
+        """Human-readable top allocation sites (empty unless tracemalloc on)."""
+        if not self.tracemalloc_enabled:
+            return []
+        try:
+            import tracemalloc
+            if not tracemalloc.is_tracing():
+                return []
+            snapshot = tracemalloc.take_snapshot()
+            stats = snapshot.statistics("lineno")[: max(1, limit)]
+            return [
+                f"{s.traceback[0]}: {s.size / 1024 / 1024:.1f} MiB ({s.count} blocks)"
+                for s in stats
+            ]
+        except Exception:  # pragma: no cover - defensive
+            return []
+
+
+def get_memory_status() -> dict:
+    """Lightweight memory snapshot for observability endpoints."""
+    rss = read_rss_mb()
+    try:
+        from app.config import get_memory_monitor_config
+        conf = get_memory_monitor_config()
+        threshold = conf.get("threshold_mb", 0)
+        enabled = conf.get("enabled", False)
+    except Exception as exc:  # pragma: no cover - defensive
+        print(f"get_memory_status: config read failed: {exc}", file=sys.stderr)
+        threshold, enabled = 0, False
+    return {
+        "rss_mb": round(rss, 1),
+        "threshold_mb": threshold,
+        "watchdog_enabled": bool(enabled),
+    }

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -17,7 +17,8 @@ def read_rss_mb(pid: int | None = None) -> float:
     Falls back to resource.ru_maxrss (peak, not current) only for the current
     process when /proc is unavailable (e.g. non-Linux). ru_maxrss units are
     platform-dependent: KB on Linux, bytes on macOS/BSD — scaled accordingly.
-    Returns 0.0 if neither source is readable.
+    Returns 0.0 if neither source is readable (treat 0.0 as "unknown", not
+    "this process uses no memory" — a real RSS is always positive).
     """
     target = "self" if pid is None else str(pid)
     try:
@@ -25,8 +26,15 @@ def read_rss_mb(pid: int | None = None) -> float:
             for line in f:
                 if line.startswith("VmRSS:"):
                     return int(line.split()[1]) / 1024.0
-    except (OSError, ValueError, IndexError):
-        pass
+    except (OSError, ValueError, IndexError) as exc:
+        if pid is not None:
+            # Surface why a foreign-process read failed so a stale/unreadable
+            # PID is diagnosable instead of silently degrading to self RSS.
+            print(
+                f"[memory_monitor] read_rss_mb: /proc/{target}/status "
+                f"unreadable: {exc}",
+                file=sys.stderr,
+            )
     if pid is not None:
         # Cannot use ru_maxrss for another process; report unknown.
         return 0.0
@@ -119,7 +127,14 @@ def _read_run_pid(koan_root) -> int | None:
         from pathlib import Path
         pid_path = Path(koan_root) / pid_file("run")
         return int(pid_path.read_text().strip())
-    except (OSError, ValueError, ImportError):
+    except ImportError as exc:
+        # app.signals is a required module; a broken import is a real fault,
+        # not the routine "run isn't active" case — surface it.
+        print(f"[memory_monitor] _read_run_pid: app.signals import failed: {exc}",
+              file=sys.stderr)
+        return None
+    except (OSError, ValueError):
+        # pid file missing/empty/stale — expected when the agent loop is down.
         return None
 
 

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -7,7 +7,11 @@ Optional tracemalloc mode captures top allocation sites for diagnosis.
 """
 from __future__ import annotations
 
+import json
 import sys
+from pathlib import Path
+
+_STATUS_FILENAME = ".memory-watchdog-status.json"
 
 
 def read_rss_mb(pid: int | None = None) -> float:
@@ -69,6 +73,7 @@ class MemoryMonitor:
         self._tracemalloc_frames = int(tracemalloc_frames)
         self._over_count = 0
         self._last_rss_mb = 0.0
+        self._rss_read_failed = False
         if self.tracemalloc_enabled:
             self._start_tracemalloc()
 
@@ -95,6 +100,21 @@ class MemoryMonitor:
         """Record current RSS; return True if a restart is warranted."""
         rss = read_rss_mb()
         self._last_rss_mb = rss
+        if rss <= 0:
+            # 0.0 means "unknown" (read failed), not "no memory". Treating it as
+            # below-threshold would silently reset _over_count and render the
+            # watchdog inert. Leave the counter unchanged and log once so a
+            # mid-session RSS-read failure degrades loudly instead of disabling
+            # protection.
+            if not self._rss_read_failed:
+                print(
+                    "[memory_monitor] sample: RSS read returned 0.0 (unknown); "
+                    "leaving overage counter unchanged",
+                    file=sys.stderr,
+                )
+                self._rss_read_failed = True
+            return self._over_count >= self.sustained_samples
+        self._rss_read_failed = False
         if self.threshold_mb > 0 and rss >= self.threshold_mb:
             self._over_count += 1
         else:
@@ -118,6 +138,44 @@ class MemoryMonitor:
         except Exception as exc:  # pragma: no cover - defensive
             print(f"[memory_monitor] top_allocations failed: {exc}", file=sys.stderr)
             return []
+
+
+def _status_path(koan_root) -> Path:
+    return Path(koan_root, "instance", _STATUS_FILENAME)
+
+
+def write_watchdog_status(koan_root, *, enabled, threshold_mb, reason="") -> None:
+    """Persist the agent loop's *runtime* watchdog decision (#2232).
+
+    _build_memory_monitor may disable the watchdog at startup (unreadable
+    baseline, or threshold <= baseline) even when config says enabled. Writing
+    the actual decision here lets observability report runtime state instead of
+    raw config, so the dashboard can't falsely advertise protection.
+    """
+    try:
+        path = _status_path(koan_root)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(
+            json.dumps(
+                {
+                    "enabled": bool(enabled),
+                    "threshold_mb": threshold_mb,
+                    "reason": reason,
+                }
+            ),
+            encoding="utf-8",
+        )
+    except OSError as exc:  # pragma: no cover - defensive
+        print(f"[memory_monitor] write_watchdog_status failed: {exc}", file=sys.stderr)
+
+
+def read_watchdog_status(koan_root) -> dict | None:
+    """Read the persisted runtime watchdog decision, or None if unavailable."""
+    try:
+        data = json.loads(_status_path(koan_root).read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else None
+    except (OSError, ValueError):
+        return None
 
 
 def _read_run_pid(koan_root) -> int | None:
@@ -167,16 +225,24 @@ def get_memory_status(koan_root=None) -> dict:
         source = "self"
 
     config_error = False
-    try:
-        from app.config import get_memory_monitor_config
-        conf = get_memory_monitor_config()
-        threshold = conf.get("threshold_mb", 0)
-        enabled = bool(conf.get("enabled", False))
-    except Exception as exc:  # pragma: no cover - defensive
-        print(f"get_memory_status: config read failed: {exc}", file=sys.stderr)
-        # Don't fabricate a plausible "disabled" state; flag the failure so
-        # consumers can distinguish it from an intentionally-off watchdog.
-        threshold, enabled, config_error = None, None, True
+    # Prefer the agent loop's persisted runtime decision over raw config: the
+    # watchdog can be disabled at startup even when config says enabled, and the
+    # dashboard must reflect what the loop is actually doing.
+    runtime = read_watchdog_status(koan_root) if koan_root is not None else None
+    if runtime is not None:
+        threshold = runtime.get("threshold_mb")
+        enabled = bool(runtime.get("enabled", False))
+    else:
+        try:
+            from app.config import get_memory_monitor_config
+            conf = get_memory_monitor_config()
+            threshold = conf.get("threshold_mb", 0)
+            enabled = bool(conf.get("enabled", False))
+        except Exception as exc:  # pragma: no cover - defensive
+            print(f"get_memory_status: config read failed: {exc}", file=sys.stderr)
+            # Don't fabricate a plausible "disabled" state; flag the failure so
+            # consumers can distinguish it from an intentionally-off watchdog.
+            threshold, enabled, config_error = None, None, True
     status = {
         "rss_mb": round(rss, 1),
         "threshold_mb": threshold,

--- a/koan/app/memory_monitor.py
+++ b/koan/app/memory_monitor.py
@@ -39,6 +39,18 @@ def read_rss_mb(pid: int | None = None) -> float:
                 f"unreadable: {exc}",
                 file=sys.stderr,
             )
+        elif Path("/proc").exists():
+            # Log the self-read failure before falling back to ru_maxrss:
+            # that fallback silently switches from current RSS to *peak* RSS
+            # (a monotonically non-decreasing metric), so make the switch
+            # observable instead of degrading the watchdog without a trace.
+            # Gated on /proc existing so non-Linux (where absence is the
+            # documented normal fallback path) doesn't spam stderr each sample.
+            print(
+                f"[memory_monitor] read_rss_mb: /proc/self/status unreadable "
+                f"({exc}); falling back to ru_maxrss (peak, not current RSS)",
+                file=sys.stderr,
+            )
     if pid is not None:
         # Cannot use ru_maxrss for another process; report unknown.
         return 0.0

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -871,9 +871,19 @@ def _build_memory_monitor():
     conf = get_memory_monitor_config()
     if not conf.get("enabled"):
         return None
-    from app.memory_monitor import MemoryMonitor
+    from app.memory_monitor import MemoryMonitor, read_rss_mb
+    threshold_mb = conf["threshold_mb"]
+    # Misconfiguration guard: a threshold at or below the current baseline RSS
+    # would trip every session and restart-loop forever. Disable instead.
+    baseline = read_rss_mb()
+    if threshold_mb <= 0 or (baseline > 0 and threshold_mb <= baseline):
+        log("koan",
+            f"Memory watchdog disabled: threshold {threshold_mb} MB ≤ baseline "
+            f"RSS {baseline:.0f} MB would restart-loop. Raise "
+            "memory_monitor.threshold_mb above baseline.")
+        return None
     return MemoryMonitor(
-        threshold_mb=conf["threshold_mb"],
+        threshold_mb=threshold_mb,
         sustained_samples=conf["sustained_samples"],
         tracemalloc_enabled=conf.get("tracemalloc", False),
         min_runs_before_restart=conf.get("min_runs_before_restart", 1),
@@ -906,7 +916,12 @@ def _handle_memory_restart(koan_root, instance, monitor, count):
     top = monitor.top_allocations(limit=10) if monitor.tracemalloc_enabled else []
     _write_memory_restart_journal(koan_root, rss, monitor.threshold_mb, count, top)
     with suppress_logged(log, "warning", "Memory-restart notify failed", Exception):
-        detail = "\n".join(top[:5]) if top else "(tracemalloc disabled)"
+        if top:
+            detail = "\n".join(top[:5])
+        elif monitor.tracemalloc_error:
+            detail = f"(tracemalloc failed to start: {monitor.tracemalloc_error})"
+        else:
+            detail = "(tracemalloc disabled)"
         _notify(
             instance,
             f"♻️ Restarting to reclaim memory: RSS {rss:.0f} MB ≥ "

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -876,6 +876,7 @@ def _build_memory_monitor():
         threshold_mb=conf["threshold_mb"],
         sustained_samples=conf["sustained_samples"],
         tracemalloc_enabled=conf.get("tracemalloc", False),
+        min_runs_before_restart=conf.get("min_runs_before_restart", 1),
     )
 
 
@@ -1219,10 +1220,14 @@ def main_loop():
                 sys.exit(RESTART_EXIT_CODE)
 
             # --- Memory watchdog (#2232) ---
+            # All knobs are frozen at startup in _build_memory_monitor() — a
+            # live config edit takes effect on the next restart, consistently
+            # for every knob (no per-iteration YAML re-read).
             if memory_monitor is not None:
-                from app.config import get_memory_monitor_config
-                min_runs = get_memory_monitor_config().get("min_runs_before_restart", 1)
-                if memory_monitor.sample() and count >= min_runs:
+                if (
+                    memory_monitor.sample()
+                    and count >= memory_monitor.min_runs_before_restart
+                ):
                     _handle_memory_restart(koan_root, instance, memory_monitor, count)
 
             # --- Pause mode ---

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -873,10 +873,18 @@ def _build_memory_monitor():
         return None
     from app.memory_monitor import MemoryMonitor, read_rss_mb
     threshold_mb = conf["threshold_mb"]
+    # read_rss_mb() returns 0.0 on read failure (a real RSS is always positive).
+    # Without a readable baseline we can't tell a safe threshold from a
+    # restart-looping one, so disable rather than create an unverifiable monitor.
+    baseline = read_rss_mb()
+    if baseline <= 0:
+        log("koan",
+            "Memory watchdog disabled: baseline RSS unreadable, cannot verify "
+            "threshold is above baseline. Watchdog stays off this session.")
+        return None
     # Misconfiguration guard: a threshold at or below the current baseline RSS
     # would trip every session and restart-loop forever. Disable instead.
-    baseline = read_rss_mb()
-    if threshold_mb <= 0 or (baseline > 0 and threshold_mb <= baseline):
+    if threshold_mb <= 0 or threshold_mb <= baseline:
         log("koan",
             f"Memory watchdog disabled: threshold {threshold_mb} MB ≤ baseline "
             f"RSS {baseline:.0f} MB would restart-loop. Raise "

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -865,11 +865,25 @@ def _commit_instance(instance: str, message: str = ""):
 # Update handler (graceful update + restart)
 # ---------------------------------------------------------------------------
 
-def _build_memory_monitor():
-    """Construct a MemoryMonitor from config, or None when disabled (#2232)."""
+def _build_memory_monitor(koan_root=None):
+    """Construct a MemoryMonitor from config, or None when disabled (#2232).
+
+    Persists the runtime enabled/disabled decision (and reason) via
+    write_watchdog_status when koan_root is given, so observability reports what
+    the loop is actually doing rather than raw config.
+    """
     from app.config import get_memory_monitor_config
+    from app.memory_monitor import write_watchdog_status
     conf = get_memory_monitor_config()
+
+    def _record(enabled, threshold_mb, reason):
+        if koan_root is not None:
+            write_watchdog_status(
+                koan_root, enabled=enabled, threshold_mb=threshold_mb, reason=reason,
+            )
+
     if not conf.get("enabled"):
+        _record(False, conf.get("threshold_mb"), "disabled in config")
         return None
     from app.memory_monitor import MemoryMonitor, read_rss_mb
     threshold_mb = conf["threshold_mb"]
@@ -881,6 +895,7 @@ def _build_memory_monitor():
         log("koan",
             "Memory watchdog disabled: baseline RSS unreadable, cannot verify "
             "threshold is above baseline. Watchdog stays off this session.")
+        _record(False, threshold_mb, "baseline RSS unreadable")
         return None
     # Misconfiguration guard: a threshold at or below the current baseline RSS
     # would trip every session and restart-loop forever. Disable instead.
@@ -889,7 +904,9 @@ def _build_memory_monitor():
             f"Memory watchdog disabled: threshold {threshold_mb} MB ≤ baseline "
             f"RSS {baseline:.0f} MB would restart-loop. Raise "
             "memory_monitor.threshold_mb above baseline.")
+        _record(False, threshold_mb, "threshold <= baseline RSS")
         return None
+    _record(True, threshold_mb, "")
     return MemoryMonitor(
         threshold_mb=threshold_mb,
         sustained_samples=conf["sustained_samples"],
@@ -1200,7 +1217,7 @@ def main_loop():
         # racing with the Telegram bridge processing of /pause.
         _startup_delay(koan_root)
 
-        memory_monitor = _build_memory_monitor()
+        memory_monitor = _build_memory_monitor(koan_root)
 
         while True:
             # --- Stop check ---

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -865,6 +865,56 @@ def _commit_instance(instance: str, message: str = ""):
 # Update handler (graceful update + restart)
 # ---------------------------------------------------------------------------
 
+def _build_memory_monitor():
+    """Construct a MemoryMonitor from config, or None when disabled (#2232)."""
+    from app.config import get_memory_monitor_config
+    conf = get_memory_monitor_config()
+    if not conf.get("enabled"):
+        return None
+    from app.memory_monitor import MemoryMonitor
+    return MemoryMonitor(
+        threshold_mb=conf["threshold_mb"],
+        sustained_samples=conf["sustained_samples"],
+        tracemalloc_enabled=conf.get("tracemalloc", False),
+    )
+
+
+def _write_memory_restart_journal(koan_root, rss_mb, threshold_mb, count, top_allocations):
+    """Append a memory-restart record for post-hoc leak analysis."""
+    from datetime import datetime, timezone
+    record = {
+        "ts": datetime.now(timezone.utc).isoformat(),
+        "event": "memory_restart",
+        "rss_mb": round(rss_mb, 1),
+        "threshold_mb": threshold_mb,
+        "runs": count,
+        "top_allocations": top_allocations,
+    }
+    path = Path(koan_root, "instance", ".memory-restarts.jsonl")
+    with suppress_logged(log, "warning", "Memory-restart journal write failed", OSError):
+        with open(path, "a", encoding="utf-8") as f:
+            f.write(json.dumps(record) + "\n")
+
+
+def _handle_memory_restart(koan_root, instance, monitor, count):
+    """Log, journal, notify, and exit with RESTART_EXIT_CODE to reclaim RSS."""
+    rss = monitor.last_rss_mb
+    log("koan",
+        f"Memory threshold exceeded: {rss:.0f} MB ≥ {monitor.threshold_mb} MB "
+        f"after {count} runs — restarting to reclaim.")
+    top = monitor.top_allocations(limit=10) if monitor.tracemalloc_enabled else []
+    _write_memory_restart_journal(koan_root, rss, monitor.threshold_mb, count, top)
+    with suppress_logged(log, "warning", "Memory-restart notify failed", Exception):
+        detail = "\n".join(top[:5]) if top else "(tracemalloc disabled)"
+        _notify(
+            instance,
+            f"♻️ Restarting to reclaim memory: RSS {rss:.0f} MB ≥ "
+            f"{monitor.threshold_mb} MB after {count} runs.\n"
+            f"Top allocations:\n{detail}",
+        )
+    sys.exit(RESTART_EXIT_CODE)
+
+
 def _handle_update(koan_root: str, instance: str, count: int) -> bool:
     """Handle /update: pull upstream updates, then trigger restart.
 
@@ -1126,6 +1176,8 @@ def main_loop():
         # racing with the Telegram bridge processing of /pause.
         _startup_delay(koan_root)
 
+        memory_monitor = _build_memory_monitor()
+
         while True:
             # --- Stop check ---
             stop_file = Path(koan_root, STOP_FILE)
@@ -1165,6 +1217,13 @@ def main_loop():
                 log("koan", "Restart requested. Exiting for re-launch...")
                 clear_restart(koan_root, target="run")
                 sys.exit(RESTART_EXIT_CODE)
+
+            # --- Memory watchdog (#2232) ---
+            if memory_monitor is not None:
+                from app.config import get_memory_monitor_config
+                min_runs = get_memory_monitor_config().get("min_runs_before_restart", 1)
+                if memory_monitor.sample() and count >= min_runs:
+                    _handle_memory_restart(koan_root, instance, memory_monitor, count)
 
             # --- Pause mode ---
             if Path(koan_root, PAUSE_FILE).exists():

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -1872,3 +1872,41 @@ class TestReviewInlineCommentsConfig:
         with _mock_config({"review_inline_comments": {"enabled": True, "max_comments": -3}}):
             cfg = get_review_inline_comments_config()
         assert cfg["max_comments"] == 25
+
+
+class TestMemoryMonitorConfig:
+    def test_defaults(self):
+        from app.config import get_memory_monitor_config
+        with _mock_config({}):
+            conf = get_memory_monitor_config()
+        assert conf["enabled"] is False
+        assert conf["threshold_mb"] == 1200
+        assert conf["sustained_samples"] == 3
+        assert conf["tracemalloc"] is False
+        assert conf["min_runs_before_restart"] == 1
+
+    def test_overrides(self):
+        from app.config import get_memory_monitor_config
+        raw = {
+            "memory_monitor": {
+                "enabled": True,
+                "threshold_mb": "900",
+                "sustained_samples": "5",
+                "tracemalloc": True,
+                "min_runs_before_restart": "2",
+            }
+        }
+        with _mock_config(raw):
+            conf = get_memory_monitor_config()
+        assert conf["enabled"] is True
+        assert conf["threshold_mb"] == 900
+        assert conf["sustained_samples"] == 5
+        assert conf["tracemalloc"] is True
+        assert conf["min_runs_before_restart"] == 2
+
+    def test_malformed_section_disabled(self):
+        from app.config import get_memory_monitor_config
+        with _mock_config({"memory_monitor": "nonsense"}):
+            conf = get_memory_monitor_config()
+        assert conf["enabled"] is False
+        assert conf["threshold_mb"] == 1200

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -1,6 +1,7 @@
 """Tests for koan/dashboard.py"""
 
 import json
+import os
 import shutil
 import subprocess
 
@@ -1871,6 +1872,16 @@ class TestApiHealth:
         assert "rss_mb" in data["memory"]
         assert data["memory"]["rss_mb"] > 0
         assert "watchdog_enabled" in data["memory"]
+
+    def test_api_health_memory_resolves_run_pid(self, app_client, tmp_path):
+        """With a valid run PID file, memory reports the agent loop's RSS."""
+        (tmp_path / ".koan-pid-run").write_text(str(os.getpid()))
+        with patch.object(dashboard.state, "KOAN_ROOT", tmp_path):
+            resp = app_client.get("/api/health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["memory"]["source"] == "agent_loop"
+        assert data["memory"]["rss_mb"] > 0
 
     def test_api_health_no_pids(self, app_client, tmp_path):
         """With no PID files, run.alive and awake.alive are False."""

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -1873,6 +1873,10 @@ class TestApiHealth:
         assert data["memory"]["rss_mb"] > 0
         assert "watchdog_enabled" in data["memory"]
 
+    @pytest.mark.skipif(
+        not Path("/proc/self/status").exists(),
+        reason="foreign-PID RSS resolution needs /proc (Linux-only)",
+    )
     def test_api_health_memory_resolves_run_pid(self, app_client, tmp_path):
         """With a valid run PID file, memory reports the agent loop's RSS."""
         (tmp_path / ".koan-pid-run").write_text(str(os.getpid()))

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -1861,6 +1861,17 @@ class TestApiHealth:
         assert "run" in data
         assert "awake" in data
 
+    def test_api_health_includes_memory(self, app_client, tmp_path):
+        """Response includes a memory block with current RSS."""
+        with patch.object(dashboard.state, "KOAN_ROOT", tmp_path):
+            resp = app_client.get("/api/health")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert "memory" in data
+        assert "rss_mb" in data["memory"]
+        assert data["memory"]["rss_mb"] > 0
+        assert "watchdog_enabled" in data["memory"]
+
     def test_api_health_no_pids(self, app_client, tmp_path):
         """With no PID files, run.alive and awake.alive are False."""
         with patch.object(dashboard.state, "KOAN_ROOT", tmp_path):

--- a/koan/tests/test_memory_monitor.py
+++ b/koan/tests/test_memory_monitor.py
@@ -1,0 +1,54 @@
+from app.memory_monitor import MemoryMonitor, read_rss_mb, get_memory_status
+
+
+def test_read_rss_mb_positive():
+    assert read_rss_mb() > 0  # this process has a real RSS
+
+
+def test_sample_triggers_after_sustained_overage():
+    m = MemoryMonitor(threshold_mb=1, sustained_samples=3)
+    # threshold 1 MB is always exceeded by the test process
+    assert m.sample() is False  # 1/3
+    assert m.sample() is False  # 2/3
+    assert m.sample() is True   # 3/3 -> restart signal
+    assert m.last_rss_mb > 0
+
+
+def test_counter_resets_when_below_threshold():
+    m = MemoryMonitor(threshold_mb=10**9, sustained_samples=2)
+    assert m.sample() is False  # never over a 1 PB threshold
+    assert m._over_count == 0
+
+
+def test_zero_threshold_never_triggers():
+    m = MemoryMonitor(threshold_mb=0, sustained_samples=1)
+    assert m.sample() is False
+
+
+def test_top_allocations_empty_when_disabled():
+    m = MemoryMonitor(threshold_mb=1, sustained_samples=1, tracemalloc_enabled=False)
+    assert m.tracemalloc_enabled is False
+    assert m.top_allocations() == []
+
+
+def test_top_allocations_returns_data_when_enabled():
+    m = MemoryMonitor(threshold_mb=1, sustained_samples=1, tracemalloc_enabled=True)
+    data = [bytearray(50_000) for _ in range(20)]  # force allocations
+    lines = m.top_allocations(limit=5)
+    assert isinstance(lines, list) and len(lines) <= 5
+    del data
+
+
+def test_get_memory_status_shape():
+    status = get_memory_status()
+    assert "rss_mb" in status
+    assert status["rss_mb"] > 0
+
+
+def test_top_allocations_reflects_large_allocations():
+    m = MemoryMonitor(threshold_mb=1, sustained_samples=1, tracemalloc_enabled=True)
+    blob = [bytearray(100_000) for _ in range(50)]  # ~5 MB after start()
+    lines = m.top_allocations(limit=10)
+    assert lines, "tracemalloc should report allocation sites"
+    assert all(isinstance(x, str) for x in lines)
+    del blob

--- a/koan/tests/test_memory_monitor.py
+++ b/koan/tests/test_memory_monitor.py
@@ -1,7 +1,12 @@
 import os
+from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from app.memory_monitor import MemoryMonitor, read_rss_mb, get_memory_status
+
+_HAS_PROC = Path("/proc/self/status").exists()
 
 
 def test_read_rss_mb_positive():
@@ -48,6 +53,9 @@ def test_get_memory_status_shape():
     assert status["rss_mb"] > 0
 
 
+@pytest.mark.skipif(
+    not _HAS_PROC, reason="foreign-PID RSS resolution needs /proc (Linux-only)"
+)
 def test_get_memory_status_resolves_run_pid():
     """When the run PID resolves, status reports that process's RSS."""
     with patch("app.memory_monitor._read_run_pid", lambda _root: os.getpid()):

--- a/koan/tests/test_memory_monitor.py
+++ b/koan/tests/test_memory_monitor.py
@@ -1,3 +1,6 @@
+import os
+from unittest.mock import patch
+
 from app.memory_monitor import MemoryMonitor, read_rss_mb, get_memory_status
 
 
@@ -43,6 +46,43 @@ def test_get_memory_status_shape():
     status = get_memory_status()
     assert "rss_mb" in status
     assert status["rss_mb"] > 0
+
+
+def test_get_memory_status_resolves_run_pid():
+    """When the run PID resolves, status reports that process's RSS."""
+    with patch("app.memory_monitor._read_run_pid", lambda _root: os.getpid()):
+        status = get_memory_status("/tmp/whatever")
+    assert status["source"] == "agent_loop"
+    assert status["rss_mb"] > 0
+
+
+def test_get_memory_status_falls_back_to_self_when_no_run_pid():
+    """No run PID -> read this process's RSS, source 'self'."""
+    with patch("app.memory_monitor._read_run_pid", lambda _root: None):
+        status = get_memory_status("/tmp/whatever")
+    assert status["source"] == "self"
+    assert status["rss_mb"] > 0
+
+
+def test_get_memory_status_flags_config_error():
+    """A config-read failure surfaces config_error rather than a fake disabled state."""
+    def boom():
+        raise RuntimeError("config exploded")
+
+    with patch("app.config.get_memory_monitor_config", boom):
+        status = get_memory_status()
+    assert status.get("config_error") is True
+    assert status["watchdog_enabled"] is None
+    assert status["threshold_mb"] is None
+
+
+def test_tracemalloc_error_recorded_on_start_failure():
+    """A failed tracemalloc.start() is recorded, not silently swallowed."""
+    with patch("tracemalloc.start", side_effect=RuntimeError("no tracing")), \
+            patch("tracemalloc.is_tracing", lambda: False):
+        m = MemoryMonitor(threshold_mb=1, sustained_samples=1, tracemalloc_enabled=True)
+    assert m.tracemalloc_enabled is False
+    assert m.tracemalloc_error is not None
 
 
 def test_top_allocations_reflects_large_allocations():

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -8290,6 +8290,18 @@ class TestMemoryWatchdog:
         assert mon.threshold_mb == 900
         assert mon.sustained_samples == 5
 
+    def test_build_memory_monitor_disabled_when_threshold_below_baseline(self):
+        """A threshold at/below current RSS would restart-loop; disable it."""
+        from app import run
+        with patch(
+            "app.config.get_memory_monitor_config",
+            lambda: {"enabled": True, "threshold_mb": 1,
+                     "sustained_samples": 3, "tracemalloc": False,
+                     "min_runs_before_restart": 1},
+        ):
+            # 1 MB is below this process's real RSS -> guard disables.
+            assert run._build_memory_monitor() is None
+
     def test_handle_memory_restart_exits_with_restart_code(self, tmp_path):
         from app import run
         from app.memory_monitor import MemoryMonitor

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -8264,3 +8264,40 @@ class TestClassifyTrustStdout:
         assert handled is False
         auth.assert_not_called()
         quota.assert_not_called()
+
+
+class TestMemoryWatchdog:
+    def test_build_memory_monitor_disabled_returns_none(self):
+        from app import run
+        with patch(
+            "app.config.get_memory_monitor_config",
+            lambda: {"enabled": False, "threshold_mb": 1200,
+                     "sustained_samples": 3, "tracemalloc": False,
+                     "min_runs_before_restart": 1},
+        ):
+            assert run._build_memory_monitor() is None
+
+    def test_build_memory_monitor_enabled_returns_monitor(self):
+        from app import run
+        with patch(
+            "app.config.get_memory_monitor_config",
+            lambda: {"enabled": True, "threshold_mb": 900,
+                     "sustained_samples": 5, "tracemalloc": False,
+                     "min_runs_before_restart": 1},
+        ):
+            mon = run._build_memory_monitor()
+        assert mon is not None
+        assert mon.threshold_mb == 900
+        assert mon.sustained_samples == 5
+
+    def test_handle_memory_restart_exits_with_restart_code(self, tmp_path):
+        from app import run
+        from app.memory_monitor import MemoryMonitor
+        from app.restart_manager import RESTART_EXIT_CODE
+
+        with patch.object(run, "_notify", lambda *a, **k: None):
+            mon = MemoryMonitor(threshold_mb=1, sustained_samples=1)
+            mon.sample()  # populate last_rss_mb
+            with pytest.raises(SystemExit) as exc:
+                run._handle_memory_restart(str(tmp_path), "test-instance", mon, count=3)
+        assert exc.value.code == RESTART_EXIT_CODE


### PR DESCRIPTION
## Summary

Adds an RSS memory watchdog (#2232) that samples the agent loop's resident set size once per iteration and self-restarts the process — only between missions, via the existing `RESTART_EXIT_CODE` re-exec path — after a sustained overage, reclaiming memory back to baseline. An opt-in `tracemalloc` mode captures top allocation sites at restart for root-cause diagnosis.

Closes https://github.com/Anantys-oss/koan/issues/2232

## Changes

- New `koan/app/memory_monitor.py`: `MemoryMonitor` (RSS sampling, sustained-threshold detection, tracemalloc snapshots), `read_rss_mb()` (`/proc/self/status` VmRSS with `resource` fallback, no new dependency), `get_memory_status()`.
- `config.py`: `get_memory_monitor_config()` accessor; documented `memory_monitor:` section in `instance.example/config.yaml` (disabled by default).
- `run.py`: `_build_memory_monitor()`, `_handle_memory_restart()`, `_write_memory_restart_journal()` (appends to `instance/.memory-restarts.jsonl`), and a loop-top sample/restart check gated on `min_runs_before_restart`.
- `dashboard/core.py`: `/api/health` now returns a `memory` block (`rss_mb`, `threshold_mb`, `watchdog_enabled`).
- Docs: `docs/operations/memory-watchdog.md` + README index entry.

## Test plan

- New unit tests: `test_memory_monitor.py` (sampling, sustained counting, reset, tracemalloc), `test_config.py` (defaults/overrides/malformed), `test_run.py` (gating + `RESTART_EXIT_CODE` exit), `test_dashboard.py` (memory block on `/api/health`).
- `KOAN_ROOT=/tmp/test-koan pytest test_memory_monitor.py test_config.py test_run.py test_dashboard.py` → 876 passed.
- `make lint` → all checks passed.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(HEAD=ecca4451)_
