### PR TITLE
feat(provider): per-role CLI provider via cli: section

### DIFF
--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -145,29 +145,53 @@ When a custom path is set, `/status` and the startup banner (`make` / `make rest
 show the binary name next to the provider (e.g. `claude (ollama-claude)`), so you can
 confirm which wrapper is in use.
 
-#### Review-specific CLI binary
+#### Per-role CLI provider (the `cli:` section)
 
-`KOAN_CLAUDE_CLI_PATH` replaces the Claude binary for **every** call. To swap it
-in for **reviews only** — e.g. run routine missions on a cheap wrapper but reviews
-on a paid Claude subscription — set `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`:
+`KOAN_CLAUDE_CLI_PATH` replaces the Claude binary for **every** call. To use a
+**different provider or binary per mission role** — e.g. run routine work on
+Codex but reviews on a paid Claude subscription — add a `cli:` section to
+`config.yaml`, parallel to `models:`:
 
-```bash
-KOAN_CLAUDE_CLI_PATH=/path/to/cheap-claude           # all other missions
-KOAN_CLAUDE_CLI_FOR_REVIEW_PATH=/path/to/review-claude  # reviews only
+```yaml
+cli:
+  default:
+    mission: codex                                  # routine missions → Codex
+    chat: codex
+    lightweight: codex
+    review_mode: claude:/path/to/review-claude      # reviews → a pinned Claude binary
+    reflect: claude
+  fallback: claude                                  # used only when a role's CLI can't run
 ```
 
-This variable takes precedence over `KOAN_CLAUDE_CLI_PATH`, but **only while a
-review is running**. It applies to `/review` and `/ultrareview` (and every
-internal Claude call those skills make — the main pass, reflection, silent-failure
-hunter, bot-comment triage), and to private reviews. It is never consulted for
-other missions, so you can set both variables at once without affecting
-non-review work. When unset or empty inside a review, Kōan falls back to
-`KOAN_CLAUDE_CLI_PATH`, then `claude`.
+Each value is a provider **flavor** (`claude`, `codex`, `copilot`, `cline`,
+`ollama-launch`) or `flavor:path`, where `path` is an absolute path or a path
+relative to `KOAN_ROOT` (same rule as `KOAN_CLAUDE_CLI_PATH`). The roles are the
+same as `models:`: `mission`, `chat`, `lightweight`, `review_mode`, `reflect`.
 
-The review binary is also surfaced in `/status` and the startup banner — its
-basename is appended as a `review:` hint (e.g.
-`claude (cheap-claude, review: review-claude)`), so you can confirm a
-review-only binary is configured without running a review.
+- **`review_mode`** drives `/review`, `/ultrareview`, and every internal review
+  call (main pass, reflection, silent-failure hunter, bot-comment triage),
+  replacing the old `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`.
+- **Model coupling:** a role's *model* is read from that role's provider block —
+  e.g. with `review_mode: claude`, the review model comes from
+  `models.claude.review_mode` (falling back to `models.default.review_mode`). So
+  `cli:` and `models:` compose: the provider you pick for a role selects which
+  `models.<provider>.<role>` model applies.
+- **`fallback`** is a single section-wide provider used only when a role's chosen
+  CLI **can't run** — the binary is missing/misconfigured (and, on the mission
+  path, when the CLI reports an auth failure) and no work was produced yet. Quota
+  exhaustion still pauses Koan; transient errors still use the normal in-place retry.
+- **Per-project overrides:** set a flat `cli:` block under a project in
+  `projects.yaml` (e.g. `cli: {mission: claude}`) to override per project.
+- **Absence = unchanged:** with no `cli:` section, every role uses the global
+  provider (`cli_provider` / `KOAN_CLI_PROVIDER`), exactly as before.
+
+`KOAN_CLAUDE_CLI_PATH` remains the default binary for the `claude` flavor when a
+role selects `claude` without an explicit path, and `cli_provider` /
+`KOAN_CLI_PROVIDER` remain the global default provider.
+
+> Tip: the ready-made wrappers in `bin/` (`zai-claude`, `oc-claude`,
+> `ollama-claude`) make good `claude:path` targets when you want a role to run a
+> Claude-compatible backend.
 
 > **Running OpenRouter models through the Claude CLI?** See
 > [openrouter.md](openrouter.md) — it uses this wrapper mechanism plus a local

--- a/docs/users/model-configuration.md
+++ b/docs/users/model-configuration.md
@@ -47,6 +47,28 @@ For each role, the first value found wins:
 When both a provider override and `models.default` set the same role, the
 provider value wins.
 
+## CLI provider per role (the `cli:` section)
+
+By default every role runs on the single global provider (`cli_provider` /
+`KOAN_CLI_PROVIDER`). To run a **different provider per role** — e.g. routine
+work on Codex but reviews on Claude — add a `cli:` section parallel to `models:`:
+
+```yaml
+cli:
+  default:
+    mission: codex
+    review_mode: claude:/path/to/review-claude   # flavor or flavor:path
+  fallback: claude                               # used only when a role's CLI can't launch
+```
+
+The role's **model** is then read from that role's provider block above. With
+`review_mode: claude`, the review model comes from `models.claude.review_mode`
+(then `models.default.review_mode`) — so `cli:` selects the provider and
+`models.<provider>.<role>` selects the model for it. Per-project overrides go in
+`projects.yaml` as a flat `cli:` block. Full details, including the single
+`cli.fallback` provider (launch/auth-failure recovery), are in
+[../providers/claude.md](../providers/claude.md).
+
 ## Migrating from the legacy layout
 
 Earlier versions used a flat `models:` block plus top-level `models_for_{provider}`

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -512,6 +512,34 @@ models:
   #   fallback: "minimax-m2.5:cloud"     # empty = use provider default
   #   review_mode: "glm-5:cloud"
   #   reflect: "glm-5:cloud"
+
+# Per-role CLI provider (optional) — parallel to `models:`.
+# Pick a DIFFERENT provider (and optionally a custom binary) for each mission
+# role. Each value is a flavor (claude/codex/copilot/cline/ollama-launch) or
+# `flavor:path`, where path is absolute or relative to KOAN_ROOT.
+#
+# The role's MODEL is read from that role's provider block above — e.g. with
+# `review_mode: claude`, the review model comes from `models.claude.review_mode`
+# (then `models.default.review_mode`). So `cli:` and `models:` compose.
+#
+# When this section is omitted, every role uses the global `cli_provider` /
+# KOAN_CLI_PROVIDER — exactly as before (no behavior change).
+#
+# Example: routine work on Codex, reviews on a pinned Claude binary, with a
+# single section-wide fallback used only when a role's CLI can't launch
+# (binary missing/misconfigured, or — on the mission path — an auth failure;
+# quota still pauses, transient errors still retry in place).
+# cli:
+#   default:
+#     mission: codex
+#     chat: codex
+#     lightweight: codex
+#     review_mode: claude:bin/zai-claude   # relative paths root at KOAN_ROOT
+#     reflect: claude
+#   fallback: claude
+# Per-project overrides live in projects.yaml as a flat `cli:` block, e.g.
+#   cli: {mission: claude, review_mode: claude:/opt/bin/review-claude}
+
 # Branch cleanup — automatic deletion of merged branches during git sync
 # Every git_sync_interval iterations, Kōan detects merged branches (both
 # regular merges via git ancestry and squash/rebase merges via GitHub API)

--- a/koan/app/CLAUDE.md
+++ b/koan/app/CLAUDE.md
@@ -67,7 +67,7 @@ Communication between processes happens through shared files in `instance/` with
 - **`provider/cline.py`** — `ClineProvider` (Cline CLI)
 - **`provider/codex.py`** — `CodexProvider` (Codex CLI); quota surfaces only via the stream-json summary
 - **`provider/copilot.py`** — `CopilotProvider` (GitHub Copilot CLI) with tool name mapping
-- **`provider/__init__.py`** — Provider registry, resolution (env → config → default), cached singleton, and convenience functions (`run_command()`, `run_command_streaming()`, `build_full_command()`). Main entry point for the provider package.
+- **`provider/__init__.py`** — Provider registry, resolution (env → config → default), cached singleton, and convenience functions (`run_command()`, `run_command_streaming()`, `build_full_command()`). Also per-role provider selection for the `cli:` config section: `get_provider_for_role()` (fresh path-bearing instance, never poisons the singleton), `get_fallback_provider()`, `resolve_role_provider()` (pre-flight fallback), and `describe_cli_roles()` (status/banner summary). Main entry point for the provider package.
 - **`cli_provider.py`** — Re-export facade (legacy); prefer importing from `provider` directly
 
 **Git & GitHub:**

--- a/koan/app/cli_exec.py
+++ b/koan/app/cli_exec.py
@@ -369,6 +369,7 @@ def run_cli_with_retry(
     *,
     max_attempts: int = CLI_RETRY_MAX_ATTEMPTS,
     backoff: Sequence[float] = CLI_RETRY_BACKOFF,
+    provider: Optional[CLIProvider] = None,
     **kwargs,
 ) -> subprocess.CompletedProcess:
     """Run a CLI command with automatic retry on transient errors.
@@ -386,6 +387,10 @@ def run_cli_with_retry(
         cmd: Command list for subprocess.
         max_attempts: Maximum number of attempts (default 3).
         backoff: Sleep durations between retries.
+        provider: Explicit provider instance (per-role CLI). Forwarded to
+            :func:`run_cli` for stdin-rewrite / invocation-lock, and its name
+            drives provider-specific error classification. ``None`` uses the
+            global provider.
         **kwargs: Passed through to :func:`run_cli`.
 
     Returns:
@@ -397,9 +402,11 @@ def run_cli_with_retry(
     kwargs.setdefault("capture_output", True)
     kwargs.setdefault("text", True)
 
+    provider_name = provider.name if provider is not None else ""
+
     last_result = None
     for attempt in range(max_attempts):
-        result = run_cli(cmd, **kwargs)
+        result = run_cli(cmd, provider=provider, **kwargs)
         last_result = result
 
         if result.returncode == 0:
@@ -409,6 +416,7 @@ def run_cli_with_retry(
             result.returncode,
             stdout=result.stdout or "",
             stderr=result.stderr or "",
+            provider_name=provider_name,
         )
 
         if category != ErrorCategory.RETRYABLE:

--- a/koan/app/cli_provider.py
+++ b/koan/app/cli_provider.py
@@ -26,10 +26,11 @@ from app.provider import (  # noqa: F401
     # Registry & resolution
     get_provider_name,
     get_provider,
+    get_provider_for_role,
+    get_fallback_provider,
+    resolve_role_provider,
     get_cli_binary,
     reset_provider,
-    review_cli_override,
-    review_cli_override_active,
     # Convenience functions
     build_cli_flags,
     build_tool_flags,

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -15,7 +15,7 @@ Functions here call it via import to ensure mocks propagate correctly.
 import os
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 def _load_config() -> dict:
@@ -229,7 +229,10 @@ def _normalize_model_config(config: dict) -> dict:
     return normalized
 
 
-def get_model_config(project_name: str = "") -> dict:
+def get_model_config(
+    project_name: str = "",
+    role_providers: Optional[Dict[str, str]] = None,
+) -> dict:
     """Get model configuration from config.yaml with per-project overrides.
 
     Resolution order for each key:
@@ -245,6 +248,13 @@ def get_model_config(project_name: str = "") -> dict:
 
     Args:
         project_name: Optional project name for per-project overrides.
+        role_providers: Optional ``{role: provider_flavor}`` map. When ``None``
+            (the default), every role resolves its provider-specific section
+            against the single global provider — byte-for-byte the historical
+            behavior. When provided, each role's model resolves against ITS
+            provider's section (``models.<that-provider>.<role>``), so per-role
+            CLI selection (the ``cli:`` section) composes with per-provider model
+            blocks. Roles absent from the map fall back to the global provider.
 
     Returns:
         Dict with keys: mission, chat, lightweight, fallback, review_mode, reflect.
@@ -275,23 +285,33 @@ def get_model_config(project_name: str = "") -> dict:
     # Start with defaults, then apply default models
     result = {k: default_models.get(k, v) for k, v in defaults.items()}
 
-    # Apply provider-specific section per key
+    # Apply provider-specific section per key.
+    #   role_providers is None  → one global provider section for every key
+    #                             (historical behavior, exact parity).
+    #   role_providers given     → each role's model resolves against ITS
+    #                             provider's section (cli: per-role selection).
     try:
         from app.provider import get_provider_name
 
-        provider_name = get_provider_name()
-        # Try both hyphenated and underscored versions of the provider name
-        # Users can write nested keys as either "ollama-launch" or "ollama_launch"
-        provider_models = models_section.get(provider_name, {}) or {}
-        if not provider_models or not isinstance(provider_models, dict):
-            # Try underscore version if hyphenated didn't work
-            provider_key = provider_name.replace("-", "_")
-            provider_models = models_section.get(provider_key, {}) or {}
+        def _provider_section(pname: str) -> dict:
+            # Try both hyphenated and underscored forms of the provider name;
+            # users may write nested keys as "ollama-launch" or "ollama_launch".
+            section = models_section.get(pname, {}) or {}
+            if not section or not isinstance(section, dict):
+                section = models_section.get(pname.replace("-", "_"), {}) or {}
+            return section if isinstance(section, dict) else {}
 
-        if isinstance(provider_models, dict):
+        global_provider = get_provider_name()
+        if role_providers is None:
+            provider_models = _provider_section(global_provider)
             for key in defaults:
                 if key in provider_models:
                     result[key] = provider_models[key]
+        else:
+            for key in defaults:
+                section = _provider_section(role_providers.get(key, global_provider))
+                if key in section:
+                    result[key] = section[key]
     except Exception as e:
         print(f"[config] provider model section lookup failed: {e}", file=sys.stderr)
 
@@ -304,6 +324,121 @@ def get_model_config(project_name: str = "") -> dict:
                 result[key] = project_models[key]
 
     return result
