### PR TITLE
docs(constitution): amend Principles III & VI for SQLite mission store (v2.0.0)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -2,31 +2,43 @@
 
 <!--
 === Sync Impact Report ===
-Version change: (unratified template) → 1.0.0
-Modified principles: none — initial ratification
-Added sections:
-  - Core Principles I–VII
-  - Constraints & Technology Stack
-  - Workflow & Quality Gates
-  - Governance
-Removed sections: none
+Version change: 1.0.0 → 2.0.0
+  MAJOR: Principle III redefined — the prior absolute "never in a database" no
+  longer holds for mission state. SQLite becomes mission state's default authority
+  behind the MissionStore port; all OTHER runtime state stays file-first.
+Modified principles:
+  - III. "Local Files, Atomic State" → "Local Files by Default; Mission State in
+    the Store". Mission state is authoritative in the backend chosen through the
+    MissionStore port (SQLite / instance/missions.db by default), config-selected,
+    documented, and exclusive; missions.md becomes a generated read-only export.
+    memory_db-style derived indexes over a file truth remain permitted. Any
+    ADDITIONAL database-authoritative state needs a further amendment.
+  - VI. "Single Writer, Single Read Path" — mission clause restated: the single
+    authority is the active MissionStore (get_mission_store()); agents/code MUST
+    NOT mutate mission state outside the port nor treat the missions.md export as
+    writable.
+Constraints & Technology Stack: mission-storage backend added to the pluggable-
+  abstraction list (alongside messaging bridges and CLI providers).
+Added / Removed sections: none.
 Templates requiring updates:
-  - .specify/templates/plan-template.md   ✅ no change — "Constitution Check" gate defers to this file
+  - .specify/templates/plan-template.md   ✅ no change — "Constitution Check" gate defers here
   - .specify/templates/spec-template.md    ✅ no change — generic speckit template
   - .specify/templates/tasks-template.md   ✅ no change — generic speckit template
