### PR TITLE
Wrap blocking review and critical audit findings in native alerts

### DIFF
--- a/koan/app/review_runner.py
+++ b/koan/app/review_runner.py
@@ -1693,7 +1693,14 @@ def _format_review_as_markdown(
     header = f"## PR Review — {title}" if title else "## PR Review"
     lines.append(header)
     lines.append("")
-    lines.append(summary_data["summary"])
+    summary_text = summary_data["summary"]
+    if not summary_data.get("lgtm", True):
+        # Blocked review: wrap the verdict in a native callout so it's
+        # un-missable in email digests and mobile (parsimony rule: one
+        # alert per comment for the verdict, not one per finding).
+        lines.extend(build_alert("IMPORTANT", summary_text).split("\n"))
+    else:
+        lines.append(summary_text)
     lines.append("")
     lines.append("---")
     lines.append("")

--- a/koan/skills/core/audit/audit_runner.py
+++ b/koan/skills/core/audit/audit_runner.py
@@ -360,7 +360,6 @@ def _build_issue_body(finding: AuditFinding) -> str:
         f"<!-- koan-audit-id: {fingerprint} -->",
     ])
     return "\n".join(lines)
-    return "\n".join(lines)
 
 
 def _build_advisory_description(finding: AuditFinding) -> str:

--- a/koan/skills/core/audit/audit_runner.py
+++ b/koan/skills/core/audit/audit_runner.py
@@ -27,6 +27,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Dict, List, NamedTuple, Optional, Tuple
 
+from app.github_alerts import build_alert
 from app.prompts import load_prompt_or_skill
 
 DEFAULT_MAX_ISSUES = 5
@@ -320,8 +321,19 @@ def _build_issue_body(finding: AuditFinding) -> str:
     severity_icon = _SEVERITY_LABELS.get(finding.severity, "\u2753")
     effort_label = _EFFORT_LABELS.get(finding.effort, finding.effort)
     fingerprint = _compute_finding_fingerprint(finding)
+    lines = []
 
-    lines = [
+    # Critical findings get a CAUTION callout so they're un-missable in
+    # email digests and mobile, where the 🔴 icon in the details table
+    # has no special color rendering. Parsimony rule: only critical —
+    # high/medium/low rely on the emoji + severity label in the table.
+    if finding.severity == "critical":
+        lines.append(
+            build_alert("CAUTION", f"**Critical: {finding.title}**")
+        )
+        lines.append("")
+
+    lines.extend([
         "## Problem",
         "",
         f"{finding.problem}",
@@ -346,7 +358,8 @@ def _build_issue_body(finding: AuditFinding) -> str:
         "---",
         "\U0001f916 Created by K\u014dan from audit session",
         f"<!-- koan-audit-id: {fingerprint} -->",
-    ]
+    ])
+    return "\n".join(lines)
     return "\n".join(lines)
 
 

--- a/koan/tests/test_audit.py
+++ b/koan/tests/test_audit.py
@@ -370,6 +370,38 @@ class TestBuildIssueBody:
             body = _build_issue_body(f)
             assert severity.capitalize() in body
 
+    def test_critical_finding_wraps_in_caution_alert(self):
+        """Critical-severity findings must lead with a > [!CAUTION] callout
+        so they're un-missable in email digests and mobile, where the 🔴
+        icon in the details table has no special color rendering.
+        """
+        finding = AuditFinding(
+            title="fix: SQL injection in query builder",
+            severity="critical",
+            category="security",
+            location="db.py:42",
+            problem="Unparameterized query.",
+        )
+        body = _build_issue_body(finding)
+        assert "> [!CAUTION]" in body
+        assert "fix: SQL injection in query builder" in body
+
+    def test_non_critical_finding_has_no_alert(self):
+        """High/medium/low findings must NOT get an alert — parsimony rule
+        reserves callouts for the single most important thing.
+        """
+        for severity in ("high", "medium", "low"):
+            finding = AuditFinding(
+                title="minor issue",
+                severity=severity,
+                category="robustness",
+                location="a.py:1",
+                problem="p",
+            )
+            body = _build_issue_body(finding)
+            assert "> [!" not in body
+
+
 
 class TestBuildPrompt:
     def test_prompt_contains_project_name(self):

--- a/koan/tests/test_audit.py
+++ b/koan/tests/test_audit.py
@@ -402,7 +402,6 @@ class TestBuildIssueBody:
             assert "> [!" not in body
 
 