+
+
+# Mission roles that the `cli:` section can route to a specific provider.
+# (`fallback` is a single section-wide provider, resolved separately.)
+_CLI_ROLES = ("mission", "chat", "lightweight", "review_mode", "reflect")
+
+
+def _parse_cli_value(raw: str) -> Tuple[str, str]:
+    """Parse a ``cli:`` value (``flavor`` or ``flavor:path``) into ``(flavor, path)``.
+
+    Splits on the FIRST colon so absolute paths containing extra colons survive.
+    The flavor is validated against the provider registry; an unknown flavor
+    logs a warning and returns ``("", "")`` so the caller falls through to the
+    global provider (a typo must never crash the agent loop). The path is
+    returned RAW — the provider resolves it (absolute / KOAN_ROOT-relative /
+    bare) in ``binary()`` via the shared ``_resolve_binary_path`` helper.
+    """
+    raw = str(raw or "").strip()
+    if not raw:
+        return ("", "")
+    flavor, sep, path = raw.partition(":")
+    flavor = flavor.strip().lower()
+    path = path.strip() if sep else ""
+    from app.provider import is_known_provider
+
+    if not is_known_provider(flavor):
+        print(
+            f"[config] cli: unknown provider flavor {flavor!r} (value {raw!r}); "
+            "ignoring and using the global provider",
+            file=sys.stderr,
+        )
+        return ("", "")
+    return (flavor, path)
+
+
+def get_cli_config(project_name: str = "") -> Dict[str, Tuple[str, str]]:
+    """Resolve the CLI provider for each mission role from the ``cli:`` section.
+
+    Returns ``{role: (flavor, path)}`` for every role in :data:`_CLI_ROLES`.
+
+    Resolution per role (highest priority first):
+      1. ``projects.yaml`` ``cli.<role>`` (per-project override, flat)
+      2. ``config.yaml`` ``cli.default.<role>``
+      3. the global provider (``get_provider_name()``) with no path
+
+    Absence parity: when no ``cli:`` section is configured, every role resolves
+    to ``(get_provider_name(), "")`` — byte-for-byte today's single-global-provider
+    behavior. This is the backward-compat contract.
+    """
+    from app.provider import get_provider_name
+
+    global_provider = get_provider_name()
+
+    config = _load_config()
+    cli_section = config.get("cli", {})
+    if not isinstance(cli_section, dict):
+        cli_section = {}
+    default_section = cli_section.get("default", {})
+    if not isinstance(default_section, dict):
+        default_section = {}
+
+    project_overrides = _load_project_overrides(project_name)
+    project_cli = project_overrides.get("cli", {})
+    if not isinstance(project_cli, dict):
+        project_cli = {}
+
+    result: Dict[str, Tuple[str, str]] = {}
+    for role in _CLI_ROLES:
+        if role in project_cli:
+            raw = project_cli[role]
+        elif role in default_section:
+            raw = default_section[role]
+        else:
+            raw = ""
+        flavor, path = _parse_cli_value(raw)
+        result[role] = (flavor, path) if flavor else (global_provider, "")
+    return result
+
+
+def get_cli_fallback(project_name: str = "") -> Tuple[str, str]:
+    """Resolve the single section-wide fallback provider (``cli.fallback``).
+
+    Returns ``(flavor, path)``, or ``("", "")`` when no fallback is configured
+    (meaning: no provider-fallback behavior). A per-project ``cli.fallback``
+    overrides the global one. Both ``cli.fallback`` and ``cli.default.fallback``
+    are accepted for forgiveness.
+    """
+    project_overrides = _load_project_overrides(project_name)
+    project_cli = project_overrides.get("cli", {})
+    if isinstance(project_cli, dict) and project_cli.get("fallback"):
+        return _parse_cli_value(project_cli["fallback"])
+
+    config = _load_config()
+    cli_section = config.get("cli", {})
+    if isinstance(cli_section, dict):
+        if cli_section.get("fallback"):
+            return _parse_cli_value(cli_section["fallback"])
+        default_section = cli_section.get("default", {})
+        if isinstance(default_section, dict) and default_section.get("fallback"):
+            return _parse_cli_value(default_section["fallback"])
+    return ("", "")
+
+
+def get_model_for_role(role: str, project_name: str = "") -> str:
+    """Return the model for a single role, resolved against the role's CLI provider.
+
+    Resolves the role's provider via the ``cli:`` section, then reads that
+    provider's model block (``models.<provider>.<role>`` → ``models.default.<role>``).
+    Convenience for single-role callers (the ``run_command*`` helpers).
+    """
+    from app.provider import get_provider_for_role
+
+    provider = get_provider_for_role(role, project_name)
+    models = get_model_config(project_name, role_providers={role: provider.name})
+    return models.get(role, "")
 
 
 def get_mcp_configs(project_name: str = "") -> List[str]:
