### PR TITLE
fix(rebase): strict target remote, fail-closed fetch, pre-push sanity gate

### DIFF
--- a/docs/users/index.md
+++ b/docs/users/index.md
@@ -1,5 +1,6 @@
 # Users
 
+* [KOAN.md — koan-only project instructions](koan-md.md)
 * [Model Configuration](model-configuration.md) - Explains how to configure which model handles each Koan role (mission, chat, lightweight, fallback, etc.) per provider via `config.yaml`, including resolution order and CLI-provider-per-role routing.
 * [Onboarding Guide](onboarding.md) - Documents the interactive 12-step onboarding wizard that sets up a new Koan instance, its resumability, personality presets, and non-interactive/CI mode.
 * [Kōan Quickstart — Zero to Hero](quickstart.md) - A 5-minute guide to the commands for driving Koan from GitHub PRs/issues, Jira, and messaging apps (Telegram/Slack), with minimal and context-augmented examples for each.

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-08
+updated: 2026-07-10
 ---
 
 # Kōan User Manual
@@ -687,6 +687,17 @@ strategy, and re-reviews up to the configured round limit. Gate failures are
 reported in the rebase summary but do not fail an otherwise successful rebase.
 
 When `/rebase` runs long, Kōan uses activity-aware limits for review and CI-fix phases: it allows long sessions when CLI output keeps flowing, but still aborts stalled phases after inactivity or a max-duration cap. If the review-feedback step *stalls* (idle/max-duration timeout), Kōan now restores the clean rebased checkpoint and still pushes the rebase (without partial feedback edits), so timeout noise does not discard a valid rebase. If the feedback step hits a *provider quota limit*, the rebase still stops so you can retry after quota reset. Any other transient feedback error remains best-effort and does not block pushing the rebase.
+
+`/rebase` is strict about *what* it rebases onto: the branch is rebased only
+onto the PR's actual base repository's branch, freshly fetched. The mission
+fails loudly — instead of pushing a suspect result — when no local git remote
+matches the PR's base repository (`[no_base_remote]`; fix with
+`git remote add`), when the base branch can't be fetched (`[fetch_failed]`),
+or when a post-rebase sanity check finds the branch not sitting on the base's
+current tip or carrying *more* unique commits than before the rebase
+(`[sanity_check_failed]` — the branch is restored to its pre-rebase state and
+nothing is pushed). A correct rebase can only keep or shrink a PR's commit
+count; growth means already-merged commits were resurrected.
 
 When a target repository pre-commit hook formats files during the feedback
 commit, Kōan stages the hook-created edits and retries the commit once. If local

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -16,7 +16,7 @@ import sys
 import threading
 import time
 from pathlib import Path
-from typing import Callable, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from app.cli_exec import popen_cli, stream_with_timeout
 from app.cli_provider import build_full_command, run_command
@@ -123,42 +123,97 @@ def has_rebase_in_progress(project_path: str) -> bool:
 _ordered_remotes = ordered_remotes
 
 
-def _is_ancestor(maybe_ancestor: str, descendant: str, cwd: str) -> bool:
-    """Return True if *maybe_ancestor* is an ancestor of (or equal to) *descendant*."""
+def _set_rebase_error(result_meta: Optional[Dict[str, str]], code: str, detail: str) -> None:
+    """Record a structured failure reason for the caller's error message."""
+    if result_meta is not None:
+        result_meta["error"] = code
+        result_meta["detail"] = detail
+
+
+def _capture_rebase_baseline(
+    target_ref: str, project_path: str,
+) -> Optional[Tuple[str, int]]:
+    """Snapshot ``(head_sha, unique_commit_count)`` before a rebase.
+
+    The unique-commit count is ``git rev-list --count <target_ref>..HEAD``
+    against the freshly fetched target ref — the number of commits GitHub
+    would show on the PR. A correct rebase can only keep or shrink this
+    number (patch-identical commits get dropped); growth means the rebase
+    resurrected already-merged commits. Returns None if the snapshot itself
+    fails (callers then skip the sanity gate rather than block the rebase).
+    """
+    try:
+        head = _run_git(
+            ["git", "rev-parse", "HEAD"], cwd=project_path, timeout=10,
+        ).strip()
+        count = int(_run_git(
+            ["git", "rev-list", "--count", f"{target_ref}..HEAD"],
+            cwd=project_path, timeout=30,
+        ).strip())
+        return head, count
+    except (RuntimeError, ValueError, subprocess.TimeoutExpired, OSError) as e:
+        print(f"[claude_step] Could not capture rebase baseline: {e}", file=sys.stderr)
+        return None
+
+
+def _verify_rebase_result(
+    target_ref: str,
+    project_path: str,
+    pre_count: int,
+) -> Optional[str]:
+    """Sanity-check a completed rebase before anything gets pushed.
+
+    Verifies two invariants and returns a human-readable violation
+    description (None when the rebase is sane):
+
+    1. The branch sits on the target ref's current tip
+       (``merge-base HEAD <target_ref>`` == ``rev-parse <target_ref>``).
+    2. The branch's unique-commit count did not grow
+       (``rev-list --count <target_ref>..HEAD`` <= *pre_count*).
+
+    Incident reference: PR #2309, where a rebase onto a stale ref rewrote
+    33 already-merged upstream commits into the branch (20 → 53 commits)
+    and was force-pushed unchecked.
+    """
+    try:
+        target_tip = _run_git(
+            ["git", "rev-parse", target_ref], cwd=project_path, timeout=10,
+        ).strip()
+        merge_base = _run_git(
+            ["git", "merge-base", "HEAD", target_ref], cwd=project_path, timeout=10,
+        ).strip()
+        post_count = int(_run_git(
+            ["git", "rev-list", "--count", f"{target_ref}..HEAD"],
+            cwd=project_path, timeout=30,
+        ).strip())
+    except (RuntimeError, ValueError, subprocess.TimeoutExpired, OSError) as e:
+        return f"post-rebase sanity check could not run: {e}"
+
+    if merge_base != target_tip:
+        return (
+            f"branch is not based on the current tip of {target_ref} "
+            f"(base {merge_base[:12]}, tip {target_tip[:12]}) — the target "
+            f"ref was stale or the rebase used the wrong base"
+        )
+    if post_count > pre_count:
+        return (
+            f"rebase grew the branch from {pre_count} to {post_count} unique "
+            f"commits — it resurrected commits already merged on {target_ref}"
+        )
+    return None
+
+
+def _restore_branch_head(project_path: str, pre_head: str) -> None:
+    """Hard-reset the checked-out branch back to its pre-rebase commit."""
     try:
         _run_git(
-            ["git", "merge-base", "--is-ancestor", maybe_ancestor, descendant],
-            cwd=cwd, timeout=10,
+            ["git", "reset", "--hard", pre_head], cwd=project_path, timeout=30,
         )