-
 class TestBuildPrompt:
     def test_prompt_contains_project_name(self):
         prompt = build_audit_prompt(

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -1026,8 +1026,9 @@ class TestFormatReviewAsMarkdown:
     def test_summary_preserves_paragraphs_and_bullets(self):
         """A structured summary (verdict + blank line + bullets) must survive
         formatting intact, so readers get skimmable output instead of one
-        dense block. The formatter passes the summary through verbatim, so the
-        blank-line break and bullet markers must appear in the rendered body.
+        dense block. When lgtm is False the summary is wrapped in a
+        [!IMPORTANT] callout, so every line (including blank paragraph
+        separators) is > -prefixed.
         """
         data = {
             "file_comments": [],
@@ -1038,8 +1039,28 @@ class TestFormatReviewAsMarkdown:
             },
         }
         md = _format_review_as_markdown(data)
-        assert "Needs work before merge.\n\n- Missing input validation" in md
-        assert "- No test coverage" in md
+        # All lines are prefixed by build_alert, including the blank separator.
+        assert "> Needs work before merge." in md
+        assert ">" in md  # blank line rendered as bare >
+        assert "> - Missing input validation" in md
+        assert "> - No test coverage" in md
+
+    def test_blocked_review_wraps_summary_in_important_alert(self):
+        """When lgtm is False, the summary must be wrapped in a > [!IMPORTANT]
+        callout so the merge verdict is un-missable in email digests and mobile.
+        """
+        md = _format_review_as_markdown(VALID_REVIEW_JSON, title="Fix auth")
+        assert "> [!IMPORTANT]" in md
+        assert "> Needs validation before merge." in md
+
+    def test_lgtm_review_does_not_wrap_summary_in_alert(self):
+        """When lgtm is True, the summary is plain text — no alert needed
+        per the parsimony rule (clean reviews need no callout).
+        """
+        md = _format_review_as_markdown(LGTM_REVIEW_JSON)
+        assert "> [!" not in md
+        assert "Clean code. Merge-ready." in md
+
 
     def test_lgtm_review(self):
         md = _format_review_as_markdown(LGTM_REVIEW_JSON)

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -1061,7 +1061,6 @@ class TestFormatReviewAsMarkdown:
         assert "> [!" not in md
         assert "Clean code. Merge-ready." in md
 
-
     def test_lgtm_review(self):
         md = _format_review_as_markdown(LGTM_REVIEW_JSON)
         assert "## PR Review" in md

--- a/specs/components/comment-formatting.md
+++ b/specs/components/comment-formatting.md
@@ -61,6 +61,8 @@ the single most important thing the reader must not miss.
 
 - `koan/app/rebase_pr.py` — WARNING when review feedback was dropped.
 - `koan/app/review_runner.py` — IMPORTANT when the branch moved mid-review.
+- `koan/app/review_runner.py` — IMPORTANT for blocked-review (`lgtm: false`) verdict summaries.
+- `koan/skills/core/audit/audit_runner.py` — CAUTION for critical-severity audit findings.
 
 ## Invariants
 


### PR DESCRIPTION
## Summary

Wraps blocking review verdicts (`lgtm: false`) in a `[!IMPORTANT]` callout and critical-severity audit findings in a `[!CAUTION]` callout via the existing `build_alert()` helper (#2301). This makes blocking verdicts un-missable in GitHub email digests and mobile, where plain prose and emoji-only severity icons have no visual weight.

Closes https://github.com/Anantys-oss/koan/issues/2302

## Changes

- **`review_runner.py`**: When `lgtm` is false, `_format_review_as_markdown()` wraps the summary in `build_alert("IMPORTANT", ...)`. Clean reviews unchanged.
- **`audit_runner.py`**: `_build_issue_body()` prepends `build_alert("CAUTION", ...)` for `severity == "critical"` findings. High/medium/low unchanged.
- **`comment-formatting.md`**: Added two new consumers to the spec's Consumers section.
- **Tests**: Positive + negative test pairs for both behaviors; updated `test_summary_preserves_paragraphs_and_bullets` for `> `-prefixed output.

## Test plan

- `pytest test_review_runner.py::TestFormatReviewAsMarkdown` — 12 pass
- `pytest test_audit.py::TestBuildIssueBody` — 4 pass (incl. 2 new)
- `pytest test_github_alerts.py` — 12 pass
- `ruff check` on both source files — clean

---
### Quality Report

**Changes**: 5 files changed, 79 insertions(+), 7 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_