### PR TITLE
fix(telegram): strip whitespace from KOAN_TELEGRAM_CHAT_ID

### DIFF
--- a/docs/messaging/telegram.md
+++ b/docs/messaging/telegram.md
@@ -66,6 +66,15 @@ You should see in the logs:
 3. **Check logs**: `make logs` — look for `[error]` entries
 4. **Restart**: `make stop && make start`
 
+### "Bad Request: chat not found"
+
+Usually the chat ID is wrong, but a stray trailing newline or surrounding
+whitespace in `KOAN_TELEGRAM_CHAT_ID` triggers the same error — common on
+Railway (env vars are injected as strings, and editors can preserve a trailing
+newline). Kōan now `.strip()`s the value at read time, so a clean restart clears
+it. If it persists, re-check the ID from `getUpdates` (group IDs are negative,
+e.g. `-1001234567890`).
+
 ### "KOAN_TELEGRAM_TOKEN not set" error
 
 Your `.env` file is missing or the variable name is wrong. Double-check the format:

--- a/koan/app/bridge_state.py
+++ b/koan/app/bridge_state.py
@@ -12,12 +12,12 @@ from pathlib import Path
 from typing import Optional
 
 from app.skills import SkillRegistry, build_registry
-from app.utils import load_dotenv
+from app.utils import get_telegram_chat_id, load_dotenv
 
 load_dotenv()
 
 BOT_TOKEN = os.environ.get("KOAN_TELEGRAM_TOKEN", "")
-CHAT_ID = os.environ.get("KOAN_TELEGRAM_CHAT_ID", "")
+CHAT_ID = get_telegram_chat_id()
 POLL_INTERVAL = int(os.environ.get("KOAN_BRIDGE_INTERVAL", "3"))
 CHAT_TIMEOUT = int(os.environ.get("KOAN_CHAT_TIMEOUT", "180"))
 

--- a/koan/app/messaging/telegram.py
+++ b/koan/app/messaging/telegram.py
@@ -93,11 +93,11 @@ class TelegramProvider(MessagingProvider):
     # -- MessagingProvider interface ------------------------------------------
 
     def configure(self) -> bool:
-        from app.utils import load_dotenv
+        from app.utils import get_telegram_chat_id, load_dotenv
         load_dotenv()
 
         self._bot_token = os.environ.get("KOAN_TELEGRAM_TOKEN", "")
