### PR TITLE
Implement: Agent "armed monitor" / backgrounded command never complete

### DIFF
--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -103,6 +103,33 @@ marker (`.koan-restart-run`); stale legacy `.koan-restart` markers are ignored.
 The loop writes real-time state to status files so the bridge, dashboard, and
 commands can report progress without directly controlling the runner.
 
+## One-shot execution model (no post-turn event loop)
+
+Koan invokes the CLI in headless print mode (`claude -p --output-format json`).
+Each mission is a **single non-interactive turn**: the CLI loops through tool
+calls internally until the model emits a final message with no further tool
+call, then exits. `run_claude_task()` blocks in the subprocess wait; the instant
+the CLI exits `0`, `_run_iteration()` runs the post-mission pipeline and
+`_finalize_mission()` marks the mission Done. **There is no event loop after the
+turn.** Any work the model defers to "after" its turn — armed monitors, "I'll
+report when it finishes", scheduled wake-ups — is silently dropped and the
+backgrounded child is killed with the process group.
+
+Consequences and safeguards:
+
+- **Result-bearing work must complete in-turn.** The agent is instructed (see
+  the `cli-execution-model` prompt partial) to block or poll within the turn
+  until a command finishes, then read its result before concluding.
+- **Foreground headroom.** Koan sets `BASH_DEFAULT_TIMEOUT_MS` /
+  `BASH_MAX_TIMEOUT_MS` (from `bash_foreground_timeout`, default 15 min, clamped
+  below `mission_timeout` with a 120s reporting buffer) so a long-but-bounded
+  command can block in the foreground rather than being backgrounded and
+  orphaned. Set `bash_foreground_timeout: 0` to keep the CLI's built-in default.
+- **Not a `max_turns` issue.** Default missions pass no `--max-turns` flag; and a
+  genuine turn-cap hit surfaces as `subtype: "error_max_turns"`, which
+  `check_json_success()` treats as failure — not the clean "Done" this class of
+  bug produced. The trigger is a *natural* turn-end after backgrounding.
+
 ## Runtime Modes And Guards
 
 - Pause mode uses `.koan-pause` state and can be time-bounded.

--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -120,8 +120,9 @@ Consequences and safeguards:
 - **Result-bearing work must complete in-turn.** The agent is instructed (see
   the `cli-execution-model` prompt partial) to block or poll within the turn
   until a command finishes, then read its result before concluding.
-- **Foreground headroom.** Koan sets `BASH_DEFAULT_TIMEOUT_MS` /
-  `BASH_MAX_TIMEOUT_MS` (from `bash_foreground_timeout`, default 15 min, clamped
+- **Foreground headroom.** For the Claude provider, Koan sets
+  `BASH_DEFAULT_TIMEOUT_MS` / `BASH_MAX_TIMEOUT_MS` (from
+  `bash_foreground_timeout`, default 15 min, clamped
   below `mission_timeout` with a 120s reporting buffer) so a long-but-bounded
   command can block in the foreground rather than being backgrounded and
   orphaned. Set `bash_foreground_timeout: 0` to keep the CLI's built-in default.

--- a/docs/architecture/mission-lifecycle.md
+++ b/docs/architecture/mission-lifecycle.md
@@ -59,6 +59,14 @@ into `workspace/`).
 6. Post-mission reflection, journal writing, PR creation, security review,
    auto-merge checks, and autoreview queuing run only when their conditions apply.
 
+### In-turn completion before finalization
+
+Finalization runs the instant the one-shot CLI turn ends. There is no event loop
+that re-invokes the model afterward, so any command whose result the mission owes
+**must finish and be read within the same turn** — otherwise the mission is
+finalized Done without it. See `docs/architecture/daemon.md` →
+"One-shot execution model".
+
 ### Pre-mission branch preparation
 
 Before a mission runs, `git_prep.prepare_project_branch()` fetches refs, stashes

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -143,6 +143,16 @@ skill_timeout: 7200
 # Default: 600 (10 min). Set 0 to disable.
 # first_output_timeout: 600
 
