### PR TITLE
fix(memory_db): vacuum expired FTS5 rows + memoize learnings search (#2182)

### DIFF
--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -96,12 +96,16 @@ in SQLite and are treated as having no skill, no tags, no expiry.
 boosts entries from the same skill. `expires_at` is enforced by both `prune_memory_log()`
 (JSONL side) and `search_entries()`/`recent_entries()` (SQLite side).
 
-`prune_memory_log()`'s SQLite mirror runs `delete_before()` (prunes by `ts`) **and**
-`vacuum_expired()`. The latter is required because an entry can expire while its `ts`
-is still recent — `delete_before` would leave that row in the FTS5 index after the
+`prune_memory_log()`'s SQLite mirror runs `delete_before()` (prunes by `ts`, only when
+this pass's JSONL scan removed something) **and** `vacuum_expired()` (runs on every
+call, unconditionally). The latter is required because an entry can expire while its
+`ts` is still recent — `delete_before` would leave that row in the FTS5 index after the
 JSONL truth log drops it, a silent divergence that grows the DB and skews BM25 stats.
+Running `vacuum_expired()` unconditionally — not gated on this run's JSONL delta — lets
+it repair divergence left behind by an earlier prune, not just the current one.
 `vacuum_expired()` mirrors `_is_expired` semantics exactly (malformed `expires_at`
-is kept, never deleted).
+is kept, never deleted), summarizing malformed rows in one aggregate warning instead
+of re-logging per row on every run.
 
 ## Write Paths
 

--- a/docs/architecture/memory.md
+++ b/docs/architecture/memory.md
@@ -52,7 +52,9 @@ existing helpers instead of ad hoc file reads.
 it uses two-phase retrieval: (1) FTS5-matched entries ranked by BM25, (2) recency
 fill for remaining slots. When empty, it falls back to JSONL tail.
 
-Learnings filtering uses FTS5 via `search_learnings()` with Jaccard fallback
+Learnings filtering uses FTS5 via `search_learnings()` (memoized per identical
+`(content, query, max_k)` call to skip the ~50ms transient-table rebuild on the
+per-iteration hot path) with Jaccard fallback
 when SQLite is unavailable.
 
 ### Observability
@@ -93,6 +95,13 @@ in SQLite and are treated as having no skill, no tags, no expiry.
 `source_skill` enables skill-aware retrieval: `read_memory_window(current_skill="review")`
 boosts entries from the same skill. `expires_at` is enforced by both `prune_memory_log()`
 (JSONL side) and `search_entries()`/`recent_entries()` (SQLite side).
+
+`prune_memory_log()`'s SQLite mirror runs `delete_before()` (prunes by `ts`) **and**
+`vacuum_expired()`. The latter is required because an entry can expire while its `ts`
+is still recent — `delete_before` would leave that row in the FTS5 index after the
+JSONL truth log drops it, a silent divergence that grows the DB and skews BM25 stats.
+`vacuum_expired()` mirrors `_is_expired` semantics exactly (malformed `expires_at`
+is kept, never deleted).
 
 ## Write Paths
 

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -23,6 +23,13 @@ _fts5_available: Optional[bool] = None
 _insert_failure_count: int = 0
 _INSERT_FAILURE_WARN_THRESHOLD: int = 5
 