-        self._chat_id = os.environ.get("KOAN_TELEGRAM_CHAT_ID", "")
+        self._chat_id = get_telegram_chat_id()
 
         if not self._bot_token or not self._chat_id:
             print(

--- a/koan/app/notify.py
+++ b/koan/app/notify.py
@@ -24,7 +24,7 @@ from typing import Dict, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
-from app.utils import load_dotenv
+from app.utils import get_telegram_chat_id, load_dotenv
 
 # Thread-local reply context for group chat threading.
 # Set by the bridge main loop before dispatching a message handler;
@@ -267,7 +267,7 @@ def _direct_send(text: str, reply_to: int = 0) -> bool:
 
     load_dotenv()
     bot_token = os.environ.get("KOAN_TELEGRAM_TOKEN", "")
-    chat_id = os.environ.get("KOAN_TELEGRAM_CHAT_ID", "")
+    chat_id = get_telegram_chat_id()
 
     if not bot_token or not chat_id:
         print("[notify] KOAN_TELEGRAM_TOKEN or KOAN_TELEGRAM_CHAT_ID not set.",

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -156,6 +156,19 @@ def get_cli_provider_env() -> str:
     return ""
 
 
+def get_telegram_chat_id() -> str:
+    """Return KOAN_TELEGRAM_CHAT_ID, stripped of stray whitespace/newlines.
+
+    Railway (and copy-paste) can inject a trailing newline that makes Telegram
+    return "Bad Request: chat not found". Numeric IDs (incl. negative group IDs)
+    are returned as-is once stripped; Telegram accepts numeric strings.
+
+    Returns:
+        The stripped environment value, or empty string if unset.
+    """
+    return os.environ.get("KOAN_TELEGRAM_CHAT_ID", "").strip()
+
+
 def parse_project(text: str) -> Tuple[Optional[str], str]:
     """Extract [project:name] or [projet:name] from text.
 

--- a/koan/tests/test_telegram_provider.py
+++ b/koan/tests/test_telegram_provider.py
@@ -29,6 +29,14 @@ class TestConfigure:
         assert "tok" in p._api_base
 
     @patch("app.utils.load_dotenv")
+    def test_strips_whitespace_from_chat_id(self, mock_dotenv, monkeypatch):
+        monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "tok")
+        monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "-1001234567890\n")
+        p = TelegramProvider()
+        assert p.configure() is True
+        assert p._chat_id == "-1001234567890"
+
+    @patch("app.utils.load_dotenv")
     def test_missing_token(self, mock_dotenv, monkeypatch):
         monkeypatch.delenv("KOAN_TELEGRAM_TOKEN", raising=False)
         monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "123")

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -1804,3 +1804,25 @@ class TestKoanTmpDir:
 
         with pytest.raises(RuntimeError, match="owned by uid"):
             koan_tmp_dir()
+
+
+class TestGetTelegramChatId:
+    def test_strips_trailing_newline(self, monkeypatch):
+        from app.utils import get_telegram_chat_id
+        monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "-1001234567890\n")
+        assert get_telegram_chat_id() == "-1001234567890"
+
+    def test_strips_surrounding_whitespace(self, monkeypatch):
+        from app.utils import get_telegram_chat_id
+        monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "  123456  ")
+        assert get_telegram_chat_id() == "123456"
+
+    def test_clean_value_unchanged(self, monkeypatch):
+        from app.utils import get_telegram_chat_id
+        monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "-1001234567890")
+        assert get_telegram_chat_id() == "-1001234567890"
+
+    def test_empty_when_unset(self, monkeypatch):
+        from app.utils import get_telegram_chat_id
+        monkeypatch.delenv("KOAN_TELEGRAM_CHAT_ID", raising=False)
+        assert get_telegram_chat_id() == ""

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -41,6 +41,10 @@ awake.py (loop, ~3s poll)
   *how* the agent behaves.
 - **Command parsing is hyphen-hostile.** Skill names/aliases use underscores; Telegram
   treats `-` as a word boundary and truncates the command.
+- **The chat ID is normalized at read time.** All reads of `KOAN_TELEGRAM_CHAT_ID` go
+  through `utils.get_telegram_chat_id()`, which `.strip()`s stray whitespace/newlines
+  (Railway/copy-paste inject a trailing newline that makes Telegram answer
+  `chat not found`). Never read the env var raw into an API payload.
 
 ## Integration points
 


### PR DESCRIPTION
## Summary

Normalize `KOAN_TELEGRAM_CHAT_ID` at read time so a stray trailing newline or surrounding whitespace (common on Railway / copy-paste) no longer reaches the Telegram API payload verbatim and triggers `Bad Request: chat not found`.

Closes https://github.com/Anantys-oss/koan/issues/2256

## Changes

- Add `utils.get_telegram_chat_id()` — reads `KOAN_TELEGRAM_CHAT_ID` and `.strip()`s it (mirrors `get_cli_provider_env()` hygiene).
- Route the three raw reads through it: `telegram.py` `configure()`, `notify.py` `_direct_send()`, `bridge_state.py` `CHAT_ID`.
- Add bridge-spec invariant + Telegram troubleshooting doc entry.

## Test plan

- New `TestGetTelegramChatId` unit tests (trailing newline, whitespace, clean, unset).
- New `TestConfigure.test_strips_whitespace_from_chat_id` on the provider.
- Full relevant suite green: `test_utils / test_telegram_provider / test_notify / test_bridge_state / test_email_notify` — 363 passed. `make lint` clean.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=5e585349)_