-        return True
-    except (RuntimeError, subprocess.TimeoutExpired, OSError):
-        return False
-
-
-def _prefetch_all_remotes(
-    base: str,
-    project_path: str,
-    preferred_remote: Optional[str] = None,
-    head_remote: Optional[str] = None,
-) -> None:
-    """Eagerly fetch the base branch from all relevant remotes.
-
-    Ensures every remote tracking ref is current before the rebase loop
-    starts, so that ancestry checks and --onto calculations use fresh data.
-    Failures are logged but never prevent the rebase attempt.
-    """
-    remotes_to_fetch: List[str] = list(
-        _ordered_remotes(preferred_remote, cwd=project_path)
-    )
-    if head_remote and head_remote not in remotes_to_fetch:
-        remotes_to_fetch.append(head_remote)
-    for remote in remotes_to_fetch:
-        try:
-            _fetch_branch(remote, base, cwd=project_path)
-        except _REBASE_EXCEPTIONS as e:
-            print(f"[claude_step] Pre-fetch {remote}/{base} failed (non-fatal): {e}",
-                  file=sys.stderr)
-
+    except _REBASE_EXCEPTIONS as e:
+        print(
+            f"[claude_step] Could not restore pre-rebase head {pre_head[:12]}: {e}",
+            file=sys.stderr,
+        )
 
 
 def _rebase_onto_target(
@@ -167,70 +222,98 @@ def _rebase_onto_target(
     preferred_remote: Optional[str] = None,
     head_remote: Optional[str] = None,
     on_conflict: Optional[Callable[[str], bool]] = None,
+    result_meta: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
-    """Rebase onto target branch, trying *preferred_remote* first.
+    """Rebase the checked-out PR branch onto the PR's target branch.
 
-    When *preferred_remote* is given (e.g. the remote matching the PR's
-    target repository), it is tried before the default ``origin`` /
-    ``upstream`` fallbacks.  When *head_remote* is known and differs from
-    the target remote, uses ``--onto`` to replay only the PR's commits.
+    The rebase target is strictly ``{preferred_remote}/{base}`` — the remote
+    matching the PR's base repository — and its tracking ref must be
+    freshly fetched. There is deliberately no fallback to other remotes and
+    no proceeding on a failed fetch: rebasing onto a fork's (or stale)
+    copy of the base branch rewrites already-merged upstream commits into
+    the PR (incident: PR #2309, 33 duplicated commits force-pushed).
 
-    All relevant remotes are pre-fetched before the rebase loop so that
-    tracking refs are guaranteed fresh for ancestry checks and --onto.
+    A plain ``git rebase`` onto the fresh target ref replays exactly the
+    PR's own commits — git cuts at ``merge-base(HEAD, target)`` and drops
+    patch-identical commits — so no ``--onto`` cut point is needed.
+    *head_remote* is accepted for backward compatibility but no longer
+    influences the rebase.
+
+    After a successful rebase, a sanity gate verifies the branch sits on
+    the target's current tip and that its unique-commit count did not grow;
+    on violation the branch is restored to its pre-rebase commit and the
+    rebase is reported as failed.
 
     Args:
-        on_conflict: Optional callback invoked when a rebase fails and a
-            rebase-in-progress is detected (i.e. conflicts exist).
-            Receives ``project_path`` and should return True if the
-            conflicts were resolved and the rebase completed, False
-            otherwise.  When None (default), conflicts cause an immediate
-            abort.
+        on_conflict: Optional callback invoked when the rebase stops on
+            conflicts. Receives ``project_path`` and returns True if the
+            conflicts were resolved and the rebase completed. When None
+            (default), conflicts cause an immediate abort.
+        result_meta: Optional dict populated with ``error`` (stable code:
+            ``no_base_remote`` / ``fetch_failed`` / ``rebase_failed`` /
+            ``sanity_check_failed``) and ``detail`` on failure.
 
     Returns:
-        Remote name used (e.g. "origin" or "upstream") on success, None on failure.
+        The remote name used on success, None on failure.
     """
-    _prefetch_all_remotes(base, project_path, preferred_remote, head_remote)
+    if not preferred_remote:
+        detail = (
+            "no git remote matches the PR's base repository — refusing to "
+            "rebase onto a guessed remote (a fork's copy of the base branch "
+            "may be stale). Add one with `git remote add <name> <url>`."
+        )
+        print(f"[claude_step] {detail}", file=sys.stderr)
+        _set_rebase_error(result_meta, "no_base_remote", detail)
+        return None
 
-    for remote in _ordered_remotes(preferred_remote, cwd=project_path):
-        if head_remote and head_remote != remote:
-            # Only use --onto when the fork has genuinely diverged from
-            # upstream (i.e. has commits that upstream doesn't).  When the
-            # fork is simply behind, --onto replays upstream commits that
-            # already exist on the target, causing spurious conflicts in
-            # files the PR never touched.
-            use_onto = not _is_ancestor(
-                f"{head_remote}/{base}", f"{remote}/{base}", project_path,
-            )
-            if use_onto:
-                try:
-                    _run_git(
-                        ["git", "rebase", "--onto", f"{remote}/{base}",
-                         f"{head_remote}/{base}", "--autostash"],
-                        cwd=project_path,
-                    )
-                    return remote
-                except _REBASE_EXCEPTIONS as e:
-                    print(f"[claude_step] --onto rebase failed: {e}", file=sys.stderr)
-                    if on_conflict and has_rebase_in_progress(project_path):
-                        if on_conflict(project_path):
-                            return remote
-                    _abort_rebase_safely(project_path)
-                    # Fall through to plain rebase
+    remote = preferred_remote
+    target_ref = f"{remote}/{base}"
 
-        # Fallback: plain rebase
-        try:
-            _run_git(
-                ["git", "rebase", "--autostash", f"{remote}/{base}"],
-                cwd=project_path,
-            )
-            return remote
-        except _REBASE_EXCEPTIONS as e:
-            print(f"[claude_step] Rebase onto {remote}/{base} failed: {e}", file=sys.stderr)
-            if on_conflict and has_rebase_in_progress(project_path):
-                if on_conflict(project_path):
-                    return remote
+    # Mandatory freshness: a stale tracking ref is exactly how a rebase
+    # rebases the branch onto an old base and resurrects merged commits.
+    try:
+        _fetch_branch(remote, base, cwd=project_path)
+    except _REBASE_EXCEPTIONS as e:
+        detail = f"fetch of {target_ref} failed: {e}"
+        print(
+            f"[claude_step] {detail} — aborting rebase instead of using a "
+            f"possibly-stale ref",
+            file=sys.stderr,
+        )
+        _set_rebase_error(result_meta, "fetch_failed", detail)
+        return None
+
+    baseline = _capture_rebase_baseline(target_ref, project_path)
+
+    try:
+        _run_git(
+            ["git", "rebase", "--autostash", target_ref],
+            cwd=project_path,
+        )
+    except _REBASE_EXCEPTIONS as e:
+        print(f"[claude_step] Rebase onto {target_ref} failed: {e}", file=sys.stderr)
+        resolved = False
+        if on_conflict and has_rebase_in_progress(project_path):
+            resolved = on_conflict(project_path)
+        if not resolved:
             _abort_rebase_safely(project_path)
-    return None
+            _set_rebase_error(result_meta, "rebase_failed", str(e))
+            return None
+
+    if baseline is not None:
+        pre_head, pre_count = baseline
+        violation = _verify_rebase_result(target_ref, project_path, pre_count)
+        if violation:
+            print(
+                f"[claude_step] Post-rebase sanity check failed: {violation} — "
+                f"restoring {pre_head[:12]} and refusing to push",
+                file=sys.stderr,
+            )
+            _restore_branch_head(project_path, pre_head)
+            _set_rebase_error(result_meta, "sanity_check_failed", violation)
+            return None
+
+    return remote
 
 
 def strip_cli_noise(text: str) -> str:

--- a/koan/app/git_prep.py
+++ b/koan/app/git_prep.py
@@ -159,7 +159,7 @@ def _sync_secondary_remotes(
     """Fetch base branch from all remotes besides the primary.
 
     Ensures remote tracking refs are fresh for fork-aware operations
-    (e.g., --onto rebase needs both origin/ and upstream/ refs current).
+    (e.g., locating a PR head branch across fork remotes).
     Non-fatal — failures are logged but never abort the mission.
     """
     rc, stdout, _ = run_git("remote", cwd=project_path)
@@ -419,8 +419,8 @@ def prepare_project_branch(
             result.error = f"reset failed: {stderr}"
             return result
 
-    # Sync secondary remotes so fork-aware operations (--onto rebase,
-    # _is_ancestor checks) see fresh tracking refs for every remote.
+    # Sync secondary remotes so fork-aware operations (e.g. locating a PR
+    # head branch across forks) see fresh tracking refs for every remote.
     _sync_secondary_remotes(base_branch, remote, project_path)
 
     return result

--- a/koan/app/pr_review.py
+++ b/koan/app/pr_review.py
@@ -16,7 +16,7 @@ import json
 import os
 import re
 from pathlib import Path
-from typing import Optional, Tuple, List
+from typing import Dict, List, Optional, Tuple
 
 from app.claude_step import (
     _force_push,
@@ -229,15 +229,22 @@ def run_pr_review(
     except Exception as e:
         return False, f"Failed to checkout branch {branch}: {e}"
 
-    # Rebase onto the upstream target branch (prefers the matched remote)
+    # Rebase onto the PR's target branch (strictly the matched base remote)
+    rebase_meta: Dict[str, str] = {}
     rebase_remote = _rebase_onto_target(
         base, project_path, preferred_remote=base_remote,
         head_remote=head_remote,
+        result_meta=rebase_meta,
     )
     if rebase_remote:
         actions_log.append(f"Rebased `{branch}` onto `{rebase_remote}/{base}`")
     else:
-        return False, f"Rebase conflict on {base} (tried origin and upstream)"
+        error_code = rebase_meta.get("error", "rebase_failed")
+        detail = rebase_meta.get("detail", "unresolved conflicts")
+        return False, (
+            f"[{error_code}] Rebase of `{branch}` onto "
+            f"`{base_remote or '?'}/{base}` aborted: {detail}"
+        )
 
     # ── Step 3: Address review feedback via Claude Code ───────────────
     has_review_feedback = bool(

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -814,24 +814,31 @@ def _run_rebase_impl(
     # ── Step 3: Rebase onto target branch ─────────────────────────────
     print(f"[rebase] Rebasing `{branch}` onto `{base}`", flush=True)
     notify_fn(f"Rebasing `{branch}` onto `{base}`...")
+    rebase_meta: Dict[str, str] = {}
     rebase_remote = _rebase_with_conflict_resolution(
         base, project_path, context, actions_log,
         notify_fn=notify_fn, skill_dir=skill_dir,
         max_conflict_rounds=get_rebase_max_conflict_rounds(),
         preferred_remote=base_remote,
         head_remote=effective_head_remote,
+        result_meta=rebase_meta,
     )
     if rebase_remote:
         actions_log.append(f"Rebased `{branch}` onto `{rebase_remote}/{base}`")
     else:
         _safe_checkout(original_branch, project_path)
-        attempted_remotes = _ordered_remotes(base_remote, cwd=project_path)
-        attempted = ", ".join(attempted_remotes) if attempted_remotes else "none"
-        guidance = _build_rebase_recovery_guidance(project_path)
+        error_code = rebase_meta.get("error", "rebase_failed")
+        detail = rebase_meta.get("detail", "")
+        if error_code == "rebase_failed":
+            guidance = _build_rebase_recovery_guidance(project_path)
+            return False, (
+                "[conflict_unresolved] "
+                f"Rebase failed on `{base_remote or '?'}/{base}`. "
+                f"Could not resolve conflicts.\n{guidance}"
+            )
         return False, (
-            "[conflict_unresolved] "
-            f"Rebase failed on `{base}` (tried: {attempted}). "
-            f"Could not resolve conflicts.\n{guidance}"
+            f"[{error_code}] Rebase of `{branch}` onto "
+            f"`{base_remote or '?'}/{base}` aborted before any push: {detail}"
         )
 
     # Save the clean rebased state before optional review-feedback edits.
@@ -1303,20 +1310,22 @@ def _rebase_with_conflict_resolution(
     max_conflict_rounds: int = 10,
     preferred_remote: Optional[str] = None,
     head_remote: Optional[str] = None,
+    result_meta: Optional[Dict[str, str]] = None,
 ) -> Optional[str]:
     """Rebase onto target branch, resolving conflicts via Claude if needed.
 
-    Delegates to :func:`claude_step._rebase_onto_target` for the core
-    fetch-and-rebase loop, injecting a conflict-resolution callback that
+    Delegates to :func:`claude_step._rebase_onto_target` for the strict
+    fetch-and-rebase flow, injecting a conflict-resolution callback that
     invokes Claude to resolve conflicted files.
 
     When ``git rebase`` hits conflicts, Claude is invoked to resolve the
     conflicted files, they are staged, and the rebase is continued.  This
-    loop repeats for up to *max_conflict_rounds* per remote (one round per
+    loop repeats for up to *max_conflict_rounds* rounds (one round per
     conflicting commit).
 
     Returns:
-        Remote name used (e.g. "origin") on success, None on total failure.
+        Remote name used (e.g. "origin") on success, None on total failure
+        (*result_meta*, when given, then carries ``error``/``detail``).
     """
 
     def _on_conflict(proj_path: str) -> bool:
@@ -1333,6 +1342,7 @@ def _rebase_with_conflict_resolution(
         preferred_remote=preferred_remote,
         head_remote=head_remote,
         on_conflict=_on_conflict,
+        result_meta=result_meta,
     )
 
 

--- a/koan/tests/test_claude_step.py
+++ b/koan/tests/test_claude_step.py
@@ -12,10 +12,10 @@ import pytest
 
 from app.claude_step import (
     StepResult,
-    _is_ancestor,
-    _prefetch_all_remotes,
+    _capture_rebase_baseline,
     _rebase_onto_target,
     _run_git,
+    _verify_rebase_result,
     commit_if_changes,
     is_hook_rejection,
     resolve_pr_location,
@@ -140,86 +140,212 @@ class TestStripCliNoise:
 # ---------- _rebase_onto_target ----------
 
 
+def _fake_rebase_git(
+    rebase_error=None,
+    fetch_error=None,
+    pre_count=2,
+    post_count=None,
+    merge_base_matches=True,
+):
+    """Build a ``_run_git`` side_effect simulating a rebase flow.
+
+    Returns ``(side_effect, state)`` where *state* records the commands
+    seen and whether the rebase command ran. ``rev-list --count`` returns
+    *pre_count* before the rebase and *post_count* (when given) after it,
+    letting tests exercise the post-rebase sanity gate.
+    """
+    state = {"rebased": False, "cmds": []}
+
+    def side_effect(cmd, **kwargs):
+        state["cmds"].append(cmd)
+        if "fetch" in cmd:
+            if fetch_error:
+                raise fetch_error
+            return ""
+        if "rebase" in cmd:
+            if rebase_error:
+                raise rebase_error
+            state["rebased"] = True
+            return ""
+        if "rev-parse" in cmd:
+            return "prehead" if cmd[-1] == "HEAD" else "targettip"
+        if "merge-base" in cmd:
+            return "targettip" if merge_base_matches else "staletip"
+        if "rev-list" in cmd:
+            if state["rebased"] and post_count is not None:
+                return str(post_count)
+            return str(pre_count)
+        return ""
+
+    return side_effect
+
+
 class TestRebaseOntoTarget:
-    """Tests for _rebase_onto_target."""
+    """Tests for _rebase_onto_target — strict-target contract."""
 
     @patch("app.claude_step._run_git")
-    def test_origin_success(self, mock_git):
-        result = _rebase_onto_target("main", "/project")
-        assert result == "origin"
-        mock_git.assert_any_call(
-            ["git", "fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"],
-            cwd="/project", timeout=60,
+    def test_no_base_remote_fails_without_touching_git(self, mock_git):
+        """No remote matching the PR's base repo → fail, never guess."""
+        meta = {}
+        result = _rebase_onto_target("main", "/project", result_meta=meta)
+        assert result is None
+        assert meta["error"] == "no_base_remote"
+        assert "git remote add" in meta["detail"]
+        mock_git.assert_not_called()
+
+    @patch("app.claude_step._run_git")
+    def test_success_plain_rebase_on_target_remote(self, mock_git):
+        mock_git.side_effect = _fake_rebase_git()
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
         )
+        assert result == "upstream"
         mock_git.assert_any_call(
             ["git", "fetch", "upstream", "+refs/heads/main:refs/remotes/upstream/main"],
             cwd="/project", timeout=60,
         )
+        rebase_cmds = [
+            c[0][0] for c in mock_git.call_args_list if "rebase" in c[0][0]
+        ]
+        assert rebase_cmds == [["git", "rebase", "--autostash", "upstream/main"]]
 
     @patch("app.cli_exec.subprocess.run")
     @patch("app.claude_step._run_git")
-    def test_origin_fails_upstream_succeeds(self, mock_git, mock_subprocess):
-        def side_effect(cmd, **kwargs):
-            if "rebase" in cmd and any("origin" in a for a in cmd):
-                raise RuntimeError("rebase failed")
+    def test_never_falls_back_to_other_remotes(self, mock_git, mock_subprocess):
+        """A failed rebase on the target remote must not retry other remotes.
+
+        Regression: PR #2309 — the old fallback loop rebased onto a fork's
+        stale main and resurrected 33 already-merged commits.
+        """
+        def selective_fail(cmd, **kwargs):
+            if "rebase" in cmd:
+                raise RuntimeError("conflict")
             return ""
-
-        mock_git.side_effect = side_effect
-        result = _rebase_onto_target("main", "/project")
-        assert result == "upstream"
-
-    @patch("app.cli_exec.subprocess.run")
-    @patch("app.claude_step._run_git")
-    def test_both_fail_returns_none(self, mock_git, mock_subprocess):
-        mock_git.side_effect = RuntimeError("fail")
-        result = _rebase_onto_target("main", "/project")
+        mock_git.side_effect = selective_fail
+        meta = {}
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream", result_meta=meta,
+        )
         assert result is None
+        assert meta["error"] == "rebase_failed"
+        rebase_cmds = [
+            c[0][0] for c in mock_git.call_args_list if "rebase" in c[0][0]
+        ]
+        assert len(rebase_cmds) == 1
+        assert rebase_cmds[0][-1] == "upstream/main"
+
+    @patch("app.claude_step._run_git")
+    def test_fetch_failure_fails_closed(self, mock_git, capsys):
+        """A failed fetch of the target ref aborts — no rebase on stale refs."""
+        mock_git.side_effect = _fake_rebase_git(
+            fetch_error=RuntimeError("network down"),
+        )
+        meta = {}
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream", result_meta=meta,
+        )
+        assert result is None
+        assert meta["error"] == "fetch_failed"
+        assert not any(
+            "rebase" in c[0][0] for c in mock_git.call_args_list
+        )
+        captured = capsys.readouterr()
+        assert "possibly-stale" in captured.err
+
+    @patch("app.claude_step.has_rebase_in_progress", return_value=True)
+    @patch("app.claude_step._run_git")
+    def test_conflict_callback_resolving_returns_remote(self, mock_git, mock_prog):
+        mock_git.side_effect = _fake_rebase_git(
+            rebase_error=RuntimeError("conflict"),
+        )
+        on_conflict = MagicMock(return_value=True)
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
+            on_conflict=on_conflict,
+        )
+        assert result == "upstream"
+        on_conflict.assert_called_once_with("/project")
 
     @patch("app.cli_exec.subprocess.run")
