### PR TITLE
fix: log GitHub exception handlers instead of silent swallowing

### DIFF
--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -6,9 +6,9 @@ which sets ``GH_TOKEN`` — this module has no auth logic.
 """
 
 import json
+import logging
 import re
 import subprocess
-import sys
 import time
 from typing import Dict, List, Optional
 
@@ -226,7 +226,10 @@ def list_open_issues(
         args.extend(["--repo", repo])
     try:
         output = run_gh(*args, cwd=cwd)
-    except (RuntimeError, subprocess.TimeoutExpired, OSError):
+    except (RuntimeError, subprocess.TimeoutExpired, OSError) as exc:
+        logging.getLogger(__name__).warning(
+            "list_open_issues failed: %s", exc, exc_info=True,
+        )
         return []
     if not output:
         return []
@@ -342,7 +345,9 @@ def fetch_issue_state(owner, repo, issue_number):
         state = result.strip().strip('"')
         return state if state in ("open", "closed") else "open"
     except Exception as e:
-        print(f"[github] fetch_issue_state error: {e}", file=sys.stderr)
+        logging.getLogger(__name__).warning(
+            "fetch_issue_state failed: %s", e, exc_info=True,
+        )
         return "open"
 
 
@@ -410,7 +415,10 @@ def get_gh_username() -> str:
 
     try:
         _cached_gh_username = run_gh("api", "user", "--jq", ".login", timeout=15)
-    except (RuntimeError, subprocess.SubprocessError, OSError):
+    except (RuntimeError, subprocess.SubprocessError, OSError) as exc:
+        logging.getLogger(__name__).warning(
+            "get_gh_username failed: %s", exc, exc_info=True,
+        )
         _cached_gh_username = ""
 
     return _cached_gh_username

--- a/koan/tests/test_github.py
+++ b/koan/tests/test_github.py
@@ -384,6 +384,16 @@ class TestGetGhUsername:
         assert get_gh_username() == ""
 
     @patch("app.github_auth.get_github_user", return_value="")
+    @patch("app.github.run_gh", side_effect=RuntimeError("network error"))
+    def test_logs_warning_on_failure(self, mock_gh, mock_get_user, caplog):
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="app.github"):
+            assert get_gh_username() == ""
+        assert "get_gh_username failed" in caplog.text
+        assert "network error" in caplog.text
+
+    @patch("app.github_auth.get_github_user", return_value="")
     @patch("app.github.run_gh", return_value="cached-user")
     def test_caches_gh_api_result(self, mock_gh, mock_get_user):
         assert get_gh_username() == "cached-user"
@@ -591,6 +601,15 @@ class TestFetchIssueState:
     @patch("app.github.api", side_effect=RuntimeError("gh failed"))
     def test_api_error_defaults_open(self, mock_api):
         assert fetch_issue_state("o", "r", 42) == "open"
+
+    @patch("app.github.api", side_effect=RuntimeError("connection refused"))
+    def test_logs_warning_on_api_error(self, mock_api, caplog):
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING, logger="app.github"):
+            assert fetch_issue_state("o", "r", 42) == "open"
+        assert "fetch_issue_state failed" in caplog.text
+        assert "connection refused" in caplog.text
 
 
 class TestFetchIssueWithComments:
@@ -1371,6 +1390,17 @@ class TestListOpenIssues:
         from app.github import list_open_issues
 
         assert list_open_issues(repo="o/r") == []
+
+    @patch("app.github.run_gh", side_effect=RuntimeError("timeout reached"))
+    def test_logs_warning_on_error(self, mock_gh, caplog):
+        import logging as _logging
+
+        from app.github import list_open_issues
+
+        with caplog.at_level(_logging.WARNING, logger="app.github"):
+            assert list_open_issues(repo="o/r") == []
+        assert "list_open_issues failed" in caplog.text
+        assert "timeout reached" in caplog.text
 
     @patch("app.github.run_gh", return_value="")
     def test_returns_empty_on_blank_output(self, mock_gh):


### PR DESCRIPTION
## Summary

Three GitHub API functions (list_open_issues, fetch_issue_state, get_gh_username) caught broad exceptions and returned empty/default values without logging, masking network failures and auth errors. Added logger.warning() with exc_info=True to all three exception handlers so operators can distinguish "no results" from "API call failed".

Closes https://github.com/Anantys-oss/koan/issues/2323

## Changes

- Add logging import; add logger.warning() with exc_info=True in list_open_issues, fetch_issue_state, and get_gh_username exception handlers
- Replace unstructured print-to-stderr in fetch_issue_state with structured logging
- Remove now-unused sys import
- Add 3 tests verifying warning logs are emitted on failures

## Test plan

- 224 tests pass (test_github.py + test_silent_exceptions.py)
- make lint passes
- New caplog tests verify warning emitted with exception message on each failure path

---
### Quality Report

**Changes**: 2 files changed, 42 insertions(+), 4 deletions(-)

**Code scan**: clean

**Tests**: passed (403 
tests)

**Branch hygiene**: clean

_Generated by [Kōan](https://koan.anantys.com)_