### PR TITLE
fix(review): post the core review before the optional enrichment passes

### DIFF
--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -705,6 +705,7 @@ def list_open_pr_branches(repo: str, author: str, cwd: str = None) -> List[str]:
 def find_bot_comment(
     owner: str, repo: str, pr_number: int, marker: str,
     bot_username: str = "",
+    prefer_newest: bool = False,
 ) -> Optional[dict]:
     """Search issue comments on a PR for a comment containing ``marker``.
 
@@ -720,6 +721,13 @@ def find_bot_comment(
     empty (unconfigured), the first marker match wins regardless of author —
     preserving backward-compatible behaviour.
 
+    When ``prefer_newest`` is True, the highest-id (most recently created)
+    match is returned instead of the first (oldest). This matters when more
+    than one comment can legitimately carry the marker at once — e.g. with
+    ``review_history.preserve_previous`` the prior review is left intact
+    alongside the freshly-posted one, both authored by the same bot, so the
+    author filter can't disambiguate and the newest match is the current one.
+
     Args:
         owner: Repository owner.
         repo: Repository name.
@@ -727,6 +735,8 @@ def find_bot_comment(
         marker: Marker string to search for (e.g. ``SUMMARY_TAG``).
         bot_username: If provided, only return a comment authored by this
             account (case-insensitive).
+        prefer_newest: If True, return the highest-id match rather than the
+            first one encountered.
 
     Returns:
         Dict with keys ``id``, ``body``, ``user`` from the GitHub API, or
@@ -747,6 +757,7 @@ def find_bot_comment(
         return None
 
     wanted_user = bot_username.strip().lower()
+    newest = None
     for line in raw.strip().split("\n"):
         try:
             comment = json.loads(line)
@@ -756,9 +767,12 @@ def find_bot_comment(
             continue
         if wanted_user and str(comment.get("user", "")).lower() != wanted_user:
             continue
-        return comment
+        if not prefer_newest:
+            return comment
+        if newest is None or comment.get("id", 0) > newest.get("id", 0):
+            newest = comment
 
-    return None
+    return newest
 
 
 def check_pvrs_enabled(repo: str, cwd: str = None) -> bool:

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1998,10 +1998,17 @@ def _append_error_section_to_review(
     appended. Best-effort: on any failure the core review still stands and only
     the extra section is lost.
 
+    ``prefer_newest=True`` re-locates the *most recent* marked comment: with
+    ``review_history.preserve_previous`` the superseded prior review is left
+    intact and still carries ``SUMMARY_TAG``, so the (default) first-match
+    lookup would append onto the old comment. The freshly-posted review always
+    has the highest comment id, so the newest match is the correct target.
+
     Returns True when the comment was updated.
     """
     located = find_bot_comment(
         owner, repo, pr_number, SUMMARY_TAG, bot_username=bot_username,
+        prefer_newest=True,
     )
     if not located:
         print(
@@ -3165,10 +3172,18 @@ def run_review(
                 )
     except Exception as exc:
         # Never let a post-hoc enrichment failure undo an already-posted review.
+        # The catch is broad on purpose (a stall or provider error must not flip
+        # the run), but surface it through notify_fn too — not stderr alone — so
+        # a persistently-broken enrichment pass (e.g. a real defect introduced by
+        # a later refactor) is visible rather than silently swallowed on every PR.
         print(
             f"[review_runner] enrichment pass failed after posting review "
             f"on PR #{pr_number}: {exc}",
             file=sys.stderr,
+        )
+        notify_fn(
+            f"Enrichment pass failed after posting review on PR #{pr_number} "
+            f"(review still landed): {exc}"
         )
 
     # Step 7c: Optionally post each finding as an inline PR comment (opt-in).

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1989,6 +1989,7 @@ def _append_error_section_to_review(
     provider_name: str = "",
     model: str = "",
     duration_seconds: float = 0,
+    coverage_note: str = "",
 ) -> bool:
     """Append the silent-failure-hunter section to the posted review comment.
 
@@ -2003,6 +2004,11 @@ def _append_error_section_to_review(
     intact and still carries ``SUMMARY_TAG``, so the (default) first-match
     lookup would append onto the old comment. The freshly-posted review always
     has the highest comment id, so the newest match is the correct target.
+
+    ``coverage_note``, when passed, is forwarded to ``_post_review_comment``
+    so it is re-prepended here too. This rebuild replaces the whole comment
+    body (``combined``), so without it the ``⚠️ Partial review`` warning that
+    the initial post prepended would be silently dropped by this edit.
 
     Returns True when the comment was updated.
     """
@@ -2024,6 +2030,7 @@ def _append_error_section_to_review(
         provider_name=provider_name,
         model=model,
         duration_seconds=duration_seconds,
+        coverage_note=coverage_note,
     )
     if not updated:
         print(
@@ -3158,6 +3165,7 @@ def run_review(
                     provider_name=review_provider_name,
                     model=review_model,
                     duration_seconds=_review_duration,
+                    coverage_note=coverage_note,
                 )
             elif error_section and not posted:
                 print(

--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1977,6 +1977,56 @@ def _post_review_comment(
         return False, str(e)
 
 
+def _append_error_section_to_review(
+    owner: str,
+    repo: str,
+    pr_number: str,
+    *,
+    review_body: str,
+    error_section: str,
+    bot_username: str = "",
+    commit_shas: Optional[List[str]] = None,
+    provider_name: str = "",
+    model: str = "",
+    duration_seconds: float = 0,
+) -> bool:
+    """Append the silent-failure-hunter section to the posted review comment.
+
+    The core review is posted *before* the enrichment passes run (so a slow or
+    failing enrichment pass can never cost the review). This re-locates that
+    comment via ``SUMMARY_TAG`` and rewrites it in place with the extra section
+    appended. Best-effort: on any failure the core review still stands and only
+    the extra section is lost.
+
+    Returns True when the comment was updated.
+    """
+    located = find_bot_comment(
+        owner, repo, pr_number, SUMMARY_TAG, bot_username=bot_username,
+    )
+    if not located:
+        print(
+            "[review_runner] could not re-locate review comment to append "
+            "silent-failure-hunter section; leaving core review as-is",
+            file=sys.stderr,
+        )
+        return False
+    combined = review_body + "\n\n---\n\n" + error_section
+    updated, err = _post_review_comment(
+        owner, repo, pr_number, combined, located,
+        commit_shas=commit_shas,
+        provider_name=provider_name,
+        model=model,
+        duration_seconds=duration_seconds,
+    )
+    if not updated:
+        print(
+            f"[review_runner] failed to append silent-failure-hunter "
+            f"section: {err}",
+            file=sys.stderr,
+        )
+    return updated
+
+
 def _collapse_old_review(
     owner: str, repo: str, comment: dict,
 ) -> None:
@@ -3001,58 +3051,18 @@ def run_review(
                 file=sys.stderr,
             )
 
-    # Step 6b: Bot comment triage pass (optional)
-    bot_triage_cfg = get_review_bot_triage_config()
-    bot_triage_enabled = bot_comments or bot_triage_cfg["enabled"]
-    extra_bot_usernames = bot_triage_cfg["bot_usernames"]
+    full_repo = f"{owner}/{repo}"
 
-    if bot_triage_enabled:
-        full_repo = f"{owner}/{repo}"
-        bot_inline = _fetch_bot_inline_comments(
-            full_repo, pr_number, bot_username, extra_bot_usernames,
-        )
-        if bot_inline:
-            notify_fn(f"Triaging {len(bot_inline)} bot comment(s) on PR #{pr_number}...")
-            triage_replies = _run_bot_comment_triage(
-                bot_inline, context.get("diff", ""), skill_dir,
-                project_path=project_path,
-                project_name=project_name or "",
-            )
-            if triage_replies:
-                bot_reply_results = _post_comment_replies(
-                    owner, repo, pr_number, triage_replies, bot_inline,
-                )
-                if bot_reply_results:
-                    print(
-                        f"[review_runner] posted {len(bot_reply_results)} bot triage reply(ies)",
-                        file=sys.stderr,
-                    )
-
-    # Step 6a: Silent-failure-hunter pass (explicit flag or auto-detected)
-    diff = context.get("diff", "")
-    run_error_hunter = errors or _should_run_error_hunter(diff)
-    if run_error_hunter:
-        notify_fn(f"Running silent-failure-hunter on PR #{pr_number}...")
-        error_section = _run_error_hunter(
-            diff, project_path, skill_dir,
-            owner=owner, repo=repo,
-            head_sha=(current_shas[-1] if current_shas else ""),
-            project_name=project_name or "",
-        )
-        if error_section:
-            review_body = review_body + "\n\n---\n\n" + error_section
-        else:
-            print(
-                "[review_runner] silent-failure-hunter: no findings",
-                file=sys.stderr,
-            )
-
-    # Step 7: Post (or update) review comment (Phase 3 — idempotent upsert)
-    # Commit SHAs are embedded in the body upfront to avoid extra API calls.
+    # Step 7 (posted BEFORE the optional enrichment passes): post (or update)
+    # the core review comment first, so a slow or failing enrichment pass (bot
+    # triage, silent-failure-hunter) can never cost the review that's already
+    # in hand. The silent-failure-hunter section, when produced, is appended to
+    # this comment via a follow-up edit below (Step 6a).
     #
-    # Re-review with new commits: post a FRESH comment instead of PATCHing.
-    # GitHub does not send notifications for edited comments, so an in-place
-    # update is invisible to the reviewer — they never see the updated review.
+    # Phase 3 — idempotent upsert. Commit SHAs are embedded in the body upfront
+    # to avoid extra API calls. Re-review with new commits: post a FRESH
+    # comment instead of PATCHing — GitHub does not notify on edits, so an
+    # in-place update is invisible to the reviewer.
     post_target = existing_comment
     new_commits = prior_shas and current_shas and set(current_shas) != set(prior_shas)
     if existing_comment and (new_commits or review_was_requested):
@@ -3083,6 +3093,83 @@ def run_review(
         live_head_sha=live_head_sha,
         coverage_note=coverage_note,
     )
+
+    # Steps 6b + 6a run AFTER the core post and are strictly best-effort: the
+    # whole enrichment block is wrapped so that once the review has landed, no
+    # enrichment failure (stall, provider error, or an unexpected exception)
+    # can flip the run's outcome to failure. run_error_hunter is pre-set so the
+    # summary reference below is defined even if the block aborts early.
+    run_error_hunter = errors or _should_run_error_hunter(context.get("diff", ""))
+    try:
+        # Step 6b: Bot comment triage — posts its own independent reply
+        # comments and never touched review_body, so running it after the post
+        # means a stall here can't delay or lose the review.
+        bot_triage_cfg = get_review_bot_triage_config()
+        bot_triage_enabled = bot_comments or bot_triage_cfg["enabled"]
+        extra_bot_usernames = bot_triage_cfg["bot_usernames"]
+
+        if bot_triage_enabled:
+            bot_inline = _fetch_bot_inline_comments(
+                full_repo, pr_number, bot_username, extra_bot_usernames,
+            )
+            if bot_inline:
+                notify_fn(f"Triaging {len(bot_inline)} bot comment(s) on PR #{pr_number}...")
+                triage_replies = _run_bot_comment_triage(
+                    bot_inline, context.get("diff", ""), skill_dir,
+                    project_path=project_path,
+                    project_name=project_name or "",
+                )
+                if triage_replies:
+                    bot_reply_results = _post_comment_replies(
+                        owner, repo, pr_number, triage_replies, bot_inline,
+                    )
+                    if bot_reply_results:
+                        print(
+                            f"[review_runner] posted {len(bot_reply_results)} bot triage reply(ies)",
+                            file=sys.stderr,
+                        )
+
+        # Step 6a: Silent-failure-hunter pass (explicit flag or auto-detected).
+        # Its section is appended to the already-posted review comment via an
+        # edit. If the core post failed, or the comment can't be re-located, the
+        # section is dropped (the core review still stands).
+        if run_error_hunter:
+            notify_fn(f"Running silent-failure-hunter on PR #{pr_number}...")
+            error_section = _run_error_hunter(
+                context.get("diff", ""), project_path, skill_dir,
+                owner=owner, repo=repo,
+                head_sha=(current_shas[-1] if current_shas else ""),
+                project_name=project_name or "",
+            )
+            if error_section and posted:
+                _append_error_section_to_review(
+                    owner, repo, pr_number,
+                    review_body=review_body,
+                    error_section=error_section,
+                    bot_username=bot_username,
+                    commit_shas=current_shas or None,
+                    provider_name=review_provider_name,
+                    model=review_model,
+                    duration_seconds=_review_duration,
+                )
+            elif error_section and not posted:
+                print(
+                    "[review_runner] silent-failure-hunter findings dropped: "
+                    "core review comment was not posted",
+                    file=sys.stderr,
+                )
+            else:
+                print(
+                    "[review_runner] silent-failure-hunter: no findings",
+                    file=sys.stderr,
+                )
+    except Exception as exc:
+        # Never let a post-hoc enrichment failure undo an already-posted review.
+        print(
+            f"[review_runner] enrichment pass failed after posting review "
+            f"on PR #{pr_number}: {exc}",
+            file=sys.stderr,
+        )
 
     # Step 7c: Optionally post each finding as an inline PR comment (opt-in).
     # Additive to the summary comment above and independently failable, so an

--- a/koan/tests/test_github.py
+++ b/koan/tests/test_github.py
@@ -1231,6 +1231,49 @@ class TestFindBotComment:
         assert result is not None
         assert result["id"] == 101
 
+    @patch("app.github.run_gh")
+    def test_prefer_newest_returns_highest_id_match(self, mock_gh):
+        """prefer_newest returns the highest-id match, not the first.
+
+        Reproduces the preserve_previous case: two same-bot comments carry the
+        marker at once (the preserved prior review + the freshly-posted one).
+        The newest — highest comment id — is the current review."""
+        old = self._make_comment(101, f"{self.MARKER} preserved prior review")
+        new = self._make_comment(303, f"{self.MARKER} fresh review")
+        mock_gh.return_value = f"{old}\n{new}"
+        result = find_bot_comment(
+            "owner", "repo", 42, self.MARKER, prefer_newest=True,
+        )
+        assert result["id"] == 303
+
+    @patch("app.github.run_gh")
+    def test_prefer_newest_ignores_input_ordering(self, mock_gh):
+        """The highest id wins even when it appears first in the response."""
+        new = self._make_comment(303, f"{self.MARKER} fresh review")
+        old = self._make_comment(101, f"{self.MARKER} preserved prior review")
+        mock_gh.return_value = f"{new}\n{old}"
+        result = find_bot_comment(
+            "owner", "repo", 42, self.MARKER, prefer_newest=True,
+        )
+        assert result["id"] == 303
+
+    @patch("app.github.run_gh")
+    def test_prefer_newest_respects_bot_username_filter(self, mock_gh):
+        """prefer_newest still honours the author filter: a newer comment by a
+        different bot is not selected over the current bot's own comment."""
+        mine = self._make_comment(
+            202, f"{self.MARKER} by me", user="koan-bot",
+        )
+        other_newer = self._make_comment(
+            303, f"{self.MARKER} by other", user="other-bot",
+        )
+        mock_gh.return_value = f"{mine}\n{other_newer}"
+        result = find_bot_comment(
+            "owner", "repo", 42, self.MARKER,
+            bot_username="koan-bot", prefer_newest=True,
+        )
+        assert result["id"] == 202
+
 
 class TestIssueEdit:
     def test_passes_repo_flag_when_provided(self):

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -1623,6 +1623,30 @@ class TestAppendErrorSectionToReview:
         )
         assert mock_find.call_args.kwargs["prefer_newest"] is True
 
+    @patch("app.review_runner.run_gh")
+    @patch(
+        "app.review_runner.find_bot_comment",
+        return_value={"id": 555, "body": "## Code Review\n\nold body"},
+    )
+    def test_coverage_note_is_reprepended(self, _mock_find, mock_gh):
+        """Regression for the #2294 x #2299 overlap: the append path rebuilds
+        the comment from the clean review_body, so without re-forwarding
+        coverage_note the already-posted `Partial review` warning would be
+        silently dropped by this edit."""
+        note = ("> ⚠️ **Partial review** — 1 file(s) omitted due to diff size "
+                 "and NOT reviewed: `huge.py`")
+        ok = _append_error_section_to_review(
+            "owner", "repo", "42",
+            review_body="## Code Review\n\nCore body",
+            error_section="### Silent failures\n\n- swallowed exception",
+            bot_username="bot",
+            coverage_note=note,
+        )
+        assert ok is True
+        joined = " ".join(str(a) for a in mock_gh.call_args[0])
+        assert "Partial review" in joined and "`huge.py`" in joined
+        assert "swallowed exception" in joined
+
 
 class TestReviewPostsBeforeEnrichment:
     """Fix #2: the core review is posted before the optional enrichment passes,
@@ -1688,6 +1712,49 @@ class TestReviewPostsBeforeEnrichment:
         # And it is NOT baked into the initial posted comment body.
         posted = " ".join(str(c) for c in mock_gh.call_args_list)
         assert "swallowed exception at x" not in posted
+
+    @patch("app.review_runner.find_bot_comment")
+    @patch("app.review_runner._fetch_pr_commit_shas", return_value=[])
+    @patch(
+        "app.review_runner._run_error_hunter",
+        return_value="### Silent failures\n\n- swallowed exception at x",
+    )
+    @patch("app.review_runner.fetch_repliable_comments", return_value=[])
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner._run_claude_review")
+    @patch("app.review_runner.fetch_pr_context")
+    @patch("app.review_runner.build_review_prompt")
+    def test_coverage_note_survives_hunter_append_overlap(
+        self, mock_prompt, mock_fetch, mock_claude, mock_gh, _mock_repliable,
+        _mock_hunter, _mock_shas, mock_find, pr_context, review_skill_dir,
+    ):
+        """Regression for the #2294 x #2299 overlap flagged in
+        https://github.com/Anantys-oss/koan/pull/2299#issuecomment-4930545352:
+        a large PR (non-empty coverage_note) that also triggers the
+        silent-failure-hunter must keep the `Partial review` warning in the
+        final comment, not just the initial post."""
+        mock_fetch.return_value = pr_context
+        mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
+        note = ("> ⚠️ **Partial review** — 1 file(s) omitted due to diff size "
+                 "and NOT reviewed: `huge.py`\n\n")
+        mock_prompt.return_value = ("REVIEW PROMPT", note)
+        # The append path re-locates the just-posted comment by SUMMARY_TAG.
+        mock_find.return_value = {"id": 999, "body": "## Code Review\n\nplaceholder"}
+
+        success, _summary, _rd = run_review(
+            "owner", "repo", "42", "/tmp/project",
+            notify_fn=MagicMock(),
+            skill_dir=review_skill_dir,
+            errors=True,  # force the silent-failure-hunter pass
+        )
+
+        assert success is True
+        # Two gh calls: the initial "pr comment" post, then the PATCH append.
+        assert mock_gh.call_count >= 2
+        final_call = mock_gh.call_args_list[-1]
+        final_body = " ".join(str(a) for a in final_call.args)
+        assert "Partial review" in final_body and "`huge.py`" in final_body
+        assert "swallowed exception at x" in final_body
 
 
 class TestRunReview:

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -27,6 +27,7 @@ from app.review_runner import (
     _extract_json_text,
     _build_review_footer,
     _post_review_comment,
+    _append_error_section_to_review,
     _post_comment_replies,
     _fetch_pr_commit_shas,
     _fetch_pr_head_oid,
@@ -1570,6 +1571,107 @@ class TestFetchPrHeadOid:
 # ---------------------------------------------------------------------------
 # run_review (integration, mocked externals)
 # ---------------------------------------------------------------------------
+
+class TestAppendErrorSectionToReview:
+    """Fix #2: the silent-failure-hunter section is appended to the already
+    posted review comment (rather than baked into the initial post)."""
+
+    @patch("app.review_runner.run_gh")
+    @patch(
+        "app.review_runner.find_bot_comment",
+        return_value={"id": 555, "body": "## Code Review\n\nold body"},
+    )
+    def test_locates_and_patches_comment(self, _mock_find, mock_gh):
+        ok = _append_error_section_to_review(
+            "owner", "repo", "42",
+            review_body="## Code Review\n\nCore body",
+            error_section="### Silent failures\n\n- swallowed exception",
+            bot_username="bot",
+        )
+        assert ok is True
+        mock_gh.assert_called_once()
+        args = mock_gh.call_args[0]
+        assert "PATCH" in args  # in-place edit of the located comment
+        assert any("555" in str(a) for a in args)  # the located comment id
+        joined = " ".join(str(a) for a in args)
+        assert "Core body" in joined and "swallowed exception" in joined
+
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner.find_bot_comment", return_value=None)
+    def test_returns_false_when_comment_not_located(self, _mock_find, mock_gh):
+        ok = _append_error_section_to_review(
+            "owner", "repo", "42",
+            review_body="body", error_section="section", bot_username="bot",
+        )
+        assert ok is False
+        mock_gh.assert_not_called()  # nothing edited, core review left as-is
+
+
+class TestReviewPostsBeforeEnrichment:
+    """Fix #2: the core review is posted before the optional enrichment passes,
+    so no enrichment failure can cost the review that already landed."""
+
+    @patch("app.review_runner._fetch_pr_commit_shas", return_value=[])
+    @patch(
+        "app.review_runner._run_error_hunter",
+        side_effect=RuntimeError("provider stalled"),
+    )
+    @patch("app.review_runner.fetch_repliable_comments", return_value=[])
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner._run_claude_review")
+    @patch("app.review_runner.fetch_pr_context")
+    def test_review_still_posts_when_error_hunter_raises(
+        self, mock_fetch, mock_claude, mock_gh, _mock_repliable,
+        _mock_hunter, _mock_shas, pr_context, review_skill_dir,
+    ):
+        """An enrichment pass raising after the post must not fail the run."""
+        mock_fetch.return_value = pr_context
+        mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
+
+        success, summary, _rd = run_review(
+            "owner", "repo", "42", "/tmp/project",
+            notify_fn=MagicMock(),
+            skill_dir=review_skill_dir,
+            errors=True,  # force the (raising) silent-failure-hunter pass
+        )
+
+        assert success is True
+        assert "42" in summary
+        mock_gh.assert_called()  # the core review was posted despite the raise
+
+    @patch("app.review_runner._fetch_pr_commit_shas", return_value=[])
+    @patch("app.review_runner._append_error_section_to_review")
+    @patch(
+        "app.review_runner._run_error_hunter",
+        return_value="### Silent failures\n\n- swallowed exception at x",
+    )
+    @patch("app.review_runner.fetch_repliable_comments", return_value=[])
+    @patch("app.review_runner.run_gh")
+    @patch("app.review_runner._run_claude_review")
+    @patch("app.review_runner.fetch_pr_context")
+    def test_error_section_appended_not_in_initial_post(
+        self, mock_fetch, mock_claude, mock_gh, _mock_repliable,
+        _mock_hunter, mock_append, _mock_shas, pr_context, review_skill_dir,
+    ):
+        """The hunter's section goes through the append path, not the first post."""
+        mock_fetch.return_value = pr_context
+        mock_claude.return_value = (json.dumps(LGTM_REVIEW_JSON), "")
+
+        success, _summary, _rd = run_review(
+            "owner", "repo", "42", "/tmp/project",
+            notify_fn=MagicMock(),
+            skill_dir=review_skill_dir,
+            errors=True,
+        )
+
+        assert success is True
+        # The section is routed to the append helper, carrying the hunter output.
+        mock_append.assert_called_once()
+        assert "swallowed exception at x" in mock_append.call_args.kwargs["error_section"]
+        # And it is NOT baked into the initial posted comment body.
+        posted = " ".join(str(c) for c in mock_gh.call_args_list)
+        assert "swallowed exception at x" not in posted
+
 
 class TestRunReview:
     @patch("app.review_runner._fetch_pr_commit_shas", return_value=[])

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -1606,6 +1606,23 @@ class TestAppendErrorSectionToReview:
         assert ok is False
         mock_gh.assert_not_called()  # nothing edited, core review left as-is
 
+    @patch("app.review_runner.run_gh")
+    @patch(
+        "app.review_runner.find_bot_comment",
+        return_value={"id": 555, "body": "## Code Review\n\nold body"},
+    )
+    def test_relocates_newest_comment(self, mock_find, _mock_gh):
+        """With preserve_previous, the preserved prior review still carries
+        SUMMARY_TAG; the append must target the newest (freshly-posted) comment,
+        so find_bot_comment is asked for prefer_newest."""
+        _append_error_section_to_review(
+            "owner", "repo", "42",
+            review_body="## Code Review\n\nCore body",
+            error_section="### Silent failures\n\n- x",
+            bot_username="bot",
+        )
+        assert mock_find.call_args.kwargs["prefer_newest"] is True
+
 
 class TestReviewPostsBeforeEnrichment:
     """Fix #2: the core review is posted before the optional enrichment passes,

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -112,6 +112,16 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   provider-side per-pass stall watchdog (see `specs/components/providers.md`,
   "read loop must be inactivity-bounded"), which makes a stalled enrichment
   pass degrade to empty rather than hang.
+  The append rebuilds the comment body from the clean `review_body`, so
+  `_append_error_section_to_review` also takes `coverage_note` and forwards
+  it to its inner `_post_review_comment` call — without it, a large PR's
+  `⚠️ Partial review` warning (prepended on the initial post; see
+  `specs/components/skills.md`, "`review` diff-size & partial-coverage
+  contract") would be silently overwritten on the hunter-append edit. Large
+  PRs (non-empty `coverage_note`) are also the PRs most likely to trigger the
+  hunter, so this overlap is exercised by
+  `TestReviewPostsBeforeEnrichment::test_coverage_note_survives_hunter_append_overlap`
+  in `koan/tests/test_review_runner.py`.
 
 ## Evaluation
 

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -103,7 +103,11 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   silent-failure-hunter section is not baked into the initial body; when it
   produces findings it is appended to the already-posted comment in place via
   `_append_error_section_to_review` (re-locates the comment by `SUMMARY_TAG`
-  and PATCHes it). If the core post failed or the comment can't be re-located,
+  and PATCHes it). The re-locate uses `find_bot_comment(..., prefer_newest=True)`
+  so that under `review_history.preserve_previous` — where the superseded prior
+  review is left intact and still carries `SUMMARY_TAG` — the section lands on
+  the freshly-posted comment (the highest comment id) rather than the older
+  preserved one. If the core post failed or the comment can't be re-located,
   the section is dropped and the core review still stands. Pairs with the
   provider-side per-pass stall watchdog (see `specs/components/providers.md`,
   "read loop must be inactivity-bounded"), which makes a stalled enrichment

--- a/specs/skills/review.md
+++ b/specs/skills/review.md
@@ -93,6 +93,21 @@ See `docs/users/skills.md` for the end-user `/review` reference and
   (byte-identical output), and the alert never blocks the post, changes the LGTM
   verdict, or re-runs analysis — re-covering the new commits is the
   incremental-review path's job on the next `/review`.
+- **Core review is posted before the optional enrichment passes.** The core
+  summary comment is posted first (`_post_review_comment`); the bot-comment
+  triage and silent-failure-hunter passes run *after* and are strictly
+  best-effort (wrapped so any failure only logs). Rationale: each enrichment
+  pass is a separate provider invocation that can stall or fail, and running
+  them before the post meant a hang there discarded the whole finished review
+  (the outer liveness watchdog SIGKILLs the runner mid-pipeline). The
+  silent-failure-hunter section is not baked into the initial body; when it
+  produces findings it is appended to the already-posted comment in place via
+  `_append_error_section_to_review` (re-locates the comment by `SUMMARY_TAG`
+  and PATCHes it). If the core post failed or the comment can't be re-located,
+  the section is dropped and the core review still stands. Pairs with the
+  provider-side per-pass stall watchdog (see `specs/components/providers.md`,
+  "read loop must be inactivity-bounded"), which makes a stalled enrichment
+  pass degrade to empty rather than hang.
 
 ## Evaluation
 


### PR DESCRIPTION
The review pipeline ran bot-comment triage and the silent-failure-hunter BEFORE posting the summary comment. Each is a separate provider invocation that can stall or fail; when one hung, run.py's outer liveness watchdog SIGKILLed the whole review_runner mid-pipeline and the finished core review was never posted (nothing landed on the PR).

Reorder so the core review comment is posted first, then run the enrichment passes as strictly best-effort (wrapped so any failure only logs and can never flip an already-posted review to failure):

- Bot-comment triage posts its own independent reply comments and never touched the review body, so it simply moves after the post.
- The silent-failure-hunter section is no longer baked into the initial body; when it produces findings it is appended to the already-posted comment in place via the new _append_error_section_to_review (re-locates the comment by SUMMARY_TAG and PATCHes it). If the core post failed or the comment can't be re-located, the section is dropped and the core review still stands.

Also hoists full_repo so the success-summary reference is always defined (previously only set inside the bot-triage branch).

Pairs with the provider-side per-pass stall watchdog: together, a stalled enrichment pass degrades to empty AND can't cost the core review.

Tests: _append_error_section_to_review locates+patches / returns False when not located; run_review still posts when the hunter raises; hunter section is routed to the append path, not the initial post. Spec updated.