+    @patch("app.claude_step.has_rebase_in_progress", return_value=True)
     @patch("app.claude_step._run_git")
-    def test_rebase_abort_called_on_failure(self, mock_git, mock_subprocess):
-        def selective_fail(cmd, **kwargs):
-            if "rebase" in cmd:
-                raise RuntimeError("conflict")
-            return ""
-        mock_git.side_effect = selective_fail
-        _rebase_onto_target("main", "/project")
+    def test_conflict_callback_failing_aborts(
+        self, mock_git, mock_prog, mock_subprocess,
+    ):
+        mock_git.side_effect = _fake_rebase_git(
+            rebase_error=RuntimeError("conflict"),
+        )
+        meta = {}
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
+            on_conflict=MagicMock(return_value=False), result_meta=meta,
+        )
+        assert result is None
+        assert meta["error"] == "rebase_failed"
         abort_calls = [
-            c
-            for c in mock_subprocess.call_args_list
+            c for c in mock_subprocess.call_args_list
             if "rebase" in c[0][0] and "--abort" in c[0][0]
         ]
-        assert len(abort_calls) == 2
+        assert len(abort_calls) == 1
+        assert abort_calls[0][1].get("timeout", 0) > 0
 
-    @patch("app.cli_exec.subprocess.run")
     @patch("app.claude_step._run_git")
