### PR TITLE
fix(telegram): coerce numeric chat_id to int for group chats

### DIFF
--- a/docs/messaging/telegram.md
+++ b/docs/messaging/telegram.md
@@ -3,7 +3,7 @@ type: doc
 title: "Telegram Setup Guide"
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-07-03
+updated: 2026-07-08
 ---
 
 # Telegram Setup Guide
@@ -82,6 +82,13 @@ Railway (env vars are injected as strings, and editors can preserve a trailing
 newline). Kōan now `.strip()`s the value at read time, so a clean restart clears
 it. If it persists, re-check the ID from `getUpdates` (group IDs are negative,
 e.g. `-1001234567890`).
+
+For **group/supergroup** IDs specifically, Railway's ENV editor can't store a
+bare negative number, so it ends up quoted (`"-1001234567890"`); Telegram has
+been observed to answer `chat not found` for a quoted group ID while accepting
+the same value as a plain integer. Kōan coerces any fully-numeric chat ID to an
+integer in the outgoing API request, so this now works whether you store it
+quoted or not.
 
 ### "KOAN_TELEGRAM_TOKEN not set" error
 

--- a/koan/app/messaging/telegram.py
+++ b/koan/app/messaging/telegram.py
@@ -333,7 +333,8 @@ class TelegramProvider(MessagingProvider):
 
     def _send_chunk(self, chunk: str, parse_mode: str = None, reply_to: int = 0) -> bool:
         """Send a single chunk via Telegram API. Raises on network error."""
-        payload = {"chat_id": self._chat_id, "text": chunk}
+        from app.utils import coerce_chat_id
+        payload = {"chat_id": coerce_chat_id(self._chat_id), "text": chunk}
         if parse_mode:
             payload["parse_mode"] = parse_mode
         if reply_to:
@@ -366,10 +367,11 @@ class TelegramProvider(MessagingProvider):
         """
         if not self._bot_token or not self._chat_id:
             return False
+        from app.utils import coerce_chat_id
         try:
             resp = requests.post(
                 f"{self._api_base}/sendChatAction",
-                json={"chat_id": self._chat_id, "action": "typing"},
+                json={"chat_id": coerce_chat_id(self._chat_id), "action": "typing"},
                 timeout=5,
             )
             return resp.json().get("ok", False)
@@ -385,11 +387,12 @@ class TelegramProvider(MessagingProvider):
         """
         if not reply_to_message_id or not self._bot_token or not self._chat_id:
             return False