@@ -1555,19 +1690,36 @@ def get_claude_flags_for_role(
     Returns:
         Space-separated CLI flags string (may be empty)
     """
-    from app.cli_provider import get_provider
+    from app.cli_provider import get_provider_for_role
 
-    models = get_model_config(project_name)
-    provider = get_provider()
+    # Map the flag-builder role to a cli: role for provider selection.
+    # A mission in REVIEW mode is driven by the review_mode provider; a
+    # contemplative session by the lightweight provider.
+    if role == "mission" and autonomous_mode == "review":
+        cli_role = "review_mode"
+    elif role == "contemplative":
+        cli_role = "lightweight"
+    else:
+        cli_role = role
+
+    provider = get_provider_for_role(cli_role, project_name)
+    # Resolve models against the role's provider section (and the fallback
+    # model against the same provider). When no cli: section is configured this
+    # resolves every key against the global provider — identical to before.
+    models = get_model_config(
+        project_name,
+        role_providers={cli_role: provider.name, "fallback": provider.name},
+    )
 
     model = ""
     fallback = ""
     disallowed: Optional[List[str]] = None
 
     if role == "mission":
-        model = models["mission"]
         if autonomous_mode == "review" and models["review_mode"]:
             model = models["review_mode"]
+        else:
+            model = models["mission"]
         fallback = models["fallback"]
         if autonomous_mode == "review":
             disallowed = ["Bash", "Edit", "Write"]

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -427,20 +427,6 @@ def get_cli_fallback(project_name: str = "") -> Tuple[str, str]:
     return ("", "")
 
 
-def get_model_for_role(role: str, project_name: str = "") -> str:
-    """Return the model for a single role, resolved against the role's CLI provider.
-
-    Resolves the role's provider via the ``cli:`` section, then reads that
-    provider's model block (``models.<provider>.<role>`` → ``models.default.<role>``).
-    Convenience for single-role callers (the ``run_command*`` helpers).
-    """
-    from app.provider import get_provider_for_role
-
-    provider = get_provider_for_role(role, project_name)
-    models = get_model_config(project_name, role_providers={role: provider.name})
-    return models.get(role, "")
-
-
 def get_mcp_configs(project_name: str = "") -> List[str]:
     """Get MCP server config file paths from config.yaml with per-project overrides.
 

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -65,6 +65,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "budget": _NESTED,
     "tools": _NESTED,
     "models": _NESTED,
+    "cli": _NESTED,
     "git_auto_merge": _NESTED,
     "github": _NESTED,
     "jira": _NESTED,
@@ -124,6 +125,15 @@ SECTION_SCHEMAS: Dict[str, Dict[str, str]] = {
         "fallback": "str",
         "reflect": "str",
         "review_mode": "str",
+    },
+    # cli: routes each mission role to a provider (flavor or flavor:path).
+    # The global form is `cli.default.<role>` plus a single `cli.fallback`;
+    # the per-role values live in the `default` mapping so only `default`
+    # (dict) and `fallback` (str) appear at the section level. Per-project
+    # overrides (flat `cli.<role>`) live in projects.yaml, not here.
+    "cli": {
+        "default": "dict",
+        "fallback": "str",
     },
     "git_auto_merge": {
         "enabled": "bool",

--- a/koan/app/contemplative_runner.py
+++ b/koan/app/contemplative_runner.py
@@ -92,15 +92,22 @@ def build_contemplative_command(
     return cmd
 
 
-def get_contemplative_flags() -> List[str]:
+def get_contemplative_flags(project_name: str = "") -> List[str]:
     """Get CLI flags for contemplative role from config.
+
+    Args:
+        project_name: Optional project name for per-project ``cli.lightweight``
+            overrides. The contemplative binary is already resolved against the
+            project's lightweight provider (``build_contemplative_command``); the
+            model flag must resolve the same way so a project-pinned binary
+            receives a matching model.
 
     Returns:
         List of CLI flag strings (may be empty).
     """
     from app.config import get_claude_flags_for_role
 
-    flags_str = get_claude_flags_for_role("contemplative")
+    flags_str = get_claude_flags_for_role("contemplative", project_name=project_name)
     if not flags_str.strip():
         return []
     return flags_str.split()
@@ -127,7 +134,7 @@ def run_contemplative_session(
     """
     from app.claude_step import run_claude
 
-    flags = get_contemplative_flags()
+    flags = get_contemplative_flags(project_name=project_name)
     cmd = build_contemplative_command(
         instance=instance,
         project_name=project_name,

--- a/koan/app/contemplative_runner.py
+++ b/koan/app/contemplative_runner.py
@@ -69,18 +69,22 @@ def build_contemplative_command(
         github_nickname=github_nickname,
     )
 
-    from app.cli_provider import build_full_command
+    from app.cli_provider import build_full_command, get_provider_for_role
     from app.config import get_contemplative_max_turns, get_contemplative_tools, get_mcp_configs
 
     tools_str = get_contemplative_tools(project_name=project_name)
     allowed_tools = [t.strip() for t in tools_str.split(",") if t.strip()]
     mcp_configs = get_mcp_configs(project_name)
 
+    # Contemplative sessions run on the lightweight role's provider (cli:
+    # section); extra_flags supplies the matching lightweight model.
+    provider = get_provider_for_role("lightweight", project_name)
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=allowed_tools,
         mcp_configs=mcp_configs,
         max_turns=get_contemplative_max_turns(),
+        provider=provider,
     )
     if extra_flags:
         cmd.extend(extra_flags)

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -481,6 +481,11 @@ def _maybe_fallback_provider_rerun(
     # Nothing to gain if the fallback resolves to the same binary that just failed.
     if fb.binary() == role_provider.binary():
         return claude_exit, stdout_file, stderr_file
+    # A fallback whose own binary is unavailable would just fail the same way —
+    # skip the wasted re-run (mirrors provider.resolve_role_provider's guard).
+    if not fb.is_available():
+        log("koan", f"Skipping fallback to '{fb.name}' — its binary is unavailable")
+        return claude_exit, stdout_file, stderr_file
 
     # Only a launch/auth failure warrants a provider swap.
     from app.cli_errors import ErrorCategory, classify_cli_error

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -332,6 +332,7 @@ def _maybe_retry_mission(
     run_num: int,
     has_mission: bool,
     provider_name: str = "",
+    provider=None,
 ) -> tuple:
     """Attempt a single retry if the CLI error is transient.
 
@@ -386,7 +387,7 @@ def _maybe_retry_mission(
         claude_exit,
         stdout_text,
         stderr_text,
-        provider_name=provider_name,
+        provider_name=(provider.name if provider is not None else provider_name),
     )
     log("error", f"CLI error classified as {category.value} (exit={claude_exit})")
 
@@ -415,9 +416,144 @@ def _maybe_retry_mission(
     retry_exit = _run.run_claude_task(
         cmd, stdout_file, stderr_file, cwd=project_path,
         instance_dir=instance, project_name=project_name, run_num=run_num,
+        provider=provider,
     )
     log("koan", f"Mission retry exit_code={retry_exit}")
     return retry_exit, stdout_file, stderr_file
+
+
+def _maybe_fallback_provider_rerun(
+    *,
+    claude_exit: int,
+    stdout_file: str,
+    stderr_file: str,
+    project_path: str,
+    pre_head: str,
+    instance: str,
+    project_name: str,
+    run_num: int,
+    has_mission: bool,
+    autonomous_mode: str,
+    prompt: str,
+    plugin_dirs,
+    system_prompt: str,
+    tier,
+    host_tmp_dir,
+    container_tmp_dir,
+    dc=None,
+) -> tuple:
+    """Re-run the mission on the ``cli.fallback`` provider after a launch/auth failure.
+
+    Distinct from :func:`_maybe_retry_mission` (which handles transient RETRYABLE
+    errors on the SAME provider). This fires only when the role's CLI could not
+    run at all, and swaps to the single section-wide ``cli.fallback`` provider.
+
+    Guards (all must hold):
+      - the role CLI failed to launch (exit 127 / binary unavailable) or auth failed,
+      - a ``cli.fallback`` is configured and resolves to a different binary,
+      - this is a mission (not a lower-priority autonomous run),
+      - no commits were produced (HEAD unmoved),
+      - the mission was not timed out / aborted / stagnated.
+
+    Quota and generic transient errors never reach here. Returns
+    ``(exit_code, stdout_file, stderr_file)``.
+    """
+    import app.run as _run
+    log = _run.log
+
+    if claude_exit == 0 or not has_mission:
+        return claude_exit, stdout_file, stderr_file
+    if (
+        _run._last_mission_timed_out
+        or _run._last_mission_aborted
+        or _run._last_mission_stagnated.is_set()
+    ):
+        return claude_exit, stdout_file, stderr_file
+
+    from app.provider import get_fallback_provider, get_provider_for_role
+
+    fb = get_fallback_provider(project_name)
+    if fb is None:
+        return claude_exit, stdout_file, stderr_file
+
+    effective_role = "review_mode" if autonomous_mode == "review" else "mission"
+    role_provider = get_provider_for_role(effective_role, project_name)
+    # Nothing to gain if the fallback resolves to the same binary that just failed.
+    if fb.binary() == role_provider.binary():
+        return claude_exit, stdout_file, stderr_file
+
+    # Only a launch/auth failure warrants a provider swap.
+    from app.cli_errors import ErrorCategory, classify_cli_error
+
+    try:
+        stdout_text = Path(stdout_file).read_text()
+    except OSError:
+        stdout_text = ""
+    try:
+        stderr_text = Path(stderr_file).read_text()
+    except OSError:
+        stderr_text = ""
+    category = classify_cli_error(
+        claude_exit, stdout_text, stderr_text, provider_name=role_provider.name,
+    )
+    launch_failed = (
+        claude_exit == 127
+        or category == ErrorCategory.AUTH
+        or not role_provider.is_available()
+    )
+    if not launch_failed:
+        return claude_exit, stdout_file, stderr_file
+
+    # Don't re-run if the failed session already produced commits.
+    post_head = _run._get_git_head(project_path)
+    if pre_head and post_head and pre_head != post_head:
+        return claude_exit, stdout_file, stderr_file
+
+    log(
+        "koan",
+        f"Role CLI '{role_provider.name}' failed to launch (exit={claude_exit}) — "
+        f"falling back to provider '{fb.name}'",
+    )
+
+    from app.mission_runner import build_mission_command
+    from app.provider import cleanup_managed_paths
+
+    cmd, cleanup_paths = build_mission_command(
+        prompt=prompt,
+        autonomous_mode=autonomous_mode,
+        extra_flags="",
+        project_name=project_name,
+        plugin_dirs=plugin_dirs,
+        system_prompt=system_prompt,
+        tier=tier,
+        system_prompt_dir=host_tmp_dir,
+        system_prompt_container_dir=container_tmp_dir,
+        provider_override=fb,
+    )
+    if dc is not None:
+        cmd = dc.wrap_command(
+            cmd, project_path,
+            host_tmp_dir=host_tmp_dir or "",
+            container_tmp_dir=container_tmp_dir or "",
+        )
+
+    # Clear output files before re-run to avoid double-counting output.
+    try:
+        open(stdout_file, "w").close()
+        open(stderr_file, "w").close()
+    except OSError:
+        pass
+
+    try:
+        fb_exit = _run.run_claude_task(
+            cmd, stdout_file, stderr_file, cwd=project_path,
+            instance_dir=instance, project_name=project_name, run_num=run_num,
+            provider=fb,
+        )
+    finally:
+        cleanup_managed_paths(cleanup_paths)
+    log("koan", f"Fallback provider '{fb.name}' exit_code={fb_exit}")
+    return fb_exit, stdout_file, stderr_file
 
 
 # ---------------------------------------------------------------------------
@@ -1145,6 +1281,14 @@ def _run_iteration(
         except Exception as e:
             _debug_log(f"[run] plugin dir generation skipped: {e}")
 
+        # Resolve the role's CLI provider (cli: section) so the EXECUTION path
+        # (stdin-rewrite + invocation lock in run_claude_task) matches the
+        # binary build_mission_command builds the command for. Same call →
+        # same instance the builder uses internally.
+        from app.provider import get_provider_for_role
+        _mission_role = "review_mode" if autonomous_mode == "review" else "mission"
+        mission_cli_provider = get_provider_for_role(_mission_role, project_name)
+
         cmd, cmd_cleanup_paths = build_mission_command(
             prompt=prompt,
             autonomous_mode=autonomous_mode,
@@ -1155,6 +1299,7 @@ def _run_iteration(
             tier=mission_tier,
             system_prompt_dir=_host_tmp_dir,
             system_prompt_container_dir=_container_tmp_dir,
+            provider_override=mission_cli_provider,
         )
 
         cmd_display = [c[:100] + '...' if len(c) > 100 else c for c in cmd[:6]]
@@ -1191,6 +1336,7 @@ def _run_iteration(
         claude_exit = _run.run_claude_task(
             cmd, stdout_file, stderr_file, cwd=project_path,
             instance_dir=instance, project_name=project_name, run_num=run_num,
+            provider=mission_cli_provider,
         )
 
         _debug_log(f"[run] cli: exit_code={claude_exit}")
@@ -1213,6 +1359,33 @@ def _run_iteration(
                 run_num=run_num,
                 has_mission=bool(mission_title),
                 provider_name=provider_name,
+                provider=mission_cli_provider,
+            )
+
+        # --- Launch/auth fallback to the cli.fallback provider ---
+        # If the role's CLI couldn't run at all (binary missing / not
+        # authenticated) and no work was produced, rebuild against the single
+        # section-wide cli.fallback provider and run once more. Quota still
+        # pauses; transient errors already used the in-place retry above.
+        if claude_exit != 0:
+            claude_exit, stdout_file, stderr_file = _maybe_fallback_provider_rerun(
+                claude_exit=claude_exit,
+                stdout_file=stdout_file,
+                stderr_file=stderr_file,
+                project_path=project_path,
+                pre_head=pre_head,
+                instance=instance,
+                project_name=project_name,
+                run_num=run_num,
+                has_mission=bool(mission_title),
+                autonomous_mode=autonomous_mode,
+                prompt=prompt,
+                plugin_dirs=plugin_dirs,
+                system_prompt=system_prompt,
+                tier=mission_tier,
+                host_tmp_dir=_host_tmp_dir,
+                container_tmp_dir=_container_tmp_dir,
+                dc=_dc if _dc_present else None,
             )
 
         # --- JSON success override ---

--- a/koan/app/mission_runner.py
+++ b/koan/app/mission_runner.py
@@ -293,6 +293,7 @@ def build_mission_command(
     tier: Optional[str] = None,
     system_prompt_dir: Optional[str] = None,
     system_prompt_container_dir: Optional[str] = None,
+    provider_override: Optional["CLIProvider"] = None,
 ) -> Tuple[List[str], List[str]]:
     """Build the CLI command for mission execution (provider-agnostic).
 
@@ -321,7 +322,7 @@ def build_mission_command(
         from app.config import get_effort_for_mode
     except ImportError:
         get_effort_for_mode = lambda _mode="": ""  # noqa: E731
-    from app.provider import build_full_command_managed
+    from app.provider import build_full_command_managed, get_provider_for_role
 
     # Get mission tools (comma-separated list)
     # REVIEW mode: enforce read-only at tool level (no Bash/Write/Edit)
@@ -331,8 +332,22 @@ def build_mission_command(
         tools_str = get_mission_tools(project_name)
         tools_list = [t.strip() for t in tools_str.split(",") if t.strip()]
 
-    # Get model configuration with per-project overrides
-    models = get_model_config(project_name)
+    # Resolve the CLI provider for this mission's role (cli: section). A review
+    # runs on the review_mode provider; everything else on the mission provider.
+    # provider_override is supplied by the launch/auth fallback re-run.
+    effective_role = "review_mode" if autonomous_mode == "review" else "mission"
+    provider = provider_override or get_provider_for_role(effective_role, project_name)
+
+    # Get model configuration with per-project overrides, resolved against the
+    # role's provider (models.<provider>.<role>) so per-role CLI + model compose.
+    models = get_model_config(
+        project_name,
+        role_providers={
+            "mission": provider.name,
+            "review_mode": provider.name,
+            "fallback": provider.name,
+        },
+    )
     model = models["mission"]
     if autonomous_mode == "review" and models["review_mode"]:
         # REVIEW mode takes precedence over tier override (safety > cost)
@@ -389,13 +404,14 @@ def build_mission_command(
         effort=effort,
         system_prompt_dir=system_prompt_dir,
         system_prompt_container_dir=system_prompt_container_dir,
+        provider=provider,
     )
 
     # Append thinking args directly — kept outside build_full_command so
-    # the provider stack doesn't need thinking-specific parameters.
+    # the provider stack doesn't need thinking-specific parameters. Use the
+    # same role-resolved provider so the flag matches the binary being run.
     if thinking_enabled:
-        from app.provider import get_provider
-        cmd.extend(get_provider().build_thinking_args(
+        cmd.extend(provider.build_thinking_args(
             enabled=True, budget_tokens=thinking_budget,
         ))
 

--- a/koan/app/pid_manager.py
+++ b/koan/app/pid_manager.py
@@ -710,12 +710,16 @@ def _show_startup_banner(koan_root: Path, provider: str) -> None:
     """
     try:
         from app.banners import print_hero_banner
-        from app.provider import get_provider_display
+        from app.provider import describe_cli_roles, get_provider_display
         from app.startup_info import gather_startup_info
         info = gather_startup_info(koan_root)
         # Show the alternate CLI binary flavor (KOAN_CLAUDE_CLI_PATH) next to
         # the provider, mirroring /status — e.g. "claude (ollama-claude)".
         info["provider"] = get_provider_display(provider)
+        # Append per-role provider overrides (cli: section) when configured.
+        roles = describe_cli_roles()
+        if roles:
+            info["provider"] += f" [{roles}]"
         print_hero_banner(info)
     except Exception as e:
         # Banner is cosmetic — log but don't block startup

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -435,6 +435,21 @@ def get_project_tools(config: dict, project_name: str) -> dict:
     return tools
 
 
+def get_project_cli(config: dict, project_name: str) -> dict:
+    """Get per-role CLI provider overrides for a project from projects.yaml.
+
+    Returns a flat dict of role -> ``flavor[:path]`` (mission, chat, lightweight,
+    review_mode, reflect) plus optional ``fallback``. Only includes keys that
+    are explicitly set — caller (``config.get_cli_config``) merges with the
+    global ``cli:`` section and the global provider default.
+    """
+    project_cfg = get_project_config(config, project_name)
+    cli = project_cfg.get("cli", {})
+    if not isinstance(cli, dict):
+        return {}
+    return cli
+
+
 def get_project_rtk_enabled(config: dict, project_name: str) -> bool:
     """Return whether the rtk awareness section should fire for a project.
 

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -21,7 +21,6 @@ Package structure:
 """
 
 import contextlib
-import contextvars
 import json
 import os
 import re
@@ -117,6 +116,11 @@ def reset_provider():
     _cached_provider_name = ""
 
 
+def is_known_provider(name: str) -> bool:
+    """True if *name* is a registered provider flavor (claude, codex, ...)."""
+    return str(name or "").strip().lower() in _PROVIDERS
+
+
 def get_provider_name() -> str:
     """Determine which CLI provider to use.
 
@@ -166,6 +170,96 @@ def get_provider_by_name(name: str) -> CLIProvider:
     return _PROVIDERS[provider_name]()
 
 
+def get_provider_for_role(role: str, project_name: str = "") -> CLIProvider:
+    """Return the provider instance for a mission role (the ``cli:`` section).
+
+    When the role resolves to the global provider with no custom binary path
+    (the parity case — including when no ``cli:`` section is configured), the
+    GLOBAL cached singleton is returned, so role-less behavior is byte-for-byte
+    unchanged. When the role names a different flavor and/or a ``flavor:path``,
+    a FRESH instance of that flavor is constructed carrying the path as a
+    per-instance binary override.
+
+    Role-bearing instances are NEVER written to ``_cached_provider`` — the
+    global singleton's identity must not be poisoned by a path-bearing instance.
+    """
+    from app.config import get_cli_config
+
+    try:
+        flavor, path = get_cli_config(project_name).get(role, ("", ""))
+    except Exception as e:  # never let config resolution break execution
+        print(f"[provider] cli role resolution failed for {role!r}: {e}", file=sys.stderr)
+        return get_provider()
+
+    if not flavor or flavor not in _PROVIDERS:
+        return get_provider()
+    # Same flavor as the global default and no custom path → reuse the singleton.
+    if flavor == get_provider_name() and not path:
+        return get_provider()
+    return _PROVIDERS[flavor](binary_path=path)
+
+
+def get_fallback_provider(project_name: str = "") -> Optional[CLIProvider]:
+    """Return the configured ``cli.fallback`` provider instance, or ``None``.
+
+    Used only for launch/auth-failure recovery (see ``mission_executor`` and the
+    ``run_command*`` helpers). Returns ``None`` when no fallback is configured.
+    Like :func:`get_provider_for_role`, never writes the global cache.
+    """
+    from app.config import get_cli_fallback
+
+    try:
+        flavor, path = get_cli_fallback(project_name)
+    except Exception as e:
+        print(f"[provider] cli fallback resolution failed: {e}", file=sys.stderr)
+        return None
+    if not flavor or flavor not in _PROVIDERS:
+        return None
+    return _PROVIDERS[flavor](binary_path=path)
+
+
+def resolve_role_provider(model_key: str, project_name: str = "") -> CLIProvider:
+    """Provider for a role, pre-flight-swapped to ``cli.fallback`` if unavailable.
+
+    Used by the stateless ``run_command*`` helpers: when the role's CLI binary
+    is not installed/resolvable (the dominant "cli not working" case — e.g. a
+    wrong ``flavor:path``), and a different, available ``cli.fallback`` is
+    configured, return the fallback up front. When no fallback applies, returns
+    the role provider unchanged so the call fails normally. (The stateful
+    mission path additionally recovers from auth failures post-run via
+    ``mission_executor._maybe_fallback_provider_rerun``.)
+    """
+    provider = get_provider_for_role(model_key, project_name)
+    if provider.is_available():
+        return provider
+    fb = get_fallback_provider(project_name)
+    if fb is not None and fb.binary() != provider.binary() and fb.is_available():
+        print(
+            f"[provider] role {model_key!r} CLI {provider.name!r} "
+            f"({provider.binary()}) unavailable — using fallback {fb.name!r}",
+            file=sys.stderr,
+        )
+        return fb
+    return provider
+
+
+def _resolve_role_provider_and_models(model_key: str, project_name: str):
+    """Resolve a role's provider (with launch-fallback) plus its model dict.
+
+    Shared by the stateless ``run_command`` / ``run_command_streaming`` helpers:
+    returns ``(provider, models)`` where ``models`` is resolved against that
+    provider's section for ``model_key`` and the fallback model.
+    """
+    from app.config import get_model_config
+
+    provider = resolve_role_provider(model_key, project_name)
+    models = get_model_config(
+        project_name,
+        role_providers={model_key: provider.name, "fallback": provider.name},
+    )
+    return provider, models
+
+
 def get_cli_binary() -> str:
     """Get the CLI binary command for the configured provider.
 
@@ -186,33 +280,18 @@ def get_cli_binary_name() -> str:
     return path.rstrip("/").rsplit("/", 1)[-1] if path else ""
 
 
-def get_review_cli_binary_name() -> str:
-    """Return the binary basename from ``KOAN_CLAUDE_CLI_FOR_REVIEW_PATH``, or '' if unset.
-
-    Mirrors :func:`get_cli_binary_name` for the review-scoped override.
-    Surfacing its basename in banners and ``/status`` lets an operator confirm
-    a review-only binary is configured — the sibling ``KOAN_CLAUDE_CLI_PATH``
-    advertises itself the same way — rather than a silent config with no
-    feedback.
-    """
-    path = os.environ.get("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "").strip()
-    return path.rstrip("/").rsplit("/", 1)[-1] if path else ""
-
-
 def get_provider_display(name: str = "") -> str:
     """Provider name for display, with the custom CLI binary flavor appended.
 
-    Returns ``"<name>"`` or ``"<name> (<binary>)"`` when
-    ``KOAN_CLAUDE_CLI_PATH`` points at a binary whose basename differs from
-    the provider name (e.g. ``claude (ollama-claude)``). When
-    ``KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`` is set, its basename is appended as a
-    ``review:`` hint (e.g. ``claude (ollama-claude, review: review-claude)``)
-    so a review-only binary is observable the same way as the default one.
-    Both flavors are suppressed when unset (or identical, for the default
-    binary), so this is a no-op for non-Claude providers. When *name* is empty
-    the configured provider is resolved via :func:`get_provider_name`. Single
-    source of truth for the provider line shown by the startup banner and
-    ``/status``.
+    Returns ``"<name>"`` or ``"<name> (<binary>)"`` when ``KOAN_CLAUDE_CLI_PATH``
+    points at a binary whose basename differs from the provider name (e.g.
+    ``claude (ollama-claude)``). Suppressed when unset or identical, so this is
+    a no-op for non-Claude providers. When *name* is empty the configured
+    provider is resolved via :func:`get_provider_name`. Single source of truth
+    for the global provider line shown by the startup banner and ``/status``.
+
+    Per-role provider overrides (the ``cli:`` config section) are summarized
+    separately by :func:`describe_cli_roles`.
     """
     if not name:
         name = get_provider_name()
@@ -220,51 +299,45 @@ def get_provider_display(name: str = "") -> str:
     binary = get_cli_binary_name()
     if binary and binary != name:
         parts.append(binary)
-    review = get_review_cli_binary_name()
-    if review:
-        parts.append(f"review: {review}")
     if parts:
         return f"{name} ({', '.join(parts)})"
     return name
 
 
-# ---------------------------------------------------------------------------
-# Review-scoped CLI binary override
-# ---------------------------------------------------------------------------
+def describe_cli_roles(project_name: str = "") -> str:
+    """Compact summary of per-role provider overrides for ``/status`` and the banner.
 
-# When active, ClaudeProvider.binary() prefers KOAN_CLAUDE_CLI_FOR_REVIEW_PATH
-# over KOAN_CLAUDE_CLI_PATH, so a review-specific Claude binary can be pinned
-# without affecting other missions. A ContextVar (not a plain flag) so the
-# override is confined to the review call subtree and auto-resets on exit, even
-# if reviews ever run concurrently. Activated only by review runners — see
-# review_runner._run_claude_review.
-_REVIEW_CLI_OVERRIDE: contextvars.ContextVar[bool] = contextvars.ContextVar(
-    "koan_review_cli_override", default=False,
-)
-
-
-def review_cli_override_active() -> bool:
-    """True when the current context should use the review-specific CLI binary.
-
-    This is the gate ``ClaudeProvider.binary()`` checks: the review binary is
-    consulted only while a review is running, so ordinary missions are
-    unaffected even when ``KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`` is set.
+    Returns e.g. ``"mission→codex, review_mode→deep-claude, fallback→claude"`` listing
+    only roles whose resolved provider/binary differs from the global default, plus
+    the ``cli.fallback`` provider if set. Empty string when no ``cli:`` section is
+    configured, so it stays a no-op for the default setup.
     """
-    return _REVIEW_CLI_OVERRIDE.get()
-
-
-@contextlib.contextmanager
-def review_cli_override():
-    """Within this block, the Claude provider prefers the review CLI binary.
-
-    No-op for non-Claude providers and when ``KOAN_CLAUDE_CLI_FOR_REVIEW_PATH``
-    is unset (binary() then falls through to its normal resolution).
-    """
-    token = _REVIEW_CLI_OVERRIDE.set(True)
     try:
-        yield
-    finally:
-        _REVIEW_CLI_OVERRIDE.reset(token)
+        from app.config import get_cli_config, get_cli_fallback
+
+        resolved = get_cli_config(project_name)
+    except Exception:
+        return ""
+
+    def _label(flavor: str, path: str) -> str:
+        if not path:
+            return flavor
+        return f"{flavor}({path.rstrip('/').rsplit('/', 1)[-1]})"
+
+    global_name = get_provider_name()
+    parts: List[str] = []
+    for role in ("mission", "chat", "lightweight", "review_mode", "reflect"):
+        flavor, path = resolved.get(role, (global_name, ""))
+        if flavor == global_name and not path:
+            continue
+        parts.append(f"{role}→{_label(flavor, path)}")
+    try:
+        fb_flavor, fb_path = get_cli_fallback(project_name)
+    except Exception:
+        fb_flavor, fb_path = "", ""
+    if fb_flavor:
+        parts.append(f"fallback→{_label(fb_flavor, fb_path)}")
+    return ", ".join(parts)
 
 
 # ---------------------------------------------------------------------------
@@ -328,6 +401,7 @@ def build_full_command(
     system_prompt_file: str = "",
     effort: str = "",
     resume_session_id: str = "",
+    provider: Optional[CLIProvider] = None,
 ) -> List[str]:
     """Build a complete CLI command for the configured provider.
 
@@ -344,13 +418,17 @@ def build_full_command(
         resume_session_id: When set and the provider supports session
             resumption, continues the given session instead of starting
             fresh.
+        provider: Explicit provider instance to build for. ``None`` (default)
+            uses the global :func:`get_provider`. Pass a per-role instance
+            (from :func:`get_provider_for_role`) to build a command for a
+            specific mission role's CLI / custom binary.
 
     Automatically reads ``skip_permissions`` from config.yaml so all
     callers get the flag without needing changes.
     """
     from app.config import get_skip_permissions
 
-    return get_provider().build_command(
+    return (provider or get_provider()).build_command(
         prompt=prompt,
         allowed_tools=allowed_tools,
         disallowed_tools=disallowed_tools,
@@ -429,6 +507,7 @@ def build_full_command_managed(
     resume_session_id: str = "",
     system_prompt_dir: Optional[str] = None,
     system_prompt_container_dir: Optional[str] = None,
+    provider: Optional[CLIProvider] = None,
 ) -> Tuple[List[str], List[str]]:
     """Build a CLI command, routing large system prompts through a temp file.
 
@@ -458,8 +537,9 @@ def build_full_command_managed(
         plugin_dirs=plugin_dirs,
         effort=effort,
         resume_session_id=resume_session_id,
+        provider=provider,
     )
-    if system_prompt and get_provider().supports_system_prompt_file():
+    if system_prompt and (provider or get_provider()).supports_system_prompt_file():
         host_path, cmd_path = _write_system_prompt_file(
             system_prompt,
             host_dir=system_prompt_dir,
@@ -521,12 +601,18 @@ def run_command(
     max_turns: int = 10,
     timeout: int = 300,
     max_turns_source: Optional[str] = "skill_max_turns",
+    project_name: str = "",
 ) -> str:
     """Build and run a CLI command, returning stripped stdout.
 
     Higher-level helper for runner modules that need to invoke the
     configured CLI provider with a prompt and get back text output.
     Combines build_full_command + subprocess execution + error handling.
+
+    The provider is resolved per role: ``model_key`` selects both the model and
+    the CLI provider (the ``cli:`` section). Pass ``project_name`` to honor
+    per-project ``cli:`` overrides; omitting it uses the section/global
+    resolution (which matches the historical behavior for these helpers).
 
     When the CLI hits its max-turns limit, the partial output is returned
     instead of raising — the caller can still extract useful results from
@@ -536,21 +622,21 @@ def run_command(
         RuntimeError: If the command exits with non-zero code (except
             max-turns, which returns partial output).
     """
-    from app.config import get_model_config
-
-    models = get_model_config()
+    provider, models = _resolve_role_provider_and_models(model_key, project_name)
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=allowed_tools,
         model=models.get(model_key, ""),
         fallback=models.get("fallback", ""),
         max_turns=max_turns,
+        provider=provider,
     )
 
     from app.cli_exec import run_cli_with_retry
 
     result = run_cli_with_retry(
         cmd,
+        provider=provider,
         capture_output=True, text=True, timeout=timeout,
         cwd=project_path,
     )
@@ -912,6 +998,7 @@ def run_command_streaming(
     max_turns: int = 10,
     timeout: int = 300,
     max_turns_source: Optional[str] = "skill_max_turns",
+    project_name: str = "",
 ) -> str:
     """Build and run a CLI command, streaming progress to stdout in real time.
 
@@ -935,10 +1022,10 @@ def run_command_streaming(
         RuntimeError: If the command exits with non-zero code (except
             max-turns, which returns partial output).
     """
-    from app.config import get_model_config
-
-    models = get_model_config()
-    provider = get_provider()
+    # Resolve the CLI provider for this role (cli: section), swapping to the
+    # cli.fallback up front if the role's binary is unavailable. An explicit
+    # `model` arg still wins over the role-derived model.
+    provider, models = _resolve_role_provider_and_models(model_key, project_name)
     use_stream_json = provider.supports_stream_json()
     cmd = build_full_command(
         prompt=prompt,
@@ -947,6 +1034,7 @@ def run_command_streaming(
         fallback=models.get("fallback", ""),
         max_turns=max_turns,
         output_format="stream-json" if use_stream_json else "",
+        provider=provider,
     )
     last_message_path: Optional[str] = None
     if provider.supports_last_message_file():

--- a/koan/app/provider/base.py
+++ b/koan/app/provider/base.py
@@ -1,5 +1,6 @@
 """Base class and constants for CLI provider abstraction."""
 
+import os
 import shutil
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -47,6 +48,37 @@ class CLIProvider:
     """
 
     name: str = ""
+
+    def __init__(self, binary_path: str = ""):
+        """Optional per-instance binary path override.
+
+        When set, ``binary()`` resolves and returns this path instead of the
+        provider's default. Used by per-role provider selection (the ``cli:``
+        config section) to pin a specific CLI binary for one mission role
+        without touching the global provider. The path is resolved by
+        :meth:`_resolve_binary_path` (absolute as-is, bare name left for PATH
+        lookup, relative rooted at ``KOAN_ROOT``).
+        """
+        self._binary_override = (binary_path or "").strip()
+
+    def _resolve_binary_path(self, raw: str) -> str:
+        """Resolve a configured binary path the same way for every provider.
+
+        Absolute path → as-is. Bare command name (no directory component) →
+        left for PATH lookup. Relative path → resolved against ``KOAN_ROOT`` so
+        config stays portable (the agent runs from ``KOAN_ROOT/koan``, not
+        ``KOAN_ROOT``, so a naive relative path would resolve wrong). Single
+        source of truth for ``KOAN_CLAUDE_CLI_PATH`` and ``cli: flavor:path``.
+        """
+        raw = (raw or "").strip()
+        if not raw:
+            return ""
+        if os.path.isabs(raw) or not os.path.dirname(raw):
+            return raw
+        root = os.environ.get("KOAN_ROOT", "").strip()
+        if root:
+            return os.path.normpath(os.path.join(root, raw))
+        return raw
 
     def binary(self) -> str:
         """Return the CLI binary name or path."""

--- a/koan/app/provider/claude.py
+++ b/koan/app/provider/claude.py
@@ -12,31 +12,16 @@ class ClaudeProvider(CLIProvider):
     name = "claude"
 
     def binary(self) -> str:
-        # Review-specific binary wins *while a review is running*: it takes
-        # precedence over KOAN_CLAUDE_CLI_PATH, but only inside a
-        # review_cli_override() context, so other missions are untouched.
-        from app.provider import review_cli_override_active
-
-        if review_cli_override_active():
-            review_path = os.environ.get(
-                "KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "",
-            ).strip()
-            if review_path:
-                return review_path
+        # Per-role override (cli: flavor:path) wins when this instance was
+        # constructed with one — see provider.get_provider_for_role().
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
+        # Otherwise the global custom binary, then the bare command. Both go
+        # through the shared resolver so KOAN_ROOT-relative paths stay portable.
         raw = os.environ.get("KOAN_CLAUDE_CLI_PATH", "").strip()
         if not raw:
             return "claude"
-        # Absolute path → as-is. Bare command name (no directory component)
-        # → leave for PATH lookup. Relative path → resolve against KOAN_ROOT
-        # so .env config is portable across installs/copies. Note the process
-        # CWD is KOAN_ROOT/koan (Makefile runs `cd koan`), not KOAN_ROOT, so a
-        # naive relative path would resolve to the wrong place.
-        if os.path.isabs(raw) or not os.path.dirname(raw):
-            return raw
-        root = os.environ.get("KOAN_ROOT", "").strip()
-        if root:
-            return os.path.normpath(os.path.join(root, raw))
-        return raw
+        return self._resolve_binary_path(raw)
 
     def supports_session_resume(self) -> bool:
         return True

--- a/koan/app/provider/cline.py
+++ b/koan/app/provider/cline.py
@@ -66,10 +66,12 @@ class ClineProvider(CLIProvider):
     name = "cline"
 
     def binary(self) -> str:
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
         return "cline"
 
     def is_available(self) -> bool:
-        return shutil.which("cline") is not None
+        return shutil.which(self.binary()) is not None
 
     def build_permission_args(self, skip_permissions: bool = False) -> List[str]:
         # Cline uses --auto-approve for unattended execution.

--- a/koan/app/provider/codex.py
+++ b/koan/app/provider/codex.py
@@ -87,10 +87,12 @@ class CodexProvider(CLIProvider):
     name = "codex"
 
     def binary(self) -> str:
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
         return "codex"
 
     def is_available(self) -> bool:
-        return shutil.which("codex") is not None
+        return shutil.which(self.binary()) is not None
 
     def build_permission_args(self, skip_permissions: bool = False) -> List[str]:
         # Codex equivalent: bypass approvals and sandbox entirely.

--- a/koan/app/provider/copilot.py
+++ b/koan/app/provider/copilot.py
@@ -40,11 +40,14 @@ class CopilotProvider(CLIProvider):
 
     name = "copilot"
 
-    def __init__(self):
+    def __init__(self, binary_path: str = ""):
+        super().__init__(binary_path)
         self._has_copilot = shutil.which("copilot") is not None
         self._has_gh = shutil.which("gh") is not None
 
     def binary(self) -> str:
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
         # Prefer standalone 'copilot' binary, fallback to 'gh'
         if self._has_copilot:
             return "copilot"

--- a/koan/app/provider/ollama_launch.py
+++ b/koan/app/provider/ollama_launch.py
@@ -74,6 +74,8 @@ class OllamaLaunchProvider(ClaudeProvider):
         )
 
     def binary(self) -> str:
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
         return "ollama"
 
     def shell_command(self) -> str:
@@ -81,7 +83,7 @@ class OllamaLaunchProvider(ClaudeProvider):
 
     def is_available(self) -> bool:
         """Check that ollama binary exists and is v0.16.0+."""
-        return shutil.which("ollama") is not None
+        return shutil.which(self.binary()) is not None
 
     def build_model_args(self, model: str = "", fallback: str = "") -> List[str]:
         # Model is handled by ollama --model flag (before --), not Claude --model.

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -746,6 +746,30 @@ def build_review_prompt(
     return load_prompt_or_skill(skill_dir, prompt_name, **kwargs)
 
 
+def _review_attribution(project_name: str = "") -> Tuple[str, str]:
+    """Return ``(provider_name, model)`` the review actually runs on.
+
+    Resolves the ``review_mode`` role against the same provider the review CLI
+    uses (``resolve_role_provider`` — including any launch-fallback swap) and
+    reads that provider's model section (``review_mode`` then ``mission``).
+    Single source of truth for both the review invocation and the footer
+    attribution, so the displayed provider/model can never drift from the
+    binary/model actually used.
+    """
+    from app.cli_provider import resolve_role_provider
+    from app.config import get_model_config
+
+    provider = resolve_role_provider("review_mode", project_name)
+    models = get_model_config(
+        project_name,
+        role_providers={
+            "review_mode": provider.name,
+            "mission": provider.name,
+        },
+    )
+    return provider.name, (models.get("review_mode") or models.get("mission", ""))
+
+
 def _run_claude_review(
     prompt: str,
     project_path: str,
@@ -770,25 +794,14 @@ def _run_claude_review(
         (output, error) tuple. output is the provider's review text (empty on
         failure), error is the failure reason (empty on success).
     """
-    from app.cli_provider import resolve_role_provider, run_command_streaming
-    from app.config import get_model_config, get_skill_max_turns
+    from app.cli_provider import run_command_streaming
+    from app.config import get_skill_max_turns
 
     if model is None:
-        # Resolve the model against the SAME provider run_command_streaming will
-        # run on (resolve_role_provider — including any launch fallback swap),
-        # NOT the global provider. Otherwise a review pinned to a Claude binary
-        # (cli.review_mode: claude:...) under a global Codex would receive a
-        # Codex model name. Mirrors build_mission_command's role_providers; the
-        # mission model is kept as the fallback, matching the prior behavior.
-        review_provider = resolve_role_provider("review_mode", project_name)
-        models = get_model_config(
-            project_name,
-            role_providers={
-                "review_mode": review_provider.name,
-                "mission": review_provider.name,
-            },
-        )
-        model = models.get("review_mode") or models.get("mission", "")
+        # Resolve the model against the review_mode provider (not the global
+        # one) so it matches the binary the review runs on — see
+        # _review_attribution, shared with the footer attribution below.
+        _, model = _review_attribution(project_name)
 
     try:
         # Resolve the review-path CLI via the "review_mode" role (the cli:
@@ -2762,15 +2775,10 @@ def run_review(
         prior_review=prior_review_text,
     )
 
-    # Resolve provider/model for footer attribution
-    from app.config import get_model_config as _get_model_config
-    from app.provider import get_provider_name
-    _review_models = _get_model_config()
-    review_model = (
-        _review_models.get("review_mode")
-        or _review_models.get("mission", "")
-    )
-    review_provider_name = get_provider_name()
+    # Resolve provider/model for footer attribution against the review_mode
+    # provider (the one the review actually runs on), so the footer reflects the
+    # binary/model used rather than the global provider.
+    review_provider_name, review_model = _review_attribution(project_name or "")
 
     # Step 3: Run provider review (read-only)
     notify_fn(f"Analyzing code changes on `{context['branch']}`...")

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -766,7 +766,7 @@ def _run_claude_review(
         (output, error) tuple. output is the provider's review text (empty on
         failure), error is the failure reason (empty on success).
     """
-    from app.cli_provider import run_command_streaming, review_cli_override
+    from app.cli_provider import run_command_streaming
     from app.config import get_model_config, get_skill_max_turns
 
     if model is None:
@@ -774,20 +774,20 @@ def _run_claude_review(
         model = models.get("review_mode") or models.get("mission", "")
 
     try:
-        # Pin the review-specific Claude binary (KOAN_CLAUDE_CLI_FOR_REVIEW_PATH)
-        # for every review-path call — main pass, reflect, error-hunter, bot
-        # triage. The override is context-scoped, so it cannot leak into other
-        # missions or the write-capable fix step.
-        with review_cli_override():
-            output = run_command_streaming(
-                prompt=prompt,
-                project_path=project_path,
-                allowed_tools=["Read", "Glob", "Grep"],
-                model_key="mission",
-                model=model,
-                max_turns=get_skill_max_turns(),
-                timeout=timeout,
-            )
+        # Resolve the review-path CLI via the "review_mode" role (the cli:
+        # config section). This pins a review-specific provider/binary — e.g.
+        # cli.review_mode: claude:/path/to/review-claude — for every review
+        # call (main pass, reflect, error-hunter, bot triage) without affecting
+        # other missions or the write-capable fix step.
+        output = run_command_streaming(
+            prompt=prompt,
+            project_path=project_path,
+            allowed_tools=["Read", "Glob", "Grep"],
+            model_key="review_mode",
+            model=model,
+            max_turns=get_skill_max_turns(),
+            timeout=timeout,
+        )
         return output, ""
     except RuntimeError as e:
         error = str(e) or "unknown error"

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1006,6 +1006,7 @@ def _should_run_error_hunter(diff: str) -> bool:
 def _run_error_hunter(
     diff: str, project_path: str, skill_dir: Optional[Path],
     owner: str = "", repo: str = "", head_sha: str = "",
+    project_name: str = "",
 ) -> str:
     """Run the silent-failure-hunter pass and return formatted markdown section.
 
@@ -1016,7 +1017,7 @@ def _run_error_hunter(
     else:
         prompt = load_prompt("silent-failure-hunter", DIFF=diff)
 
-    raw_output, error = _run_claude_review(prompt, project_path)
+    raw_output, error = _run_claude_review(prompt, project_path, project_name=project_name)
     if not raw_output:
         print(
             f"[review_runner] silent-failure-hunter pass failed: {error}",
@@ -1150,6 +1151,7 @@ def _run_bot_comment_triage(
     diff: str,
     skill_dir: Optional[Path],
     project_path: str = "",
+    project_name: str = "",
 ) -> List[dict]:
     """Run Claude triage on bot inline comments.
 
@@ -1179,7 +1181,7 @@ def _run_bot_comment_triage(
         return []
 
     try:
-        raw_output, error = _run_claude_review(prompt, project_path)
+        raw_output, error = _run_claude_review(prompt, project_path, project_name=project_name)
         if not raw_output:
             print(f"[review_runner] bot comment triage failed: {error}", file=sys.stderr)
             return []
@@ -2742,6 +2744,7 @@ def run_review(
                 triage_replies = _run_bot_comment_triage(
                     bot_inline, context.get("diff", ""), skill_dir,
                     project_path=project_path,
+                    project_name=project_name or "",
                 )
                 if triage_replies:
                     bot_reply_results = _post_comment_replies(
@@ -2849,6 +2852,7 @@ def run_review(
             triage_replies = _run_bot_comment_triage(
                 bot_inline, context.get("diff", ""), skill_dir,
                 project_path=project_path,
+                project_name=project_name or "",
             )
             if triage_replies:
                 bot_reply_results = _post_comment_replies(
@@ -2869,6 +2873,7 @@ def run_review(
             diff, project_path, skill_dir,
             owner=owner, repo=repo,
             head_sha=(current_shas[-1] if current_shas else ""),
+            project_name=project_name or "",
         )
         if error_section:
             review_body = review_body + "\n\n---\n\n" + error_section

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -751,6 +751,7 @@ def _run_claude_review(
     project_path: str,
     timeout: int = 600,
     model: Optional[str] = None,
+    project_name: str = "",
 ) -> Tuple[str, str]:
     """Run provider CLI with read-only tools and return the output text.
 
@@ -759,18 +760,34 @@ def _run_claude_review(
         project_path: Path to the project for codebase context.
         timeout: Maximum seconds to wait (default 600s — large PRs need
                  more time than the old 300s default).
-        model: Optional model override. When None, uses models["review_mode"]
-               if configured, otherwise models["mission"].
+        model: Optional model override. When None, the review_mode model is
+               resolved against the review_mode PROVIDER's section (so it
+               matches the binary the review runs on), falling back to that
+               provider's mission model.
+        project_name: Project name for per-project ``cli.review_mode`` overrides.
 
     Returns:
         (output, error) tuple. output is the provider's review text (empty on
         failure), error is the failure reason (empty on success).
     """
-    from app.cli_provider import run_command_streaming
+    from app.cli_provider import resolve_role_provider, run_command_streaming
     from app.config import get_model_config, get_skill_max_turns
 
     if model is None:
-        models = get_model_config()
+        # Resolve the model against the SAME provider run_command_streaming will
+        # run on (resolve_role_provider — including any launch fallback swap),
+        # NOT the global provider. Otherwise a review pinned to a Claude binary
+        # (cli.review_mode: claude:...) under a global Codex would receive a
+        # Codex model name. Mirrors build_mission_command's role_providers; the
+        # mission model is kept as the fallback, matching the prior behavior.
+        review_provider = resolve_role_provider("review_mode", project_name)
+        models = get_model_config(
+            project_name,
+            role_providers={
+                "review_mode": review_provider.name,
+                "mission": review_provider.name,
+            },
+        )
         model = models.get("review_mode") or models.get("mission", "")
 
     try:
@@ -787,6 +804,7 @@ def _run_claude_review(
             model=model,
             max_turns=get_skill_max_turns(),
             timeout=timeout,
+            project_name=project_name,
         )
         return output, ""
     except RuntimeError as e:
@@ -875,6 +893,7 @@ def _reflect_findings(
     threshold: int,
     skill_dir: Optional[Path] = None,
     calibration_hints: str = "",
+    project_name: str = "",
 ) -> list:
     """Run a second-pass reflection on review findings and filter low-signal ones.
 
@@ -914,7 +933,9 @@ def _reflect_findings(
         print(f"[reflect] prompt build failed: {e}", file=sys.stderr)
         return findings
 
-    raw_output, error = _run_claude_review(prompt, project_path, model=model)
+    raw_output, error = _run_claude_review(
+        prompt, project_path, model=model, project_name=project_name,
+    )
     if not raw_output:
         return findings
 
@@ -2403,7 +2424,8 @@ def _run_review_analysis(
       - ``error``: short provider error string, set only when the provider
         produced no output at all.
     """
-    raw_output, error = _run_claude_review(prompt, project_path)
+    pname = project_name or ""
+    raw_output, error = _run_claude_review(prompt, project_path, project_name=pname)
     if not raw_output:
         return None, "", error
 
@@ -2415,13 +2437,23 @@ def _run_review_analysis(
             "You MUST respond with ONLY a valid JSON object matching the "
             "schema described above. No markdown, no text, just JSON."
         )
-        retry_output, _ = _run_claude_review(retry_prompt, project_path)
+        retry_output, _ = _run_claude_review(retry_prompt, project_path, project_name=pname)
         if retry_output:
             review_data = _parse_review_json(retry_output)
 
     if review_data is not None and review_data.get("file_comments"):
+        from app.cli_provider import resolve_role_provider
         from app.config import get_model_config, get_review_reflect_config
-        models = get_model_config()
+        # Resolve the reflect model against the review_mode PROVIDER's section,
+        # since the reflect pass runs on that same binary (see _run_claude_review).
+        review_provider = resolve_role_provider("review_mode", pname)
+        models = get_model_config(
+            pname,
+            role_providers={
+                "reflect": review_provider.name,
+                "lightweight": review_provider.name,
+            },
+        )
         reflect_cfg = get_review_reflect_config()
         reflect_model = models.get("reflect") or models.get("lightweight")
         reflect_threshold = reflect_cfg.get("threshold", 5)
@@ -2434,6 +2466,7 @@ def _run_review_analysis(
             reflect_threshold,
             skill_dir=skill_dir,
             calibration_hints=calibration_hints,
+            project_name=pname,
         )
 
     return review_data, raw_output, error

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -301,6 +301,7 @@ def run_claude_task(
     instance_dir: str = "",
     project_name: str = "",
     run_num: int = 0,
+    provider=None,
 ) -> int:
     """Run Claude CLI as a subprocess with SIGINT isolation and timeout.
 
@@ -347,8 +348,12 @@ def run_claude_task(
     koan_root_active = os.environ.get("KOAN_ROOT", "")
     try:
         with open(stdout_file, "w") as out_f, open(stderr_file, "w") as err_f:
+            # provider is the role-resolved instance (cli: section); popen_cli
+            # uses it for stdin-rewrite + invocation lock so they match the
+            # binary the command was built for. None → global provider.
             proc, cleanup = popen_cli(
                 cmd,
+                provider=provider,
                 stdout=out_f,
                 stderr=err_f,
                 cwd=cwd,

--- a/koan/app/session_manager.py
+++ b/koan/app/session_manager.py
@@ -225,6 +225,7 @@ def spawn_session(
         Session with subprocess started and registered.
     """
     from app.mission_runner import build_mission_command
+    from app.provider import get_provider_for_role
 
     # Create worktree
     wt = create_worktree(project_path, base_branch=base_branch)
@@ -236,11 +237,20 @@ def spawn_session(
     # Inject mission context into worktree CLAUDE.md
     inject_worktree_claude_md(wt.path, mission_text)
 
+    # Resolve the role's CLI provider (cli: section) once, so the command is
+    # BUILT and EXECUTED under the same provider — otherwise popen_cli would
+    # fall back to the global provider for stdin-rewrite and the invocation
+    # lock, mismatching a cross-provider role (e.g. cli.mission: codex under a
+    # global claude). Mirrors mission_executor._run_iteration.
+    effective_role = "review_mode" if autonomous_mode == "review" else "mission"
+    session_cli_provider = get_provider_for_role(effective_role, project_name)
+
     # Build CLI command
     cmd, cmd_cleanup_paths = build_mission_command(
         prompt=mission_text,
         autonomous_mode=autonomous_mode,
         project_name=project_name,
+        provider_override=session_cli_provider,
     )
 
     # Create temp files for stdout/stderr
@@ -276,6 +286,7 @@ def spawn_session(
         err_f = open(stderr_file, "w")  # noqa: SIM115
         proc, cli_cleanup = popen_cli(
             cmd,
+            provider=session_cli_provider,
             stdout=out_f,
             stderr=err_f,
             cwd=wt.path,

--- a/koan/tests/test_cli_config.py
+++ b/koan/tests/test_cli_config.py
@@ -1,7 +1,7 @@
 """Tests for the `cli:` config section: parsing, resolution, model coupling.
 
-Covers app.config._parse_cli_value / get_cli_config / get_cli_fallback /
-get_model_for_role and the role-aware get_model_config(role_providers=...).
+Covers app.config._parse_cli_value / get_cli_config / get_cli_fallback and
+the role-aware get_model_config(role_providers=...).
 """
 
 from contextlib import contextmanager
@@ -126,7 +126,7 @@ class TestGetCliFallback:
 
 
 # ---------------------------------------------------------------------------
-# Model coupling: get_model_config(role_providers=...) + get_model_for_role
+# Model coupling: get_model_config(role_providers=...)
 # ---------------------------------------------------------------------------
 
 class TestModelCoupling:
@@ -154,14 +154,3 @@ class TestModelCoupling:
                 resolved = cfg.get_model_config(role_providers={"mission": "codex", "review_mode": "claude"})
         assert resolved["mission"] == "gpt-5-codex"   # models.codex.mission
         assert resolved["review_mode"] == "opus"        # models.claude.review_mode
-
-    def test_get_model_for_role_uses_role_provider(self):
-        full = {
-            "cli_provider": "codex",
-            "models": self._MODELS,
-            "cli": {"default": {"review_mode": "claude"}},
-        }
-        with _config(full):
-            with patch("app.provider.get_provider_name", return_value="codex"):
-                assert cfg.get_model_for_role("review_mode") == "opus"
-                assert cfg.get_model_for_role("mission") == "gpt-5-codex"

--- a/koan/tests/test_cli_config.py
+++ b/koan/tests/test_cli_config.py
@@ -1,0 +1,167 @@
+"""Tests for the `cli:` config section: parsing, resolution, model coupling.
+
+Covers app.config._parse_cli_value / get_cli_config / get_cli_fallback /
+get_model_for_role and the role-aware get_model_config(role_providers=...).
+"""
+
+from contextlib import contextmanager
+from unittest.mock import patch
+
+import app.config as cfg
+import app.provider as provider
+
+
+@contextmanager
+def _config(full_config, project_overrides=None):
+    """Patch every config-loading seam to return the given dicts."""
+    project_overrides = project_overrides or {}
+    with patch("app.config._load_config", return_value=full_config), \
+         patch("app.config._load_project_overrides", return_value=project_overrides), \
+         patch("app.utils.load_config", return_value=full_config):
+        provider.reset_provider()
+        yield
+
+
+# ---------------------------------------------------------------------------
+# _parse_cli_value
+# ---------------------------------------------------------------------------
+
+class TestParseCliValue:
+    def test_flavor_only(self):
+        assert cfg._parse_cli_value("claude") == ("claude", "")
+
+    def test_flavor_with_absolute_path(self):
+        assert cfg._parse_cli_value("claude:/abs/deep-claude") == ("claude", "/abs/deep-claude")
+
+    def test_flavor_with_relative_path(self):
+        assert cfg._parse_cli_value("codex:bin/wrap") == ("codex", "bin/wrap")
+
+    def test_splits_on_first_colon_only(self):
+        # Extra colons in the path survive.
+        assert cfg._parse_cli_value("claude:/a:b/x") == ("claude", "/a:b/x")
+
+    def test_whitespace_trimmed(self):
+        assert cfg._parse_cli_value("  claude : /p/x ".replace(" : ", ":").strip()) == ("claude", "/p/x")
+
+    def test_unknown_flavor_returns_empty(self, capsys):
+        assert cfg._parse_cli_value("bogus:/x") == ("", "")
+        assert "unknown provider flavor" in capsys.readouterr().err
+
+    def test_empty_returns_empty(self):
+        assert cfg._parse_cli_value("") == ("", "")
+        assert cfg._parse_cli_value(None) == ("", "")
+
+
+# ---------------------------------------------------------------------------
+# get_cli_config
+# ---------------------------------------------------------------------------
+
+class TestGetCliConfig:
+    def test_absence_parity_all_roles_global(self):
+        """No cli: section → every role resolves to (global_provider, '')."""
+        with _config({"cli_provider": "codex"}):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                resolved = cfg.get_cli_config()
+        assert resolved == {
+            "mission": ("codex", ""),
+            "chat": ("codex", ""),
+            "lightweight": ("codex", ""),
+            "review_mode": ("codex", ""),
+            "reflect": ("codex", ""),
+        }
+
+    def test_default_section_per_role(self):
+        full = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/p/deep-claude", "mission": "codex"}},
+        }
+        with _config(full):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                resolved = cfg.get_cli_config()
+        assert resolved["review_mode"] == ("claude", "/p/deep-claude")
+        assert resolved["mission"] == ("codex", "")
+        # Unset roles fall back to the global provider.
+        assert resolved["chat"] == ("codex", "")
+
+    def test_project_override_beats_default(self):
+        full = {"cli_provider": "codex", "cli": {"default": {"mission": "codex"}}}
+        proj = {"cli": {"mission": "claude:/p/x"}}
+        with _config(full, project_overrides=proj):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                resolved = cfg.get_cli_config("proj")
+        assert resolved["mission"] == ("claude", "/p/x")
+
+    def test_unknown_flavor_falls_through_to_global(self):
+        full = {"cli_provider": "codex", "cli": {"default": {"mission": "bogus"}}}
+        with _config(full):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                resolved = cfg.get_cli_config()
+        assert resolved["mission"] == ("codex", "")
+
+
+# ---------------------------------------------------------------------------
+# get_cli_fallback
+# ---------------------------------------------------------------------------
+
+class TestGetCliFallback:
+    def test_unset_returns_empty(self):
+        with _config({"cli_provider": "codex"}):
+            assert cfg.get_cli_fallback() == ("", "")
+
+    def test_section_level_fallback(self):
+        full = {"cli": {"fallback": "claude:/p/deep-claude"}}
+        with _config(full):
+            assert cfg.get_cli_fallback() == ("claude", "/p/deep-claude")
+
+    def test_default_level_fallback_accepted(self):
+        full = {"cli": {"default": {"fallback": "claude"}}}
+        with _config(full):
+            assert cfg.get_cli_fallback() == ("claude", "")
+
+    def test_project_override_beats_global(self):
+        full = {"cli": {"fallback": "codex"}}
+        proj = {"cli": {"fallback": "claude:/p/x"}}
+        with _config(full, project_overrides=proj):
+            assert cfg.get_cli_fallback("proj") == ("claude", "/p/x")
+
+
+# ---------------------------------------------------------------------------
+# Model coupling: get_model_config(role_providers=...) + get_model_for_role
+# ---------------------------------------------------------------------------
+
+class TestModelCoupling:
+    _MODELS = {
+        "default": {"mission": "", "review_mode": "", "lightweight": "haiku", "fallback": "sonnet"},
+        "codex": {"mission": "gpt-5-codex"},
+        "claude": {"review_mode": "opus", "mission": "sonnet"},
+    }
+
+    def test_role_providers_none_equals_all_global(self):
+        """Parity: role_providers=None == an all-global role_providers map."""
+        full = {"cli_provider": "codex", "models": self._MODELS}
+        with _config(full):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                none_cfg = cfg.get_model_config()
+                all_global = cfg.get_model_config(role_providers={
+                    k: "codex" for k in ("mission", "chat", "lightweight", "fallback", "review_mode", "reflect")
+                })
+        assert none_cfg == all_global
+
+    def test_each_role_resolves_against_its_provider(self):
+        full = {"cli_provider": "codex", "models": self._MODELS}
+        with _config(full):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                resolved = cfg.get_model_config(role_providers={"mission": "codex", "review_mode": "claude"})
+        assert resolved["mission"] == "gpt-5-codex"   # models.codex.mission
+        assert resolved["review_mode"] == "opus"        # models.claude.review_mode
+
+    def test_get_model_for_role_uses_role_provider(self):
+        full = {
+            "cli_provider": "codex",
+            "models": self._MODELS,
+            "cli": {"default": {"review_mode": "claude"}},
+        }
+        with _config(full):
+            with patch("app.provider.get_provider_name", return_value="codex"):
+                assert cfg.get_model_for_role("review_mode") == "opus"
+                assert cfg.get_model_for_role("mission") == "gpt-5-codex"

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -19,7 +19,9 @@ from app.cli_provider import (
     build_max_turns_flags,
     build_full_command,
     run_command,
-    review_cli_override,
+    get_provider_for_role,
+    get_fallback_provider,
+    resolve_role_provider,
     CLAUDE_TOOLS,
     TOOL_NAME_MAP,
 )
@@ -131,44 +133,31 @@ class TestClaudeProvider:
         assert cmd[0] == "/srv/koan/bin/zai-claude"
         assert cmd[1:] == ["-p", "hello"]
 
-    # -- Review-scoped binary (KOAN_CLAUDE_CLI_FOR_REVIEW_PATH) -------------
+    # -- Per-instance binary override (cli: flavor:path) -------------------
 
-    def test_binary_review_override_used_when_active(self, monkeypatch):
-        """Inside review_cli_override(), the review-specific binary is used."""
+    def test_binary_override_absolute(self, monkeypatch):
+        """A constructor binary_path overrides env resolution (absolute)."""
         monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/bin/review-claude")
-        with review_cli_override():
-            assert self.provider.binary() == "/opt/bin/review-claude"
+        p = ClaudeProvider(binary_path="/opt/bin/deep-claude")
+        assert p.binary() == "/opt/bin/deep-claude"
 
-    def test_binary_review_override_ignored_when_inactive(self, monkeypatch):
-        """Outside a review, the review var never affects other missions."""
-        monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/bin/review-claude")
-        assert self.provider.binary() == "claude"
+    def test_binary_override_relative_rooted_at_koan_root(self, monkeypatch):
+        """A relative override path resolves against KOAN_ROOT, like the env path."""
+        monkeypatch.setenv("KOAN_ROOT", "/srv/koan")
+        p = ClaudeProvider(binary_path="bin/deep-claude")
+        assert p.binary() == "/srv/koan/bin/deep-claude"
 
-    def test_binary_review_override_precedence(self, monkeypatch):
-        """Review binary wins over KOAN_CLAUDE_CLI_PATH while a review runs."""
+    def test_binary_override_wins_over_env(self, monkeypatch):
+        """The per-instance override beats KOAN_CLAUDE_CLI_PATH."""
         monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "/opt/bin/default-claude")
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/bin/review-claude")
-        with review_cli_override():
-            assert self.provider.binary() == "/opt/bin/review-claude"
-        # And falls back to the default binary once the review context exits.
-        assert self.provider.binary() == "/opt/bin/default-claude"
+        p = ClaudeProvider(binary_path="/opt/bin/deep-claude")
+        assert p.binary() == "/opt/bin/deep-claude"
 
-    def test_binary_review_override_empty_falls_back(self, monkeypatch):
-        """An empty review var falls through to KOAN_CLAUDE_CLI_PATH."""
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "/opt/bin/default-claude")
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "   ")
-        with review_cli_override():
-            assert self.provider.binary() == "/opt/bin/default-claude"
-
-    def test_build_command_uses_review_binary_under_override(self, monkeypatch):
-        """The full command-building path resolves the review binary."""
+    def test_binary_override_flows_into_build_command(self, monkeypatch):
         monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/bin/review-claude")
-        with review_cli_override():
-            cmd = self.provider.build_command(prompt="hello")
-        assert cmd[0] == "/opt/bin/review-claude"
+        p = ClaudeProvider(binary_path="/opt/bin/deep-claude")
+        cmd = p.build_command(prompt="hello")
+        assert cmd[0] == "/opt/bin/deep-claude"
         assert cmd[1:] == ["-p", "hello"]
 
     def test_name(self):
@@ -1172,3 +1161,150 @@ class TestSessionResume:
              patch("app.config.get_skip_permissions", return_value=True):
             cmd = build_full_command(prompt="test")
             assert "--resume" not in cmd
+
+
+# ---------------------------------------------------------------------------
+# Per-role provider selection (cli: section)
+# ---------------------------------------------------------------------------
+
+class TestRoleProviderSelection:
+    """Tests for get_provider_for_role / get_fallback_provider / resolve_role_provider."""
+
+    def setup_method(self):
+        reset_provider()
+
+    def teardown_method(self):
+        reset_provider()
+
+    def _patch_config(self, full_config):
+        """Patch every config-loading seam to return *full_config*."""
+        return [
+            patch("app.config._load_config", return_value=full_config),
+            patch("app.config._load_project_overrides", return_value={}),
+            patch("app.utils.load_config", return_value=full_config),
+        ]
+
+    def _run(self, full_config, fn):
+        patches = self._patch_config(full_config)
+        for p in patches:
+            p.start()
+        try:
+            return fn()
+        finally:
+            for p in patches:
+                p.stop()
+
+    def test_unset_role_returns_global_singleton(self):
+        """No cli: section → role provider IS the global singleton (parity)."""
+        cfg = {"cli_provider": "codex"}
+
+        def check():
+            glob = get_provider()
+            role = get_provider_for_role("mission")
+            assert role is glob
+            assert role.name == "codex"
+        self._run(cfg, check)
+
+    def test_custom_flavor_and_path(self):
+        """cli.review_mode: claude:/path → fresh claude instance with that binary."""
+        cfg = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/p/deep-claude"}},
+        }
+
+        def check():
+            rev = get_provider_for_role("review_mode")
+            assert rev.name == "claude"
+            assert rev.binary() == "/p/deep-claude"
+        self._run(cfg, check)
+
+    def test_does_not_poison_global_singleton(self):
+        """A path-bearing role instance must never replace the global singleton."""
+        cfg = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/p/deep-claude"}},
+        }
+
+        def check():
+            glob_before = get_provider()
+            rev = get_provider_for_role("review_mode")
+            assert rev is not glob_before
+            # Global identity + binary unchanged after the role call.
+            assert get_provider() is glob_before
+            assert get_provider().name == "codex"
+            assert get_provider().binary() == "codex"
+        self._run(cfg, check)
+
+    def test_same_flavor_no_path_reuses_singleton(self):
+        """A role naming the global flavor with no path reuses the singleton."""
+        cfg = {"cli_provider": "codex", "cli": {"default": {"mission": "codex"}}}
+
+        def check():
+            assert get_provider_for_role("mission") is get_provider()
+        self._run(cfg, check)
+
+    def test_fallback_provider_unset_returns_none(self):
+        cfg = {"cli_provider": "codex"}
+        self._run(cfg, lambda: None)
+        assert self._run(cfg, get_fallback_provider) is None
+
+    def test_fallback_provider_configured(self):
+        cfg = {"cli_provider": "codex", "cli": {"fallback": "claude:/p/deep-claude"}}
+
+        def check():
+            fb = get_fallback_provider()
+            assert fb is not None
+            assert fb.name == "claude"
+            assert fb.binary() == "/p/deep-claude"
+        self._run(cfg, check)
+
+    def test_resolve_role_provider_swaps_when_unavailable(self):
+        """Pre-flight: a missing role binary swaps to an available fallback."""
+        cfg = {
+            "cli_provider": "codex",
+            "cli": {
+                "default": {"review_mode": "claude:/nonexistent/deep-claude"},
+                "fallback": "codex",
+            },
+        }
+
+        def check():
+            with patch("shutil.which", side_effect=lambda b: None if "deep-claude" in b else "/usr/bin/" + b):
+                resolved = resolve_role_provider("review_mode")
+            assert resolved.name == "codex"
+        self._run(cfg, check)
+
+    def test_resolve_role_provider_unchanged_without_fallback(self):
+        """No fallback configured → return the (unavailable) role provider as-is."""
+        cfg = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/nonexistent/deep-claude"}},
+        }
+
+        def check():
+            with patch("shutil.which", side_effect=lambda b: None if "deep-claude" in b else "/usr/bin/" + b):
+                resolved = resolve_role_provider("review_mode")
+            assert resolved.name == "claude"
+            assert resolved.binary() == "/nonexistent/deep-claude"
+        self._run(cfg, check)
+
+    def test_describe_cli_roles_empty_when_unset(self):
+        """No cli: section → empty summary (no-op for the default setup)."""
+        from app.provider import describe_cli_roles
+        cfg = {"cli_provider": "codex"}
+        assert self._run(cfg, describe_cli_roles) == ""
+
+    def test_describe_cli_roles_lists_overrides_and_fallback(self):
+        from app.provider import describe_cli_roles
+        cfg = {
+            "cli_provider": "codex",
+            "cli": {
+                "default": {"review_mode": "claude:/opt/bin/deep-claude"},
+                "fallback": "claude",
+            },
+        }
+        summary = self._run(cfg, describe_cli_roles)
+        # Only the differing role is listed (mission/chat/etc stay on codex).
+        assert "review_mode→claude(deep-claude)" in summary
+        assert "fallback→claude" in summary
+        assert "mission→" not in summary

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -1198,6 +1198,8 @@ class TestGetContemplativeChanceInvalidConfig:
 
 
 class TestGetClaudeFlagsForRole:
+    # The role provider is resolved via get_provider_for_role (cli: section);
+    # patch that and inspect the resolved provider's build_extra_flags call.
     def test_mission_role(self):
         from app.config import get_claude_flags_for_role
         with _mock_config({}), \
@@ -1205,7 +1207,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "opus", "review_mode": "",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = ["--model", "sonnet", "--fallback", "opus"]
             result = get_claude_flags_for_role("mission")
             mock_prov.return_value.build_extra_flags.assert_called_once_with(
@@ -1220,7 +1222,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "opus", "review_mode": "haiku",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = []
             get_claude_flags_for_role("mission", autonomous_mode="review")
             call_kwargs = mock_prov.return_value.build_extra_flags.call_args[1]
@@ -1234,7 +1236,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "opus", "review_mode": "",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = ["--model", "haiku"]
             get_claude_flags_for_role("contemplative")
             call_kwargs = mock_prov.return_value.build_extra_flags.call_args[1]
@@ -1248,7 +1250,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "opus", "lightweight": "haiku",
                  "fallback": "sonnet", "review_mode": "",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = []
             get_claude_flags_for_role("chat")
             call_kwargs = mock_prov.return_value.build_extra_flags.call_args[1]
@@ -1263,7 +1265,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "opus", "review_mode": "",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = []
             result = get_claude_flags_for_role("lightweight")
             call_kwargs = mock_prov.return_value.build_extra_flags.call_args[1]
@@ -1278,10 +1280,12 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "", "review_mode": "",
              }) as mock_models, \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = []
             get_claude_flags_for_role("mission", project_name="myapp")
-            mock_models.assert_called_once_with("myapp")
+            # project_name is forwarded as the first positional arg (the
+            # role_providers kwarg is an implementation detail).
+            assert mock_models.call_args.args[0] == "myapp"
 
     def test_mission_review_mode_empty_uses_mission_model(self):
         from app.config import get_claude_flags_for_role
@@ -1290,7 +1294,7 @@ class TestGetClaudeFlagsForRole:
                  "mission": "sonnet", "chat": "haiku", "lightweight": "haiku",
                  "fallback": "opus", "review_mode": "",
              }), \
-             patch("app.cli_provider.get_provider") as mock_prov:
+             patch("app.cli_provider.get_provider_for_role") as mock_prov:
             mock_prov.return_value.build_extra_flags.return_value = []
             get_claude_flags_for_role("mission", autonomous_mode="review")
             call_kwargs = mock_prov.return_value.build_extra_flags.call_args[1]

--- a/koan/tests/test_contemplative_runner.py
+++ b/koan/tests/test_contemplative_runner.py
@@ -211,7 +211,15 @@ class TestGetContemplativeFlags:
         mock_flags.return_value = "--model claude-sonnet-4-5-20250929"
         result = get_contemplative_flags()
         assert result == ["--model", "claude-sonnet-4-5-20250929"]
-        mock_flags.assert_called_once_with("contemplative")
+        mock_flags.assert_called_once_with("contemplative", project_name="")
+
+    @patch("app.config.get_claude_flags_for_role")
+    def test_forwards_project_name(self, mock_flags):
+        """Per-project cli.lightweight: project_name reaches the flag builder so
+        the contemplative model matches its (project-aware) binary."""
+        mock_flags.return_value = "--model sonnet"
+        get_contemplative_flags(project_name="my-toolkit")
+        mock_flags.assert_called_once_with("contemplative", project_name="my-toolkit")
 
     @patch("app.config.get_claude_flags_for_role")
     def test_empty_flags(self, mock_flags):
@@ -262,6 +270,26 @@ class TestRunContemplativeSession:
         assert result["output"] == "session output"
         mock_run_claude.assert_called_once_with(
             ["claude", "-p", "prompt"], cwd="/path/instance", timeout=300
+        )
+
+    @patch("app.claude_step.run_claude")
+    @patch("app.contemplative_runner.build_contemplative_command")
+    @patch("app.config.get_claude_flags_for_role", return_value="")
+    def test_session_threads_project_name_to_flags(
+        self, mock_role_flags, mock_cmd, mock_run_claude,
+    ):
+        """run_contemplative_session forwards project_name so the model flag
+        resolves against the project's lightweight provider (cli.lightweight),
+        matching the project-aware binary."""
+        mock_cmd.return_value = ["claude", "-p", "p"]
+        mock_run_claude.return_value = {"success": True, "output": "", "error": ""}
+        run_contemplative_session(
+            instance="/path/instance",
+            project_name="my-toolkit",
+            session_info="test",
+        )
+        mock_role_flags.assert_called_once_with(
+            "contemplative", project_name="my-toolkit"
         )
 
     @patch("app.claude_step.run_claude")

--- a/koan/tests/test_mission_executor.py
+++ b/koan/tests/test_mission_executor.py
@@ -195,6 +195,101 @@ class TestMaybeRetryMission:
 
 
 # ---------------------------------------------------------------------------
+# _maybe_fallback_provider_rerun
+# ---------------------------------------------------------------------------
+
+class TestMaybeFallbackProviderRerun:
+
+    @pytest.fixture(autouse=True)
+    def _reset_state(self):
+        import app.run as _run
+        _run._last_mission_timed_out = False
+        _run._last_mission_aborted = False
+        _run._last_mission_stagnated.clear()
+        yield
+        _run._last_mission_timed_out = False
+        _run._last_mission_aborted = False
+        _run._last_mission_stagnated.clear()
+
+    def _call(self, **overrides):
+        from app.mission_executor import _maybe_fallback_provider_rerun
+        kwargs = dict(
+            claude_exit=127,
+            stdout_file="/tmp/nonexistent-out",
+            stderr_file="/tmp/nonexistent-err",
+            project_path="/tmp/proj",
+            pre_head="head1",
+            instance="/tmp/inst",
+            project_name="koan",
+            run_num=1,
+            has_mission=True,
+            autonomous_mode="implement",
+            prompt="do it",
+            plugin_dirs=None,
+            system_prompt="",
+            tier=None,
+            host_tmp_dir=None,
+            container_tmp_dir=None,
+        )
+        kwargs.update(overrides)
+        return _maybe_fallback_provider_rerun(**kwargs)
+
+    @staticmethod
+    def _provider(name, binary, available=True):
+        from unittest.mock import MagicMock
+        p = MagicMock()
+        p.name = name
+        p.binary.return_value = binary
+        p.is_available.return_value = available
+        return p
+
+    def test_skips_when_fallback_binary_unavailable(self):
+        """The fix: a fallback whose own binary is missing is not re-run."""
+        fb = self._provider("codex", "/bad/codex", available=False)
+        role = self._provider("claude", "claude")
+        with patch("app.run.log"), \
+             patch("app.provider.get_fallback_provider", return_value=fb), \
+             patch("app.provider.get_provider_for_role", return_value=role), \
+             patch("app.run.run_claude_task") as mock_run_task:
+            exit_code, _, _ = self._call()
+        assert exit_code == 127
+        mock_run_task.assert_not_called()
+
+    def test_reruns_on_available_fallback(self, tmp_path):
+        """Launch failure + available, different fallback + no commits → re-run."""
+        from app.cli_errors import ErrorCategory
+        out = tmp_path / "out"; out.write_text("not authenticated")
+        err = tmp_path / "err"; err.write_text("")
+        fb = self._provider("codex", "codex")
+        role = self._provider("claude", "claude")
+        with patch("app.run.log"), \
+             patch("app.provider.get_fallback_provider", return_value=fb), \
+             patch("app.provider.get_provider_for_role", return_value=role), \
+             patch("app.cli_errors.classify_cli_error", return_value=ErrorCategory.AUTH), \
+             patch("app.run._get_git_head", return_value="head1"), \
+             patch("app.mission_runner.build_mission_command", return_value=(["codex"], [])), \
+             patch("app.run.run_claude_task", return_value=0) as mock_run_task:
+            exit_code, _, _ = self._call(
+                stdout_file=str(out), stderr_file=str(err),
+            )
+        assert exit_code == 0
+        # Re-run executed under the fallback provider.
+        assert mock_run_task.call_args.kwargs["provider"] is fb
+
+    def test_skips_when_fallback_same_binary(self):
+        """Same binary as the role that failed → nothing to gain, skip."""
+        fb = self._provider("claude", "claude")
+        role = self._provider("claude", "claude")
+        with patch("app.run.log"), \
+             patch("app.provider.get_fallback_provider", return_value=fb), \
+             patch("app.provider.get_provider_for_role", return_value=role), \
+             patch("app.run.run_claude_task") as mock_run_task:
+            exit_code, _, _ = self._call()
+        assert exit_code == 127
+        mock_run_task.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # _handle_skill_dispatch — cli_skill translation branches (no skill_cmd match)
 # ---------------------------------------------------------------------------
 

--- a/koan/tests/test_mission_runner.py
+++ b/koan/tests/test_mission_runner.py
@@ -1757,7 +1757,9 @@ class TestBuildMissionCommandProjectOverrides:
                 "mission": "sonnet", "review_mode": "", "fallback": "haiku",
             }
             build_mission_command(prompt="test", project_name="backend")
-            mock_models.assert_called_once_with("backend")
+            # project_name is forwarded as the first positional arg; the
+            # role_providers kwarg is an implementation detail.
+            assert mock_models.call_args.args[0] == "backend"
 
     @patch("app.cli_provider.get_provider_name", return_value="claude")
     def test_multiple_plugin_dirs(self, mock_provider):

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -763,23 +763,35 @@ class TestGetCliBinaryName:
         assert get_cli_binary_name() == ""
 
 
-class TestGetReviewCliBinaryName:
-    """get_review_cli_binary_name: KOAN_CLAUDE_CLI_FOR_REVIEW_PATH basename, or ''."""
+class TestPerInstanceBinaryOverride:
+    """CLIProvider(binary_path=...) is honored by binary()/is_available()."""
 
-    def test_returns_basename_when_set(self, monkeypatch):
-        from app.provider import get_review_cli_binary_name
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/koan/review-claude")
-        assert get_review_cli_binary_name() == "review-claude"
+    def test_each_provider_honors_override(self, monkeypatch):
+        from app.provider import (
+            ClaudeProvider, CodexProvider, ClineProvider,
+            CopilotProvider, OllamaLaunchProvider,
+        )
+        monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
+        for cls in (ClaudeProvider, CodexProvider, ClineProvider,
+                    CopilotProvider, OllamaLaunchProvider):
+            assert cls(binary_path="/opt/bin/custom").binary() == "/opt/bin/custom"
 
-    def test_strips_trailing_slash(self, monkeypatch):
-        from app.provider import get_review_cli_binary_name
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/usr/local/bin/my-review-claude/")
-        assert get_review_cli_binary_name() == "my-review-claude"
+    def test_override_relative_rooted_at_koan_root(self, monkeypatch):
+        from app.provider import CodexProvider
+        monkeypatch.setenv("KOAN_ROOT", "/srv/koan")
+        assert CodexProvider(binary_path="bin/wrap").binary() == "/srv/koan/bin/wrap"
 
-    def test_empty_when_unset(self, monkeypatch):
-        from app.provider import get_review_cli_binary_name
-        monkeypatch.delenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", raising=False)
-        assert get_review_cli_binary_name() == ""
+    def test_default_binary_when_no_override(self, monkeypatch):
+        from app.provider import CodexProvider, ClineProvider
+        monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
+        assert CodexProvider().binary() == "codex"
+        assert ClineProvider().binary() == "cline"
+
+    def test_is_available_uses_overridden_binary(self):
+        from app.provider import CodexProvider
+        with patch("shutil.which", side_effect=lambda b: b if b == "/opt/bin/custom" else None):
+            assert CodexProvider(binary_path="/opt/bin/custom").is_available() is True
+            assert CodexProvider().is_available() is False
 
 
 class TestGetProviderDisplay:
@@ -808,27 +820,6 @@ class TestGetProviderDisplay:
         monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "/x/my-claude")
         # An explicit name (e.g. the "ollama" sentinel) is not overridden.
         assert get_provider_display("ollama") == "ollama (my-claude)"
-
-    def test_appends_review_hint(self, monkeypatch):
-        from app.provider import get_provider_display
-        monkeypatch.delenv("KOAN_CLAUDE_CLI_PATH", raising=False)
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/koan/review-claude")
-        with patch("app.provider.get_provider_name", return_value="claude"):
-            assert get_provider_display() == "claude (review: review-claude)"
-
-    def test_appends_both_default_and_review(self, monkeypatch):
-        from app.provider import get_provider_display
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "/opt/koan/cheap-claude")
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", "/opt/koan/review-claude")
-        with patch("app.provider.get_provider_name", return_value="claude"):
-            assert get_provider_display() == "claude (cheap-claude, review: review-claude)"
-
-    def test_no_review_hint_when_unset(self, monkeypatch):
-        from app.provider import get_provider_display
-        monkeypatch.setenv("KOAN_CLAUDE_CLI_PATH", "/opt/koan/ollama-claude")
-        monkeypatch.delenv("KOAN_CLAUDE_CLI_FOR_REVIEW_PATH", raising=False)
-        with patch("app.provider.get_provider_name", return_value="claude"):
-            assert get_provider_display() == "claude (ollama-claude)"
 
 
 class TestRunCommand:

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -787,6 +787,17 @@ class TestPerInstanceBinaryOverride:
         assert CodexProvider().binary() == "codex"
         assert ClineProvider().binary() == "cline"
 
+    def test_copilot_init_calls_super(self):
+        """Regression (PR #2251 #2): CopilotProvider overrides __init__, so it
+        must call super().__init__ — otherwise binary() reading _binary_override
+        raises AttributeError on EVERY call, including the no-args parity path
+        that get_provider() uses."""
+        from app.provider import CopilotProvider
+        # Default construction (no cli: override) must not raise.
+        assert isinstance(CopilotProvider().binary(), str)
+        # And the override path resolves the custom binary.
+        assert CopilotProvider(binary_path="/opt/bin/cop").binary() == "/opt/bin/cop"
+
     def test_is_available_uses_overridden_binary(self):
         from app.provider import CodexProvider
         with patch("shutil.which", side_effect=lambda b: b if b == "/opt/bin/custom" else None):

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -4582,7 +4582,8 @@ class TestRunClaudeReviewModelOverride:
 
         _, kwargs = mock_run.call_args
         assert kwargs.get("model") == "review-model"
-        assert kwargs.get("model_key") == "mission"
+        # The review path resolves its CLI via the "review_mode" role (cli:).
+        assert kwargs.get("model_key") == "review_mode"
 
     @patch("app.cli_provider.run_command_streaming")
     @patch("app.config.get_model_config", return_value={"review_mode": "", "mission": "mission-model"})
@@ -4598,7 +4599,8 @@ class TestRunClaudeReviewModelOverride:
 
         _, kwargs = mock_run.call_args
         assert kwargs.get("model") == "mission-model"
-        assert kwargs.get("model_key") == "mission"
+        # The review path resolves its CLI via the "review_mode" role (cli:).
+        assert kwargs.get("model_key") == "review_mode"
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -4693,6 +4693,29 @@ class TestReviewBinaryRouting:
         assert cmd[cmd.index("--model") + 1] == "opus"
         assert "codex-WRONG" not in cmd
 
+    def test_review_attribution_uses_review_provider(self):
+        """The footer attribution (provider + model) reflects the review_mode
+        provider, not the global one (PR #2251 comment-4848512613)."""
+        from unittest.mock import patch
+        import app.provider as provider
+        from app.review_runner import _review_attribution
+
+        full = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/opt/review-claude"}},
+            "models": {
+                "codex": {"review_mode": "codex-WRONG"},
+                "claude": {"review_mode": "opus"},
+            },
+        }
+        with patch("app.config._load_config", return_value=full), \
+             patch("app.config._load_project_overrides", return_value={}), \
+             patch("app.utils.load_config", return_value=full):
+            provider.reset_provider()
+            name, model = _review_attribution()
+        assert name == "claude"
+        assert model == "opus"
+
     def test_per_project_cli_review_mode_applies(self):
         """A per-project cli.review_mode override routes the review binary."""
         from unittest.mock import MagicMock, patch

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -6125,6 +6125,37 @@ class TestRunBotCommentTriage:
         replies = _run_bot_comment_triage(bot_comments, "diff", skill_dir)
         assert replies == []
 
+    @patch("app.review_runner._run_claude_review")
+    def test_forwards_project_name_to_claude_review(self, mock_claude):
+        """Per-project cli.review_mode is honored: project_name reaches the review CLI."""
+        from app.review_runner import _run_bot_comment_triage
+        mock_claude.return_value = ("[]", "")
+        skill_dir = Path(__file__).resolve().parent.parent / "skills" / "core" / "review"
+        _run_bot_comment_triage(
+            [{"id": 1, "body": "x", "path": "a.py", "line": 1}],
+            "diff", skill_dir, project_name="my-toolkit",
+        )
+        _, kwargs = mock_claude.call_args
+        assert kwargs["project_name"] == "my-toolkit"
+
+
+# ---------------------------------------------------------------------------
+# Silent-failure-hunter pass — project_name threading
+# ---------------------------------------------------------------------------
+
+class TestRunErrorHunter:
+    """Tests for _run_error_hunter (silent-failure-hunter pass)."""
+
+    @patch("app.review_runner._run_claude_review")
+    def test_forwards_project_name_to_claude_review(self, mock_claude):
+        """Per-project cli.review_mode is honored on the error-hunter pass too."""
+        from app.review_runner import _run_error_hunter
+        mock_claude.return_value = ("", "boom")
+        skill_dir = Path(__file__).resolve().parent.parent / "skills" / "core" / "review"
+        _run_error_hunter("diff", "/tmp/proj", skill_dir, project_name="my-toolkit")
+        _, kwargs = mock_claude.call_args
+        assert kwargs["project_name"] == "my-toolkit"
+
 
 # ---------------------------------------------------------------------------
 # Bot comment triage — run_review integration

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -4649,6 +4649,80 @@ class TestReviewBinaryRouting:
         assert captured["provider"].name == "claude"
         assert captured["provider"].binary() == "/opt/review-claude"
 
+    def test_review_model_resolves_from_review_provider_section(self):
+        """The review --model comes from models.<review_provider>.review_mode,
+        not the global provider's section (PR #2251 comment-4848143029)."""
+        from unittest.mock import MagicMock, patch
+        import app.provider as provider
+        from app.review_runner import _run_claude_review
+
+        # Global codex; reviews pinned to Claude. The review model must be the
+        # Claude review_mode model (opus), NOT the codex one.
+        full = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/opt/review-claude"}},
+            "models": {
+                "default": {"review_mode": ""},
+                "codex": {"review_mode": "codex-WRONG"},
+                "claude": {"review_mode": "opus"},
+            },
+            "skip_permissions": False,
+        }
+        captured = {}
+
+        def fake_popen(cmd, provider=None, **kwargs):
+            captured["cmd"] = cmd
+            proc = MagicMock()
+            stdout = MagicMock()
+            stdout.__iter__.return_value = iter([])
+            proc.stdout = stdout
+            proc.stderr.read.return_value = ""
+            proc.returncode = 0
+            proc.wait.return_value = 0
+            return proc, (lambda: None)
+
+        with patch("app.config._load_config", return_value=full), \
+             patch("app.config._load_project_overrides", return_value={}), \
+             patch("app.utils.load_config", return_value=full), \
+             patch("app.cli_exec.popen_cli", side_effect=fake_popen):
+            provider.reset_provider()
+            _run_claude_review("review this", "/tmp/project")
+
+        cmd = captured["cmd"]
+        assert "--model" in cmd
+        assert cmd[cmd.index("--model") + 1] == "opus"
+        assert "codex-WRONG" not in cmd
+
+    def test_per_project_cli_review_mode_applies(self):
+        """A per-project cli.review_mode override routes the review binary."""
+        from unittest.mock import MagicMock, patch
+        import app.provider as provider
+        from app.review_runner import _run_claude_review
+
+        full = {"cli_provider": "codex", "skip_permissions": False}
+        project_overrides = {"cli": {"review_mode": "claude:/opt/proj-review-claude"}}
+        captured = {}
+
+        def fake_popen(cmd, provider=None, **kwargs):
+            captured["cmd"] = cmd
+            proc = MagicMock()
+            stdout = MagicMock()
+            stdout.__iter__.return_value = iter([])
+            proc.stdout = stdout
+            proc.stderr.read.return_value = ""
+            proc.returncode = 0
+            proc.wait.return_value = 0
+            return proc, (lambda: None)
+
+        with patch("app.config._load_config", return_value=full), \
+             patch("app.config._load_project_overrides", return_value=project_overrides), \
+             patch("app.utils.load_config", return_value=full), \
+             patch("app.cli_exec.popen_cli", side_effect=fake_popen):
+            provider.reset_provider()
+            _run_claude_review("review this", "/tmp/project", project_name="myproj")
+
+        assert captured["cmd"][0] == "/opt/proj-review-claude"
+
 
 # ---------------------------------------------------------------------------
 # run_review reflection integration

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -4603,6 +4603,53 @@ class TestRunClaudeReviewModelOverride:
         assert kwargs.get("model_key") == "review_mode"
 
 
+class TestReviewBinaryRouting:
+    """End-to-end: the review subprocess binary follows cli.review_mode.
+
+    Closes the verification gap from PR #2251 review (Important #1): proves the
+    review *binary*, not just the model_key, routes through the review_mode
+    provider — replacing KOAN_CLAUDE_CLI_FOR_REVIEW_PATH.
+    """
+
+    def test_review_command_uses_cli_review_mode_binary(self):
+        from unittest.mock import MagicMock, patch
+        import app.provider as provider
+        from app.review_runner import _run_claude_review
+
+        # Global provider is codex; reviews are pinned to a custom claude binary.
+        full = {
+            "cli_provider": "codex",
+            "cli": {"default": {"review_mode": "claude:/opt/review-claude"}},
+            "skip_permissions": False,
+        }
+        captured = {}
+
+        def fake_popen(cmd, provider=None, **kwargs):
+            captured["cmd"] = cmd
+            captured["provider"] = provider
+            proc = MagicMock()
+            stdout = MagicMock()
+            stdout.__iter__.return_value = iter([])  # no stream output
+            proc.stdout = stdout
+            proc.stderr.read.return_value = ""
+            proc.returncode = 0
+            proc.wait.return_value = 0
+            return proc, (lambda: None)
+
+        with patch("app.config._load_config", return_value=full), \
+             patch("app.config._load_project_overrides", return_value={}), \
+             patch("app.utils.load_config", return_value=full), \
+             patch("app.cli_exec.popen_cli", side_effect=fake_popen):
+            provider.reset_provider()
+            _run_claude_review("review this", "/tmp/project")
+
+        # The command that ran is the cli.review_mode binary, and popen_cli
+        # received the matching review_mode provider instance.
+        assert captured["cmd"][0] == "/opt/review-claude"
+        assert captured["provider"].name == "claude"
+        assert captured["provider"].binary() == "/opt/review-claude"
+
+
 # ---------------------------------------------------------------------------
 # run_review reflection integration
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_session_manager.py
+++ b/koan/tests/test_session_manager.py
@@ -353,6 +353,74 @@ class TestKillSession:
         assert mock_killpg.call_args_list[1].args == (22222, signal.SIGKILL)
 
 
+class TestSpawnSessionProviderThreading:
+    """spawn_session must execute under the role's CLI provider (cli: section)."""
+
+    @patch("app.session_manager.inject_worktree_claude_md")
+    @patch("app.session_manager.create_worktree")
+    def test_role_provider_threaded_into_popen_cli(
+        self, mock_create_wt, mock_inject, registry, tmp_path,
+    ):
+        """cli.mission: codex under a global claude → popen_cli gets the codex
+        provider, and build_mission_command gets the same provider_override."""
+        import app.provider as provider
+
+        wt = MagicMock()
+        wt.session_id = "test-prov"
+        wt.path = str(tmp_path / "worktree")
+        wt.branch = "koan/session-test-prov"
+        mock_create_wt.return_value = wt
+
+        full = {
+            "cli_provider": "claude",  # global
+            "cli": {"default": {"mission": "codex"}},
+            "skip_permissions": False,
+        }
+        captured = {}
+
+        def fake_build(*args, **kwargs):
+            captured["build_provider"] = kwargs.get("provider_override")
+            return (["codex", "-p", "x"], [])
+
+        opened = []
+        real_open = open
+
+        def tracking_open(path, mode="r", **kwargs):
+            f = real_open(path, mode, **kwargs)
+            opened.append(f)
+            return f
+
+        def fake_popen(cmd, provider=None, **kwargs):
+            captured["popen_provider"] = provider
+            return MagicMock(pid=4321), MagicMock()
+
+        with patch("app.config._load_config", return_value=full), \
+             patch("app.config._load_project_overrides", return_value={}), \
+             patch("app.utils.load_config", return_value=full), \
+             patch("app.mission_runner.build_mission_command", side_effect=fake_build), \
+             patch("builtins.open", side_effect=tracking_open), \
+             patch("app.cli_exec.popen_cli", side_effect=fake_popen):
+            provider.reset_provider()
+            spawn_session(
+                mission_text="do it",
+                project_name="p",
+                project_path=str(tmp_path),
+                instance_dir=registry.instance_dir,
+                registry=registry,
+                autonomous_mode="implement",
+            )
+
+        for f in opened:
+            f.close()
+
+        # popen_cli received a provider, it is the codex role provider, and it
+        # is the SAME instance passed to build_mission_command (not the global
+        # claude singleton).
+        assert captured["popen_provider"] is not None
+        assert captured["popen_provider"].name == "codex"
+        assert captured["popen_provider"] is captured["build_provider"]
+
+
 class TestSpawnSessionFileHandleLeak:
     """Verify file handles are closed when spawn_session fails."""
 

--- a/projects.example.yaml
+++ b/projects.example.yaml
@@ -106,6 +106,17 @@ defaults:
   #   mission: ""
   #   chat: ""
 
+  # Per-role CLI provider overrides — pick a provider (and optional custom
+  # binary) per mission role for this project, overriding the global `cli:`
+  # section in config.yaml. Flat role -> `flavor` or `flavor:path` (path is
+  # absolute or relative to KOAN_ROOT). Plus an optional single `fallback`.
+  # The role's model still resolves against that provider's models.<provider>
+  # block. See docs/providers/claude.md.
+  # cli:
+  #   mission: codex
+  #   review_mode: claude:/opt/bin/review-claude
+  #   fallback: claude
+
   # Tool restrictions — control which tools are available per project.
   # Keys: mission (for autonomous work), chat (for Telegram conversations).
   # Useful for restricting write access on certain repos.

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -29,27 +29,40 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 | `base.supports_usage_tracking()` / `record_usage()` | Per-provider usage hooks. Not all CLIs surface usage the same way. |
 | `__init__.run_command()` / `run_command_streaming()` | The single invocation entry points. Callers should not spawn provider subprocesses directly. |
 | `__init__.build_full_command()` | Assembles the provider-specific argv. |
-| `__init__.get_provider_display()` / `get_cli_binary_name()` / `get_review_cli_binary_name()` | Display helpers. `get_provider_display()` returns `"<name>"` or `"<name> (<binary>)"` when `KOAN_CLAUDE_CLI_PATH` points at a different binary; when `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH` is set its basename is appended as a `review:` hint (e.g. `claude (cheap-claude, review: review-claude)`). Single source of truth for the provider line shown by the startup banner and `/status` — both knobs are observable so a review-only binary is never a silent config. |
-| `__init__.review_cli_override()` / `review_cli_override_active()` | Context-scoped flag. While active, `ClaudeProvider.binary()` prefers `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH` over `KOAN_CLAUDE_CLI_PATH`, so a review-only binary can be pinned without affecting other missions. Activated solely by `review_runner._run_claude_review()` (the single review-path Claude chokepoint). |
-| Provider resolution | Order: `KOAN_CLI_PROVIDER` env (fallback `CLI_PROVIDER`) → `projects.yaml`/`config.yaml` → default. Centralized in `utils.get_cli_provider_env()`. |
-| `ClaudeProvider.binary()` | Resolves the Claude binary: `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH` (only inside a `review_cli_override()` context — ignored otherwise so it never leaks into other missions) → then `KOAN_CLAUDE_CLI_PATH` handled as absolute → as-is / relative → `normpath(join(KOAN_ROOT, …))` / bare name → PATH lookup / unset-empty → `"claude"`. `KOAN_CLAUDE_CLI_PATH` relative paths root at `KOAN_ROOT` (not CWD — the agent runs from `KOAN_ROOT/koan`); bare names are never re-rooted. The review override is returned as-is. |
+| `__init__.get_provider_display()` / `get_cli_binary_name()` | Display helpers. `get_provider_display()` returns `"<name>"` or `"<name> (<binary>)"` when `KOAN_CLAUDE_CLI_PATH` points at a different binary. Single source of truth for the global provider line shown by the startup banner and `/status`. Per-role provider overrides are summarized separately by `describe_cli_roles()`. |
+| `__init__.get_provider_for_role(role, project_name)` / `get_fallback_provider(project_name)` / `resolve_role_provider(role, project_name)` | Per-role provider selection (the `cli:` config section). `get_provider_for_role` returns the **global cached singleton** when the role is unset (parity) or a **fresh** `_PROVIDERS[flavor](binary_path=path)` otherwise — never written to `_cached_provider`. `get_fallback_provider` returns the single section-wide `cli.fallback` instance (or `None`). `resolve_role_provider` is the stateless-helper entry point: it pre-flight-swaps to the fallback when the role binary is unavailable. |
+| `cli:` config / `config.get_cli_config()` / `get_cli_fallback()` | New config section parallel to `models:`. `cli.default.<role>` (+ per-project flat `cli.<role>`) maps a mission role (`mission`/`chat`/`lightweight`/`review_mode`/`reflect`) to a `flavor` or `flavor:path`; a single `cli.fallback` provider is used on launch/auth failure. The role's MODEL resolves against that provider's `models.<provider>.<role>` block (`get_model_config(role_providers=…)`). Replaces the removed `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`. |
+| Provider resolution | Order: `KOAN_CLI_PROVIDER` env (fallback `CLI_PROVIDER`) → `projects.yaml`/`config.yaml` → default. Centralized in `utils.get_cli_provider_env()`. This resolves the GLOBAL provider; `cli.<role>` layers per-role selection on top via `get_provider_for_role`. |
+| `CLIProvider(binary_path="")` / `ClaudeProvider.binary()` | The base class takes an optional per-instance `binary_path` override (the replacement for the removed review ContextVar); `_resolve_binary_path()` is the shared resolver (absolute → as-is / relative → `normpath(join(KOAN_ROOT, …))` / bare name → PATH lookup). `ClaudeProvider.binary()`: `_binary_override` if set → else `KOAN_CLAUDE_CLI_PATH` → else `"claude"`. Every provider's `binary()` honors the override so `flavor:path` works uniformly. Relative paths root at `KOAN_ROOT` (not CWD — the agent runs from `KOAN_ROOT/koan`); bare names are never re-rooted. |
 
 ## Invariants
 
 - **One invocation lock per uid.** Provider auth state is per-user, so the subprocess
   lock lives under `koan_tmp_dir()` (per-uid), not a fixed `/tmp` path.
-- **Provider resolution has a fixed precedence** (env → config → default). New
-  resolution inputs slot into that order; do not add parallel resolution paths.
-- **`KOAN_CLAUDE_CLI_PATH` relative paths root at `KOAN_ROOT`, not CWD.** The
+- **Provider resolution has a fixed precedence** (env → config → default) for the
+  GLOBAL provider. Per-role selection (`cli.<role>`) layers on top via
+  `get_provider_for_role`; it does not introduce a second GLOBAL resolution path.
+- **`KOAN_CLAUDE_CLI_PATH` and `cli: flavor:path` relative paths root at `KOAN_ROOT`, not CWD.** The
   agent runs from `KOAN_ROOT/koan` (the Makefile does `cd koan`), so a naive
-  relative path would resolve to the wrong place. Joining against `KOAN_ROOT`
-  in `binary()` is what makes the portable `.env` form work; a future
-  simplification that re-targets the join at CWD silently breaks every such
-  setup. Bare command names stay PATH lookups and are never re-rooted.
-- **Claude binary resolution is gated by review context.** `KOAN_CLAUDE_CLI_FOR_REVIEW_PATH`
-  wins over `KOAN_CLAUDE_CLI_PATH` *only* while `review_cli_override()` is active; outside
-  a review it is invisible. New per-call binary overrides must follow this context-gated
-  pattern (a `ContextVar` activated at the call site), never an unconditional env read.
+  relative path would resolve to the wrong place. The shared `_resolve_binary_path()`
+  joins against `KOAN_ROOT`; a future simplification that re-targets the join at
+  CWD silently breaks every such setup. Bare command names stay PATH lookups and
+  are never re-rooted.
+- **Per-role provider instances must never poison the global singleton.**
+  `get_provider_for_role`/`get_fallback_provider` construct a fresh
+  `_PROVIDERS[flavor](binary_path=path)` and return it directly; they must never
+  assign `_cached_provider`. `get_provider()` (role-less) stays the cached
+  singleton. A path-bearing instance leaking into the cache would silently
+  rebind every role-less caller to a custom binary.
+- **The `cli:` absence contract is exact parity.** With no `cli:` section, every
+  role resolves to `(get_provider_name(), "")` and `get_model_config(role_providers=None)`
+  is byte-for-byte the historical behavior. Changes here must preserve that.
+- **Provider fallback is launch/auth only, never quota/transient.** The single
+  `cli.fallback` provider is substituted only on binary-not-found (exit 127 /
+  `is_available()` False) or `ErrorCategory.AUTH`, and (on the mission path) only
+  when no commits were produced. Quota still pauses; transient errors still use
+  the in-place retry. Do not widen this to quota — that would double-spend across
+  subscriptions and change the pause contract.
 - **Tool-name vocabularies differ per provider.** Copilot maps its own names; the
   abstraction must translate, not leak provider-specific tool names upward.
 - **Quota/usage extraction is provider-specific.** Claude exposes usage in
@@ -61,13 +74,23 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 
 - Invoked by `run.run_claude_task()` and skill runners.
 - Usage flows to `usage_tracker.py` / `burn_rate.py` via the `record_usage()` hook.
-- Per-project provider override from `projects_config.get_project_cli_provider()`.
+- Per-role provider selection from the `cli:` section (`config.get_cli_config()`),
+  threaded into `mission_runner.build_mission_command()` (mission/review roles),
+  the `run_command*` helpers (their `model_key` role), and
+  `contemplative_runner.build_contemplative_command()` (lightweight role). The
+  launch/auth fallback re-run lives in `mission_executor._maybe_fallback_provider_rerun()`.
 - `devcontainer.py` wraps the provider argv with `devcontainer exec` (claude-only
-  credential steps).
+  credential steps); the fallback re-run re-applies this wrap.
 
 ## Known debt / watch-outs
 
 - `cli_provider.py` is a legacy re-export — prefer importing from `provider` directly.
+- `projects_config.get_project_cli_provider()` (the old per-project global-provider
+  accessor) is still NOT wired into `get_provider()`; the `cli:` section (incl. its
+  per-project flat form) is the supported per-project provider mechanism going forward.
+- The stateless `run_command*` helpers fall back on *launch* failure (binary
+  unavailable) via `resolve_role_provider`'s pre-flight `is_available()` swap;
+  full AUTH-triggered fallback exists only on the stateful mission path.
 - `ClaudeProvider` has no `detect_auth_failure()` override, so auth signals like
   "Please run /login" must be caught by the shared `_AUTH_RE` patterns against
   `[cli]`-prefixed runtime lines before delegating to the provider.


### PR DESCRIPTION
Add a `cli:` config section, parallel to `models:`, selecting which CLI
provider (and optional custom binary) runs each mission role (mission,
chat, lightweight, review_mode, reflect), plus a single section-wide
`fallback` provider used on launch/auth failure. Each value is a
`flavor` or `flavor:path`; per-project overrides live in projects.yaml.

A role's model resolves against that provider's models.<provider>.<role>
block, so cli: and models: compose.

This replaces and removes KOAN_CLAUDE_CLI_FOR_REVIEW_PATH and the
review-scoped ContextVar binary override; reviews now route through the
`review_mode` role. With no cli: section configured, every role uses the
global provider exactly as before (parity).

Mechanism:
- CLIProvider gains an optional per-instance binary_path; every provider's
  binary() honors it via the shared _resolve_binary_path helper.
- get_provider_for_role / get_fallback_provider / resolve_role_provider
  resolve a role's provider without poisoning the global singleton.
- get_model_config(role_providers=...) resolves each role's model against
  its own provider section (role_providers=None preserves old behavior).
- The resolved provider is threaded through build_full_command[_managed],
  build_mission_command, run_command*, run_cli_with_retry, and
  run_claude_task so stdin-rewrite and the invocation lock match the
  binary the command was built for.
- Launch/auth fallback: full re-run on the mission path
  (_maybe_fallback_provider_rerun, guarded by no-commits + devcontainer
  re-wrap); pre-flight availability swap on the stateless helpers. Quota
  still pauses; transient errors still retry in place.
Specs and docs updated (providers spec, claude.md, model-configuration,
config/projects examples). Full suite green; ruff clean.