-    def test_rebase_abort_called_with_timeout(self, mock_git, mock_subprocess):
-        """git rebase --abort must have a timeout to prevent hangs in cleanup."""
-        def selective_fail(cmd, **kwargs):
-            if "rebase" in cmd:
-                raise RuntimeError("conflict")
-            return ""
-        mock_git.side_effect = selective_fail
-        _rebase_onto_target("main", "/project")
-        abort_calls = [
-            c
-            for c in mock_subprocess.call_args_list
-            if "rebase" in c[0][0] and "--abort" in c[0][0]
+    def test_sanity_gate_blocks_commit_growth(self, mock_git, capsys):
+        """A rebase that grows the unique-commit count must not survive.
+
+        Regression: PR #2309 went from 20 to 53 commits after a rebase onto
+        a stale ref and was force-pushed unchecked.
+        """
+        mock_git.side_effect = _fake_rebase_git(pre_count=20, post_count=53)
+        meta = {}
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream", result_meta=meta,
+        )
+        assert result is None
+        assert meta["error"] == "sanity_check_failed"
+        assert "20 to 53" in meta["detail"]
+        reset_cmds = [
+            c[0][0] for c in mock_git.call_args_list if "reset" in c[0][0]
         ]
-        assert len(abort_calls) >= 1
-        for call in abort_calls:
-            assert call[1].get("timeout", 0) > 0
+        assert reset_cmds == [["git", "reset", "--hard", "prehead"]]
+        assert "refusing to push" in capsys.readouterr().err
+
+    @patch("app.claude_step._run_git")
+    def test_sanity_gate_blocks_stale_base(self, mock_git):
+        """Post-rebase, the branch must sit on the target's current tip."""
+        mock_git.side_effect = _fake_rebase_git(merge_base_matches=False)
+        meta = {}
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream", result_meta=meta,
+        )
+        assert result is None
+        assert meta["error"] == "sanity_check_failed"
+        assert "stale" in meta["detail"]
+
+    @patch("app.claude_step._run_git")
+    def test_head_remote_never_used_for_onto(self, mock_git):
+        """head_remote is accepted for compat but must not produce --onto."""
+        mock_git.side_effect = _fake_rebase_git()
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
+            head_remote="origin",
+        )
+        assert result == "upstream"
+        for c in mock_git.call_args_list:
+            assert "--onto" not in c[0][0]
+            if "rebase" in c[0][0]:
+                assert "origin/main" not in c[0][0]
 
     @patch("app.cli_exec.subprocess.run")
     @patch("app.claude_step._run_git")
     def test_timeout_caught_and_logged(self, mock_git, mock_subprocess, capsys):
         """TimeoutExpired should be caught (not just Exception) and logged."""
-        def selective_fail(cmd, **kwargs):
-            if "rebase" in cmd:
-                raise subprocess.TimeoutExpired("git", 60)
-            return ""
-        mock_git.side_effect = selective_fail
-        result = _rebase_onto_target("main", "/project")
+        mock_git.side_effect = _fake_rebase_git(
+            rebase_error=subprocess.TimeoutExpired("git", 60),
+        )
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
+        )
         assert result is None
         captured = capsys.readouterr()
         assert "Rebase onto" in captured.err
@@ -229,12 +355,12 @@ class TestRebaseOntoTarget:
     @patch("app.claude_step._run_git")
     def test_os_error_caught_and_logged(self, mock_git, mock_subprocess, capsys):
         """OSError (e.g. git not found) should be caught and logged."""
-        def selective_fail(cmd, **kwargs):
-            if "rebase" in cmd:
-                raise OSError("No such file or directory: 'git'")
-            return ""
-        mock_git.side_effect = selective_fail
-        result = _rebase_onto_target("main", "/project")
+        mock_git.side_effect = _fake_rebase_git(
+            rebase_error=OSError("No such file or directory: 'git'"),
+        )
+        result = _rebase_onto_target(
+            "main", "/project", preferred_remote="upstream",
+        )
         assert result is None
         captured = capsys.readouterr()
         assert "Rebase onto" in captured.err
@@ -245,169 +371,156 @@ class TestRebaseOntoTarget:
         """Unexpected exceptions (e.g. ValueError) should propagate, not be swallowed."""
         mock_git.side_effect = ValueError("unexpected error")
         with pytest.raises(ValueError, match="unexpected"):
-            _rebase_onto_target("main", "/project")
+            _rebase_onto_target(
+                "main", "/project", preferred_remote="upstream",
+            )
 
 
-# ---------- _is_ancestor ----------
+# ---------- _capture_rebase_baseline / _verify_rebase_result ----------
 
 
-class TestIsAncestor:
-    """Tests for _is_ancestor helper."""
-
-    @patch("app.claude_step._run_git")
-    def test_returns_true_when_ancestor(self, mock_git):
-        mock_git.return_value = ""
-        assert _is_ancestor("origin/main", "upstream/main", "/project") is True
-        mock_git.assert_called_once()
-        cmd = mock_git.call_args[0][0]
-        assert cmd == ["git", "merge-base", "--is-ancestor", "origin/main", "upstream/main"]
+class TestCaptureRebaseBaseline:
+    """Tests for the pre-rebase snapshot helper."""
 
     @patch("app.claude_step._run_git")
-    def test_returns_false_when_not_ancestor(self, mock_git):
-        mock_git.side_effect = RuntimeError("exit 1")
-        assert _is_ancestor("origin/main", "upstream/main", "/project") is False
+    def test_returns_head_and_count(self, mock_git):
+        mock_git.side_effect = ["abc123\n", "20\n"]
+        assert _capture_rebase_baseline("upstream/main", "/project") == ("abc123", 20)
 
     @patch("app.claude_step._run_git")
