### PR TITLE
fix(config): tolerate null `projects:` section in projects.yaml (#2273)

### DIFF
--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -40,7 +40,7 @@ def _load_project_overrides(project_name: str) -> dict:
         projects_config = load_projects_config(koan_root)
         if not projects_config:
             return {}
-        if project_name not in projects_config.get("projects", {}):
+        if project_name not in (projects_config.get("projects") or {}):
             return {}
         return get_project_config(projects_config, project_name)
     except Exception as e:
@@ -1784,7 +1784,7 @@ def get_auto_merge_config(config: dict, project_name: str) -> dict:
         from app.projects_config import load_projects_config, get_project_auto_merge
         koan_root = os.environ.get("KOAN_ROOT", "")
         projects_config = load_projects_config(koan_root) if koan_root else None
-        if projects_config and project_name in projects_config.get("projects", {}):
+        if projects_config and project_name in (projects_config.get("projects") or {}):
             return get_project_auto_merge(projects_config, project_name)
     except Exception as e:
         print(f"[config] Auto-merge config load error for {project_name}: {e}", file=sys.stderr)

--- a/koan/app/github_skill_helpers.py
+++ b/koan/app/github_skill_helpers.py
@@ -385,7 +385,7 @@ def _find_repo_name_matches(repo: str) -> list:
         config = load_projects_config(str(KOAN_ROOT))
         if not config:
             return matches
-        for project in config.get("projects", {}).values():
+        for project in (config.get("projects") or {}).values():
             if not isinstance(project, dict):
                 continue
             gh_url = project.get("github_url", "")

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -1143,7 +1143,7 @@ def _filter_exploration_projects(
             filtered.append((name, path))
             continue
 
-        project_cfg = config.get("projects", {}).get(name, {}) or {}
+        project_cfg = (config.get("projects") or {}).get(name, {}) or {}
         urls_to_check = set()
         primary_url = project_cfg.get("github_url", "")
         if primary_url:
@@ -1215,7 +1215,7 @@ def _filter_exploration_projects(
             final_filtered.append((name, path))
             continue
 
-        project_cfg = config.get("projects", {}).get(name, {}) or {}
+        project_cfg = (config.get("projects") or {}).get(name, {}) or {}
         urls = set()
         primary = project_cfg.get("github_url", "")
         if primary:

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -586,7 +586,7 @@ def _get_known_repos_from_projects(koan_root: str) -> Optional[set]:
     # 1. projects.yaml — primary source
     projects_config = load_projects_config(koan_root)
     if projects_config:
-        for proj in projects_config.get("projects", {}).values():
+        for proj in (projects_config.get("projects") or {}).values():
             if not isinstance(proj, dict):
                 continue
             gh_url = proj.get("github_url", "")

--- a/koan/app/pr_checkup.py
+++ b/koan/app/pr_checkup.py
@@ -32,7 +32,7 @@ def _get_all_github_repos(koan_root: str) -> List[Dict]:
         return []
 
     results = []
-    projects = config.get("projects", {})
+    projects = config.get("projects") or {}
     for name, proj in projects.items():
         if proj is None:
             continue

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -110,6 +110,15 @@ def load_projects_config(koan_root: str) -> Optional[dict]:
 
     _validate_config(data)
 
+    # Normalize null sections to empty dicts. A `projects:` (or `defaults:`)
+    # key present but empty — e.g. every entry commented out — parses to None.
+    # Coercing here means no downstream consumer has to guard against None
+    # when it does `config.get("projects", {}).items()` / `in` / indexing.
+    if data.get("projects") is None:
+        data["projects"] = {}
+    if data.get("defaults") is None:
+        data["defaults"] = {}
+
     with _cache_lock:
         _cache[cache_key] = (current_mtime, data)
 
@@ -277,6 +286,8 @@ def get_projects_from_config(config: dict) -> List[Tuple[str, str]]:
 
 def _find_project_entry(projects: dict, project_name: str) -> dict:
     """Case-insensitive lookup of a project entry in the projects dict."""
+    # A null `projects:` section (all entries commented out) parses to None.
+    projects = projects or {}
     # Fast path: exact match
     entry = projects.get(project_name)
     if entry is not None:
@@ -911,7 +922,7 @@ def ensure_github_urls(koan_root: str) -> List[str]:
     if config is None:
         return []
 
-    projects = config.get("projects", {})
+    projects = config.get("projects") or {}
     if not projects:
         return []
 

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -114,6 +114,15 @@ def load_projects_config(koan_root: str) -> Optional[dict]:
     # key present but empty — e.g. every entry commented out — parses to None.
     # Coercing here means no downstream consumer has to guard against None
     # when it does `config.get("projects", {}).items()` / `in` / indexing.
+    if "projects" in data and data.get("projects") is None:
+        # Warn the operator: a present-but-empty section is usually an
+        # oversight (all entries commented out) rather than intent.
+        print(
+            "[projects_config] warning: 'projects:' section in projects.yaml "
+            "is empty (null) — treating as no configured projects",
+            file=sys.stderr,
+        )
+        data["projects"] = {}
     if data.get("projects") is None:
         data["projects"] = {}
     if data.get("defaults") is None:

--- a/koan/app/projects_merged.py
+++ b/koan/app/projects_merged.py
@@ -276,7 +276,7 @@ def get_yaml_project_names(koan_root: str) -> set:
             return set()
         
         return {
-            name for name, proj in config.get("projects", {}).items()
+            name for name, proj in (config.get("projects") or {}).items()
             if isinstance(proj, dict) and proj.get("path")
         }
     except (ValueError, OSError):

--- a/koan/app/remote_rename_detector.py
+++ b/koan/app/remote_rename_detector.py
@@ -145,7 +145,7 @@ def _update_projects_config(koan_root: str, fixed: dict):
         if config is None:
             return
 
-        projects = config.get("projects", {})
+        projects = config.get("projects") or {}
         modified = False
 
         for name, new_slug in fixed.items():

--- a/koan/app/rename_project.py
+++ b/koan/app/rename_project.py
@@ -138,7 +138,7 @@ def run_rename(koan_root: Path, old_name: str, new_name: str, dry_run: bool = Tr
     # Validate old project exists
     with open(yaml_path) as f:
         config = yaml.safe_load(f)
-    projects = config.get("projects", {})
+    projects = config.get("projects") or {}
     if old_name not in projects:
         print(f"Error: project '{old_name}' not found in projects.yaml", file=sys.stderr)
         print(f"Available projects: {', '.join(projects.keys())}", file=sys.stderr)

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -856,7 +856,7 @@ def _persist_and_cache_remotes(
     try:
         from app.projects_config import load_projects_config, save_projects_config
         config = load_projects_config(str(KOAN_ROOT))
-        if config and name in config.get("projects", {}):
+        if config and name in (config.get("projects") or {}):
             proj = config["projects"][name]
             if isinstance(proj, dict) and proj.get("path"):
                 if primary and not proj.get("github_url"):

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -907,7 +907,7 @@ def _resolve_via_fork_parent(
     if not config:
         return None
 
-    for project in config.get("projects", {}).values():
+    for project in (config.get("projects") or {}).values():
         if not isinstance(project, dict):
             continue
         gh_url = (project.get("github_url") or "").lower()
@@ -972,7 +972,7 @@ def resolve_project_path(repo_name: str, owner: Optional[str] = None) -> Optiona
             from app.projects_config import load_projects_config
             _projects_config = load_projects_config(str(KOAN_ROOT))
             if _projects_config:
-                for project in _projects_config.get("projects", {}).values():
+                for project in (_projects_config.get("projects") or {}).values():
                     if isinstance(project, dict):
                         # Check primary github_url
                         gh_url = project.get("github_url", "")
@@ -1058,7 +1058,7 @@ def resolve_project_path(repo_name: str, owner: Optional[str] = None) -> Optiona
             config = _projects_config
             if config:
                 candidates = []
-                for project in config.get("projects", {}).values():
+                for project in (config.get("projects") or {}).values():
                     if not isinstance(project, dict):
                         continue
                     all_urls = []

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -4241,3 +4241,22 @@ class TestProgressNotifier:
         notify = lm._progress_notifier()
         notify("Processing 3 GitHub notification(s)...")
         assert sent == ["Processing 3 GitHub notification(s)..."]
+
+
+class TestKnownReposNullProjects:
+    """Regression: a projects.yaml with an empty ``projects:`` key parses to
+    ``projects: null``, which must not crash the run loop (issue #2273)."""
+
+    def test_null_projects_section_does_not_crash(self, tmp_path, monkeypatch):
+        from app.loop_manager import _get_known_repos_from_projects
+        import app.projects_config as pc
+
+        # `projects:` present but empty (all entries commented out) → YAML null
+        (tmp_path / "projects.yaml").write_text("projects:\n")
+        # Bypass the mtime cache so this file is actually parsed
+        monkeypatch.setattr(pc, "_cache", {}, raising=False)
+
+        # Must degrade gracefully instead of raising AttributeError on None.
+        # No configured repos → None sentinel ("watch all") or an empty set.
+        result = _get_known_repos_from_projects(str(tmp_path))
+        assert result is None or isinstance(result, set)

--- a/koan/tests/test_projects_config.py
+++ b/koan/tests/test_projects_config.py
@@ -124,6 +124,13 @@ projects:
         assert config is not None
         assert config["projects"] == {}
 
+    def test_null_projects_section_warns_operator(self, koan_root, capsys):
+        """A present-but-null 'projects:' section is usually an oversight, so
+        the loader emits a warning to stderr (per reviewer request)."""
+        _write_yaml(koan_root, "projects:\n")
+        load_projects_config(koan_root)
+        assert "empty (null)" in capsys.readouterr().err
+
     def test_empty_projects_is_valid(self, koan_root):
         """Empty projects: dict is valid — workspace will provide projects."""
         _write_yaml(koan_root, "projects: {}")

--- a/koan/tests/test_projects_config.py
+++ b/koan/tests/test_projects_config.py
@@ -105,12 +105,24 @@ projects:
             load_projects_config(koan_root)
 
     def test_missing_projects_section_is_valid(self, koan_root):
-        """projects: section is optional — defaults-only yaml is valid."""
+        """projects: section is optional — defaults-only yaml is valid.
+
+        The loader normalizes a missing/null projects section to an empty
+        dict so downstream consumers never see None (issue #2273)."""
         _write_yaml(koan_root, "defaults:\n  enabled: true\n")
         config = load_projects_config(koan_root)
         assert config is not None
         assert "defaults" in config
-        assert config.get("projects") is None
+        assert config["projects"] == {}
+
+    def test_null_projects_section_normalized_to_empty_dict(self, koan_root):
+        """A 'projects:' key present but empty (all entries commented out)
+        parses to None; the loader must normalize it to {} so the run loop
+        never crashes on `.get("projects", {}).values()` (issue #2273)."""
+        _write_yaml(koan_root, "projects:\n")
+        config = load_projects_config(koan_root)
+        assert config is not None
+        assert config["projects"] == {}
 
     def test_empty_projects_is_valid(self, koan_root):
         """Empty projects: dict is valid — workspace will provide projects."""
@@ -306,6 +318,14 @@ class TestGetProjectConfig:
         result = get_project_config(config, "app")
         assert result["git_auto_merge"]["enabled"] is True
         assert result["git_auto_merge"]["base_branch"] == "main"
+
+    def test_null_projects_value(self):
+        """A 'projects:' key present but empty parses to None. get_project_config
+        must not raise AttributeError (regression for the GitHub-notification
+        authorized-users path)."""
+        config = {"projects": None}
+        result = get_project_config(config, "anything")
+        assert isinstance(result, dict)
 
     def test_project_overrides_defaults(self):
         config = {


### PR DESCRIPTION
## Summary

Fixes #2273 — a `projects.yaml` whose `projects:` key is present but empty (every entry commented out) parses to `projects: null`, which crashed Kōan across multiple code paths with `'NoneType' object has no attribute 'get'/'values'`.

## Root cause

`projects:` with no active entries → `projects: null`. Consumers used `config.get("projects", {})`, whose `{}` default only applies when the key is **absent**. A present-but-`null` value returns `None`, so any `.values()` / `.items()` / `.get()` / `in` / indexing on it raised `AttributeError`/`TypeError`.

Observed crash sites:
- Run loop, every iteration: `_get_known_repos_from_projects()` (`loop_manager.py`) → `None.values()`.
- GitHub notification worker, every mention: `get_github_authorized_users` → `get_project_config` → `_find_project_entry` → `None.get(project_name)`.
- Git sync remote resolution: `get_project_submit_to_repository` → `get_project_config`.

**Not a regression** — the pattern is identical on `main` and `incubating`. An empty/absent `projects:` section is a legitimate config shape (projects can come entirely from the workspace or `KOAN_PROJECTS`), so it must degrade to "no configured projects", never crash.

## Fix

**Root-cause fix at the loader:** `load_projects_config()` normalizes a missing or `null` `projects:` / `defaults:` section to `{}`, so no downstream consumer ever observes `None`.

**Defense in depth** (covers configs built outside the loader — tests, raw `yaml.safe_load`):
- `_find_project_entry()` coerces `None → {}`.
- Hardened every remaining `.get("projects", {})` site that iterates / indexes / membership-tests the section, across: `loop_manager`, `github_skill_helpers`, `utils` (×4), `projects_merged`, `config` (×2), `pr_checkup`, `remote_rename_detector`, `rename_project`, `projects_config`. Uses parenthesized `(... or {})` where `in` precedence matters.

## Testing

- Loader normalization tests: missing section **and** null section → `projects == {}`.
- `get_project_config` with `projects: None` (the notification-worker crash path) → returns a dict, no raise.
- `_get_known_repos_from_projects` regression test: verified it **fails** without the fix, **passes** with it.
- Full suites pass: `test_projects_config`, `test_loop_manager`, `test_utils`, `test_config`, `test_pr_checkup`, `test_git_prep`, `test_github_config`, `test_projects_migration`, `test_rename_project`, `test_remote_rename_detector`. `make lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)