### PR TITLE
feat(speckit): give /speckit a unique 🏭 icon

### DIFF
--- a/koan/skills/core/speckit/SKILL.md
+++ b/koan/skills/core/speckit/SKILL.md
@@ -2,7 +2,7 @@
 name: speckit
 scope: core
 group: code
-emoji: 📋
+emoji: 🏭
 description: "Run a spec-kit pipeline (specify -> plan -> tasks -> implement) for a goal or tracker issue, then best-effort review/CI and a draft PR"
 version: 1.0.0
 audience: hybrid

--- a/koan/skills/core/speckit/handler.py
+++ b/koan/skills/core/speckit/handler.py
@@ -50,4 +50,4 @@ def handle(ctx):
     queued = orch.queue_mission(ctx.instance_dir, "speckit", project_name, goal)
     if not queued:
         return f"ℹ️ A /speckit mission for {project_name} is already queued."
-    return f"📋 Queued /speckit for {project_name}: {goal}"
+    return f"🏭 Queued /speckit for {project_name}: {goal}"

--- a/koan/skills/core/speckit/speckit_runner.py
+++ b/koan/skills/core/speckit/speckit_runner.py
@@ -96,7 +96,7 @@ def run_speckit(
 
     label = project_name or project_path
     _progress(f"Running /speckit for {label}: {goal_text[:80]}")
-    notify_fn(f"📋 /speckit started for {label}: {goal_text[:120]}")
+    notify_fn(f"🏭 /speckit started for {label}: {goal_text[:120]}")
 
     prompt = load_prompt_or_skill(
         _SKILL_DIR,


### PR DESCRIPTION
## What

Switch the `/speckit` core skill's visual identity from **📋 (clipboard)** to **🏭 (factory)**.

## Why

📋 was **shared** with the `brief` and `list` skills, so `/speckit` blended in visually. 🏭 is unused by any other core skill and fits speckit's assembly-line pipeline: `specify → plan → tasks → implement → draft PR` (one commit per task).

## Changes

Three cosmetic occurrences, all now 🏭:

- `koan/skills/core/speckit/SKILL.md` — `emoji:` field (icon in `/help`, Telegram, dashboard)
- `koan/skills/core/speckit/handler.py` — `🏭 Queued /speckit …` reply
- `koan/skills/core/speckit/speckit_runner.py` — `🏭 /speckit started …` notification

## Scope / notes

- Cosmetic only — no behavior change. No test asserted the old emoji or notification prefixes.
- `speckit_from_branch` intentionally left unchanged.
- `make lint` clean; `test_speckit_skill.py` green (27 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)