### PR TITLE
fix(deep_research): de-prioritize self-marked-done tech-debt topics

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -45,6 +45,11 @@ _STOP_WORDS = frozenset({
 
 _BRANCH_ISSUE_RE = re.compile(r"(?:implement|fix|issue)[/-](\d+)")
 
+# A technical-debt line a human has annotated as already finished. Humans strike
+# items off with a checkbox, a ✅, or a standalone "done"/"completed". Such items
+# should not surface as fresh high-priority work (\b avoids matching "undone").
+_COMPLETED_MARKER_RE = re.compile(r"✅|\[x\]|\bdone\b|\bcompleted\b", re.IGNORECASE)
+
 # GitHub's closing keywords — only these forms in a PR body reliably mean
 # "this PR resolves issue N". Restricting to them avoids treating incidental
 # "#123" mentions in prose as coverage.
@@ -462,11 +467,19 @@ class DeepResearch:
             # Skip if recently worked on
             if any(item.lower() in t.lower() for t in recent_topics):
                 continue
+            # An item the human already annotated as finished (✅/[x]/"done")
+            # shouldn't compete for attention as fresh priority-2 work — drop it
+            # to priority 3 and flag it so the agent verifies before picking it.
+            done = bool(_COMPLETED_MARKER_RE.search(item))
             suggestions.append({
                 "topic": item,
                 "source": "priorities.md (Technical Debt)",
-                "reasoning": "Known tech debt item, good for DEEP mode",
-                "priority": 2,
+                "reasoning": (
+                    "Marked complete in priorities.md — verify it still needs work"
+                    if done
+                    else "Known tech debt item, good for DEEP mode"
+                ),
+                "priority": 3 if done else 2,
             })
 
         # Priority 2: Git-churn hotspots — structurally unstable files.

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -441,6 +441,44 @@ class TestTopicSuggestions:
             assert not any("Test coverage" in t for t in titles)
             assert any("#2" in t for t in titles)
 
+    def test_completed_debt_deprioritized(self, research_env):
+        """A tech-debt item self-marked done drops to priority 3, not 2."""
+        priorities_content = """## Technical Debt
+
+- Refactor the payment module
+- atoomic PRs cleanup done (session 12)
+- Migrate undone helpers to OO
+"""
+        priorities_file = (
+            research_env["instance"]
+            / "memory"
+            / "projects"
+            / research_env["project_name"]
+            / "priorities.md"
+        )
+        priorities_file.write_text(priorities_content)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(returncode=1)  # gh fails
+
+            research = DeepResearch(
+                research_env["instance"],
+                research_env["project_name"],
+                research_env["project_path"],
+            )
+
+            result = research.suggest_topics()
+            by_topic = {s["topic"]: s for s in result}
+
+            # The "done"-annotated item is demoted and flagged.
+            done_item = by_topic["atoomic PRs cleanup done (session 12)"]
+            assert done_item["priority"] == 3
+            assert "verify" in done_item["reasoning"].lower()
+
+            # A real item stays priority 2; "undone" must not trigger the marker.
+            assert by_topic["Refactor the payment module"]["priority"] == 2
+            assert by_topic["Migrate undone helpers to OO"]["priority"] == 2
+
 
 class TestOutputFormatting:
     """Tests for output formatting."""


### PR DESCRIPTION
**What**: Tech-debt topics in `priorities.md` that a human already annotated as finished no longer surface as fresh priority-2 work.

**Why**: `suggest_topics()` emitted every `## Technical Debt` line verbatim at priority 2. A line like `atoomic PRs cleanup done (session 12)` was therefore offered as a 🔴 high-priority DEEP topic *every session* — completed work competing with live topics. `priorities.md` is human territory, so the fix lives in the code that interprets it, not the file.

**How**: Added `_COMPLETED_MARKER_RE` (`✅`, `[x]`, or standalone `done`/`completed`). A matching debt item drops to priority 3 with a "verify it still needs work" reasoning rather than being silently skipped — the ambiguity ("12 PRs remain") means demote, not delete. `\b` boundaries keep `undone` from triggering.

**Testing**: New `test_completed_debt_deprioritized` asserts the done-marked item lands at priority 3+flag while a real item and an `undone` item stay at priority 2. Full `test_deep_research.py` green (87), ruff clean.