-    def test_returns_false_on_timeout(self, mock_git):
-        mock_git.side_effect = subprocess.TimeoutExpired("git", 10)
-        assert _is_ancestor("origin/main", "upstream/main", "/project") is False
+    def test_returns_none_on_git_error(self, mock_git):
+        mock_git.side_effect = RuntimeError("boom")
+        assert _capture_rebase_baseline("upstream/main", "/project") is None
 
-
-# ---------- _rebase_onto_target with head_remote ----------
-
-
-class TestRebaseOntoTargetForkAware:
-    """Tests for --onto logic when head_remote (fork) differs from target."""
-
-    @patch("app.claude_step._is_ancestor", return_value=True)
     @patch("app.claude_step._run_git")
-    def test_stale_fork_skips_onto_uses_plain_rebase(self, mock_git, mock_ancestor):
-        """When fork/main is ancestor of upstream/main, --onto is skipped.
+    def test_returns_none_on_unparseable_count(self, mock_git):
+        mock_git.side_effect = ["abc123\n", "not-a-number\n"]
+        assert _capture_rebase_baseline("upstream/main", "/project") is None
 
-        This is the bug scenario: fork is simply behind upstream. Using
-        --onto would replay upstream commits that already exist, causing
-        spurious conflicts in files the PR never touched.
+
+class TestVerifyRebaseResult:
+    """Tests for the post-rebase sanity gate."""
+
+    @patch("app.claude_step._run_git")
+    def test_sane_rebase_passes(self, mock_git):
+        mock_git.side_effect = ["tip\n", "tip\n", "18\n"]
+        assert _verify_rebase_result("upstream/main", "/project", 20) is None
+
+    @patch("app.claude_step._run_git")
+    def test_commit_growth_is_a_violation(self, mock_git):
+        mock_git.side_effect = ["tip\n", "tip\n", "53\n"]
+        violation = _verify_rebase_result("upstream/main", "/project", 20)
+        assert violation is not None
+        assert "20 to 53" in violation
+
+    @patch("app.claude_step._run_git")
+    def test_not_on_target_tip_is_a_violation(self, mock_git):
+        mock_git.side_effect = ["tip\n", "oldbase\n", "20\n"]
+        violation = _verify_rebase_result("upstream/main", "/project", 20)
+        assert violation is not None
+        assert "not based on the current tip" in violation
+
+    @patch("app.claude_step._run_git")
+    def test_check_error_reported_as_violation(self, mock_git):
+        """If the gate itself can't run, that is a violation, not a pass."""
+        mock_git.side_effect = RuntimeError("boom")
+        violation = _verify_rebase_result("upstream/main", "/project", 20)
+        assert violation is not None
+        assert "could not run" in violation
+
+
+# ---------- _rebase_onto_target with real git repos ----------
+
+
+def _git(cwd, *args):
+    """Run git in *cwd*, raising on failure."""
+    subprocess.run(
+        ["git", "-c", "user.email=t@t", "-c", "user.name=t",
+         "-c", "commit.gpgsign=false", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    )
+
+
+def _git_out(cwd, *args) -> str:
+    return subprocess.run(
+        ["git", *args], cwd=cwd, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _commit_file(repo, name, content, message):
+    (repo / name).write_text(content)
+    _git(repo, "add", name)
+    _git(repo, "commit", "-m", message)
+
+
+class TestRebaseOntoTargetRealGit:
+    """End-to-end tests of the strict rebase flow against real repos."""
+
+    @pytest.fixture
+    def work_repo(self, tmp_path):
+        """A bare base repo, a seed clone advancing it, and a work clone.
+
+        The work clone's remote is named ``target`` and holds a checked-out
+        ``feature`` branch with 2 commits, forked before the base advanced
+        by 1 more commit.
         """
+        bare = tmp_path / "base.git"
+        bare.mkdir()
+        _git(bare, "init", "--bare", "-b", "main", ".")
+
+        seed = tmp_path / "seed"
+        _git(tmp_path, "clone", str(bare), "seed")
+        _commit_file(seed, "a.txt", "one", "c1")
+        _git(seed, "push", "origin", "main")
+
+        work = tmp_path / "work"
+        _git(tmp_path, "clone", "-o", "target", str(bare), "work")
+        _git(work, "config", "user.email", "t@t")
+        _git(work, "config", "user.name", "t")
+        _git(work, "checkout", "-b", "feature")
+        _commit_file(work, "f1.txt", "f1", "feature 1")
+        _commit_file(work, "f2.txt", "f2", "feature 2")
+
+        # Advance the base after the feature branch forked
+        _commit_file(seed, "b.txt", "two", "c2")
+        _git(seed, "push", "origin", "main")
+        return work
+
+    def test_happy_path_rebases_onto_fresh_tip(self, work_repo):
         result = _rebase_onto_target(
-            "main", "/project",
-            preferred_remote="upstream",
-            head_remote="origin",
+            "main", str(work_repo), preferred_remote="target",
         )
-        assert result == "upstream"
-        # Should have fetched upstream/main and origin/main, then plain rebase
-        rebase_calls = [
-            c for c in mock_git.call_args_list
-            if any("rebase" in str(a) for a in c[0][0])
-        ]
-        assert len(rebase_calls) == 1
-        rebase_cmd = rebase_calls[0][0][0]
-        assert "--onto" not in rebase_cmd
+        assert result == "target"
+        assert _git_out(work_repo, "rev-list", "--count", "target/main..HEAD") == "2"
+        assert _git_out(work_repo, "merge-base", "HEAD", "target/main") == \
+            _git_out(work_repo, "rev-parse", "target/main")
 
-    @patch("app.claude_step._is_ancestor", return_value=False)
-    @patch("app.claude_step._run_git")
-    def test_diverged_fork_uses_onto(self, mock_git, mock_ancestor):
-        """When fork/main has diverged from upstream/main, --onto is used."""
+    def test_unreachable_remote_fails_closed(self, work_repo, tmp_path):
+        """If the target can't be fetched, no rebase happens on stale refs."""
+        pre_head = _git_out(work_repo, "rev-parse", "HEAD")
+        _git(work_repo, "remote", "set-url", "target", str(tmp_path / "gone.git"))
+        meta = {}
         result = _rebase_onto_target(
-            "main", "/project",
-            preferred_remote="upstream",
-            head_remote="origin",
+            "main", str(work_repo), preferred_remote="target", result_meta=meta,
         )
-        assert result == "upstream"
-        rebase_calls = [
-            c for c in mock_git.call_args_list
-            if any("rebase" in str(a) for a in c[0][0])
-        ]
-        assert len(rebase_calls) == 1
-        rebase_cmd = rebase_calls[0][0][0]
-        assert "--onto" in rebase_cmd
-        assert "upstream/main" in rebase_cmd
-        assert "origin/main" in rebase_cmd
+        assert result is None
+        assert meta["error"] == "fetch_failed"
+        assert _git_out(work_repo, "rev-parse", "HEAD") == pre_head
 
-    @patch("app.claude_step._run_git")
-    def test_head_remote_fetch_fails_falls_through(self, mock_git):
-        """When fetching fork's base branch fails, falls through to plain rebase."""
-        def side_effect(cmd, **kwargs):
-            if "origin" in cmd and "fetch" in cmd[1]:
-                raise RuntimeError("fetch failed")
-            return ""
-        mock_git.side_effect = side_effect
-        result = _rebase_onto_target(
-            "main", "/project",
-            preferred_remote="upstream",
-            head_remote="origin",
-        )
-        assert result == "upstream"
-        rebase_calls = [
-            c for c in mock_git.call_args_list
-            if any("rebase" in str(a) for a in c[0][0])
-        ]
-        assert len(rebase_calls) == 1
-        rebase_cmd = rebase_calls[0][0][0]
-        assert "--onto" not in rebase_cmd
+    def test_verify_flags_branch_left_behind_target(self, work_repo):
+        """_verify_rebase_result catches a branch based below the target tip."""
+        _git(work_repo, "fetch", "target",
+             "+refs/heads/main:refs/remotes/target/main")
+        # No rebase ran: feature still forks from c1 while target/main is at c2
+        violation = _verify_rebase_result("target/main", str(work_repo), 2)
+        assert violation is not None
+        assert "not based on the current tip" in violation
 
-
-# ---------- _prefetch_all_remotes ----------
-
-
-class TestPrefetchAllRemotes:
-    """Tests for _prefetch_all_remotes — eager base branch sync."""
-
-    @patch("app.claude_step._run_git")
-    def test_fetches_origin_and_upstream(self, mock_git):
-        _prefetch_all_remotes("main", "/project")
-        assert mock_git.call_count == 2
-        mock_git.assert_any_call(
-            ["git", "fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"],
-            cwd="/project", timeout=60,
-        )
-        mock_git.assert_any_call(
-            ["git", "fetch", "upstream", "+refs/heads/main:refs/remotes/upstream/main"],
-            cwd="/project", timeout=60,
-        )
-
-    @patch("app.claude_step._run_git")
-    def test_includes_head_remote(self, mock_git):
-        _prefetch_all_remotes("main", "/project", head_remote="myfork")
-        fetched = [c[0][0][2] for c in mock_git.call_args_list]
-        assert "myfork" in fetched
-        assert "origin" in fetched
-        assert "upstream" in fetched
-
-    @patch("app.claude_step._run_git")
-    def test_preferred_remote_first(self, mock_git):
-        _prefetch_all_remotes("main", "/project", preferred_remote="upstream")
-        first_call_remote = mock_git.call_args_list[0][0][0][2]
-        assert first_call_remote == "upstream"
-
-    @patch("app.claude_step._run_git")
-    def test_no_duplicate_when_head_in_ordered(self, mock_git):
-        _prefetch_all_remotes("main", "/project", head_remote="origin")
-        assert mock_git.call_count == 2
-
-    @patch("app.claude_step._run_git")
-    def test_failure_is_nonfatal(self, mock_git, capsys):
-        mock_git.side_effect = RuntimeError("network down")
-        _prefetch_all_remotes("main", "/project")
-        captured = capsys.readouterr()
-        assert "Pre-fetch" in captured.err
-        assert "non-fatal" in captured.err
-
-    @patch("app.claude_step._run_git")
-    def test_timeout_is_nonfatal(self, mock_git, capsys):
-        mock_git.side_effect = subprocess.TimeoutExpired("git", 60)
-        _prefetch_all_remotes("main", "/project")
-        captured = capsys.readouterr()
-        assert "Pre-fetch" in captured.err
-
-    @patch("app.claude_step._ordered_remotes", return_value=["origin"])
-    @patch("app.claude_step._run_git")
-    def test_origin_only_repo_skips_upstream(self, mock_git, mock_remotes):
-        _prefetch_all_remotes("main", "/project")
-        mock_remotes.assert_called_once_with(None, cwd="/project")
-        mock_git.assert_called_once_with(
-            ["git", "fetch", "origin", "+refs/heads/main:refs/remotes/origin/main"],
-            cwd="/project", timeout=60,
-        )
+    def test_verify_passes_after_correct_rebase(self, work_repo):
+        assert _rebase_onto_target(
+            "main", str(work_repo), preferred_remote="target",
+        ) == "target"
+        assert _verify_rebase_result("target/main", str(work_repo), 2) is None
 
 
 

--- a/koan/tests/test_pr_review.py
+++ b/koan/tests/test_pr_review.py
@@ -379,26 +379,31 @@ class TestRebaseOntoTarget:
     @patch("app.claude_step._run_git")
     @patch("app.claude_step.subprocess.run")
     def test_success_returns_remote_name(self, mock_subproc, mock_git):
-        result = _rebase_onto_target("main", "/tmp/p")
+        def mock_run(cmd, **kwargs):
+            if "rev-parse" in cmd or "merge-base" in cmd:
+                return "tip"
+            if "rev-list" in cmd:
+                return "2"
+            return ""
+        mock_git.side_effect = mock_run
+        result = _rebase_onto_target("main", "/tmp/p", preferred_remote="origin")
         assert result == "origin"
 
     @patch("app.claude_step._run_git")
     @patch("app.claude_step.subprocess.run")
-    def test_falls_back_to_upstream(self, mock_subproc, mock_git):
-        """When origin rebase fails, tries upstream."""
-        def selective_fail(cmd, **kwargs):
-            if "rebase" in cmd and any("origin" in a for a in cmd):
-                raise RuntimeError("conflict on origin")
-            return ""
-        mock_git.side_effect = selective_fail
-        result = _rebase_onto_target("main", "/tmp/p")
-        assert result == "upstream"
+    def test_no_base_remote_returns_none(self, mock_subproc, mock_git):
+        """Without a resolved base remote there is no fallback guessing."""
+        meta = {}
+        result = _rebase_onto_target("main", "/tmp/p", result_meta=meta)
+        assert result is None
+        assert meta["error"] == "no_base_remote"
+        mock_git.assert_not_called()
 
     @patch("app.claude_step._run_git")
     @patch("app.claude_step.subprocess.run")
-    def test_all_remotes_fail_returns_none(self, mock_subproc, mock_git):
+    def test_rebase_failure_returns_none(self, mock_subproc, mock_git):
         mock_git.side_effect = RuntimeError("conflict")
-        result = _rebase_onto_target("main", "/tmp/p")
+        result = _rebase_onto_target("main", "/tmp/p", preferred_remote="origin")
         assert result is None
 
 
@@ -681,6 +686,13 @@ class TestBuildQualityReviewPrompt:
 # ---------------------------------------------------------------------------
 
 class TestRunPrReview:
+    @pytest.fixture(autouse=True)
+    def _base_remote_resolves(self, monkeypatch):
+        """The strict rebase contract requires a resolved base remote;
+        simulate a checkout whose ``origin`` matches the PR's base repo."""
+        monkeypatch.setattr(
+            "app.pr_review._find_remote_for_repo", lambda *a, **k: "origin",
+        )
     def _mock_pr_context(self):
         return json.dumps({
             "title": "Fix bug",

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -373,31 +373,46 @@ class TestGetConflictedFiles:
 # ---------------------------------------------------------------------------
 
 class TestRebaseOntoTarget:
-    def test_successful_rebase_on_origin(self):
-        mock_result = MagicMock(returncode=0, stdout="", stderr="")
-        with patch("app.claude_step.subprocess.run", return_value=mock_result):
-            result = _rebase_onto_target("main", "/project")
+    def test_successful_rebase_on_base_remote(self):
+        def mock_git(cmd, **kwargs):
+            if "rev-parse" in cmd or "merge-base" in cmd:
+                return "tip"
+            if "rev-list" in cmd:
+                return "2"
+            return ""
+
+        with patch("app.claude_step._run_git", side_effect=mock_git):
+            result = _rebase_onto_target(
+                "main", "/project", preferred_remote="origin",
+            )
             assert result == "origin"
 
-    def test_falls_back_to_upstream(self):
-        def mock_run(cmd, **kwargs):
-            result = MagicMock(returncode=0, stdout="", stderr="")
-            if "rebase" in cmd and any("origin" in a for a in cmd) and "--abort" not in cmd:
-                raise RuntimeError("rebase failed")
-            return result
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
-            result = _rebase_onto_target("main", "/project")
-            assert result == "upstream"
+    def test_no_base_remote_refuses_to_guess(self):
+        """Without a remote matching the PR's base repo, the rebase fails
+        instead of falling back to some other remote (PR #2309 regression)."""
+        meta = {}
+        with patch("app.claude_step._run_git") as mock_git:
+            result = _rebase_onto_target("main", "/project", result_meta=meta)
+        assert result is None
+        assert meta["error"] == "no_base_remote"
+        mock_git.assert_not_called()
 
     def test_returns_none_on_conflict(self):
-        def mock_run(cmd, **kwargs):
-            if "rebase" in cmd and "--abort" not in cmd:
+        def mock_git(cmd, **kwargs):
+            if "rebase" in cmd:
                 raise RuntimeError("conflict")
-            return MagicMock(returncode=0, stdout="", stderr="")
+            if "rev-parse" in cmd or "merge-base" in cmd:
+                return "tip"
+            if "rev-list" in cmd:
+                return "2"
+            return ""
 
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
-            result = _rebase_onto_target("main", "/project")
+        mock_abort = MagicMock(returncode=0, stdout="", stderr="")
+        with patch("app.claude_step._run_git", side_effect=mock_git), \
+             patch("app.claude_step.subprocess.run", return_value=mock_abort):
+            result = _rebase_onto_target(
+                "main", "/project", preferred_remote="origin",
+            )
             assert result is None
 
 
@@ -1589,22 +1604,34 @@ class TestRunRebase:
 
     @patch("app.rebase_pr._safe_checkout")
     @patch("app.rebase_pr.fetch_pr_context")
-    def test_rebase_conflict_lists_actual_attempted_remotes(self, mock_ctx, mock_safe):
+    def test_rebase_failure_surfaces_structured_reason(self, mock_ctx, mock_safe):
+        """A structured failure code from the rebase (e.g. the post-rebase
+        sanity gate) must reach the mission summary — and make clear that
+        nothing was pushed."""
         mock_ctx.return_value = {
             "title": "T", "body": "", "branch": "feat",
             "base": "main", "state": "", "author": "", "url": "",
             "diff": "", "review_comments": "", "reviews": "", "issue_comments": "",
         }
+
+        def fake_rebase(*args, **kwargs):
+            kwargs["result_meta"]["error"] = "sanity_check_failed"
+            kwargs["result_meta"]["detail"] = (
+                "rebase grew the branch from 20 to 53 unique commits"
+            )
+            return None
+
         notify = MagicMock()
         with patch("app.rebase_pr._get_current_branch", return_value="original"), \
              patch("app.rebase_pr._checkout_pr_branch"), \
-             patch("app.rebase_pr._ordered_remotes", return_value=["origin"]), \
-             patch("app.rebase_pr._rebase_with_conflict_resolution", return_value=None):
+             patch("app.rebase_pr._rebase_with_conflict_resolution",
+                   side_effect=fake_rebase):
             success, summary = run_rebase("o", "r", "1", "/p", notify_fn=notify)
 
         assert success is False
-        assert "tried: origin" in summary
-        assert "upstream" not in summary
+        assert "[sanity_check_failed]" in summary
+        assert "20 to 53" in summary
+        assert "aborted before any push" in summary
 
     @patch("app.rebase_pr._fix_existing_ci_failures", return_value=False)
     @patch("app.rebase_pr._run_ci_check_and_fix", return_value="")
@@ -2468,21 +2495,29 @@ class TestMain:
 
 
 # ---------------------------------------------------------------------------
-# --onto rebase (cross-fork PR support)
+# Cross-fork PR rebase (strict target, no --onto)
 # ---------------------------------------------------------------------------
 
-class TestRebaseOntoTarget_OntoMode:
-    """Tests for --onto rebase when head_remote differs from target remote."""
+class TestRebaseOntoTargetCrossFork:
+    """Cross-fork PRs rebase onto the target remote only — never --onto.
 
-    def test_uses_onto_when_fork_diverged(self):
-        """--onto should be used when fork has genuinely diverged from upstream."""
-        calls = []
+    Rebasing with a fork's base branch as the --onto cut point is how
+    PR #2309 replayed ~1,900 commits and resurrected 33 merged ones; a
+    plain rebase onto the fresh target ref replays exactly the PR's own
+    commits (git cuts at merge-base and drops patch-identical commits).
+    """
+
+    @staticmethod
+    def _record_git(calls):
         def mock_run(cmd, **kwargs):
             calls.append(cmd)
             return MagicMock(returncode=0, stdout="", stderr="")
+        return mock_run
 
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
-             patch("app.claude_step._is_ancestor", return_value=False):
+    def test_cross_fork_uses_plain_rebase_on_target(self):
+        calls = []
+        with patch("app.claude_step.subprocess.run",
+                   side_effect=self._record_git(calls)):
             result = _rebase_onto_target(
                 "main", "/project",
                 preferred_remote="upstream",
@@ -2490,44 +2525,19 @@ class TestRebaseOntoTarget_OntoMode:
             )
 
         assert result == "upstream"
-        # Should have fetched both remotes' base branches
         fetch_cmds = [c for c in calls if c[:2] == ["git", "fetch"]]
-        assert ["git", "fetch", "upstream", "+refs/heads/main:refs/remotes/upstream/main"] in fetch_cmds
-        # Should use --onto
-        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        assert len(rebase_cmds) == 1
-        assert "--onto" in rebase_cmds[0]
-        assert "upstream/main" in rebase_cmds[0]
-        assert "origin/main" in rebase_cmds[0]
-
-    def test_skips_onto_when_fork_is_behind(self):
-        """When fork is simply behind upstream, skip --onto and use plain rebase."""
-        calls = []
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
-             patch("app.claude_step._is_ancestor", return_value=True):
-            result = _rebase_onto_target(
-                "main", "/project",
-                preferred_remote="upstream",
-                head_remote="origin",
-            )
-
-        assert result == "upstream"
+        assert ["git", "fetch", "upstream",
+                "+refs/heads/main:refs/remotes/upstream/main"] in fetch_cmds
         rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
         assert len(rebase_cmds) == 1
         assert "--onto" not in rebase_cmds[0]
+        assert "upstream/main" in rebase_cmds[0]
+        assert "origin/main" not in rebase_cmds[0]
 
-    def test_plain_rebase_when_head_remote_same_as_target(self):
-        """When head_remote == target remote, use plain rebase (same-repo PR)."""
+    def test_same_remote_uses_plain_rebase(self):
         calls = []
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
+        with patch("app.claude_step.subprocess.run",
+                   side_effect=self._record_git(calls)):
             result = _rebase_onto_target(
                 "main", "/project",
                 preferred_remote="origin",
@@ -2539,53 +2549,13 @@ class TestRebaseOntoTarget_OntoMode:
         assert len(rebase_cmds) == 1
         assert "--onto" not in rebase_cmds[0]
 
-    def test_plain_rebase_when_head_remote_is_none(self):
-        """When head_remote is None, use plain rebase."""
+    def test_failed_rebase_never_retries_another_remote(self):
+        """The old fallback loop rebased onto other remotes' (stale) mains."""
         calls = []
         def mock_run(cmd, **kwargs):
             calls.append(cmd)
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run):
-            result = _rebase_onto_target("main", "/project", head_remote=None)
-
-        assert result == "origin"
-        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        assert len(rebase_cmds) == 1
-        assert "--onto" not in rebase_cmds[0]
-
-    def test_onto_failure_falls_back_to_plain_rebase(self):
-        """If --onto rebase fails, fall back to plain rebase."""
-        calls = []
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            if "rebase" in cmd and "--onto" in cmd:
-                raise RuntimeError("onto rebase conflict")
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
-             patch("app.claude_step._is_ancestor", return_value=False):
-            result = _rebase_onto_target(
-                "main", "/project",
-                preferred_remote="upstream",
-                head_remote="origin",
-            )
-
-        assert result == "upstream"
-        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        # Should have tried --onto first, then plain rebase
-        assert len(rebase_cmds) == 2
-        assert "--onto" in rebase_cmds[0]
-        assert "--onto" not in rebase_cmds[1]
-
-    def test_onto_head_remote_fetch_failure_falls_back(self):
-        """If fetching head_remote/base fails, fall back to plain rebase."""
-        calls = []
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            # head_remote fetch fails
-            if cmd[:3] == ["git", "fetch", "origin"] and any("main" in arg for arg in cmd):
-                raise RuntimeError("fetch failed")
+            if "rebase" in cmd and "--abort" not in cmd:
+                raise RuntimeError("conflict")
             return MagicMock(returncode=0, stdout="", stderr="")
 
         with patch("app.claude_step.subprocess.run", side_effect=mock_run):
@@ -2595,15 +2565,14 @@ class TestRebaseOntoTarget_OntoMode:
                 head_remote="origin",
             )
 
-        assert result == "upstream"
-        # Should have fallen back to plain rebase
+        assert result is None
         rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
         assert len(rebase_cmds) == 1
-        assert "--onto" not in rebase_cmds[0]
+        assert "upstream/main" in rebase_cmds[0]
 
 
-class TestRebaseWithConflictResolution_OntoMode:
-    """Tests for --onto rebase in _rebase_with_conflict_resolution."""
+class TestRebaseWithConflictResolutionCrossFork:
+    """_rebase_with_conflict_resolution follows the same strict contract."""
 
     def _base_context(self):
         return {
@@ -2612,27 +2581,7 @@ class TestRebaseWithConflictResolution_OntoMode:
             "reviews": "", "issue_comments": "",
         }
 
-    def test_uses_onto_when_fork_diverged(self):
-        """--onto should be used when fork has genuinely diverged."""
-        calls = []
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
-             patch("app.claude_step._is_ancestor", return_value=False):
-            result = _rebase_with_conflict_resolution(
-                "main", "/project", self._base_context(), [],
-                preferred_remote="upstream",
-                head_remote="origin",
-            )
-
-        assert result == "upstream"
-        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        assert any("--onto" in c for c in rebase_cmds)
-
-    def test_plain_rebase_when_same_remote(self):
-        """Same-repo PR: head_remote == target, no --onto."""
+    def test_cross_fork_plain_rebase_on_target(self):
         calls = []
         def mock_run(cmd, **kwargs):
             calls.append(cmd)
@@ -2641,39 +2590,33 @@ class TestRebaseWithConflictResolution_OntoMode:
         with patch("app.claude_step.subprocess.run", side_effect=mock_run):
             result = _rebase_with_conflict_resolution(
                 "main", "/project", self._base_context(), [],
-                preferred_remote="origin",
-                head_remote="origin",
-            )
-
-        assert result == "origin"
-        rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        assert all("--onto" not in c for c in rebase_cmds)
-
-    def test_onto_failure_falls_back_to_plain_rebase(self):
-        """If --onto fails (non-conflict), should fall back to plain rebase."""
-        calls = []
-        rebase_dir = MagicMock()
-        rebase_dir.exists.return_value = False
-
-        def mock_run(cmd, **kwargs):
-            calls.append(cmd)
-            if "rebase" in cmd and "--onto" in cmd:
-                raise RuntimeError("onto failed")
-            return MagicMock(returncode=0, stdout="", stderr="")
-
-        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
-             patch("app.claude_step._is_ancestor", return_value=False), \
-             patch("app.claude_step.has_rebase_in_progress", return_value=False):
-            result = _rebase_with_conflict_resolution(
-                "main", "/project", self._base_context(), [],
                 preferred_remote="upstream",
                 head_remote="origin",
             )
 
         assert result == "upstream"
         rebase_cmds = [c for c in calls if "rebase" in c and "--abort" not in c]
-        plain_rebases = [c for c in rebase_cmds if "--onto" not in c]
-        assert len(plain_rebases) >= 1
+        assert rebase_cmds
+        assert all("--onto" not in c for c in rebase_cmds)
+
+    def test_failure_reports_structured_reason(self):
+        def mock_run(cmd, **kwargs):
+            if "rebase" in cmd and "--abort" not in cmd:
+                raise RuntimeError("conflict")
+            return MagicMock(returncode=0, stdout="", stderr="")
+
+        meta = {}
+        with patch("app.claude_step.subprocess.run", side_effect=mock_run), \
+             patch("app.claude_step.has_rebase_in_progress", return_value=False):
+            result = _rebase_with_conflict_resolution(
+                "main", "/project", self._base_context(), [],
+                preferred_remote="upstream",
+                head_remote="origin",
+                result_meta=meta,
+            )
+
+        assert result is None
+        assert meta["error"] == "rebase_failed"
 
 
 class TestFetchPrContextHeadOwner:

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -4,7 +4,7 @@ title: "Component Spec — Git & GitHub"
 description: "Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows."
 tags: [git-github]
 created: 2026-06-27
-updated: 2026-06-27
+updated: 2026-07-10
 ---
 
 # Component Spec — Git & GitHub
@@ -32,6 +32,8 @@ workflows.
 | `github_webhook.py::maybe_start_from_config()` | Opt-in HMAC-verified push receiver; writes `.koan-check-notifications` to collapse poll latency 60-180s → ~10s. Polling remains the fallback. |
 | `github_command_handler.py` | @mention → mission: validate → permission check → react → create mission. Also the assignment fallback (`process_single_notification` processes @mentions first, then `_try_assignment_notification`): `review_requested` → `/review`, `assign` → `/implement`. When `review_draft_skip.enabled` is true, a `review_requested` on a **draft** PR is a soft skip (mark read, no thread/cooldown tracking): because no dedup state is written, any re-surfaced request is re-evaluated fresh. An explicit `/review` once the PR is ready is the remedy — the gate does **not** rely on automatic resume (GitHub does not reliably re-fire `review_requested` on the draft→ready transition), so an info notification is sent on deferral to avoid silent loss; explicit `/review` mentions are never gated. |
 | `claude_step.py::run_ci_fix_loop()` | Shared CI-fix loop; `use_polling` toggles polling vs single-shot recheck; caller supplies `prompt_builder`. |
+| `claude_step.py::_rebase_onto_target()` | Strict PR rebase: target is **only** `{base_remote}/{base}` (the remote matching the PR's base repo, resolved by `rebase_pr._find_remote_for_repo`); fails closed when no remote matches or the target fetch fails; always a plain `git rebase` (never `--onto`); post-rebase sanity gate before any push. Structured failure codes via `result_meta` (`no_base_remote` / `fetch_failed` / `rebase_failed` / `sanity_check_failed`). |
+| `claude_step.py::_verify_rebase_result()` | Post-rebase gate: branch must sit on the target's current tip and its unique-commit count (`rev-list --count target..HEAD`) must not grow vs the pre-rebase baseline. On violation the branch is hard-reset to its pre-rebase commit and the rebase reported failed — nothing is pushed. |
 | `head_tracker.py` | Detects remote HEAD change (master→main), throttled 12h, state in `.head-tracker.json`. |
 | `github_url_parser.py` | Single PR/issue URL parsing path. |
 
@@ -47,6 +49,13 @@ workflows.
   (`gh auth token --user <owner>`); tokens are redacted in logs.
 - **Mock above `retry_with_backoff`.** Test error handling at `run_gh()`/`api()`, never
   at `subprocess.run` — the latter sleeps 1+2+4s per retry (anti-pattern 6).
+- **Rebases target the PR's base repo remote, freshly fetched, or fail.** No fallback
+  to other remotes (a fork's `main` is stale by construction), no proceeding on a
+  failed fetch, no `--onto` with a fork branch as cut point, and no push when the
+  post-rebase sanity gate flags a stale base or commit-count growth. A failed rebase
+  mission is recoverable; a polluted force-push is not (incident: PR #2309 — a rebase
+  onto a 4-days-stale ref with the fork's 1,889-commits-behind `main` as cut point
+  resurrected 33 already-merged commits and force-pushed them unchecked).
 
 ## Integration points
 


### PR DESCRIPTION
## What

Hardens the `/rebase` (and `/review`) PR-rebase machinery so it can never again
force-push a branch polluted with already-merged commits.

- `claude_step._rebase_onto_target()` now rebases **only** onto the remote matching the
  PR's base repository, freshly fetched — no fallback to other remotes, fail-closed when
  no remote matches (`no_base_remote`) or the target fetch fails (`fetch_failed`).
- The cross-fork `--onto` path (with its fail-open `_is_ancestor` check and the fork's
  default branch as replay cut point) is removed: a plain `git rebase` onto the fresh
  target ref replays exactly the PR's own commits (git cuts at merge-base and drops
  patch-identical commits).
- New post-rebase sanity gate (`_verify_rebase_result`): before anything can be pushed,
  the branch must sit on the target's **current tip** and its unique-commit count must
  not have **grown**. On violation the branch is hard-reset to its pre-rebase commit and
  the mission fails (`sanity_check_failed`) — nothing is pushed.
- Structured failure codes flow to mission summaries via `result_meta` in both
  `rebase_pr.py` and `pr_review.py`.

## Why — PR #2309 post-mortem

A `/rebase` mission on #2309 turned a 20-commit PR into **53 commits / 177 files**:
`git cherry` shows 33 of them are patch-identical duplicates of commits already merged
on `main`, and the branch ended up based on a ref **4 days / 79 commits stale**. Three
compounding design flaws made that possible:

1. the remote-fallback loop could "successfully" rebase onto any configured remote's
   copy of `main` — fork mains are stale by construction (the bot fork's `main` was
   1,889 commits behind);
2. pre-rebase fetches were non-fatal, so a failed fetch left a stale tracking ref that
   was still used as the rebase target;
3. the `--onto` cut point was the fork's never-synced `main`, creating a ~1,900-commit
   replay range whose correctness depended entirely on patch-id dedup against a
   perfectly fresh target ref.

A failed rebase mission is recoverable; a polluted force-push is not — every ambiguity
now resolves to "fail loudly, push nothing".

## How verified

- New unit coverage of every failure code, the no-fallback invariant, conflict-callback
  paths, and the sanity gate (including branch restoration), plus real-git integration
  tests (bare base repo + work clone): happy path, unreachable remote fails closed,
  and `_verify_rebase_result` flagging a branch left behind the target tip.
- `make lint` clean; full test suite green.
- Spec updated (`specs/components/git-github.md`: new contracts + hard invariant);
  user manual documents the new `/rebase` failure codes.

- [x] **Architectural change** — this PR modifies a durable design contract (`specs/components/**` or `specs/skills/**`). The new architecture needs review before approval. Rationale: adding new specs

🤖 Generated with [Claude Code](https://claude.com/claude-code)