+# Memoization for search_learnings: rebuilding the transient FTS5 table costs
+# ~50ms per call and prompt_builder invokes it every iteration. Key on the
+# exact inputs (content + query + max_k) so a repeated identical call skips the
+# rebuild while any change to the learnings file or query misses the cache.
+_learnings_cache: "Dict[tuple, List[str]]" = {}
+_LEARNINGS_CACHE_MAX = 32
+
 
 def _check_fts5(conn: sqlite3.Connection) -> bool:
     """Test whether FTS5 is available in this Python build.
@@ -356,6 +363,11 @@ def search_learnings(
     if not fts_query:
         return []
 
+    cache_key = (hash(learnings_content), fts_query, max_k)
+    cached = _learnings_cache.get(cache_key)
+    if cached is not None:
+        return list(cached)
+
     mem_conn = None
     try:
         mem_conn = sqlite3.connect(":memory:")
@@ -389,7 +401,11 @@ def search_learnings(
         ).fetchall()
 
         idx_to_line = {int(row[1]): row[0] for row in rows}
-        return [idx_to_line[i] for i in sorted(idx_to_line)]
+        result = [idx_to_line[i] for i in sorted(idx_to_line)]
+        if len(_learnings_cache) >= _LEARNINGS_CACHE_MAX:
+            _learnings_cache.clear()
+        _learnings_cache[cache_key] = result
+        return list(result)
     except sqlite3.DatabaseError as e:
         logger.warning("[memory_db] search_learnings failed: %s", e)
         return []
@@ -443,6 +459,37 @@ def delete_before(conn: sqlite3.Connection, cutoff_iso: str) -> int:
         return cursor.rowcount
     except sqlite3.DatabaseError as e:
         logger.warning("[memory_db] delete_before failed: %s", e)
+        return 0
+
+
+def vacuum_expired(conn: sqlite3.Connection, now_iso: Optional[str] = None) -> int:
+    """Delete rows whose ``expires_at`` is in the past. Returns count removed.
+
+    ``delete_before`` only prunes by ``ts``, so an entry that expired while its
+    ``ts`` is still recent lingers in the FTS5 index after the JSONL truth log
+    drops it — a silent divergence that grows the DB and skews BM25 stats.
+    This mirrors ``_is_expired`` semantics exactly (malformed ``expires_at``
+    is kept, never deleted) by filtering candidates in Python before deleting
+    by rowid.
+    """
+    if now_iso is None:
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    try:
+        rows = conn.execute(
+            "SELECT rowid, expires_at FROM entries WHERE expires_at != ''"
+        ).fetchall()
+        expired_ids = [rowid for rowid, exp in rows if _is_expired(exp, now_iso)]
+        if not expired_ids:
+            return 0
+        conn.executemany(
+            "DELETE FROM entries WHERE rowid = ?",
+            [(rowid,) for rowid in expired_ids],
+        )
+        conn.commit()
+        logger.info("[memory_db] vacuum_expired removed %d expired rows", len(expired_ids))
+        return len(expired_ids)
+    except sqlite3.DatabaseError as e:
+        logger.warning("[memory_db] vacuum_expired failed: %s", e)
         return 0
 
 

--- a/koan/app/memory_db.py
+++ b/koan/app/memory_db.py
@@ -363,7 +363,7 @@ def search_learnings(
     if not fts_query:
         return []
 
-    cache_key = (hash(learnings_content), fts_query, max_k)
+    cache_key = (learnings_content, fts_query, max_k)
     cached = _learnings_cache.get(cache_key)
     if cached is not None:
         return list(cached)
@@ -469,8 +469,11 @@ def vacuum_expired(conn: sqlite3.Connection, now_iso: Optional[str] = None) -> i
     ``ts`` is still recent lingers in the FTS5 index after the JSONL truth log
     drops it — a silent divergence that grows the DB and skews BM25 stats.
     This mirrors ``_is_expired`` semantics exactly (malformed ``expires_at``
-    is kept, never deleted) by filtering candidates in Python before deleting
-    by rowid.
+    is kept, never deleted), but scans candidates inline rather than calling
+    ``_is_expired`` per row: that function warns on every malformed value, and
+    a persistently malformed row would otherwise re-log the same warning on
+    every prune run. Malformed rows are instead summarized in one aggregate
+    warning.
     """
     if now_iso is None:
         now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -478,7 +481,21 @@ def vacuum_expired(conn: sqlite3.Connection, now_iso: Optional[str] = None) -> i
         rows = conn.execute(
             "SELECT rowid, expires_at FROM entries WHERE expires_at != ''"
         ).fetchall()
