### PR TITLE
fix(rebase): separate "applied" vs "not changed" in the PR comment

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-10
+updated: 2026-07-11
 ---
 
 # Kōan User Manual
@@ -709,11 +709,12 @@ of labeling the result as a simple rebase.
 
 After completion, Kōan posts a structured comment on the PR with these sections:
 
-1. **Summary** — Classifies the rebase (simple / with adjustments / with conflict resolution)
-2. **Changes applied** — List of modifications beyond the rebase itself (review feedback, conflict resolution, CI fixes)
-3. **Stats** — Diff summary (files changed, insertions, deletions)
-4. **Actions performed** — Pipeline steps in a collapsible `<details>` block
-5. **CI status** — Test/CI outcome
+1. **Summary** — Classifies the rebase (simple / with adjustments / with conflict resolution). When feedback was reviewed but nothing needed changing, it says so explicitly ("no code changes were needed") rather than implying a fix.
+2. **Changes applied** — Only the modifications actually made beyond the rebase (review feedback that changed code, conflict resolution, CI fixes)
+3. **Not changed (and why)** — Reviewer points intentionally left as-is, each with the reason (already fixed in an earlier pass, advisory / below the severity filter, or disagreed). Kept separate from *Changes applied* so an unchanged point is never presented as if it were just fixed.
+4. **Stats** — Diff summary (files changed, insertions, deletions)
+5. **Actions performed** — Pipeline steps in a collapsible `<details>` block
+6. **CI status** — Test/CI outcome
 
 <details>
 <summary>Use cases</summary>

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -2069,9 +2069,11 @@ def _apply_review_feedback(
         from app.commit_conventions import strip_commit_subject_line
         change_summary = strip_commit_subject_line(change_summary)
 
-    # Truncate overly long summaries (keep last portion which is the summary)
-    if len(change_summary) > 1000:
-        change_summary = change_summary[-1000:]
+    # Truncate overly long summaries. Keep the HEAD: the structured summary leads
+    # with the APPLIED: section, so tail-trimming would drop the changes actually
+    # made and leave only skipped items.
+    if len(change_summary) > 1500:
+        change_summary = change_summary[:1500].rstrip()
 
     return change_summary
 
@@ -2237,6 +2239,44 @@ def _push_with_fallback(
     }
 
 
+# Section headers Claude emits in its rebase summary. Matched only when they are
+# the WHOLE line (the `$` anchor), so a content bullet like "Applied the fix to X"
+# is never mistaken for a header. Tolerant of surrounding bold/colon and the older
+# "**Changes**" / "**Skipped**" phrasings.
+_APPLIED_HDR_RE = re.compile(r"^\**\s*(?:applied|changes?)\s*:?\s*\**$", re.I)
+_SKIPPED_HDR_RE = re.compile(
+    r"^\**\s*(?:skipped|not\s+changed|no\s+change[sd]?)\s*:?\s*\**$", re.I
+)
+
+
+def _split_change_summary(change_summary: str) -> Tuple[List[str], List[str]]:
+    """Split Claude's rebase summary into ``(applied, skipped)`` bullet lists.
+
+    Recognizes the ``APPLIED:`` / ``SKIPPED:`` section headers the rebase prompt
+    asks for (plus looser ``Changes`` / ``Skipped`` / ``Not changed`` variants).
+    Lines before any recognized header default to *applied*, so a summary that
+    omits the structure still renders as changes — backward compatible with
+    older prompt outputs and non-conforming responses.
+    """
+    applied: List[str] = []
+    skipped: List[str] = []
+    bucket = applied
+    for raw in change_summary.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if _APPLIED_HDR_RE.match(line):
+            bucket = applied
+            continue
+        if _SKIPPED_HDR_RE.match(line):
+            bucket = skipped
+            continue
+        line = re.sub(r"^[-*]\s+", "", line).strip()  # drop a leading bullet marker
+        if line:
+            bucket.append(line)
+    return applied, skipped
+
+
 def _build_rebase_comment(
     pr_number: str,
     branch: str,
@@ -2271,13 +2311,33 @@ def _build_rebase_comment(
     )
     has_conflicts = any("conflict" in a.lower() for a in actions_log)
 
+    # Split the reviewer-feedback summary into what was actually changed vs. what
+    # was deliberately left alone (already fixed / advisory / disagreed). Rendered
+    # as two distinct sections so an unchanged point is never presented as a change.
+    applied_summary, skipped_summary = _split_change_summary(change_summary)
+    change_items = _extract_change_items(actions_log, "\n".join(applied_summary))
+
     # ── 1. Summary ──────────────────────────────────────────────────
     if has_feedback:
         rebase_type = "Rebase with requested adjustments"
-        summary_line = (
-            f"Branch `{branch}` was rebased onto `{base}` and review "
-            f"feedback was applied."
-        )
+        if change_items:
+            summary_line = (
+                f"Branch `{branch}` was rebased onto `{base}` and review "
+                f"feedback was applied."
+            )
+        elif skipped_summary:
+            # Feedback was reviewed but nothing needed changing — say so plainly
+            # instead of implying a fix was made.
+            summary_line = (
+                f"Branch `{branch}` was rebased onto `{base}`. No code changes "
+                f"were needed — each reviewer point was already addressed or "
+                f"advisory (see “Not changed” below)."
+            )
+        else:
+            summary_line = (
+                f"Branch `{branch}` was rebased onto `{base}` and review "
+                f"feedback was applied."
+            )
     elif feedback_failed:
         rebase_type = "Rebase completed; review feedback not applied"
         summary_line = (
@@ -2314,12 +2374,17 @@ def _build_rebase_comment(
             + "\n"
         )
 
-    # ── 2. Changes ──────────────────────────────────────────────────
-    # Only include when there are meaningful changes beyond rebasing
-    change_items = _extract_change_items(actions_log, change_summary)
+    # ── 2. Changes / Not changed ────────────────────────────────────
+    # Only include when there are meaningful changes beyond rebasing.
     if change_items:
         parts.append("### Changes applied\n")
         parts.extend(f"- {item}" for item in change_items)
+        parts.append("")
+    # Points the reviewer raised that were intentionally left as-is, in their own
+    # clearly-labeled section — so "already fixed" reads as skipped, not applied.
+    if skipped_summary:
+        parts.append("### Not changed (and why)\n")
+        parts.extend(f"- {item}" for item in skipped_summary)
         parts.append("")
 
     # ── 3. Stats ────────────────────────────────────────────────────

--- a/koan/skills/core/rebase/prompts/rebase.md
+++ b/koan/skills/core/rebase/prompts/rebase.md
@@ -59,11 +59,27 @@ Stay on the current branch. Your changes will be committed and pushed automatica
 3. **Be focused.** Only change what was requested — no drive-by refactoring, no extra improvements.
 4. **Do not run tests.** The caller handles testing separately.
 
-When you're done, output a concise summary of what you changed and why.
-This summary will be used in the git commit message and PR comment, so it must
-clearly explain each change and justify it by referencing the reviewer's request.
-Use bullet points if you made multiple changes. Be specific about what was
-modified (e.g. "Renamed `get_user()` to `fetch_user()` per reviewer request")
-rather than vague (e.g. "Applied feedback").
+When you're done, report a concise summary using these two labeled sections, so
+it renders unambiguously in the PR comment and commit message. Use the headers
+verbatim, and **omit a section that has no items** (do not write "none"):
+
+```
+APPLIED:
+- one bullet per change you actually made, specific and justified by the
+  reviewer's request — e.g. "Renamed `get_user()` to `fetch_user()` per reviewer
+  request", not vague like "Applied feedback".
+
+SKIPPED:
+- one bullet per reviewer point you deliberately did NOT change, each with the
+  reason: already fixed in an earlier pass, advisory / below the severity you
+  were asked to address, or you disagree (say which, with a short technical
+  reason).
+```
+
+Put each reviewer point under exactly one section. If you changed everything
+requested, omit `SKIPPED:`. If you changed **nothing** — because every point was
+already addressed or advisory — include only `SKIPPED:`, so the comment clearly
+shows no code change was needed and why (never present an unchanged point as if
+you had just fixed it).
 
 {COMMIT_SUBJECT_INSTRUCTION}

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -22,6 +22,7 @@ from app.rebase_pr import (
     _apply_review_feedback,
     _build_ci_fix_prompt,
     _build_rebase_comment,
+    _split_change_summary,
     _build_rebase_prompt,
     _build_rebase_recovery_guidance,
     _checkout_pr_branch,
@@ -697,6 +698,96 @@ class TestBuildRebaseComment:
         assert "<details>" in result
         assert "Actions performed" in result
         assert "</details>" in result
+
+    def test_applied_and_skipped_rendered_in_separate_sections(self):
+        # The reproducing scenario: one point fixed, one left as already-resolved.
+        # The skipped point must NOT appear under "Changes applied".
+        result = _build_rebase_comment(
+            "42", "koan/implement-37", "main",
+            ["Rebased onto origin/main", "Applied review feedback"],
+            {"title": "App shell", "review_comments": "z-index + dot"},
+            change_summary=(
+                "APPLIED:\n"
+                "- MobileNav drawer z-index: raised overlay/content to z-[var(--z-modal)]\n"
+                "SKIPPED:\n"
+                "- text-muted dot fix — already resolved in an earlier pass\n"
+                "- main-frame padding — advisory, below severity filter\n"
+            ),
+        )
+        assert "### Changes applied" in result
+        assert "### Not changed (and why)" in result
+        # The applied change is under Changes applied, before Not changed.
+        changes_idx = result.index("### Changes applied")
+        skipped_idx = result.index("### Not changed")
+        assert result.index("drawer z-index") > changes_idx
+        assert result.index("drawer z-index") < skipped_idx
+        # The already-resolved point sits under Not changed, not Changes applied.
+        assert result.index("already resolved") > skipped_idx
+        assert "review feedback was applied" in result
+
+    def test_only_skipped_reports_no_changes_needed(self):
+        # Everything was already addressed / advisory — the comment must say so,
+        # not imply a fix was made.
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main", "Applied review feedback"],
+            {"title": "Fix"},
+            change_summary=(
+                "SKIPPED:\n"
+                "- the requested change was already present on the branch\n"
+            ),
+        )
+        assert "No code changes were needed" in result
+        assert "### Not changed (and why)" in result
+        assert "### Changes applied" not in result
+        # Must not falsely claim feedback produced a change.
+        assert "review feedback was applied" not in result
+
+    def test_unstructured_summary_defaults_to_changes_applied(self):
+        # Backward compat: a summary without APPLIED/SKIPPED headers is all-applied.
+        result = _build_rebase_comment(
+            "42", "koan/fix", "main",
+            ["Rebased onto origin/main", "Applied review feedback"],
+            {"title": "Fix"},
+            change_summary="Renamed get_user() to fetch_user() per reviewer request",
+        )
+        assert "### Changes applied" in result
+        assert "fetch_user()" in result
+        assert "### Not changed (and why)" not in result
+
+
+class TestSplitChangeSummary:
+    def test_splits_applied_and_skipped(self):
+        applied, skipped = _split_change_summary(
+            "APPLIED:\n- raised z-index\nSKIPPED:\n- dot already fixed\n- padding advisory"
+        )
+        assert applied == ["raised z-index"]
+        assert skipped == ["dot already fixed", "padding advisory"]
+
+    def test_no_headers_all_applied(self):
+        applied, skipped = _split_change_summary("- did a thing\n- did another")
+        assert applied == ["did a thing", "did another"]
+        assert skipped == []
+
+    def test_only_skipped(self):
+        applied, skipped = _split_change_summary("SKIPPED:\n- already done")
+        assert applied == []
+        assert skipped == ["already done"]
+
+    def test_tolerates_bold_legacy_headers(self):
+        applied, skipped = _split_change_summary(
+            "**Changes**\n- fixed X\n**Skipped**\n- Y already resolved"
+        )
+        assert applied == ["fixed X"]
+        assert skipped == ["Y already resolved"]
+
+    def test_content_line_not_mistaken_for_header(self):
+        applied, skipped = _split_change_summary("- Applied the fix to the parser")
+        assert applied == ["Applied the fix to the parser"]
+        assert skipped == []
+
+    def test_empty_summary(self):
+        assert _split_change_summary("") == ([], [])
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The `/rebase` feedback comment dumped Claude's entire free-form summary under one **"### Changes applied"** header. When Claude noted a reviewer point it *deliberately left alone* — already fixed in an earlier pass, advisory / below the severity filter, or disagreed — that "already resolved" line rendered **as if it were a change just made**. It reads like Koan claimed the requested fix was already done when it wasn't, even though the actually-requested fix *was* applied and committed.

## Fix

Make the comment structurally honest — an unchanged point is never shown as a change:

- **Prompt** (`rebase.md`): Claude now reports in two labeled sections, `APPLIED:` and `SKIPPED:`, and includes only `SKIPPED:` when nothing needed changing.
- **`_split_change_summary()`**: parses those sections (tolerant of looser `Changes`/`Skipped`/`Not changed` + bold variants). Lines before any header default to *applied*, so unstructured/older summaries still render as changes (backward compatible).
- **`_build_rebase_comment()`**: renders **### Changes applied** (things actually changed) and a separate **### Not changed (and why)** (skipped points + reason). When only skipped items exist, the summary line says *"No code changes were needed …"* instead of *"review feedback was applied"*.
- Keep the summary **head** (not tail) on truncation, since `APPLIED:` leads.

### Before → After (real reproducing case)

Before, "text-muted dot fix — already resolved" appeared under **Changes applied**. After:

```
### Changes applied
- MobileNav drawer z-index: raised overlay/content to z-[var(--z-modal)] …

### Not changed (and why)
- text-muted dot fix — already resolved in the earlier rebase …
- main-frame padding — advisory, below the severity filter.
```

## Tests / docs
- New tests for the split parser, separated-section rendering, only-skipped ("no changes needed"), and unstructured backward-compat. Full `test_rebase_pr.py` green (260).
- `docs/users/user-manual.md` rebase-comment section updated.

Not an architectural change — no durable-contract (`specs/components/**`, `specs/skills/**`) edits; the comment format was never a spec contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)