### PR TITLE
fix(github): reset unregistered-repo @mention alert on registration (#2279)

### DIFF
--- a/docs/messaging/github-commands.md
+++ b/docs/messaging/github-commands.md
@@ -187,6 +187,8 @@ This is a top-level config key (not nested under `github:`). When enabled, Kōan
 
 When `enable_multiple_instances` is **false** (default, single-instance mode), notifications from unregistered repos are automatically marked as read to prevent inbox accumulation — no other instance will claim them.
 
+The @mention-dropped warning is one-shot per repo for the life of the process (it will not repeat every poll cycle). It resets once you add the repo to `projects.yaml`: the next time an @mention arrives it is acted on normally, and if the repo is ever removed again a fresh warning is emitted. Restarting Kōan also re-arms the warning as a standing reminder that the repo is still not registered.
+
 ### Per-project overrides (`projects.yaml`)
 
 Override `authorized_users` and `reply_authorized_users` for specific repositories:

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -685,9 +685,16 @@ def get_known_repos_from_projects(koan_root: str) -> Optional[set]:
 def _warn_unregistered_mention_repos(
     skipped_mention_repos: dict,
     instance_dir: str,
+    known_repos: Optional[set] = None,
 ) -> None:
-    """Alert the user when @mentions are dropped from repos not in projects.yaml."""
-    if not skipped_mention_repos:
+    """Alert the user when @mentions are dropped from repos not in projects.yaml.
+
+    The per-repo warning is one-shot per process. It resets once the repo is
+    added to projects.yaml: any warned repo now present in ``known_repos`` is
+    pruned from the dedup set, so if it is later removed and drops a mention
+    again the operator is warned afresh (AC #3 of issue #2279).
+    """
+    if not skipped_mention_repos and not known_repos:
         return
 
     with suppress_logged(_log_loop, "error", "Multi-instance config check failed", ImportError, OSError):
@@ -696,6 +703,17 @@ def _warn_unregistered_mention_repos(
             return
 
     with _warned_unregistered_repos_lock:
+        # Reset-on-registration: drop any warned repo that is now known so a
+        # future de-registration + re-drop warns again instead of staying
+        # silently suppressed by a stale entry. known_repos are normalized
+        # lowercase while skipped_mention_repos keys keep original case, so
+        # compare case-insensitively.
+        if known_repos:
+            known_lower = {r.lower() for r in known_repos}
+            _warned_unregistered_repos.difference_update(
+                {r for r in _warned_unregistered_repos if r.lower() in known_lower}
+            )
+
         new_repos = {
             repo for repo in skipped_mention_repos
             if repo not in _warned_unregistered_repos
@@ -990,8 +1008,11 @@ def process_github_notifications(
         result = fetch_unread_notifications(known_repos, since=since_value)
         notifications = result.actionable
 
-        # Warn about @mentions dropped from unregistered repos (once per repo per session).
-        _warn_unregistered_mention_repos(result.skipped_mention_repos, instance_dir)
+        # Warn about @mentions dropped from unregistered repos (once per repo per
+        # session; resets if the repo is later added to projects.yaml).
+        _warn_unregistered_mention_repos(
+            result.skipped_mention_repos, instance_dir, known_repos=known_repos,
+        )
 
         # Record the check timestamp for the next ``since`` window.
         new_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/koan/tests/test_loop_manager.py
+++ b/koan/tests/test_loop_manager.py
@@ -2419,6 +2419,49 @@ class TestWarnUnregisteredMentionRepos:
         )
         mock_send.assert_not_called()
 
+    @patch("app.notify.send_telegram", return_value=True)
+    def test_reset_after_repo_registered(self, mock_send, tmp_path):
+        from app.loop_manager import _warn_unregistered_mention_repos
+
+        # First drop while unregistered → warns once.
+        _warn_unregistered_mention_repos(
+            {"owner/repo": 2}, str(tmp_path), known_repos={"other/known"},
+        )
+        assert mock_send.call_count == 1
+
+        # Repo gets registered: now present in known_repos. A stray drop in the
+        # same cycle (e.g. a notification fetched before the filter caught up)
+        # must prune the warned entry rather than stay suppressed.
+        mock_send.reset_mock()
+        _warn_unregistered_mention_repos(
+            {}, str(tmp_path), known_repos={"other/known", "owner/repo"},
+        )
+        assert mock_send.call_count == 0  # nothing to warn, but entry pruned
+
+        # Repo removed again and drops once more → warns afresh (no stale suppression).
+        mock_send.reset_mock()
+        _warn_unregistered_mention_repos(
+            {"owner/repo": 1}, str(tmp_path), known_repos={"other/known"},
+        )
+        assert mock_send.call_count == 1
+
+    @patch("app.notify.send_telegram", return_value=True)
+    def test_prune_is_case_insensitive(self, mock_send, tmp_path):
+        from app.loop_manager import _warn_unregistered_mention_repos
+        import app.loop_manager as lm
+
+        _warn_unregistered_mention_repos(
+            {"Owner/Repo": 1}, str(tmp_path), known_repos=None,
+        )
+        # known_repos are normalized lowercase; prune must still match.
+        _warn_unregistered_mention_repos(
+            {}, str(tmp_path), known_repos={"owner/repo"},
+        )
+        with lm._warned_unregistered_repos_lock:
+            assert not any(
+                r.lower() == "owner/repo" for r in lm._warned_unregistered_repos
+            )
+
 
 class TestSingleInstanceDrainSkipped:
     """Verify single-instance mode drains notifications from unregistered repos."""

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -61,6 +61,11 @@ workflows.
 
 - Notifications wired into `loop_manager.process_github_notifications()`, which also
   drives `review_comment_dispatch.py` and `ci_dispatch.py`.
+- The unregistered-repo @mention alert (`loop_manager._warn_unregistered_mention_repos`)
+  is deduped per repo in the in-memory `_warned_unregistered_repos` set and suppressed
+  entirely when `enable_multiple_instances` is set. Invariant: a warned repo is pruned
+  from the set once it appears in `known_repos`, so registering then later removing a
+  repo warns again rather than staying silently suppressed by a stale entry.
 - Webhook receiver started in the bridge (`maybe_start_from_config()`) or standalone
   (`make webhook`).
 - Commit messages shaped by `commit_conventions.py`.


### PR DESCRIPTION
## Summary

Issue #2279 (surface silently-dropped @mentions from unregistered repos) was ~90% shipped. This closes the final acceptance criterion — the alert must reset once the repo is registered — by pruning any warned repo that is now present in `known_repos` from the in-memory dedup set, so an add→remove→re-add cycle warns afresh instead of staying silently suppressed by a stale entry.

Closes https://github.com/Anantys-oss/koan/issues/2279

## Changes

- `_warn_unregistered_mention_repos()` gains a `known_repos` param and prunes now-registered repos (case-insensitively) from `_warned_unregistered_repos` inside the existing lock; call site passes the already-computed `known_repos`.
- Two regression tests in `TestWarnUnregisteredMentionRepos` (reset-on-registration + case-insensitive prune).
- Documented the reset-on-registration semantics in `docs/messaging/github-commands.md` and the git-github spec.

**Architectural change**: adds a reset-on-registration invariant to the unregistered-mention alert contract in `specs/components/git-github.md`.

## Test plan

- `pytest koan/tests/test_loop_manager.py::TestWarnUnregisteredMentionRepos` — 8 passed
- Regression: test_loop_manager + test_github_notifications + test_github_notif_logging + test_check_notifications — 436 passed
- `make lint` — clean

---
_Generated by [Kōan](https://koan.anantys.com)_ _(model claude-opus-4-8 · HEAD=53aa4157)_