+# Max Bash-tool foreground timeout for mission subprocesses, in SECONDS.
+# Injected as BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS (Claude CLI). Lets the
+# agent block on a long-but-bounded command in the foreground instead of
+# backgrounding it (backgrounded children are orphaned when the one-shot session
+# ends, so the mission is finalized Done without the promised result). Clamped
+# below mission_timeout (a 120s reporting buffer is reserved). Set to 0 to keep
+# the Claude CLI's built-in Bash default (~2 min).
+# Default: 900 (15 minutes).
+# bash_foreground_timeout: 900
+
 # Rebase first output timeout — optional override for /rebase skill runs.
 # Useful for large PRs where "Applying review feedback" can be quiet for longer.
 # Falls back to first_output_timeout when unset.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -1012,6 +1012,10 @@ def get_bash_foreground_timeout_ms() -> int:
     if requested_s <= 0:
         return 0
     mission_s = get_mission_timeout()
+    if mission_s <= 0:
+        # Mission watchdog disabled (unlimited mission time) — no ceiling to
+        # keep a buffer under, so honor the requested value as-is.
+        return requested_s * 1000
     # Keep a 120s reporting buffer under the mission watchdog; never exceed it.
     ceiling_s = max(60, mission_s - 120)
     return min(requested_s, ceiling_s) * 1000

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -995,6 +995,28 @@ def get_mission_timeout() -> int:
     return _safe_int(config.get("mission_timeout", 3600), 3600)
 
 