-        expired_ids = [rowid for rowid, exp in rows if _is_expired(exp, now_iso)]
+        expired_ids = []
+        malformed_count = 0
+        for rowid, exp in rows:
+            try:
+                datetime.strptime(exp, "%Y-%m-%dT%H:%M:%SZ")
+            except ValueError:
+                malformed_count += 1
+                continue
+            if exp < now_iso:
+                expired_ids.append(rowid)
+        if malformed_count:
+            logger.warning(
+                "[memory_db] vacuum_expired: %d row(s) with malformed expires_at kept",
+                malformed_count,
+            )
         if not expired_ids:
             return 0
         conn.executemany(

--- a/koan/app/memory_manager.py
+++ b/koan/app/memory_manager.py
@@ -1520,12 +1520,15 @@ class MemoryManager:
         # Mirror deletion to SQLite FTS5 index (best-effort)
         if removed > 0:
             try:
-                from app.memory_db import ensure_db, delete_before
+                from app.memory_db import ensure_db, delete_before, vacuum_expired
                 conn = ensure_db(str(self.instance_dir))
                 if conn is not None:
                     try:
                         cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
                         delete_before(conn, cutoff_iso)
+                        # delete_before only prunes by ts; expired-but-recent
+                        # rows would otherwise linger, diverging from the JSONL.
+                        vacuum_expired(conn)
                     finally:
                         conn.close()
             except Exception as e:

--- a/koan/app/memory_manager.py
+++ b/koan/app/memory_manager.py
@@ -1517,22 +1517,26 @@ class MemoryManager:
         finally:
             f.close()
 
-        # Mirror deletion to SQLite FTS5 index (best-effort)
-        if removed > 0:
-            try:
-                from app.memory_db import ensure_db, delete_before, vacuum_expired
-                conn = ensure_db(str(self.instance_dir))
-                if conn is not None:
-                    try:
+        # Mirror deletion to SQLite FTS5 index (best-effort). vacuum_expired
+        # runs unconditionally on every call, not just when this pass's JSONL
+        # scan removed something: its job is to repair rows that expired
+        # during an *earlier* prune (or before this repair existed) and were
+        # left behind in SQLite — gating it on `removed` would skip that
+        # repair on every run where the JSONL side happens to have nothing
+        # new to drop.
+        try:
+            from app.memory_db import ensure_db, delete_before, vacuum_expired
+            conn = ensure_db(str(self.instance_dir))
+            if conn is not None:
+                try:
+                    if removed > 0:
                         cutoff_iso = cutoff.strftime("%Y-%m-%dT%H:%M:%SZ")
                         delete_before(conn, cutoff_iso)
-                        # delete_before only prunes by ts; expired-but-recent
-                        # rows would otherwise linger, diverging from the JSONL.
-                        vacuum_expired(conn)
-                    finally:
-                        conn.close()
-            except Exception as e:
-                logger.warning("[memory_manager] SQLite prune mirror failed: %s", e)
+                    vacuum_expired(conn)
+                finally:
+                    conn.close()
+        except Exception as e:
+            logger.warning("[memory_manager] SQLite prune mirror failed: %s", e)
 
         return removed
 

--- a/koan/tests/test_memory_db.py
+++ b/koan/tests/test_memory_db.py
@@ -73,8 +73,10 @@ def reset_fts5_flag():
     """Reset the module-level _fts5_available flag between tests."""
     import app.memory_db as mdb
     mdb._fts5_available = None
+    mdb._learnings_cache.clear()
     yield
     mdb._fts5_available = None
+    mdb._learnings_cache.clear()
 
 
 class TestEnsureDb:
@@ -313,6 +315,76 @@ class TestDeleteBefore:
         removed = delete_before(conn, "2025-01-01T00:00:00Z")
         assert removed == 1
         assert entry_count(conn) == 1
+        conn.close()
+
+
+class TestVacuumExpired:
+
+    def test_deletes_expired_but_recent_ts(self, instance_dir):
+        # An entry expired while its ts is still recent — delete_before (keyed
+        # on ts) would leave it, causing JSONL↔SQLite divergence.
+        from app.memory_db import ensure_db, insert_entry, vacuum_expired, entry_count
+        conn = ensure_db(instance_dir)
+        insert_entry(conn, {"ts": "2026-06-01T00:00:00Z", "type": "session",
+                            "project": "koan", "content": "expired",
+                            "expires_at": "2026-06-15T00:00:00Z"})
+        insert_entry(conn, {"ts": "2026-06-01T00:00:00Z", "type": "session",
+                            "project": "koan", "content": "live",
+                            "expires_at": "2099-01-01T00:00:00Z"})
+        insert_entry(conn, {"ts": "2026-06-01T00:00:00Z", "type": "session",
+                            "project": "koan", "content": "no-expiry"})
+        removed = vacuum_expired(conn, now_iso="2026-07-01T00:00:00Z")
+        assert removed == 1
+        assert entry_count(conn) == 2
+        conn.close()
+
+    def test_keeps_malformed_expires_at(self, instance_dir):
+        from app.memory_db import ensure_db, insert_entry, vacuum_expired, entry_count
+        conn = ensure_db(instance_dir)
+        insert_entry(conn, {"ts": "2026-06-01T00:00:00Z", "type": "session",
+                            "project": "koan", "content": "bad",
+                            "expires_at": "not-a-date"})
+        removed = vacuum_expired(conn, now_iso="2026-07-01T00:00:00Z")
+        assert removed == 0
+        assert entry_count(conn) == 1
+        conn.close()
+
+    def test_returns_zero_when_nothing_expired(self, instance_dir):
+        from app.memory_db import ensure_db, insert_entry, vacuum_expired
+        conn = ensure_db(instance_dir)
+        insert_entry(conn, {"ts": "2026-06-01T00:00:00Z", "type": "session",
+                            "project": "koan", "content": "live",
+                            "expires_at": "2099-01-01T00:00:00Z"})
+        assert vacuum_expired(conn, now_iso="2026-07-01T00:00:00Z") == 0
+        conn.close()
+
+
+class TestSearchLearningsCache:
+
+    def test_identical_call_skips_fts5_rebuild(self, instance_dir):
+        import app.memory_db as mdb
+        from app.memory_db import ensure_db, search_learnings
+        conn = ensure_db(instance_dir)
+        content = (
+            "- JWT token expiry causes race condition in session handler\n"
+            "- Database connection pooling tunes at 25\n"
+        )
+        first = search_learnings(conn, content, "race condition", max_k=4)
+        assert first  # non-empty result got cached
+        # Second identical call must NOT open a new in-memory FTS5 connection.
+        with patch.object(mdb.sqlite3, "connect", side_effect=AssertionError("rebuilt")):
+            second = search_learnings(conn, content, "race condition", max_k=4)
+        assert second == first
+        conn.close()
+
+    def test_changed_content_misses_cache(self, instance_dir):
+        from app.memory_db import ensure_db, search_learnings
+        conn = ensure_db(instance_dir)
+        c1 = "- alpha authentication problem\n"
+        c2 = "- alpha authentication problem\n- beta authentication fix\n"
+        r1 = search_learnings(conn, c1, "authentication", max_k=10)
+        r2 = search_learnings(conn, c2, "authentication", max_k=10)
+        assert len(r2) > len(r1)
         conn.close()
 
 


### PR DESCRIPTION
**What:** Repair a silent JSONL↔SQLite memory divergence (expired-but-recent rows) and memoize the learnings FTS5 search. Partial fix for #2182 (items 2 & 3).

**Why:** `prune_memory_log()` drops expired entries from the JSONL truth log, but its SQLite mirror only ran `delete_before()` — which prunes by `ts`. An entry that expired while its `ts` is still recent stayed in the FTS5 index forever: the DB grows and BM25 corpus stats skew, while query-time `_is_expired` filtering masks the leak. Separately, `search_learnings()` rebuilt a transient in-memory FTS5 table (~50ms) on every call, and `prompt_builder` calls it per iteration.

**How:**
- `vacuum_expired(conn)` deletes rows whose `expires_at` is past, filtering candidates in Python so it mirrors `_is_expired` exactly (malformed `expires_at` is kept, never deleted). Wired into `prune_memory_log()`'s existing SQLite mirror block, next to `delete_before`.
- `search_learnings()` memoizes on `(hash(content), fts_query, max_k)` — an identical repeat call returns the cached list without rebuilding the table; any file or query change misses the cache. Bounded cache (clears at 32 entries).

Items 1 (`reconcile_db`) and 4 (reconcile flag) of #2182 are deferred: they hold a write lock per reindex chunk and need concurrent-access testing against the bridge process, so they belong in their own PR (see the issue's Risks section).

**Testing:** 5 new unit tests (3 vacuum, 2 cache). `test_memory_db.py` 54 passed, `test_memory_manager.py` 167 passed, ruff clean. Full suite: only the pre-existing `test_reset_parser::test_us_timezone` failure (missing tzdata in env, unrelated).