-  - .specify/templates/commands/           ✅ n/a — no commands directory present
-Follow-up TODOs:
-  - RESOLVED(SPECS_DIR_COLLISION) [2026-07-04]: Kōan's `specs/` holds component/skill
-    design contracts (see specs/README.md) alongside speckit's per-feature
-    `specs/<feature>/` planning folders. Reconciled by treating them as two
-    coexisting populations at different, non-colliding paths rather than merging
-    or renaming: component/skill specs are durable and wiki-indexed; speckit
-    folders are ephemeral, status-tagged, and never frontmattered (speckit's own
-    tooling rewrites them wholesale). A shipped speckit feature's durable artifact
-    is the updated `specs/components/<group>.md`, not the speckit folder itself.
-    Full rationale in `specs/README.md` ("components/, skills/ vs.
-    <NNN-feature-slug>/") and `wiki/SCHEMA.md` ("Why speckit feature folders get
-    no frontmatter").
+Follow-up reconciliations — DEFERRED to the implementation PR (spec
+  004-mission-store, PR 2), NOT done in this amendment. These artifacts describe
+  the CURRENT file-based mission behavior, which Principle VII requires we preserve
+  until the code actually changes; PR 2 updates them in the same branch as the code:
+  - CLAUDE.md — "pulling missions from a shared file"; missions.md as the queue
+  - koan/app/CLAUDE.md — "missions.md — Task queue" → generated read-only export
+  - specs/components/core.md — mission-queue contract + single-writer invariant
+  - docs/architecture/{overview,shared-state,mission-lifecycle}.md — mission state location
+Rationale basis: specs/004-mission-store/{spec,plan,data-model,contracts}.md;
+  issue #2140; epic #2147. Design PR: #2295. Supersedes the mirror approach in #2209.
+Prior history: v1.0.0 initial ratification [2026-06-28]. SPECS_DIR_COLLISION was
+  RESOLVED [2026-07-04] — component/skill specs are durable + wiki-indexed while
+  speckit `specs/<feature>/` folders are ephemeral and unfrontmattered; a shipped
+  feature's durable artifact is the updated specs/components/<group>.md. Full
+  rationale in specs/README.md and wiki/SCHEMA.md.
 Source basis: specs/README.md, specs/components/{core,agent-loop,providers}.md,
 docs/architecture/{overview,shared-state}.md, docs/design/decisions.md,
 docs/security/threat-model-agent-disalignment.md, CLAUDE.md.
@@ -76,23 +88,43 @@ explains how to **use** Kōan; it does not define contracts.
 *Rationale*: Specs anchor deliberate, contract-first refactoring and prevent
 silent contract breakage across a high-fan-in daemon.
 
-### III. Local Files, Atomic State
+### III. Local Files by Default; Mission State in the Store
 
 Runtime state lives in plain, inspectable files under `instance/`
-(Markdown/YAML/JSON/trackers), never in a database. Shared files MUST be written
+(Markdown/YAML/JSON/trackers) **by default**. Shared files MUST be written
 through `utils.atomic_write()` (temp file + rename + `fcntl.flock()`); never
 perform a raw read-modify-write on an `instance/` file.
 
+- **Mission state is the one authorized database exception.** It is authoritative
+  in the backend selected through the `MissionStore` port — SQLite
+  (`instance/missions.db`) by default — resolved by one config accessor,
+  documented, and **exclusive** (never a second concurrent authority alongside a
+  file). `missions.md` becomes a generated **read-only export**, not an input;
+  mission mutations flow only through the port (Principle VI). An alternative
+  backend may be supplied by configuration without forking core code.
+- A database used purely as a **derived index** over a file source of truth (e.g.
+  `memory_db`'s FTS5 index over the JSONL memory log) remains permitted — it is
+  not an authority.
+- **All other runtime state stays in files** (config, outbox, journal, trackers,
+  soul, memory JSONL truth). Any *additional* database-authoritative state
+  requires a further amendment.
 - The bridge (`awake.py`) and runner (`run.py`) are separate processes; bugs
-  harmless in one process corrupt state when both are active.
+  harmless in one process corrupt state when both are active. Store transactions
+  (mission state) and `atomic_write()` (the remaining files) prevent corruption
+  across the two.
 - Transient scratch files and the provider invocation lock live under the
   per-uid `utils.koan_tmp_dir()` (`$XDG_RUNTIME_DIR/koan` or `/tmp/koan-<uid>/`,
   mode `0700`) — NOT in `instance/` or a fixed `/tmp` name. This is what lets
   multiple users run Kōan on one host without colliding.
 
-*Rationale*: Plain files keep state auditable, easy to back up, and easy for
-humans and LLMs to inspect; atomic writes prevent corruption across the two
-processes.
+*Rationale*: Plain files keep most state auditable, easy to back up, and easy for
+humans and LLMs to inspect. Mission state is the narrow exception: it is the
+hottest, most-queried artifact (15+ callsites; count/list scans) and the one
+whose schema must keep evolving (terminal status, failure reason, cost). An
+indexed, single-authority store removes fragile regex parsing and the dual-write
+divergence a file+mirror design cannot escape (see #2209). The exception is
+narrow, config-selected, exclusive, and behind an abstraction — file-first holds
+everywhere else.
 
 ### IV. Provider Isolation
 
@@ -137,16 +169,19 @@ instance.
 
 Each shared resource has exactly one authority and one access path.
 
-- `missions.md` mutations flow ONLY through the lifecycle functions
-  (`start_mission`, `complete_mission`, `fail_mission`). Agents and code MUST
-  NOT hand-edit `missions.md`.
+- Mission state has exactly one authority — the active `MissionStore`
+  implementation, reached through one port (`get_mission_store()`). Agents and
+  code MUST NOT mutate mission state outside the port, and MUST NOT treat the
+  generated `missions.md` export as writable. (The `file` adapter's realization of
+  this, if one is supplied, still funnels through the port.)
 - Each config concern has exactly one read path — an accessor in `config.py` or
   `projects_config.py` (`projects.yaml` > `KOAN_PROJECTS`). Never read
   `os.environ`/YAML inline; add or reuse the accessor.
 - `run.py` is the single host of the CLI subprocess; every exit from In Progress
   funnels through `_finalize_mission()`.
 - Bilingual section headers (`Pending`/`In Progress`/`Done` and the French
-  equivalents) MUST be preserved by every parser.
+  equivalents) MUST be preserved by the `missions.md` export renderer and the
+  one-time ingest.
 
 *Rationale*: One authority per resource prevents interleaved writes and
 divergent config reads in a two-process daemon.
@@ -175,9 +210,10 @@ enforceable gate, not a ritual.
   `load_skill_prompt()`. No inline prompts in Python. System prompts MUST be
   generic — never reference instance-specific identifiers.
 - **Stack surface**: Flask 3.x powers the dashboard and REST API only; the loop
-  itself has no web framework. Messaging bridges (Telegram/Slack/etc.) and CLI
-  providers are pluggable. Add new providers/bridges behind their abstraction,
-  not by forking core code.
+  itself has no web framework. Messaging bridges (Telegram/Slack/etc.), CLI
+  providers, and the mission-storage backend (the `MissionStore` port) are
+  pluggable. Add new providers/bridges/backends behind their abstraction, not by
+  forking core code.
 - **Testing discipline**: `KOAN_ROOT` MUST be set when running tests
   (`KOAN_ROOT=/tmp/test-koan .venv/bin/pytest …`). Never call the Claude
   subprocess in tests — mock `format_and_send`. Test **behavior, not
@@ -230,4 +266,4 @@ The `code-reviewer` and `security_review` paths treat the principles as gates,
 not suggestions. Unjustified complexity MUST be recorded in the plan's
 Complexity Tracking table with a rejected-simpler-alternative rationale.
 
-**Version**: 1.0.0 | **Ratified**: 2026-06-28 | **Last Amended**: 2026-06-28
+**Version**: 2.0.0 | **Ratified**: 2026-06-28 | **Last Amended**: 2026-07-09

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -91,9 +91,12 @@ silent contract breakage across a high-fan-in daemon.
 ### III. Local Files by Default; Mission State in the Store
 
 Runtime state lives in plain, inspectable files under `instance/`
-(Markdown/YAML/JSON/trackers) **by default**. Shared files MUST be written
-through `utils.atomic_write()` (temp file + rename + `fcntl.flock()`); never
-perform a raw read-modify-write on an `instance/` file.
+(Markdown/YAML/JSON/trackers) by default — **with exactly one exception: mission
+state is authoritative in a database (SQLite by default) behind the
+`MissionStore` port** (detailed in the first bullet). Everything else stays in
+files. Shared files MUST be written through `utils.atomic_write()` (temp file +
+rename + `fcntl.flock()`); never perform a raw read-modify-write on an
+`instance/` file.
 
 - **Mission state is the one authorized database exception.** It is authoritative
   in the backend selected through the `MissionStore` port — SQLite


### PR DESCRIPTION
## What this is

A **constitutional amendment** — the governance precondition for [#2295](https://github.com/Anantys-oss/koan/pull/2295) (spec `004-mission-store`), which migrates mission state to a single **SQLite store behind a `MissionStore` port**. Per the constitution's own governance ("a conflict with a principle MUST be resolved by **amendment**, not by exception"), the design cannot be implemented until this is ratified. Touches **only** `.specify/memory/constitution.md`.

## Why it's needed

Principle III currently says runtime state lives in files "**never in a database**." Making SQLite the source of truth for missions conflicts head-on. This amendment resolves that conflict narrowly.

## What changes

- **Principle III** → "Local Files by Default; Mission State in the Store."
  - Mission state becomes authoritative in the backend selected through the `MissionStore` port — **SQLite (`instance/missions.db`) by default** — config-selected, documented, and **exclusive** (never a second concurrent authority). `missions.md` becomes a generated **read-only export**.
  - **All other runtime state stays file-first** (config, outbox, journal, trackers, soul, memory JSONL truth). A **derived index** over a file truth (e.g. `memory_db` FTS5) stays permitted. Any *additional* DB-authoritative state needs a further amendment.
- **Principle VI** mission clause restated: the single authority is the active `MissionStore` (`get_mission_store()`); agents/code must not mutate mission state outside the port nor treat the `missions.md` export as writable.
- **Constraints**: mission-storage backend added to the pluggable-abstraction list (alongside bridges + CLI providers).

## The version bump is your call

Drafted as **MAJOR (1.0.0 → 2.0.0)** because it redefines III such that prior compliance no longer holds (the versioning policy's definition of MAJOR). A ratifier could argue MINOR (it *expands* guidance behind an abstraction, file-first still the default everywhere else). **Please decide and adjust the footer + Sync Impact Report if you prefer MINOR.**

## Deliberate scoping decision to review

The amendment procedure says "reconcile every dependent artifact in the same change." I **deferred** the doc reconciliations (`CLAUDE.md`, `koan/app/CLAUDE.md`, `specs/components/core.md`, architecture docs) to the **implementation PR (004 PR 2)**, and listed them in the Sync Impact Report. Rationale: those docs describe the **current file-based behavior**, which is unchanged until the code lands — rewriting them now to describe SQLite would violate **Principle VII** ("code is the immediate source of truth; preserve current behavior"). If you'd rather reconcile them here, say so and I'll move them in.

## How to use it

Draft while the version bump is undecided. Once you've settled MAJOR-vs-MINOR: mark ready → review → merge. Merging this changes **no runtime behavior**; it only authorizes the design so I can start **PR 2** (port + `SqliteMissionStore` + conformance suite + config + ingest + export + visibility commands).

Refs #2140 · epic #2147 · design #2295 · supersedes the mirror in #2209.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
