### PR TITLE
fix(deep_research): detect 'Closes: #N' colon form in dedup

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -47,9 +47,11 @@ _BRANCH_ISSUE_RE = re.compile(r"(?:implement|fix|issue)[/-](\d+)")
 
 # GitHub's closing keywords — only these forms in a PR body reliably mean
 # "this PR resolves issue N". Restricting to them avoids treating incidental
-# "#123" mentions in prose as coverage.
+# "#123" mentions in prose as coverage. The leading \b prevents matching a
+# keyword embedded in a larger word ("prefixes #5"); the optional colon mirrors
+# GitHub's own parser, which accepts "Closes: #N" as well as "Closes #N".
 _CLOSING_ISSUE_RE = re.compile(
-    r"(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#(\d+)", re.IGNORECASE
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)(?::|\s)\s*#(\d+)", re.IGNORECASE
 )
 
 

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -1480,6 +1480,43 @@ class TestPrCoverage:
         assert 2131 in coverage["issue_numbers"]
         assert coverage["pr_issues"][400] == {2131}
 
+    def test_build_pr_coverage_body_closing_keyword_colon(self, research_env):
+        """GitHub's colon form ('Closes: #N') counts as coverage.
+
+        GitHub's own parser links the issue for both 'Closes #N' and
+        'Closes: #N'; the dedup must recognise both or it re-picks an
+        already-covered issue as an autonomous topic.
+        """
+        research = self._make_research(research_env, [
+            {
+                "number": 410,
+                "title": "feat: thing",
+                "headRefName": "koan0/thing",
+                "body": "Adds a thing.\n\nFixes: #777",
+            },
+        ])
+
+        coverage = research._build_pr_coverage()
+
+        assert 777 in coverage["issue_numbers"]
+        assert coverage["pr_issues"][410] == {777}
+
+    def test_build_pr_coverage_body_ignores_keyword_in_larger_word(self, research_env):
+        """A closing keyword embedded in a longer word is not coverage."""
+        research = self._make_research(research_env, [
+            {
+                "number": 411,
+                "title": "feat: thing",
+                "headRefName": "koan0/thing",
+                "body": "This prefixes #123 onto each line; suffixes #124 too.",
+            },
+        ])
+
+        coverage = research._build_pr_coverage()
+
+        assert 123 not in coverage["issue_numbers"]
+        assert 124 not in coverage["issue_numbers"]
+
     def test_build_pr_coverage_body_ignores_incidental_refs(self, research_env):
         """Non-closing '#N' mentions in the body are not treated as coverage."""
         research = self._make_research(research_env, [


### PR DESCRIPTION
**What**: The deep-research PR-coverage dedup now recognises GitHub's colon closing form (`Closes: #N`) and stops matching closing keywords embedded in larger words.

**Why**: Autonomous topic selection filters out topics already covered by an open PR. Coverage was detected only from `Closes #N` (whitespace form). PRs whose body uses `Fixes: #N` / `Closes: #N` — which GitHub itself links — were not registered as covering their issue, so the agent could re-pick an already-in-progress issue and open a duplicate PR. A second, latent defect: the regex had no leading word boundary, so `prefixes #5` matched as `fixes #5`. Both are the assumption-coherent class — prior tests used the no-colon fixture form, so they stayed green.

**How**: `_CLOSING_ISSUE_RE` gains a leading `\b` and an optional colon (`(?::|\s)\s*`), mirroring GitHub's parser. No behaviour change for the existing `Closes #N` form.

**Testing**: Two regression tests (colon form counts; keyword-in-word does not). Full `test_deep_research.py` green (88), `make lint` clean.