+        from app.utils import coerce_chat_id
         try:
             resp = requests.post(
                 f"{self._api_base}/setMessageReaction",
                 json={
-                    "chat_id": self._chat_id,
+                    "chat_id": coerce_chat_id(self._chat_id),
                     "message_id": reply_to_message_id,
                     "reaction": [{"type": "emoji", "emoji": emoji}],
                 },

--- a/koan/app/notify.py
+++ b/koan/app/notify.py
@@ -24,7 +24,7 @@ from typing import Dict, Optional, Tuple
 
 log = logging.getLogger(__name__)
 
-from app.utils import get_telegram_chat_id, load_dotenv
+from app.utils import coerce_chat_id, get_telegram_chat_id, load_dotenv
 
 # Thread-local reply context for group chat threading.
 # Set by the bridge main loop before dispatching a message handler;
@@ -323,7 +323,7 @@ def _direct_send_chunk(api_base: str, chat_id: str, chunk: str,
     """Send a single message chunk via Telegram API. Raises on network error."""
     import requests
 
-    payload = {"chat_id": chat_id, "text": chunk}
+    payload = {"chat_id": coerce_chat_id(chat_id), "text": chunk}
     if parse_mode:
         payload["parse_mode"] = parse_mode
     if reply_to:

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -29,7 +29,7 @@ import threading
 import time
 import yaml
 from pathlib import Path
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Union
 
 
 if "KOAN_ROOT" not in os.environ:
@@ -167,6 +167,27 @@ def get_telegram_chat_id() -> str:
         The stripped environment value, or empty string if unset.
     """
     return os.environ.get("KOAN_TELEGRAM_CHAT_ID", "").strip()
+
+
+def coerce_chat_id(chat_id: Union[str, int]) -> Union[str, int]:
+    """Coerce a numeric Telegram chat ID to ``int`` for the API payload.
+
+    Telegram group/supergroup IDs are negative integers (e.g. ``-1001234567890``).
+    Railway's ENV editor cannot store a bare negative number, so it is quoted as a
+    string; empirically Telegram's API returns "Bad Request: chat not found" for a
+    quoted group ID while the same value as a JSON integer works. Coerce a
+    fully-numeric (optionally negative) ID to ``int``; leave anything else — Slack
+    channel strings, ``@channelusername``, empty — untouched.
+    """
+    s = str(chat_id).strip()
+    if s.lstrip("-").isdigit():
+        try:
+            return int(s)
+        except ValueError:
+            # str.isdigit() is True for exotic numerals (superscripts, etc.)
+            # that int() rejects; leave those untouched.
+            return s
+    return s
 
 
 def parse_project(text: str) -> Tuple[Optional[str], str]:

--- a/koan/tests/test_notify.py
+++ b/koan/tests/test_notify.py
@@ -231,6 +231,17 @@ class TestDirectSend:
         assert "bottok" in mock_post.call_args[0][0]
 
     @patch("app.notify.load_dotenv")
+    def test_numeric_group_id_sent_as_int(self, mock_dotenv, monkeypatch):
+        """A quoted negative group ID reaches the API payload as an int."""
+        monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "tok")
+        monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "-1001234567890")
+        mock_resp = MagicMock()
+        mock_resp.json.return_value = {"ok": True}
+        with patch("requests.post", return_value=mock_resp) as mock_post:
+            assert _direct_send("hello") is True
+        assert mock_post.call_args[1]["json"]["chat_id"] == -1001234567890
+
+    @patch("app.notify.load_dotenv")
     def test_api_error_returns_false(self, mock_dotenv, monkeypatch):
         monkeypatch.setenv("KOAN_TELEGRAM_TOKEN", "tok")
         monkeypatch.setenv("KOAN_TELEGRAM_CHAT_ID", "123")

--- a/koan/tests/test_telegram_provider.py
+++ b/koan/tests/test_telegram_provider.py
@@ -167,6 +167,39 @@ class TestSendRaw:
         assert "2/3" in notice_text
 
 
+class TestChatIdPayloadCoercion:
+    """Numeric chat IDs go into the API payload as int (Telegram group-chat fix)."""
+
+    @patch("app.messaging.telegram.requests.post")
+    def test_numeric_group_id_sent_as_int(self, mock_post, provider):
+        provider._chat_id = "-1001234567890"
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        provider._send_raw("hi")
+        assert mock_post.call_args[1]["json"]["chat_id"] == -1001234567890
+        assert isinstance(mock_post.call_args[1]["json"]["chat_id"], int)
+
+    @patch("app.messaging.telegram.requests.post")
+    def test_non_numeric_id_left_as_string(self, mock_post, provider):
+        provider._chat_id = "@my_channel"
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        provider._send_raw("hi")
+        assert mock_post.call_args[1]["json"]["chat_id"] == "@my_channel"
+
+    @patch("app.messaging.telegram.requests.post")
+    def test_typing_action_coerces_chat_id(self, mock_post, provider):
+        provider._chat_id = "-1001234567890"
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        provider.send_typing()
+        assert mock_post.call_args[1]["json"]["chat_id"] == -1001234567890
+
+    @patch("app.messaging.telegram.requests.post")
+    def test_reaction_coerces_chat_id(self, mock_post, provider):
+        provider._chat_id = "-1001234567890"
+        mock_post.return_value = MagicMock(json=lambda: {"ok": True})
+        provider.add_reaction(55, "✅")
+        assert mock_post.call_args[1]["json"]["chat_id"] == -1001234567890
+
+
 class TestSendMessage:
     """Tests for send_message with flood protection."""
 
@@ -357,7 +390,7 @@ class TestSendTyping:
         mock_post.assert_called_once()
         call_json = mock_post.call_args[1]["json"]
         assert call_json["action"] == "typing"
-        assert call_json["chat_id"] == "12345"
+        assert call_json["chat_id"] == 12345
 
     @patch("app.messaging.telegram.requests.post")
     def test_returns_false_on_api_error(self, mock_post, provider):
@@ -492,7 +525,7 @@ class TestAddReaction:
         assert provider.add_reaction(55, "✅") is True
         args, kwargs = mock_post.call_args
         assert args[0].endswith("/setMessageReaction")
-        assert kwargs["json"]["chat_id"] == "12345"
+        assert kwargs["json"]["chat_id"] == 12345
         assert kwargs["json"]["message_id"] == 55
         assert kwargs["json"]["reaction"] == [{"type": "emoji", "emoji": "✅"}]
 

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -1923,3 +1923,43 @@ class TestGetTelegramChatId:
         from app.utils import get_telegram_chat_id
         monkeypatch.delenv("KOAN_TELEGRAM_CHAT_ID", raising=False)
         assert get_telegram_chat_id() == ""
+
+
+class TestCoerceChatId:
+    def test_negative_group_id_becomes_int(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("-1001234567890") == -1001234567890
+
+    def test_positive_user_id_becomes_int(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("123456") == 123456
+
+    def test_strips_before_coercing(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("  -1001234567890\n") == -1001234567890
+
+    def test_int_passes_through(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id(-1001234567890) == -1001234567890
+
+    def test_channel_username_unchanged(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("@my_channel") == "@my_channel"
+
+    def test_non_numeric_string_unchanged(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("C0123SLACK") == "C0123SLACK"
+
+    def test_empty_unchanged(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("") == ""
+
+    def test_lone_minus_unchanged(self):
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("-") == "-"
+
+    def test_exotic_numeral_not_coerced(self):
+        # str.isdigit() is True for superscripts but int() rejects them —
+        # must not raise, must leave the value untouched.
+        from app.utils import coerce_chat_id
+        assert coerce_chat_id("²") == "²"

--- a/specs/components/bridge.md
+++ b/specs/components/bridge.md
@@ -3,7 +3,7 @@ type: component-spec
 title: "Component Spec — Telegram Bridge"
 tags: [bridge]
 created: 2026-06-27
-updated: 2026-07-03
+updated: 2026-07-08
 ---
 
 # Component Spec — Telegram Bridge
@@ -56,6 +56,15 @@ awake.py (loop, ~3s poll)
   through `utils.get_telegram_chat_id()`, which `.strip()`s stray whitespace/newlines
   (Railway/copy-paste inject a trailing newline that makes Telegram answer
   `chat not found`). Never read the env var raw into an API payload.
+- **The chat ID is coerced to `int` at the outbound API payload.** Every Telegram
+  `chat_id` field (`sendMessage`, `sendChatAction`, `setMessageReaction`, and
+  `notify._direct_send_chunk`) wraps the value in `utils.coerce_chat_id()`, which turns a
+  fully-numeric (optionally negative) ID into `int` and passes anything else — Slack
+  channel strings, `@channelusername` — through unchanged. Railway's ENV editor cannot
+  store a bare negative group ID, so it becomes a quoted string; empirically Telegram
+  returns `chat not found` for a quoted group ID but accepts the JSON integer. The stored
+  identity string (`get_telegram_chat_id()` / `bridge_state.CHAT_ID`) stays a string for
+  inbound `chat.id` equality checks; coercion happens only where the payload is built.
 
 ## Integration points
 


### PR DESCRIPTION
## Summary

Telegram group/supergroup chat IDs are negative integers (`-1001234567890`). Railway's ENV editor can't store a bare negative number, so it becomes a quoted string; Telegram returns `Bad Request: chat not found` for a quoted group ID in the JSON POST body while accepting the same value as an integer. The existing `get_telegram_chat_id().strip()` fixed the whitespace trigger but left the string-vs-int trigger for group chats.

Closes https://github.com/Anantys-oss/koan/issues/2256

## Changes

- Add `utils.coerce_chat_id()` — coerces a fully-numeric (optionally negative) chat ID to `int`, passes non-numeric IDs (Slack channels, `@channelusername`, empty) through unchanged; guards `int()` against exotic `isdigit()`-true numerals.
- Wrap every outbound Telegram `chat_id` JSON payload with it: `sendMessage`, `sendChatAction`, `setMessageReaction` (`messaging/telegram.py`) and `notify._direct_send_chunk`.
- Stored identity string (`get_telegram_chat_id()` / `bridge_state.CHAT_ID`) stays a string for inbound `chat.id` equality checks — coercion happens only where the JSON body is built. (GET-param probes like `getChat` are unaffected: `requests` stringifies ints there anyway.)
- Update `specs/components/bridge.md` and `docs/messaging/telegram.md`.

## Test plan

- New unit tests for `coerce_chat_id` (negative group ID, positive user ID, strip-then-coerce, int passthrough, `@channel`, Slack string, empty, lone `-`, exotic numeral).
- Behavioral tests asserting the API payload `chat_id` is an `int` for numeric IDs and a string otherwise across `_send_raw`, `send_typing`, `add_reaction`, and `notify._direct_send`.
- Full messaging + notify + utils + awake suites: 724 passed. `make lint` clean.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(provider claude · model claude-opus-4-8 · HEAD=36a9f07f)_