+def get_bash_foreground_timeout_ms() -> int:
+    """Max Bash-tool foreground timeout (ms) for mission subprocesses.
+
+    Lets the agent block on a long-but-bounded command in the foreground
+    instead of backgrounding it (which orphans the child when the one-shot
+    session ends). Clamped strictly below ``mission_timeout`` so the model
+    keeps a buffer to read the result and write its conclusion before the
+    mission watchdog SIGTERMs the process group.
+
+    Config key: bash_foreground_timeout (seconds, default: 900 — 15 min).
+    Returns 0 to signal "leave the CLI default" when explicitly disabled.
+    """
+    config = _load_config()
+    requested_s = _safe_int(config.get("bash_foreground_timeout", 900), 900)
+    if requested_s <= 0:
+        return 0
+    mission_s = get_mission_timeout()
+    # Keep a 120s reporting buffer under the mission watchdog; never exceed it.
+    ceiling_s = max(60, mission_s - 120)
+    return min(requested_s, ceiling_s) * 1000
+
+
 def get_first_output_timeout() -> int:
     """Get timeout in seconds for first output from CLI subprocesses.
 

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -46,6 +46,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "skill_max_turns": "int",
     "analysis_max_turns": "int",
     "mission_timeout": "int",
+    "bash_foreground_timeout": "int",
     "first_output_timeout": "int",
     "rebase_first_output_timeout": "int",
     "rebase_review_idle_timeout": "int",

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -338,7 +338,11 @@ def run_claude_task(
         )
 
     from app.cli_exec import popen_cli
-    from app.config import get_bash_foreground_timeout_ms, get_mission_timeout
+    from app.config import (
+        get_bash_foreground_timeout_ms,
+        get_cli_provider_name,
+        get_mission_timeout,
+    )
     from app.utils import cleanup_mission_tmp_dir, create_mission_tmp_dir
 
     mission_timeout = get_mission_timeout()
@@ -346,9 +350,12 @@ def run_claude_task(
     # Give the agent enough foreground headroom to BLOCK on a long-but-bounded
     # command rather than backgrounding it (backgrounded children are orphaned
     # when the one-shot session ends — see the cli-execution-model prompt).
+    # BASH_DEFAULT_TIMEOUT_MS / BASH_MAX_TIMEOUT_MS are Claude-CLI-specific, so
+    # only inject them for the Claude provider (inert but noise for others).
     mission_env = dict(os.environ)
+    _provider_name = getattr(provider, "name", "") or get_cli_provider_name()
     _bash_ms = get_bash_foreground_timeout_ms()
-    if _bash_ms > 0:
+    if _bash_ms > 0 and _provider_name == "claude":
         mission_env["BASH_DEFAULT_TIMEOUT_MS"] = str(_bash_ms)
         mission_env["BASH_MAX_TIMEOUT_MS"] = str(_bash_ms)
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -338,10 +338,19 @@ def run_claude_task(
         )
 
     from app.cli_exec import popen_cli
-    from app.config import get_mission_timeout
+    from app.config import get_bash_foreground_timeout_ms, get_mission_timeout
     from app.utils import cleanup_mission_tmp_dir, create_mission_tmp_dir
 
     mission_timeout = get_mission_timeout()
+
+    # Give the agent enough foreground headroom to BLOCK on a long-but-bounded
+    # command rather than backgrounding it (backgrounded children are orphaned
+    # when the one-shot session ends — see the cli-execution-model prompt).
+    mission_env = dict(os.environ)
+    _bash_ms = get_bash_foreground_timeout_ms()
+    if _bash_ms > 0:
+        mission_env["BASH_DEFAULT_TIMEOUT_MS"] = str(_bash_ms)
+        mission_env["BASH_MAX_TIMEOUT_MS"] = str(_bash_ms)
 
     # Per-mission TMPDIR: everything the agent creates via mktemp/$TMPDIR is
     # reaped in the outer finally below; crash leftovers are swept at startup
@@ -362,9 +371,9 @@ def run_claude_task(
             # provider is the role-resolved instance (cli: section); popen_cli
             # uses it for stdin-rewrite + invocation lock so they match the
             # binary the command was built for. None → global provider.
-            popen_kwargs = {}
+            popen_kwargs = {"env": mission_env}
             if mission_tmp:
-                popen_kwargs["env"] = {**os.environ, "TMPDIR": mission_tmp}
+                popen_kwargs["env"] = {**mission_env, "TMPDIR": mission_tmp}
             proc, cleanup = popen_cli(
                 cmd,
                 provider=provider,

--- a/koan/system-prompts/_partials/cli-execution-model.md
+++ b/koan/system-prompts/_partials/cli-execution-model.md
@@ -23,7 +23,7 @@ Reuse the redirect-to-file pattern (as with `make test` above) so a large
 command's output doesn't burn tokens — read the file only when you need the detail:
 
 ```bash
-log=$(mktemp /tmp/koan-cmd-XXXXXX)
+log=$(mktemp "${TMPDIR:-/tmp}/koan-cmd-XXXXXX")
 ( <long-running command> > "$log" 2>&1; echo "DONE:$?" >> "$log" ) &
 # Poll within THIS turn until the sentinel appears — do not end your turn yet.
 until grep -q '^DONE:' "$log"; do sleep 30; done

--- a/koan/system-prompts/_partials/cli-execution-model.md
+++ b/koan/system-prompts/_partials/cli-execution-model.md
@@ -1,0 +1,32 @@
+## Execution model: you run one-shot — finish result-bearing work before ending your turn
+
+Each mission is a **single non-interactive session**. The moment you end your
+turn (a final message with no tool call), the session exits and Kōan finalizes
+the mission. **There is no event loop afterward.** "Armed monitors", "I'll
+report when it finishes", scheduled wake-ups, and any deferred re-invocation
+**do not work** — that work is silently dropped, the backgrounded process is
+killed, and the mission is marked Done without the result.
+
+**Never end your turn while a result you owe is still pending.** If the mission
+asks you to run something and report its output, the command must finish — and
+you must read its result — **before** you write your conclusion.
+
+**How to wait for long commands.** A single foreground command may run up to the
+Bash tool timeout. For commands that fit within it, run them in the foreground
+and block. For longer ones, run in the background **and poll within the same
+turn** — loop `sleep`-then-check on a completion sentinel until it finishes, then
+read the result. Do **not** background a command and then stop. You have the whole
+mission budget (`mission_timeout`, default **60 minutes**), so blocking or polling
+for many minutes inside one turn is expected.
+
+Reuse the redirect-to-file pattern (as with `make test` above) so a large
+command's output doesn't burn tokens — read the file only when you need the detail:
+
+```bash
+log=$(mktemp /tmp/koan-cmd-XXXXXX)
+( <long-running command> > "$log" 2>&1; echo "DONE:$?" >> "$log" ) &
+# Poll within THIS turn until the sentinel appears — do not end your turn yet.
+until grep -q '^DONE:' "$log"; do sleep 30; done
+exit_code=$(grep '^DONE:' "$log" | tail -1 | cut -d: -f2)
+tail -n 40 "$log"   # report the result from here
+```

--- a/koan/system-prompts/agent.md
+++ b/koan/system-prompts/agent.md
@@ -149,6 +149,9 @@ When executing a mission, follow this sequence:
    if [ $TEST_EXIT -ne 0 ]; then cat "$test_log"; fi
    ```
    Only read the output file when tests fail. On success, log the result from the exit code alone.
+   **Block until the suite completes — never background it and end your turn.**
+
+{@include cli-execution-model}
 5. **Commit**: Write clear commit messages. Conventional commits when the project uses them.
    Do NOT add a `Co-Authored-By:` trailer or a "Generated with Claude Code" line — commits
    land under the operator's own git identity with no co-author attribution.

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -1053,6 +1053,41 @@ class TestGetMissionTimeout:
             assert get_mission_timeout() == 0
 
 
+# --- get_bash_foreground_timeout_ms ---
+
+
+class TestGetBashForegroundTimeoutMs:
+    def test_default(self):
+        from app.config import get_bash_foreground_timeout_ms
+
+        with _mock_config({}):
+            # Default 900s (15 min) with default mission_timeout 3600s.
+            assert get_bash_foreground_timeout_ms() == 900_000
+
+    def test_custom_honored(self):
+        from app.config import get_bash_foreground_timeout_ms
+
+        with _mock_config({"mission_timeout": 3600,
+                           "bash_foreground_timeout": 600}):
+            assert get_bash_foreground_timeout_ms() == 600_000
+
+    def test_clamped_below_mission_timeout(self):
+        from app.config import get_bash_foreground_timeout_ms
+
+        # Requested 3600s must clamp strictly under mission_timeout 600s.
+        with _mock_config({"mission_timeout": 600,
+                           "bash_foreground_timeout": 3600}):
+            ms = get_bash_foreground_timeout_ms()
+            assert ms > 0
+            assert ms < 600 * 1000
+
+    def test_zero_disables(self):
+        from app.config import get_bash_foreground_timeout_ms
+
+        with _mock_config({"bash_foreground_timeout": 0}):
+            assert get_bash_foreground_timeout_ms() == 0
+
+
 # --- get_post_mission_timeout ---
 
 

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -1087,6 +1087,15 @@ class TestGetBashForegroundTimeoutMs:
         with _mock_config({"bash_foreground_timeout": 0}):
             assert get_bash_foreground_timeout_ms() == 0
 
+    def test_mission_timeout_zero_is_unbounded(self):
+        """mission_timeout: 0 disables the watchdog — the Bash foreground
+        timeout must honor the requested value as-is, not clamp to 60s."""
+        from app.config import get_bash_foreground_timeout_ms
+
+        with _mock_config({"mission_timeout": 0,
+                           "bash_foreground_timeout": 900}):
+            assert get_bash_foreground_timeout_ms() == 900_000
+
 
 # --- get_post_mission_timeout ---
 

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -741,6 +741,20 @@ class TestLoadPromptWithIncludes:
         unresolved = re.findall(r"\{@include\s+[\w-]+\}", result)
         assert unresolved == [], f"Unresolved includes in agent.md: {unresolved}"
 
+    def test_agent_prompt_includes_cli_execution_model(self):
+        """The one-shot execution-model partial resolves into the agent prompt."""
+        text = load_prompt(
+            "agent",
+            MISSION_INSTRUCTION="do the thing",
+            PROJECT_NAME="my-toolkit",
+            BRANCH_PREFIX="koan/",
+        )
+        lower = text.lower()
+        assert "one-shot" in lower
+        assert "never end your turn" in lower
+        assert "poll" in lower
+        assert "{@include cli-execution-model}" not in text
+
     def test_all_skill_prompts_resolve_includes(self):
         """Every skill prompt with {@include} directives must resolve completely."""
         import re

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -69,7 +69,8 @@ mission_runner (post-processing)   # usage tracking, pending.md archival, reflec
   enforced at the prompt layer (`_partials/cli-execution-model.md`) and supported
   by a raised Bash foreground timeout (`get_bash_foreground_timeout_ms()`,
   injected into the mission subprocess env as `BASH_DEFAULT_TIMEOUT_MS` /
-  `BASH_MAX_TIMEOUT_MS`, clamped below `mission_timeout`). `max_turns` is
+  `BASH_MAX_TIMEOUT_MS` for the Claude provider only, clamped below
+  `mission_timeout`). `max_turns` is
   orthogonal: default missions impose no `--max-turns` cap (`build_mission_command`
   passes `0` unless `complexity_routing` assigns a tier), and a cap-hit is
   classified as failure (`subtype: "error_max_turns"`), not a clean success.

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -61,6 +61,18 @@ mission_runner (post-processing)   # usage tracking, pending.md archival, reflec
 
 ## Invariants
 
+- **One-shot headless invocation, in-turn completion.** Missions run via
+  `claude -p --output-format json` — a single non-interactive turn with no
+  post-turn event loop. Deferred re-invocation (background monitors, scheduled
+  wake-ups, "report later") is NOT available; such work is dropped and the child
+  is killed. Result-bearing work MUST complete before the model ends its turn —
+  enforced at the prompt layer (`_partials/cli-execution-model.md`) and supported
+  by a raised Bash foreground timeout (`get_bash_foreground_timeout_ms()`,
+  injected into the mission subprocess env as `BASH_DEFAULT_TIMEOUT_MS` /
+  `BASH_MAX_TIMEOUT_MS`, clamped below `mission_timeout`). `max_turns` is
+  orthogonal: default missions impose no `--max-turns` cap (`build_mission_command`
+  passes `0` unless `complexity_routing` assigns a tier), and a cap-hit is
+  classified as failure (`subtype: "error_max_turns"`), not a clean success.
 - **`run.py` never commits to main and never merges.** This is a hard safety boundary
   enforced by prompt + convention; the loop's job is to host the subprocess, not to
   alter git state itself.


### PR DESCRIPTION
## Summary

- Added a `cli-execution-model` prompt partial that teaches the agent to complete all result-bearing work before ending its turn
- Injected the partial into `agent.md` so every mission receives the one-shot execution model instruction
- Added `get_bash_foreground_timeout_ms()` config helper and wired it into `run_claude_task()` via `BASH_DEFAULT_TIMEOUT_MS` / `BASH_MAX_TIMEOUT_MS` env vars
- Documented the one-shot execution model in `docs/architecture/daemon.md`, `mission-lifecycle.md`, and `specs/components/agent-loop.md`
- Added `bash_foreground_timeout` config key (default 900 s, clamped below `mission_timeout`) with example in `instance.example/config.yaml`

## Why

The agent was occasionally backgrounding long-running commands and ending its turn before they finished. Because Kōan runs one-shot headless sessions with no post-turn event loop, those backgrounded children were killed and the mission was finalized Done without the promised result. This change closes that gap by both instructing the agent to block and giving it enough Bash foreground timeout headroom to do so safely.

## How

- Created `koan/system-prompts/_partials/cli-execution-model.md` with explicit instructions and a polling pattern for long commands
- Included the partial in `agent.md` via the existing `{@include}` directive, inserted after the test-step foreground-blocking note
- Added `get_bash_foreground_timeout_ms()` in `config.py` that reads `bash_foreground_timeout` (seconds), clamps to `max(60, mission_timeout - 120)` to preserve a reporting buffer, and converts to ms
- Set `BASH_DEFAULT_TIMEOUT_MS` and `BASH_MAX_TIMEOUT_MS` in the mission subprocess environment in `run.py` when the value is non-zero
- Updated agent-loop spec invariants to formally capture the one-shot contract and its enforcement points

## Testing

- 4 new unit tests in `TestGetBashForegroundTimeoutMs` covering default value, custom override, clamping below mission timeout, and zero-disables path
- 1 new prompt test asserting the `cli-execution-model` partial resolves into the compiled agent prompt and its key phrases are present
- Existing `test_all_includes_in_agent_prompt_resolve` test continues to pass, confirming no unresolved `{@include}` directives remain
- Full test suite passes with no regressions

Closes https://github.com/Anantys-oss/koan/issues/2249

---
_Generated by [Kōan](https://koan.anantys.com)_ _(Claude · model opus · HEAD=b3ad2173 · 6m31s)_