### PR TITLE
fix(deep_research): word-boundary topic dedup, not raw substring

### DIFF
--- a/koan/app/deep_research.py
+++ b/koan/app/deep_research.py
@@ -79,6 +79,25 @@ def _extract_closing_issue_numbers(body: str) -> set[int]:
     return {int(m) for m in _CLOSING_ISSUE_RE.findall(body)}
 
 
+def _recently_covered(candidate: str, recent_topics: list[str]) -> bool:
+    """True if ``candidate`` appears as a whole phrase in any recent topic.
+
+    Replaces raw substring containment (``candidate in topic``) for the
+    "skip if recently worked on" dedup. Raw containment has two failure modes:
+    a blank candidate matches every topic (``"" in t`` is always True), and a
+    short candidate matches inside a longer word (``"auth"`` in
+    ``"authentication"``). Word-boundary lookarounds (not ``\\b``, which
+    misbehaves when the candidate starts/ends with non-word chars like a file
+    path) require the match to be flanked by non-word characters or string
+    edges, so only genuine whole-phrase overlaps dedup a suggestion.
+    """
+    needle = candidate.strip().lower()
+    if not needle:
+        return False
+    pattern = re.compile(rf"(?<!\w){re.escape(needle)}(?!\w)")
+    return any(pattern.search(t.lower()) for t in recent_topics)
+
+
 def _extract_branch_issue_numbers(branch: str) -> set[int]:
     """Extract issue numbers from branch naming patterns like 'implement-1042'."""
     return {int(m) for m in _BRANCH_ISSUE_RE.findall(branch)}
@@ -449,7 +468,7 @@ class DeepResearch:
             labels = [l.get("name", "") for l in issue.get("labels", [])]
 
             # Skip if recently worked on
-            if any(title.lower() in t.lower() for t in recent_topics):
+            if _recently_covered(title, recent_topics):
                 continue
 
             priority = 2
@@ -470,7 +489,7 @@ class DeepResearch:
         # Priority 2-3: Technical debt items
         for item in priorities.get("technical_debt", []):
             # Skip if recently worked on
-            if any(item.lower() in t.lower() for t in recent_topics):
+            if _recently_covered(item, recent_topics):
                 continue
             # An item the human already annotated as finished (✅/[x]/"done")
             # shouldn't compete for attention as fresh priority-2 work — drop it
@@ -491,7 +510,7 @@ class DeepResearch:
         # Weighted below human priorities (1) but above journal recaps.
         for spot in self._gather_file_hotspots():
             topic = f"Investigate high-churn file: {spot['file']}"
-            if any(spot["file"].lower() in t.lower() for t in recent_topics):
+            if _recently_covered(spot["file"], recent_topics):
                 continue
             suggestions.append({
                 "topic": topic,

--- a/koan/tests/test_deep_research.py
+++ b/koan/tests/test_deep_research.py
@@ -8,7 +8,12 @@ from unittest.mock import patch, MagicMock
 
 import pytest
 
-from app.deep_research import DeepResearch, _extract_issue_numbers, _normalize_tokens
+from app.deep_research import (
+    DeepResearch,
+    _extract_issue_numbers,
+    _normalize_tokens,
+    _recently_covered,
+)
 
 pytestmark = pytest.mark.slow
 
@@ -1853,3 +1858,57 @@ class TestFeedbackBoostTagging:
         goal = next(t for t in topics if "Long-term goal" in t["topic"])
         assert goal["priority"] == 3
         assert "deprioritized" not in goal["reasoning"]
+
+
+class TestRecentlyCovered:
+    """Word-boundary dedup for the 'skip if recently worked on' filter."""
+
+    def test_blank_candidate_never_matches(self):
+        """An empty/whitespace candidate must not dedup against every topic."""
+        assert _recently_covered("", ["some recent topic"]) is False
+        assert _recently_covered("   ", ["some recent topic"]) is False
+
+    def test_partial_word_does_not_match(self):
+        """A short candidate must not match inside a longer word."""
+        assert _recently_covered("auth", ["Investigate authentication flow"]) is False
+
+    def test_whole_phrase_matches(self):
+        """A genuine whole-phrase overlap dedups (case-insensitive)."""
+        assert _recently_covered("Auth module", ["## Fixed the auth module bug"]) is True
+
+    def test_no_topics_never_matches(self):
+        assert _recently_covered("anything", []) is False
+
+    def test_file_path_candidate_matches_whole(self):
+        """Path-like candidates (non-word chars) still match as a whole unit."""
+        assert _recently_covered(
+            "koan/app/run.py", ["Investigate high-churn file: koan/app/run.py"]
+        ) is True
+        # but not glued inside a longer token
+        assert _recently_covered("run.py", ["run.pytest harness"]) is False
+
+
+class TestSuggestTopicsDedupBoundary:
+    """suggest_topics must not drop a valid issue on a partial-word collision."""
+
+    def _research(self, env):
+        research = DeepResearch(env["instance"], env["project_name"], env["project_path"])
+        research._pending_prs = []
+        return research
+
+    def test_issue_survives_partial_word_collision(self, research_env):
+        """An 'auth' issue is not deduped by an unrelated 'authentication' topic."""
+        research = self._research(research_env)
+        with patch.object(research, "get_open_issues", return_value=[
+                 {"number": 7, "title": "auth", "labels": []},
+             ]), \
+             patch.object(research, "get_recent_journal_topics",
+                          return_value=["## Investigate authentication flow"]), \
+             patch.object(research, "get_priorities", return_value={
+                 "current_focus": [], "strategic_goals": [],
+                 "technical_debt": [], "do_not_touch": [], "notes": "",
+             }), \
+             patch.object(research, "_gather_file_hotspots", return_value=[]):
+            topics = research.suggest_topics()
+
+        assert any("#7" in t["topic"] for t in topics)


### PR DESCRIPTION
## What
Replace raw substring containment with word-boundary matching in `deep_research.suggest_topics()`'s "skip if recently worked on" dedup.

## Why
The dedup used `candidate.lower() in topic.lower()`, which silently dropped valid topics from the DEEP-mode suggestion list in two cases:
- **Blank candidate** — an issue with an empty title makes `"" in t` always True, so it's deduped against *any* recent journal header.
- **Partial-word collision** — a short candidate matches inside a longer word: an open issue titled `auth` is dropped when an unrelated journal header mentions `authentication`.

Both harm the #1 priority (better topic selection) by hiding real work from the agent.

## How
Centralize the three dedup sites (open issues, technical-debt items, churn hotspots) behind one `_recently_covered()` helper that:
- returns False for blank/whitespace candidates, and
- matches on non-word boundaries via `(?<!\w)...(?!\w)` lookarounds rather than `\b` — the lookaround form behaves correctly when the candidate starts/ends with non-word characters (e.g. the path `koan/app/run.py`).

Genuine whole-phrase overlaps still dedup as before.

## Testing
`make lint` clean. `pytest koan/tests/test_deep_research.py` → 94 passed (+6 new: `_recently_covered` unit cases + a `suggest_topics` regression proving an `auth` issue survives an `authentication` journal collision).
