### PR TITLE
fix(review): surface partial-coverage warning instead of silently truncating large diffs

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -100,6 +100,16 @@ banner to the comment noting that the findings predate your latest push — so y
 don't act on stale feedback. Re-run `/review` to cover the new commits. Nothing
 changes for the common case where the branch didn't move.
 
+**Large diffs & partial-coverage warning:** Review diffs are packed to fit a
+token budget by the diff compressor (`optimizations.review_compressor.token_budget`,
+default 80,000 tokens — the single knob controlling review diff size). The
+fetch-time character cap is *derived* from that budget (budget × 3.5 chars/token
+× 4 headroom), so the compressor — not a blind character cut — decides coverage
+on large-context models. Whenever any file is omitted (fetch-time backstop,
+compressor packing, or trivial-file triage), the posted review opens with a
+`⚠️ Partial review` block listing every omitted file, so partial coverage is
+never silent.
+
 Skills marked **GitHub @mention** can be triggered by commenting `@koan-bot <command>` on a PR or issue. See [GitHub commands](../messaging/github-commands.md).
 
 ## PR Management

--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -105,7 +105,9 @@ token budget by the diff compressor (`optimizations.review_compressor.token_budg
 default 80,000 tokens — the single knob controlling review diff size). The
 fetch-time character cap is *derived* from that budget (budget × 3.5 chars/token
 × 4 headroom), so the compressor — not a blind character cut — decides coverage
-on large-context models. Whenever any file is omitted (fetch-time backstop,
+on large-context models. If the compressor is disabled, a token-safe backstop
+(budget × 3.5, no headroom) truncates the diff instead, so the size guard holds
+in every config. Whenever any file is omitted (fetch-time backstop,
 compressor packing, or trivial-file triage), the posted review opens with a
 `⚠️ Partial review` block listing every omitted file, so partial coverage is
 never silent.

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -2590,6 +2590,41 @@ def is_review_compressor_enabled() -> bool:
     return bool(enabled) if isinstance(enabled, bool) else True
 
 
+# Exact inverse of diff_compressor.estimate_tokens (chars / 3.5). Keeping the
+# two in sync means a diff that fits get_review_max_diff_chars() also fits the
+# compressor's token budget by its own estimate.
+_REVIEW_CHARS_PER_TOKEN = 3.5
+# Headroom multiplier: the fetch-time char cap is a coarse OOM backstop, NOT
+# the coverage guardrail. It must sit well ABOVE the compressor budget so the
+# compressor receives the whole diff (it needs every file to prioritise) and
+# does the intelligent packing + skip-reporting. The blind fetch cut only
+# fires on pathological diffs far larger than any realistic PR.
+_REVIEW_FETCH_HEADROOM = 4
+
+
+def get_review_compressor_token_budget() -> int:
+    """Token budget for the review diff compressor.
+
+    Reads ``optimizations.review_compressor.token_budget`` (default 80_000).
+    This is the single knob controlling review diff size — the fetch-time
+    char cap (:func:`get_review_max_diff_chars`) is derived from it.
+    """
+    raw = _get_review_compressor_dict().get("token_budget", 80_000)
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        return 80_000
+    return raw
+
+
+def get_review_max_diff_chars() -> int:
+    """Fetch-time character cap for review diffs, derived from the token budget.
+
+    = token_budget × 3.5 chars/token × 4 headroom. Generous by design so the
+    compressor (the real coverage guardrail) sees the full diff.
+    """
+    budget = get_review_compressor_token_budget()
+    return int(budget * _REVIEW_CHARS_PER_TOKEN * _REVIEW_FETCH_HEADROOM)
+
+
 def _get_rtk_dict() -> dict:
     """Return the ``optimizations.rtk`` mapping (or an empty dict).
 

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -2625,6 +2625,18 @@ def get_review_max_diff_chars() -> int:
     return int(budget * _REVIEW_CHARS_PER_TOKEN * _REVIEW_FETCH_HEADROOM)
 
 
+def get_review_uncompressed_max_diff_chars() -> int:
+    """Token-safe diff cap for the compressor-*off* path.
+
+    = token_budget × 3.5 chars/token (NO headroom multiplier). When
+    ``review_compressor.enabled`` is false, no intelligent packer re-shrinks the
+    fetched diff, so the raw diff must itself stay within the budget or it would
+    overflow the model context and hard-fail the review. This keeps the
+    single-knob property while preserving a size backstop in every config.
+    """
+    return int(get_review_compressor_token_budget() * _REVIEW_CHARS_PER_TOKEN)
+
+
 def _get_rtk_dict() -> dict:
     """Return the ``optimizations.rtk`` mapping (or an empty dict).
 

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -57,7 +57,12 @@ from app.git_utils import ordered_remotes as _ordered_remotes
 from app.github import run_gh, sanitize_github_comment
 from app.prompts import load_prompt, load_prompt_or_skill, load_skill_prompt  # noqa: F401 — safety import
 from app.retry import retry_with_backoff
-from app.utils import _GITHUB_REMOTE_RE, truncate_diff, truncate_text
+from app.utils import (
+    _GITHUB_REMOTE_RE,
+    truncate_diff,
+    truncate_diff_with_skips,
+    truncate_text,
+)
 
 def _resolve_own_login() -> str:
     """Resolve our own GitHub login (the configured ``github.nickname``).
@@ -399,11 +404,18 @@ def fetch_pr_context(
     repo: str,
     pr_number: str,
     project_path: Optional[str] = None,
+    max_diff_chars: int = 32000,
 ) -> dict:
     """Fetch PR details, diff, and all comments via gh CLI.
 
     Returns a dict with keys: title, body, branch, base, state, author, url,
-    diff, review_comments, reviews, issue_comments.
+    diff, diff_skipped_files, review_comments, reviews, issue_comments.
+
+    ``max_diff_chars`` caps the fetch-time diff size. The legacy 32K default
+    preserves behaviour for rebase/squash/recreate/ci_queue callers; ``/review``
+    passes a large budget-derived cap so the diff compressor (its real coverage
+    guardrail) receives the whole diff. Any files cut here are reported via the
+    returned ``diff_skipped_files`` list.
 
     When ``project_path`` is provided, oversized-PR diff failures
     (GitHub HTTP 406: > 300 files) trigger a local ``git fetch`` +
@@ -532,6 +544,8 @@ def fetch_pr_context(
     # there are invisible pending reviews.
     has_pending_reviews = api_review_comment_count > 0 and fetched_comment_count == 0
 
+    truncated_diff, diff_skipped_files = truncate_diff_with_skips(diff, max_diff_chars)
+
     return {
         "title": metadata.get("title", ""),
         "body": metadata.get("body", ""),
@@ -541,7 +555,8 @@ def fetch_pr_context(
         "author": metadata.get("author", {}).get("login", ""),
         "head_owner": metadata.get("headRepositoryOwner", {}).get("login", ""),
         "url": metadata.get("url", ""),
-        "diff": truncate_diff(diff, 32000),
+        "diff": truncated_diff,
+        "diff_skipped_files": diff_skipped_files,
         "diff_error": truncate_text(diff_error, 1000),
         "review_comments": truncate_text(comments_json, 4000),
         "reviews": truncate_text(reviews_json, 3000),

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -27,14 +27,14 @@ from typing import List, Optional, Tuple
 from urllib.parse import quote
 
 from app.claude_step import resolve_pr_location
-from app.config import get_review_bot_triage_config, get_review_compressor_token_budget, get_review_history_config, get_review_inline_comments_config, get_review_max_diff_chars, get_review_reply_config, get_review_verdict_config, is_review_compressor_enabled
+from app.config import get_review_bot_triage_config, get_review_compressor_token_budget, get_review_history_config, get_review_inline_comments_config, get_review_max_diff_chars, get_review_reply_config, get_review_uncompressed_max_diff_chars, get_review_verdict_config, is_review_compressor_enabled
 from app.run_log import log
 from app.diff_compressor import compress_diff
 from app.github import run_gh, sanitize_github_comment, find_bot_comment
 from app.github_url_parser import ISSUE_URL_PATTERN
 from app.prompts import load_prompt, load_prompt_or_skill, load_skill_prompt
 from app.rebase_pr import fetch_pr_context
-from app.utils import KOAN_ROOT
+from app.utils import KOAN_ROOT, truncate_diff_with_skips
 from app.review_markers import (
     SUMMARY_TAG,
     COMMIT_IDS_START,
@@ -734,6 +734,20 @@ def build_review_prompt(
                 "review",
                 f"Diff compressed — {len(compressor_skipped)} file(s) skipped: "
                 + ", ".join(compressor_skipped),
+            )
+    else:
+        # Compressor off: no packer re-shrinks the fetch-time diff, so apply a
+        # token-safe backstop here or the raw diff (up to the generous fetch
+        # cap) could overflow the model context and hard-fail the review. Skips
+        # flow into the same coverage note as compressor skips.
+        raw_diff, compressor_skipped = truncate_diff_with_skips(
+            raw_diff, get_review_uncompressed_max_diff_chars()
+        )
+        if compressor_skipped:
+            log(
+                "review",
+                f"Compressor off — diff truncated, {len(compressor_skipped)} "
+                f"file(s) skipped: " + ", ".join(compressor_skipped),
             )
 
     # ONE unified coverage note — the same value feeds the {SKIPPED_FILES}

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -724,30 +724,32 @@ def build_review_prompt(
         project_memory += _build_review_session_memory(project_name, task_text)
 
     raw_diff = context["diff"]
-    compressor_skipped: list = []
+    # Files skipped to fit the token budget — either packed out by the
+    # compressor (on-path) or cut by the token-safe backstop (off-path).
+    budget_skipped: list = []
     if is_review_compressor_enabled():
         compressed = compress_diff(raw_diff, get_review_compressor_token_budget())
         raw_diff = compressed.diff_text
-        compressor_skipped = compressed.skipped_files
-        if compressor_skipped:
+        budget_skipped = compressed.skipped_files
+        if budget_skipped:
             log(
                 "review",
-                f"Diff compressed — {len(compressor_skipped)} file(s) skipped: "
-                + ", ".join(compressor_skipped),
+                f"Diff compressed — {len(budget_skipped)} file(s) skipped: "
+                + ", ".join(budget_skipped),
             )
     else:
         # Compressor off: no packer re-shrinks the fetch-time diff, so apply a
         # token-safe backstop here or the raw diff (up to the generous fetch
         # cap) could overflow the model context and hard-fail the review. Skips
         # flow into the same coverage note as compressor skips.
-        raw_diff, compressor_skipped = truncate_diff_with_skips(
+        raw_diff, budget_skipped = truncate_diff_with_skips(
             raw_diff, get_review_uncompressed_max_diff_chars()
         )
-        if compressor_skipped:
+        if budget_skipped:
             log(
                 "review",
-                f"Compressor off — diff truncated, {len(compressor_skipped)} "
-                f"file(s) skipped: " + ", ".join(compressor_skipped),
+                f"Compressor off — diff truncated, {len(budget_skipped)} "
+                f"file(s) skipped: " + ", ".join(budget_skipped),
             )
 
     # ONE unified coverage note — the same value feeds the {SKIPPED_FILES}
@@ -755,7 +757,7 @@ def build_review_prompt(
     # prompt and the posted body can never diverge.
     coverage_note = _build_coverage_note(
         fetch_skipped=context.get("diff_skipped_files", []),
-        compressor_skipped=compressor_skipped,
+        compressor_skipped=budget_skipped,
         triaged_files=triaged_files,
     )
 

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -27,7 +27,7 @@ from typing import List, Optional, Tuple
 from urllib.parse import quote
 
 from app.claude_step import resolve_pr_location
-from app.config import get_review_bot_triage_config, get_review_history_config, get_review_inline_comments_config, get_review_reply_config, get_review_verdict_config, is_review_compressor_enabled
+from app.config import get_review_bot_triage_config, get_review_compressor_token_budget, get_review_history_config, get_review_inline_comments_config, get_review_max_diff_chars, get_review_reply_config, get_review_verdict_config, is_review_compressor_enabled
 from app.run_log import log
 from app.diff_compressor import compress_diff
 from app.github import run_gh, sanitize_github_comment, find_bot_comment
@@ -614,6 +614,40 @@ def _resolve_issue_context(
         return ""
 
 
+def _build_coverage_note(
+    fetch_skipped: list,
+    compressor_skipped: list,
+    triaged_files: Optional[list],
+) -> str:
+    """Build ONE unified coverage note used for both the review prompt's
+    {SKIPPED_FILES} slot and the note prepended to the posted GitHub review.
+
+    - fetch_skipped:      files cut at diff-fetch time (oversized-diff backstop)
+    - compressor_skipped: files packed out by the token-budget compressor
+    - triaged_files:      trivial files intentionally skipped (informational)
+
+    Returning a single value (no copy-then-append) guarantees the prompt and
+    the posted body never diverge.
+    """
+    # dict.fromkeys preserves order and dedupes (a file cut at fetch never
+    # reaches the compressor, but dedupe defensively).
+    omitted = list(dict.fromkeys([*(fetch_skipped or []), *(compressor_skipped or [])]))
+    parts: list[str] = []
+    if omitted:
+        listing = ", ".join(f"`{f}`" for f in omitted)
+        parts.append(
+            f"> ⚠️ **Partial review** — {len(omitted)} file(s) omitted "
+            f"due to diff size and NOT reviewed: {listing}"
+        )
+    if triaged_files:
+        triaged_list = ", ".join(f"`{t.path}` ({t.reason})" for t in triaged_files)
+        parts.append(
+            f"> ℹ️ Triaged {len(triaged_files)} trivial file(s) "
+            f"(not reviewed): {triaged_list}"
+        )
+    return ("\n>\n".join(parts) + "\n\n") if parts else ""
+
+
 def build_review_prompt(
     context: dict,
     skill_dir: Optional[Path] = None,
@@ -626,7 +660,7 @@ def build_review_prompt(
     project_name: str = "",
     prior_review: Optional[str] = None,
     issue_context: Optional[str] = None,
-) -> str:
+) -> Tuple[str, str]:
     """Build a prompt for Claude to review a PR.
 
     When plan_body is provided, selects the plan-aware prompt variant
@@ -690,31 +724,26 @@ def build_review_prompt(
         project_memory += _build_review_session_memory(project_name, task_text)
 
     raw_diff = context["diff"]
-    skipped_note = ""
+    compressor_skipped: list = []
     if is_review_compressor_enabled():
-        compressed = compress_diff(raw_diff)
+        compressed = compress_diff(raw_diff, get_review_compressor_token_budget())
         raw_diff = compressed.diff_text
-        if compressed.skipped_files:
+        compressor_skipped = compressed.skipped_files
+        if compressor_skipped:
             log(
                 "review",
-                f"Diff compressed — {len(compressed.skipped_files)} file(s) skipped: "
-                + ", ".join(compressed.skipped_files),
-            )
-            skipped_list = ", ".join(f"`{f}`" for f in compressed.skipped_files)
-            skipped_note = (
-                f"> ⚠️ Diff compressed — {len(compressed.skipped_files)} file(s) omitted"
-                f" due to size: {skipped_list}\n\n"
+                f"Diff compressed — {len(compressor_skipped)} file(s) skipped: "
+                + ", ".join(compressor_skipped),
             )
 
-    if triaged_files:
-        triaged_list = ", ".join(
-            f"`{t.path}` ({t.reason})" for t in triaged_files
-        )
-        triage_note = (
-            f"> ℹ️ Triaged {len(triaged_files)} trivial file(s)"
-            f" (not reviewed): {triaged_list}\n\n"
-        )
-        skipped_note = skipped_note + triage_note
+    # ONE unified coverage note — the same value feeds the {SKIPPED_FILES}
+    # prompt slot AND is returned for prepending to the posted review, so the
+    # prompt and the posted body can never diverge.
+    coverage_note = _build_coverage_note(
+        fetch_skipped=context.get("diff_skipped_files", []),
+        compressor_skipped=compressor_skipped,
+        triaged_files=triaged_files,
+    )
 
     if issue_context is None:
         issue_context = _resolve_issue_context(context, project_name, project_path)
@@ -732,7 +761,7 @@ def build_review_prompt(
         REPLIABLE_COMMENTS=repliable_text,
         PRIOR_REVIEW=prior_review_block,
         PROJECT_MEMORY=project_memory,
-        SKIPPED_FILES=skipped_note,
+        SKIPPED_FILES=coverage_note,   # same value returned below
         ISSUE_CONTEXT=issue_context or "",
     )
 
@@ -743,7 +772,8 @@ def build_review_prompt(
             plan_body = _truncate_plan(plan_body)
         kwargs["PLAN"] = plan_body
 
-    return load_prompt_or_skill(skill_dir, prompt_name, **kwargs)
+    prompt = load_prompt_or_skill(skill_dir, prompt_name, **kwargs)
+    return prompt, coverage_note
 
 
 def _review_attribution(project_name: str = "") -> Tuple[str, str]:
@@ -1842,6 +1872,7 @@ def _post_review_comment(
     model: str = "",
     duration_seconds: float = 0,
     live_head_sha: str = "",
+    coverage_note: str = "",
 ) -> Tuple[bool, str]:
     """Post (or update) the review as a comment on the PR.
 
@@ -1859,8 +1890,16 @@ def _post_review_comment(
     end of the review content (the branch moved during review). Empty
     ``live_head_sha`` (the default) leaves the body byte-identical.
 
+    When ``coverage_note`` is non-empty, it is prepended to the review body
+    *before* the GitHub-length truncation so the partial-review warning is
+    never the part that gets cut.
+
     Returns (True, "") on success, (False, error_detail) on failure.
     """
+    # Surface partial-coverage warning at the very top, before truncation.
+    if coverage_note:
+        review_text = f"{coverage_note.rstrip()}\n\n{review_text}"
+
     # Truncate if too long for GitHub (max ~65536 chars)
     max_len = 60000
     if len(review_text) > max_len:
@@ -2637,7 +2676,10 @@ def run_private_review(
     notify_fn(f"Privately reviewing PR #{pr_number} ({full_repo})...")
 
     try:
-        context = fetch_pr_context(owner, repo, pr_number, project_path)
+        context = fetch_pr_context(
+            owner, repo, pr_number, project_path,
+            max_diff_chars=get_review_max_diff_chars(),
+        )
     except Exception as e:
         return False, f"Failed to fetch PR context: {e}", None, {}
 
@@ -2652,7 +2694,7 @@ def run_private_review(
 
     plan_body = _resolve_plan_body(plan_url, context.get("body", ""))
 
-    prompt = build_review_prompt(
+    prompt, _coverage_note = build_review_prompt(
         context,
         skill_dir=skill_dir,
         architecture=architecture,
@@ -2768,6 +2810,7 @@ def run_review(
         with ThreadPoolExecutor(max_workers=min(2, github_workers)) as pool:
             f_context = pool.submit(
                 fetch_pr_context, owner, repo, pr_number, project_path,
+                max_diff_chars=get_review_max_diff_chars(),
             )
             f_comments = pool.submit(
                 fetch_repliable_comments, owner, repo, pr_number, True, bot_username,
@@ -2779,7 +2822,10 @@ def run_review(
             repliable_comments = f_comments.result()
     else:
         try:
-            context = fetch_pr_context(owner, repo, pr_number, project_path)
+            context = fetch_pr_context(
+                owner, repo, pr_number, project_path,
+                max_diff_chars=get_review_max_diff_chars(),
+            )
         except Exception as e:
             return False, f"Failed to fetch PR context: {e}", None
         repliable_comments = fetch_repliable_comments(
@@ -2872,7 +2918,7 @@ def run_review(
         extract_prior_review_body(existing_comment.get("body", ""))
         if existing_comment else None
     )
-    prompt = build_review_prompt(
+    prompt, coverage_note = build_review_prompt(
         context, skill_dir=skill_dir, architecture=architecture,
         comments=comments, repliable_comments=repliable_comments,
         plan_body=plan_body or None, project_path=project_path,
@@ -3019,6 +3065,7 @@ def run_review(
         model=review_model,
         duration_seconds=_review_duration,
         live_head_sha=live_head_sha,
+        coverage_note=coverage_note,
     )
 
     # Step 7c: Optionally post each finding as an inline PR comment (opt-in).

--- a/koan/app/skill_evals.py
+++ b/koan/app/skill_evals.py
@@ -936,7 +936,7 @@ def review_live_fn(
 
     skill_dir = _SKILLS_CORE_DIR / case.skill
     context = build_minimal_review_context(case)
-    prompt = build(context, skill_dir=skill_dir, project_path=None)
+    prompt, _coverage_note = build(context, skill_dir=skill_dir, project_path=None)
     raw, error = run(prompt, project_path)
     if error:
         raise RuntimeError(f"review invocation failed: {error}")

--- a/koan/app/utils.py
+++ b/koan/app/utils.py
@@ -607,17 +607,16 @@ def truncate_text(text: str, max_chars: int) -> str:
     return text[:max_chars] + "\n...(truncated)"
 
 
-def truncate_diff(diff: str, max_chars: int) -> str:
-    """Truncate a unified diff intelligently, preserving whole file blocks.
+def truncate_diff_with_skips(diff: str, max_chars: int) -> tuple[str, list[str]]:
+    """Truncate a unified diff preserving whole file blocks, returning the
+    truncated text AND the list of omitted file paths.
 
-    Instead of cutting at an arbitrary character offset (which leaves the
-    reviewer guessing what was cut), this splits the diff into per-file
-    blocks and keeps as many complete blocks as fit within *max_chars*.
-    Files that don't fit are listed as a summary at the end so the
-    reviewer knows they exist.
+    Same packing logic as :func:`truncate_diff`; the omitted-file list is
+    surfaced so callers can report partial coverage instead of relying on
+    the in-body footer alone.
     """
     if not diff or len(diff) <= max_chars:
-        return diff
+        return diff, []
 
     # Split into per-file blocks at 'diff --git' boundaries.
     raw_blocks = re.split(r'(?=^diff --git )', diff, flags=re.MULTILINE)
@@ -625,7 +624,7 @@ def truncate_diff(diff: str, max_chars: int) -> str:
 
     if not blocks:
         # Can't parse structure — fall back to character truncation.
-        return truncate_text(diff, max_chars)
+        return truncate_text(diff, max_chars), []
 
     # Pre-scan filenames so we can estimate the worst-case footer size
     # and reserve budget for it, ensuring output stays within max_chars.
@@ -635,7 +634,7 @@ def truncate_diff(diff: str, max_chars: int) -> str:
         filenames.append(m.group(1) if m else "(unknown file)")
 
     # Greedy first pass: keep blocks that fit without any footer.
-    kept: list[str] = []
+    kept: list[tuple[str, str]] = []
     skipped: list[str] = []
     used = 0
 
@@ -660,7 +659,19 @@ def truncate_diff(diff: str, max_chars: int) -> str:
     result = "".join(b for b, _ in kept)
     if skipped:
         result += _build_footer(skipped, len(kept))
-    return result
+    return result, skipped
+
+
+def truncate_diff(diff: str, max_chars: int) -> str:
+    """Truncate a unified diff intelligently, preserving whole file blocks.
+
+    Instead of cutting at an arbitrary character offset (which leaves the
+    reviewer guessing what was cut), this splits the diff into per-file
+    blocks and keeps as many complete blocks as fit within *max_chars*.
+    Files that don't fit are listed as a summary at the end so the
+    reviewer knows they exist.
+    """
+    return truncate_diff_with_skips(diff, max_chars)[0]
 
 
 def _build_footer(skipped: list[str], kept_count: int) -> str:

--- a/koan/skills/core/review/SKILL.md
+++ b/koan/skills/core/review/SKILL.md
@@ -16,3 +16,16 @@ commands:
     aliases: [rv]
 handler: handler.py
 ---
+
+## Large diffs & partial-coverage reporting
+
+Review diffs are packed to fit a token budget by the diff compressor
+(`optimizations.review_compressor.token_budget`, default 80,000 tokens — the
+single knob controlling review diff size). The fetch-time character cap is
+*derived* from that budget (budget × 3.5 chars/token × 4 headroom), so on
+large-context models the compressor — not a blind character cut — decides
+coverage.
+
+Whenever any file is omitted (fetch-time backstop, compressor packing, or
+trivial-file triage), the posted review opens with a `⚠️ Partial review` block
+listing every omitted file, so partial coverage is never silent.

--- a/koan/skills/core/review/SKILL.md
+++ b/koan/skills/core/review/SKILL.md
@@ -24,7 +24,8 @@ Review diffs are packed to fit a token budget by the diff compressor
 single knob controlling review diff size). The fetch-time character cap is
 *derived* from that budget (budget × 3.5 chars/token × 4 headroom), so on
 large-context models the compressor — not a blind character cut — decides
-coverage.
+coverage. When the compressor is disabled, a token-safe backstop (budget × 3.5,
+no headroom) truncates the diff so the size guard holds in every config.
 
 Whenever any file is omitted (fetch-time backstop, compressor packing, or
 trivial-file triage), the posted review opens with a `⚠️ Partial review` block

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -2060,3 +2060,46 @@ class TestMemoryMonitorConfig:
             conf = get_memory_monitor_config()
         assert conf["enabled"] is False
         assert conf["threshold_mb"] == 1200
+
+
+class TestReviewCompressorBudget:
+    def test_token_budget_default(self):
+        from app.config import get_review_compressor_token_budget
+        with _mock_config({}):
+            assert get_review_compressor_token_budget() == 80_000
+
+    def test_token_budget_override(self):
+        from app.config import get_review_compressor_token_budget
+        with _mock_config(
+            {"optimizations": {"review_compressor": {"token_budget": 120_000}}}
+        ):
+            assert get_review_compressor_token_budget() == 120_000
+
+    def test_token_budget_malformed_falls_back(self):
+        from app.config import get_review_compressor_token_budget
+        with _mock_config(
+            {"optimizations": {"review_compressor": {"token_budget": "huge"}}}
+        ):
+            assert get_review_compressor_token_budget() == 80_000
+
+    def test_token_budget_bool_falls_back(self):
+        from app.config import get_review_compressor_token_budget
+        with _mock_config(
+            {"optimizations": {"review_compressor": {"token_budget": True}}}
+        ):
+            assert get_review_compressor_token_budget() == 80_000
+
+    def test_max_diff_chars_derived_from_budget(self):
+        from app.config import get_review_max_diff_chars
+        with _mock_config(
+            {"optimizations": {"review_compressor": {"token_budget": 80_000}}}
+        ):
+            # 80_000 tokens * 3.5 chars/token * 4 headroom
+            assert get_review_max_diff_chars() == 1_120_000
+
+    def test_max_diff_chars_scales_with_budget(self):
+        from app.config import get_review_max_diff_chars
+        with _mock_config(
+            {"optimizations": {"review_compressor": {"token_budget": 40_000}}}
+        ):
+            assert get_review_max_diff_chars() == 560_000

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -719,6 +719,52 @@ class TestFetchPrContext:
         assert "Please fix" in context["reviews"]
         assert "Will do" in context["issue_comments"]
         assert context["has_pending_reviews"] is False  # comments fetched OK
+        assert context["diff_skipped_files"] == []  # small diff, nothing cut
+
+    @staticmethod
+    def _big_two_file_diff():
+        a = "diff --git a/a.py b/a.py\n--- a/a.py\n+++ b/a.py\n@@ -1 +1 @@\n+y\n"
+        b = (
+            "diff --git a/b.py b/b.py\n--- a/b.py\n+++ b/b.py\n@@ -1 +1 @@\n"
+            + "+x\n" * 5000
+        )
+        return a + b
+
+    @patch("app.github.subprocess.run")
+    def test_records_diff_skips_under_small_cap(self, mock_run):
+        big = self._big_two_file_diff()
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "T", "headRefName": "br", "baseRefName": "main",
+                "state": "OPEN", "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(returncode=0, stdout=big),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        context = fetch_pr_context("o", "r", "1", max_diff_chars=500)
+        assert "b.py" in context["diff_skipped_files"]
+
+    @patch("app.github.subprocess.run")
+    def test_large_cap_admits_full_diff(self, mock_run):
+        big = self._big_two_file_diff()
+        mock_run.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps({
+                "title": "T", "headRefName": "br", "baseRefName": "main",
+                "state": "OPEN", "author": {"login": "dev"},
+                "url": "https://github.com/o/r/pull/1",
+            })),
+            MagicMock(returncode=0, stdout="0"),
+            MagicMock(returncode=0, stdout=big),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+            MagicMock(returncode=0, stdout=""),
+        ]
+        context = fetch_pr_context("o", "r", "1", max_diff_chars=1_000_000)
+        assert context["diff_skipped_files"] == []
 
     @patch("app.github.subprocess.run")
     def test_handles_empty_responses(self, mock_run):

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -102,7 +102,7 @@ def plan_review_skill_dir(tmp_path):
 class TestBuildReviewPrompt:
     def test_with_skill_dir(self, pr_context, review_skill_dir):
         """Prompt is built from skill dir template."""
-        prompt = build_review_prompt(pr_context, skill_dir=review_skill_dir)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=review_skill_dir)
         assert "Fix auth bypass" in prompt
         assert "dev123" in prompt
         assert "fix-auth" in prompt
@@ -110,7 +110,7 @@ class TestBuildReviewPrompt:
 
     def test_placeholders_substituted(self, pr_context, review_skill_dir):
         """All {PLACEHOLDER} values are substituted."""
-        prompt = build_review_prompt(pr_context, skill_dir=review_skill_dir)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=review_skill_dir)
         assert "{TITLE}" not in prompt
         assert "{AUTHOR}" not in prompt
         assert "{BRANCH}" not in prompt
@@ -149,15 +149,54 @@ class TestBuildReviewPrompt:
 
     def test_skipped_files_note_absent_for_small_diff(self, pr_context, review_skill_dir):
         """No skipped-files note when diff fits within budget."""
-        prompt = build_review_prompt(pr_context, skill_dir=review_skill_dir)
-        assert "omitted due to size" not in prompt
+        prompt, _ = build_review_prompt(pr_context, skill_dir=review_skill_dir)
+        assert "Partial review" not in prompt
+
+    def test_build_coverage_note_merges_all_sources(self):
+        from types import SimpleNamespace
+        from app.review_runner import _build_coverage_note
+        triaged = [SimpleNamespace(path="gen.pb.go", reason="generated")]
+        note = _build_coverage_note(
+            fetch_skipped=["huge.py"],
+            compressor_skipped=["big.py"],
+            triaged_files=triaged,
+        )
+        assert "Partial review" in note
+        assert "`huge.py`" in note and "`big.py`" in note
+        assert "Triaged" in note and "`gen.pb.go`" in note
+
+    def test_build_coverage_note_empty_when_nothing_skipped(self):
+        from app.review_runner import _build_coverage_note
+        assert _build_coverage_note([], [], None) == ""
+
+    def test_build_coverage_note_dedupes_across_stages(self):
+        from app.review_runner import _build_coverage_note
+        note = _build_coverage_note(
+            fetch_skipped=["dup.py"],
+            compressor_skipped=["dup.py"],
+            triaged_files=None,
+        )
+        assert note.count("`dup.py`") == 1
+        assert "1 file(s) omitted" in note
+
+    def test_build_review_prompt_returns_note_matching_prompt_slot(
+        self, pr_context, review_skill_dir,
+    ):
+        """The returned coverage_note is exactly what lands in the {SKIPPED_FILES} slot."""
+        pr_context = dict(pr_context, diff_skipped_files=["dropped.py"])
+        prompt, coverage_note = build_review_prompt(
+            pr_context, skill_dir=review_skill_dir,
+        )
+        assert "`dropped.py`" in coverage_note
+        # No divergence: the returned note is present verbatim in the prompt body.
+        assert coverage_note.strip() in prompt
 
     def test_explicit_issue_context_injected(self, pr_context, tmp_path):
         """An explicit issue_context lands in the {ISSUE_CONTEXT} slot."""
         prompts_dir = tmp_path / "prompts"
         prompts_dir.mkdir()
         (prompts_dir / "review.md").write_text("Body: {BODY}{ISSUE_CONTEXT}\nDiff: {DIFF}\n")
-        prompt = build_review_prompt(
+        prompt, _ = build_review_prompt(
             pr_context, skill_dir=tmp_path,
             issue_context="\n## Issue Tracker Context\n\n- PROJ-1: Fix it\n",
         )
@@ -182,7 +221,7 @@ class TestBuildReviewPrompt:
             "app.issue_tracker.enrichment.fetch_issue_context",
             return_value="\n## Issue Tracker Context\n\n- PROJ-9: Title\n",
         ) as fetch_mock:
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=tmp_path,
                 project_name="myproj", project_path="/tmp/myproj",
             )
@@ -200,7 +239,7 @@ class TestBuildReviewPrompt:
         ), patch(
             "app.issue_tracker.enrichment.fetch_issue_context",
         ) as fetch_mock:
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=tmp_path, project_name="myproj",
             )
         fetch_mock.assert_not_called()
@@ -260,7 +299,7 @@ class TestReviewVerdictContract:
 
     def test_partials_resolve_into_real_prompt(self, pr_context, real_review_skill_dir):
         """Sanity: the shipped prompt has its {@include} partials resolved."""
-        prompt = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
         assert "{@include" not in prompt
         # "Output ONLY the JSON object" lives in the review-output-rules partial,
         # so its presence proves the partial was rendered, not left as a token.
@@ -270,7 +309,7 @@ class TestReviewVerdictContract:
         self, pr_context, real_review_skill_dir
     ):
         """review.md carries an explicit Verdict Contract (body-only marker)."""
-        prompt = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
         # This sentence exists only in the review.md Verdict Contract section —
         # not in any partial — so it is a non-vacuous, single-source marker.
         assert "Never reject a PR" in prompt
@@ -285,7 +324,7 @@ class TestReviewVerdictContract:
         rendered prompt (not the source file) keeps the test honest about what
         the model actually sees.
         """
-        prompt = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=real_review_skill_dir)
         assert "suggestion" in prompt.lower()
         # "non-blocking" is present only in the sharpened rule; the pre-fix
         # wording ("no blocking issues") did not contain it.
@@ -307,7 +346,7 @@ class TestPriorReviewSlot:
         with patch(
             "app.config.get_review_context_config", return_value=self._cfg(),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 prior_review="FINDING_ALPHA: validate the token",
             )
@@ -318,7 +357,7 @@ class TestPriorReviewSlot:
         with patch(
             "app.config.get_review_context_config", return_value=self._cfg(),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir, prior_review=None,
             )
         assert "(No prior automated review.)" in prompt
@@ -336,7 +375,7 @@ class TestPriorReviewSlot:
         with patch(
             "app.config.get_review_context_config", return_value=self._cfg(),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 prior_review="prior review text",
             )
@@ -354,7 +393,7 @@ class TestPriorReviewSlot:
         with patch(
             "app.config.get_review_context_config", return_value=self._cfg(),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir, prior_review=None,
             )
         assert "KEEP_THIS_BODY" in prompt
@@ -365,7 +404,7 @@ class TestPriorReviewSlot:
             "app.config.get_review_context_config",
             return_value=self._cfg(prior_review_max_chars=20),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir, prior_review=long_text,
             )
         assert "HEAD_KEPT" in prompt
@@ -377,7 +416,7 @@ class TestPriorReviewSlot:
             "app.config.get_review_context_config",
             return_value=self._cfg(include_bot_feedback=False),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 prior_review="SHOULD_NOT_APPEAR",
             )
@@ -397,7 +436,7 @@ class TestPriorReviewSlot:
         with patch(
             "app.config.get_review_context_config", return_value=self._cfg(),
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_dir,
                 prior_review="FINDING_BETA: handle the proxy case",
             )
@@ -444,7 +483,7 @@ class TestReviewProjectMemory:
             "app.config.get_review_memory_config",
             return_value={"enabled": False, "max_entries": 8},
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 project_path="/fake/proj", project_name="my-toolkit",
             )
@@ -472,7 +511,7 @@ class TestReviewProjectMemory:
             "app.config.get_review_memory_config",
             return_value={"enabled": True, "max_entries": 8},
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 project_path="/fake/proj", project_name="my-toolkit",
             )
@@ -495,7 +534,7 @@ class TestReviewProjectMemory:
             "app.config.get_review_memory_config",
             return_value={"enabled": True, "max_entries": 8},
         ):
-            prompt = build_review_prompt(
+            prompt, _ = build_review_prompt(
                 pr_context, skill_dir=review_skill_dir,
                 project_path="/fake/proj",
             )
@@ -1347,6 +1386,28 @@ class TestPostReviewComment:
         assert "truncated" in body.lower()
 
     @patch("app.review_runner.run_gh")
+    def test_coverage_note_prepended_to_posted_body(self, mock_gh):
+        """The coverage note is prepended to the posted review body, above the verdict."""
+        note = ("> ⚠️ **Partial review** — 2 file(s) omitted due to diff size "
+                "and NOT reviewed: `big.py`, `huge.py`")
+        _post_review_comment(
+            "owner", "repo", "42", "LGTM, no issues found.",
+            coverage_note=note,
+        )
+        body = [a for a in mock_gh.call_args[0] if isinstance(a, str) and "LGTM" in a][0]
+        assert "Partial review" in body
+        assert "`big.py`" in body and "`huge.py`" in body
+        # Warning appears before the verdict text.
+        assert body.index("Partial review") < body.index("LGTM")
+
+    @patch("app.review_runner.run_gh")
+    def test_no_coverage_note_leaves_body_clean(self, mock_gh):
+        """Empty coverage note adds no warning."""
+        _post_review_comment("owner", "repo", "42", "LGTM", coverage_note="")
+        body = [a for a in mock_gh.call_args[0] if isinstance(a, str) and "LGTM" in a][0]
+        assert "Partial review" not in body
+
+    @patch("app.review_runner.run_gh")
     def test_no_double_heading_for_structured_review(self, mock_gh):
         """Reviews starting with ## don't get an extra ## Code Review header."""
         from app.review_markers import SUMMARY_TAG
@@ -1536,7 +1597,11 @@ class TestRunReview:
         assert "42" in summary
         assert review_data is not None
         assert review_data["review_summary"]["lgtm"] is True
-        mock_fetch.assert_called_once_with("owner", "repo", "42", "/tmp/project")
+        from app.config import get_review_max_diff_chars
+        mock_fetch.assert_called_once_with(
+            "owner", "repo", "42", "/tmp/project",
+            max_diff_chars=get_review_max_diff_chars(),
+        )
         mock_claude.assert_called_once()
         mock_gh.assert_called_once()  # post comment
         assert mock_notify.call_count >= 2
@@ -2177,7 +2242,7 @@ class TestArchitectureFlag:
             "Issue: {ISSUE_COMMENTS}\n"
         )
 
-        prompt = build_review_prompt(
+        prompt, _ = build_review_prompt(
             pr_context, skill_dir=tmp_path, architecture=True,
         )
         assert "ARCH REVIEW:" in prompt
@@ -2187,7 +2252,7 @@ class TestArchitectureFlag:
         self, pr_context, review_skill_dir,
     ):
         """build_review_prompt without architecture uses standard review template."""
-        prompt = build_review_prompt(
+        prompt, _ = build_review_prompt(
             pr_context, skill_dir=review_skill_dir, architecture=False,
         )
         assert "Review PR:" in prompt
@@ -2373,7 +2438,7 @@ class TestUltraReview:
         """ultra=True selects the architecture prompt AND runs the error hunter,
         and the posted summary is labelled as an ultra review."""
         mock_fetch.return_value = pr_context
-        mock_build.return_value = "PROMPT"
+        mock_build.return_value = ("PROMPT", "")
         mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
         mock_notify = MagicMock()
 
@@ -2946,7 +3011,7 @@ class TestBuildReviewPromptWithPlan:
         (prompts_dir / "review.md").write_text("Standard review: {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
         (prompts_dir / "review-with-plan.md").write_text("Plan review: {PLAN} {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
 
-        prompt = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body="The plan content.")
+        prompt, _ = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body="The plan content.")
         assert "Plan review:" in prompt
         assert "The plan content." in prompt
 
@@ -2957,7 +3022,7 @@ class TestBuildReviewPromptWithPlan:
         (prompts_dir / "review.md").write_text("Standard review: {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
         (prompts_dir / "review-with-plan.md").write_text("Plan review: {PLAN} {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
 
-        prompt = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body=None)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body=None)
         assert "Standard review:" in prompt
         assert "Plan review:" not in prompt
 
@@ -2968,7 +3033,7 @@ class TestBuildReviewPromptWithPlan:
         (prompts_dir / "review-architecture.md").write_text("Architecture review: {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
         (prompts_dir / "review-with-plan.md").write_text("Plan review: {PLAN} {TITLE} {AUTHOR} {BRANCH} {BASE} {BODY} {DIFF} {REVIEWS} {REVIEW_COMMENTS} {ISSUE_COMMENTS} {REPLIABLE_COMMENTS}")
 
-        prompt = build_review_prompt(
+        prompt, _ = build_review_prompt(
             pr_context, skill_dir=tmp_path,
             architecture=True, plan_body="The plan.",
         )
@@ -2983,7 +3048,7 @@ class TestBuildReviewPromptWithPlan:
 
         large_plan = "## Summary\n\nShort summary.\n\n" + "x" * 90_000
         pr_context["diff"] = "small diff"
-        prompt = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body=large_plan)
+        prompt, _ = build_review_prompt(pr_context, skill_dir=tmp_path, plan_body=large_plan)
         # The plan should have been truncated — not 90K chars
         assert len(prompt) < 90_000 + 5000
 

--- a/koan/tests/test_skill_evals.py
+++ b/koan/tests/test_skill_evals.py
@@ -509,6 +509,23 @@ class TestReviewLiveFn:
         assert captured["prompt"] == "PROMPT"
         assert captured["raw"] == "RAW"
 
+    def test_real_build_passes_string_prompt_to_run(self):
+        # Regression guard: build_review_prompt returns (prompt, note); the
+        # adapter must unpack it so _run_claude_review receives a str, not the
+        # tuple. Uses the real build (only _run/_parse stubbed).
+        captured = {}
+
+        def run(prompt, project_path):
+            captured["prompt"] = prompt
+            return ("RAW", "")
+
+        review_live_fn(
+            _sqli_case(), "/repo",
+            _run=run,
+            _parse=lambda raw: _review([], lgtm=True),
+        )
+        assert isinstance(captured["prompt"], str)
+
     def test_provider_error_raises(self):
         def run(prompt, project_path):
             return ("", "quota exceeded")

--- a/koan/tests/test_skill_evals.py
+++ b/koan/tests/test_skill_evals.py
@@ -489,7 +489,7 @@ class TestReviewLiveFn:
 
         def build(ctx, skill_dir=None, project_path=None):
             captured["ctx"] = ctx
-            return "PROMPT"
+            return "PROMPT", ""
 
         def run(prompt, project_path):
             captured["prompt"] = prompt

--- a/koan/tests/test_utils.py
+++ b/koan/tests/test_utils.py
@@ -1154,6 +1154,46 @@ class TestTruncateDiff:
         assert "truncated" in result
 
 
+class TestTruncateDiffWithSkips:
+    """Tests for truncate_diff_with_skips() — surfaces the omitted-file list."""
+
+    def _make_file_block(self, filename, lines=10):
+        header = f"diff --git a/{filename} b/{filename}\n"
+        header += f"--- a/{filename}\n+++ b/{filename}\n"
+        header += "@@ -1,5 +1,5 @@\n"
+        body = "".join(f"+line {i}\n" for i in range(lines))
+        return header + body
+
+    def test_with_skips_reports_omitted_files(self):
+        from app.utils import truncate_diff_with_skips
+        block_a = self._make_file_block("a.py", lines=3)
+        block_b = self._make_file_block("b.py", lines=50)
+        diff = block_a + block_b
+        budget = len(block_a) + 120
+        text, skipped = truncate_diff_with_skips(diff, budget)
+        assert "b.py" in skipped
+        assert "Omitted files" in text  # footer still embedded for the prompt body
+
+    def test_truncate_diff_output_unchanged(self):
+        from app.utils import truncate_diff, truncate_diff_with_skips
+        block_a = self._make_file_block("a.py", lines=3)
+        block_b = self._make_file_block("b.py", lines=50)
+        diff = block_a + block_b
+        budget = len(block_a) + 120
+        assert truncate_diff(diff, budget) == truncate_diff_with_skips(diff, budget)[0]
+
+    def test_with_skips_no_truncation_when_under_cap(self):
+        from app.utils import truncate_diff_with_skips
+        diff = self._make_file_block("a.py", lines=3)
+        text, skipped = truncate_diff_with_skips(diff, 10_000)
+        assert skipped == []
+        assert text == diff
+
+    def test_empty_diff(self):
+        from app.utils import truncate_diff_with_skips
+        assert truncate_diff_with_skips("", 100) == ("", [])
+
+
 class TestIsKnownProject:
     """Tests for is_known_project() shared utility."""
 

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -146,7 +146,12 @@ behavioural unit tests instead):
   (`optimizations.review_compressor.token_budget`, default 80,000), read via
   `config.get_review_compressor_token_budget()`. The fetch-time character cap is
   *derived* from it — `config.get_review_max_diff_chars()` = budget × 3.5 × 4 —
-  so there is no independent, conflicting numeric cap.
+  so there is no independent, conflicting numeric cap. When the compressor is
+  *disabled* (`review_compressor.enabled: false`), no packer re-shrinks the diff,
+  so `build_review_prompt()` applies a token-safe backstop
+  `config.get_review_uncompressed_max_diff_chars()` = budget × 3.5 (no headroom)
+  via `utils.truncate_diff_with_skips()` — the size guard holds in every config
+  and its skips feed the same coverage note.
 - `fetch_pr_context(...)` (in `rebase_pr.py`) takes `max_diff_chars` (legacy default
   32 000 for rebase/squash/recreate/ci_queue callers; `/review` passes the derived
   cap) and returns a `diff_skipped_files` list via `utils.truncate_diff_with_skips()`

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -4,7 +4,7 @@ title: "Component Spec — Skills System"
 description: "Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness)."
 tags: [skills]
 created: 2026-06-27
-updated: 2026-07-02
+updated: 2026-07-09
 ---
 
 # Component Spec — Skills System
@@ -139,6 +139,24 @@ behavioural unit tests instead):
 - Custom skills under `instance/skills/<scope>/` can be cloned Git repos for team sharing
   (`skill_manager.py`).
 - GitHub/Jira @mentions route through `external_skill_dispatch.py`.
+
+### `review` diff-size & partial-coverage contract
+
+- **Single source of truth for diff size** is the compressor token budget
+  (`optimizations.review_compressor.token_budget`, default 80,000), read via
+  `config.get_review_compressor_token_budget()`. The fetch-time character cap is
+  *derived* from it — `config.get_review_max_diff_chars()` = budget × 3.5 × 4 —
+  so there is no independent, conflicting numeric cap.
+- `fetch_pr_context(...)` (in `rebase_pr.py`) takes `max_diff_chars` (legacy default
+  32 000 for rebase/squash/recreate/ci_queue callers; `/review` passes the derived
+  cap) and returns a `diff_skipped_files` list via `utils.truncate_diff_with_skips()`
+  so files cut at fetch time are first-class, not buried in the diff footer.
+- `review_runner.build_review_prompt()` returns a `(prompt, coverage_note)` tuple.
+  `_build_coverage_note()` merges fetch-time skips, compressor skips, and triaged
+  files into **one** value used both for the `{SKIPPED_FILES}` prompt slot and the
+  returned note — the two can never diverge. `_post_review_comment(..., coverage_note=)`
+  prepends the note (a `⚠️ Partial review` block) above the review body, before the
+  60 K GitHub-length truncation, so partial coverage is never silent.
 
 ## Known debt / watch-outs
 


### PR DESCRIPTION
## Summary

`/review` silently truncated large PR diffs to 32,000 chars at fetch time — *upstream* of the diff compressor — so large-PR reviews looked complete but only covered the first few files. This makes the compressor's token budget the single source of truth, derives a generous fetch-time cap from it, reports omitted files at every stage, and prepends one `⚠️ Partial review` block to the posted GitHub review.

Closes https://github.com/Anantys-oss/koan/issues/2292

## Changes

- **config**: `get_review_compressor_token_budget()` (default 80,000) + `get_review_max_diff_chars()` (= budget × 3.5 × 4). Single knob.
- **utils**: `truncate_diff_with_skips()` returns `(text, skipped_files)`; `truncate_diff` delegates (byte-identical output).
- **rebase_pr**: `fetch_pr_context` gains `max_diff_chars` (legacy 32000 default for rebase/squash/recreate/ci_queue) and returns `diff_skipped_files`.
- **review_runner**: `_build_coverage_note()` merges fetch + compressor + triaged skips into ONE value; `build_review_prompt` returns `(prompt, coverage_note)`; `_post_review_comment` prepends the note before the 60K truncation; `/review` fetches with the derived cap.
- **docs/spec**: SKILL.md, `docs/users/skills.md`, `specs/components/skills.md`.

## Test plan

- New tests: config getters, `truncate_diff_with_skips`, `fetch_pr_context` skip recording, `_build_coverage_note` merge/dedupe, tuple-return contract (note verbatim in prompt), coverage note reaching the posted `gh` body.
- `pytest test_review_runner.py test_config.py test_utils.py test_rebase_pr.py` — 1103 passed; 3 failures are pre-existing telegram outcome-gating test-isolation flakes (fail identically on `main`, unrelated).
- `make lint` passes.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(HEAD=edfcbe9c)_
