### PR TITLE
fix(pr_feedback): pass --limit to open-PR fetch (silent 30-cap)

### DIFF
--- a/koan/app/pr_feedback.py
+++ b/koan/app/pr_feedback.py
@@ -189,11 +189,16 @@ def fetch_merged_prs(
     return results
 
 
-def fetch_open_prs(project_path: str) -> List[dict]:
+def fetch_open_prs(project_path: str, limit: int = 200) -> List[dict]:
     """Fetch currently open koan/* PRs.
 
     Args:
         project_path: Path to the git repo.
+        limit: Maximum PRs to fetch. ``gh pr list`` defaults to 30 and
+            truncates silently; because open PRs across all branch prefixes
+            are fetched before the koan/* filter runs, a low cap can drop
+            matching PRs past the 30th raw result — including the oldest
+            (lowest-numbered) ones that carry the strongest aging signal.
 
     Returns:
         List of PR dicts with: number, title, createdAt, headRefName,
@@ -215,6 +220,7 @@ def fetch_open_prs(project_path: str) -> List[dict]:
         raw = run_gh(
             "pr", "list",
             "--state", "open",
+            "--limit", str(limit),
             "--json", "number,title,createdAt,headRefName",
             cwd=project_path,
             timeout=15,

--- a/koan/tests/test_pr_feedback.py
+++ b/koan/tests/test_pr_feedback.py
@@ -413,6 +413,18 @@ class TestFetchOpenPrs:
         result = fetch_open_prs("/fake/path")
         assert result == []
 
+    @patch("app.config.get_branch_prefix", return_value="koan/")
+    @patch("subprocess.run")
+    def test_passes_limit_to_gh(self, mock_run, _prefix):
+        # gh pr list defaults to 30 and truncates silently; the fetch must
+        # pass an explicit --limit so aging koan/* PRs past the 30th raw
+        # result are not dropped before the prefix filter runs.
+        mock_run.return_value = _mock_gh_success([])
+        fetch_open_prs("/fake/path", limit=200)
+        argv = mock_run.call_args[0][0]
+        assert "--limit" in argv
+        assert argv[argv.index("--limit") + 1] == "200"
+
 
 # ─── get_alignment_summary ───────────────────────────────────────────────
 


### PR DESCRIPTION
**What**: `fetch_open_prs()` now passes an explicit `--limit` to `gh pr list`.

**Why**: `gh pr list` defaults to 30 results and truncates silently. `fetch_open_prs()` fetches open PRs across *all* branch prefixes and only then filters to `koan/*` in Python — so with >30 open PRs, matching PRs past the 30th raw result vanished before the filter ever ran. The dropped ones are the oldest, lowest-numbered PRs (gh sorts newest-first), which are exactly the aging PRs that carry the strongest signal for `get_alignment_summary()`'s topic-selection nudge injected into the autonomous prompt. This repo currently has 35+ open PRs, so the bug is active.

**How**: Added a `limit: int = 200` param and pass `--limit`, mirroring the sibling `fetch_merged_prs()` which already does this. Same silent-truncation class as #2247 (`get_pending_prs`) and the documented gh 30-cap (#2231).

**Testing**: New regression test asserts the gh invocation includes `--limit`. Full `test_pr_feedback.py` suite green (64 passed), ruff clean.
