### PR TITLE
fix(deep_research): cap-limit open-PR coverage fetch (gh 30-default)

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -32,6 +32,10 @@ from app.diff_triage import _GENERATED_PATTERNS, _LOCKFILE_NAMES
 
 # Below this many commits a churn ranking is statistical noise — skip entirely.
 _MIN_COMMITS_FOR_HOTSPOTS = 20
+# `gh pr list` defaults to 30 results; a busy review queue exceeds that and the
+# PR-coverage map would silently truncate, letting dedup miss covered topics and
+# re-pick them as duplicate autonomous work. Cap high enough to hold the queue.
+_MAX_OPEN_PRS_FOR_COVERAGE = 200
 # Test files are intentionally high-churn; they are not debt hotspots.
 _TEST_PATH_RE = re.compile(r"(?:^|/)(?:tests?|__tests__)/|(?:^|/)test_[^/]+\.[a-z]+$|_test\.[a-z]+$")
 
@@ -184,6 +188,7 @@ class DeepResearch:
             output = run_gh(
                 "pr", "list",
                 "--state", "open",
+                "--limit", str(_MAX_OPEN_PRS_FOR_COVERAGE),
                 "--json", "number,title,createdAt,headRefName,body",
                 cwd=self.project_path,
             )

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -1104,6 +1104,24 @@ class TestGetPendingPrsEdgeCases:
 
             assert result == []
 
+    def test_passes_limit_to_avoid_30_cap(self, research_env):
+        """Fetch passes an explicit --limit so a >30 PR queue isn't silently truncated."""
+        with patch("app.github.run_gh", return_value="[]") as mock_gh:
+            research = DeepResearch(
+                research_env["instance"],
+                research_env["project_name"],
+                research_env["project_path"],
+            )
+            research._pending_prs = None  # Reset autouse cache
+
+            research.get_pending_prs()
+
+            args = mock_gh.call_args.args
+            assert "--limit" in args
+            # The limit value follows the flag and exceeds gh's 30 default.
+            limit_val = int(args[args.index("--limit") + 1])
+            assert limit_val > 30
+
 
 # ---------------------------------------------------------------------------
 # get_open_issues edge cases


### PR DESCRIPTION
**What:** Pass an explicit `--limit` when fetching open PRs for DEEP-mode topic coverage.

**Why:** `get_pending_prs()` ran `gh pr list --state open` with no `--limit`, so it silently capped at gh's 30-result default. On a busy review queue (>30 open PRs — this repo regularly sits near/over that) PRs beyond the 30th drop out of the coverage map. `_topic_has_open_pr` then can't see them, so `suggest_topics` re-picks a topic that an open PR already covers → duplicate autonomous work. Same silent-truncation class as the documented gh 30-item cap (#2231). `get_open_issues` already passes `--limit`; this aligns the PR fetch.

**How:** Added `_MAX_OPEN_PRS_FOR_COVERAGE = 200` and passed it as `--limit`. 200 comfortably holds the queue without unbounded fetches.

**Testing:** New regression `test_passes_limit_to_avoid_30_cap` asserts the flag is passed with a value >30. Full `test_deep_research.py` suite: 87 passed. Lint clean.
