### PR TITLE
fix(add_project): clone into resolved workspace dir so project is discoverable

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -4,7 +4,7 @@ title: "Kōan User Manual"
 description: "A tiered (beginner/intermediate/power-user) walkthrough of everything Kōan can do, from queuing your first mission through parallel sessions, deep exploration, and full configuration."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-11
+updated: 2026-07-12
 ---
 
 # Kōan User Manual
@@ -2009,6 +2009,11 @@ See [docs/operations/auto-update.md](../operations/auto-update.md) for details.
 
 - **Usage:** `/add_project <github-url> [name]`
 - **Aliases:** —
+
+The repo is cloned into the **active workspace directory** — `instance/workspace/`
+on hosted deploys (persistent volume), or `workspace/` on local installs — and
+registered via auto-discovery. No manual `projects.yaml` edit is required; the
+project appears in `/projects` immediately.
 
 <details>
 <summary>Use cases</summary>

--- a/koan/app/projects_merged.py
+++ b/koan/app/projects_merged.py
@@ -68,13 +68,19 @@ def _is_yaml_stale(koan_root: str) -> bool:
 
 
 def _get_workspace_mtime(koan_root: str) -> Optional[float]:
-    """Get workspace/ directory mtime, or None if missing.
+    """Get the active workspace directory mtime, or None if missing.
+
+    Resolves through resolve_workspace_dir so cache invalidation watches the
+    exact directory discover_workspace_projects scans (instance/workspace on
+    hosted deploys, else <root>/workspace). Watching the wrong directory would
+    leave a freshly added project invisible until restart (issue #2338).
 
     The directory mtime changes whenever entries are added or removed,
     which is exactly when workspace project discovery needs to re-scan.
     """
+    from app.workspace_discovery import resolve_workspace_dir
     try:
-        return (Path(koan_root) / "workspace").stat().st_mtime
+        return resolve_workspace_dir(koan_root).stat().st_mtime
     except OSError:
         return None
 

--- a/koan/app/workspace_discovery.py
+++ b/koan/app/workspace_discovery.py
@@ -13,6 +13,27 @@ from typing import List, Optional, Tuple
 logger = logging.getLogger(__name__)
 
 
+def resolve_workspace_dir(koan_root) -> Path:
+    """Return the canonical workspace directory for a koan_root.
+
+    Prefers ``<root>/instance/workspace`` (the persistent volume on hosted
+    deploys) when it exists, else ``<root>/workspace`` (local/dev installs).
+
+    This is the SINGLE source of truth for where workspace projects live.
+    Both the reader (:func:`discover_workspace_projects`) and any writer
+    (the ``/add_project`` skill) MUST resolve through here, otherwise a
+    cloned repo can land in a directory discovery never scans (issue #2338).
+
+    Accepts both ``str`` and ``Path`` (``ctx.koan_root`` is a ``Path``;
+    ``projects_merged`` passes ``str``).
+    """
+    root = Path(koan_root)
+    inst_ws = root / "instance" / "workspace"
+    if inst_ws.is_dir():
+        return inst_ws
+    return root / "workspace"
+
+
 def discover_workspace_projects(koan_root: str) -> List[Tuple[str, str]]:
     """Scan workspace/ directory for projects.
 
@@ -21,10 +42,10 @@ def discover_workspace_projects(koan_root: str) -> List[Tuple[str, str]]:
     Returns empty list if workspace/ doesn't exist.
 
     Prefers instance/workspace (persistent volume on hosted deploys),
-    falling back to <root>/workspace for local/dev installs.
+    falling back to <root>/workspace for local/dev installs — resolved
+    through :func:`resolve_workspace_dir`.
     """
-    inst_ws = Path(koan_root) / "instance" / "workspace"
-    workspace_dir = inst_ws if inst_ws.is_dir() else Path(koan_root) / "workspace"
+    workspace_dir = resolve_workspace_dir(koan_root)
     if not workspace_dir.is_dir():
         return []
 

--- a/koan/skills/core/add_project/handler.py
+++ b/koan/skills/core/add_project/handler.py
@@ -13,6 +13,7 @@ import re
 from pathlib import Path
 
 from app.git_utils import run_git_strict
+from app.workspace_discovery import resolve_workspace_dir
 
 logger = logging.getLogger(__name__)
 
@@ -44,15 +45,18 @@ def handle(ctx):
         return f"Invalid project name: {project_name}"
 
     koan_root = str(ctx.koan_root)
-    workspace_dir = Path(koan_root) / "workspace"
+    # Resolve the workspace through the SAME helper discovery uses, so the
+    # clone lands where /projects and the agent loop actually look. On hosted
+    # deploys this is <root>/instance/workspace; locally it's <root>/workspace.
+    workspace_dir = resolve_workspace_dir(koan_root)
     project_dir = workspace_dir / project_name
 
     # Check for existing project
     if project_dir.exists():
         return f"Project '{project_name}' already exists at {project_dir}"
 
-    # Ensure workspace directory exists
-    workspace_dir.mkdir(exist_ok=True)
+    # Ensure workspace directory exists (parents: instance/ may not pre-exist)
+    workspace_dir.mkdir(parents=True, exist_ok=True)
 
     # Check push access BEFORE cloning — determines setup strategy
     has_push = _check_push_access_safe(owner, repo)

--- a/koan/tests/test_add_project_skill.py
+++ b/koan/tests/test_add_project_skill.py
@@ -465,6 +465,33 @@ class TestHandle:
         assert "Clone failed" in result
         assert "timeout" in result
 
+    def test_clones_into_instance_workspace_when_present(self, handler, ctx):
+        """On hosted layout (instance/workspace exists), the clone lands there
+        and discovery immediately sees the new project (issue #2338)."""
+        from app.workspace_discovery import discover_workspace_projects
+
+        tmp_path = ctx.koan_root
+        inst_ws = tmp_path / "instance" / "workspace"
+        inst_ws.mkdir(parents=True)
+        ctx.args = "owner/repo"
+
+        def fake_clone(url, target_dir):
+            # Simulate gh cloning a real git repo into the resolved target.
+            (Path(target_dir) / ".git").mkdir(parents=True)
+
+        with patch.object(handler, "_check_push_access_safe", return_value=True), \
+             patch.object(handler, "_git_clone", side_effect=fake_clone), \
+             patch("app.projects_merged.refresh_projects"):
+            result = handler.handle(ctx)
+
+        # Clone target is under instance/workspace, NOT <root>/workspace
+        assert (inst_ws / "repo" / ".git").is_dir()
+        assert not (tmp_path / "workspace" / "repo").exists()
+        assert "added to workspace." in result
+        # Discovery (which prefers instance/workspace) now finds it.
+        names = [n for n, _ in discover_workspace_projects(str(tmp_path))]
+        assert "repo" in names
+
 
 # ===========================================================================
 # _check_push_access_safe

--- a/koan/tests/test_projects_merged.py
+++ b/koan/tests/test_projects_merged.py
@@ -348,6 +348,27 @@ projects:
         assert "ws-proj" in names
 
 
+class TestInstanceWorkspaceResolution:
+    """Cache invalidation watches the resolved workspace dir (issue #2338)."""
+
+    def test_instance_workspace_add_invalidates_cache(self, tmp_path):
+        inst_ws = tmp_path / "instance" / "workspace"
+        inst_ws.mkdir(parents=True)
+        (inst_ws / "alpha").mkdir()
+
+        invalidate_cache()
+        first = {n for n, _ in get_all_projects(str(tmp_path))}
+        assert first == {"alpha"}
+
+        # Add a second project the way /add_project would (under instance/workspace).
+        (inst_ws / "beta").mkdir()
+        # Ensure mtime differs (filesystem resolution can be 1s on Linux)
+        os.utime(str(inst_ws), (inst_ws.stat().st_atime + 1, inst_ws.stat().st_mtime + 1))
+
+        second = {n for n, _ in get_all_projects(str(tmp_path))}
+        assert second == {"alpha", "beta"}  # cache saw the new dir, no restart needed
+
+
 class TestGithubUrlCache:
     def test_set_and_get(self):
         set_github_url("myproj", "https://github.com/me/myproj")

--- a/koan/tests/test_workspace_discovery.py
+++ b/koan/tests/test_workspace_discovery.py
@@ -6,7 +6,26 @@ from unittest.mock import patch, PropertyMock
 
 import pytest
 
-from app.workspace_discovery import _validate_entry, discover_workspace_projects
+from app.workspace_discovery import (
+    _validate_entry,
+    discover_workspace_projects,
+    resolve_workspace_dir,
+)
+
+
+class TestResolveWorkspaceDir:
+    def test_prefers_instance_workspace_when_present(self, tmp_path):
+        inst_ws = tmp_path / "instance" / "workspace"
+        inst_ws.mkdir(parents=True)
+        (tmp_path / "workspace").mkdir()
+        assert resolve_workspace_dir(tmp_path) == inst_ws
+
+    def test_falls_back_to_root_workspace(self, tmp_path):
+        # No instance/workspace present
+        assert resolve_workspace_dir(tmp_path) == tmp_path / "workspace"
+
+    def test_accepts_str_and_path(self, tmp_path):
+        assert resolve_workspace_dir(str(tmp_path)) == tmp_path / "workspace"
 
 
 @pytest.fixture

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -4,7 +4,7 @@ title: "Component Spec — Skills System"
 description: "Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness)."
 tags: [skills]
 created: 2026-06-27
-updated: 2026-07-10
+updated: 2026-07-12
 ---
 
 # Component Spec — Skills System
@@ -181,6 +181,19 @@ runner/loader-based skills that thread `project_path` (`review`, `refactor`, `pl
 prompt-only skills (`_execute_prompt` returns raw `prompt_body`, no loader) are out of
 scope and rely on general `KOAN.md`. Precedence: mission instruction > `.koan/skills/<skill>/*`
 > `KOAN.md`/`.koan/KOAN.md` > skill built-in prompt > `CLAUDE.md`/defaults.
+
+### `add_project` workspace resolution (contract)
+
+The clone target and project discovery MUST resolve the workspace directory
+through the single helper `app.workspace_discovery.resolve_workspace_dir`
+(prefers `<root>/instance/workspace` when present, else `<root>/workspace`).
+Any new writer of workspace projects resolves through this helper — a writer
+that hardcodes `<root>/workspace` will place clones where discovery does not
+scan on hosted deploys (the #2338 regression, where `/add_project` cloned into
+`<root>/workspace` while discovery read `<root>/instance/workspace`). The
+`add_project` handler, `discover_workspace_projects`, and the merged-registry
+cache-invalidation mtime (`projects_merged._get_workspace_mtime`) all share
+this one resolver so write-path, read-path, and cache-watch stay aligned.
 
 ## Known debt / watch-outs
 


### PR DESCRIPTION
## Summary

`/add_project <github-url>` via Telegram cloned into `<KOAN_ROOT>/workspace/` while project discovery reads `<KOAN_ROOT>/instance/workspace/` (the persistent-volume location preferred when it exists). The clone succeeded but was never discovered, forcing operators to hand-edit `projects.yaml`. This introduces one canonical `resolve_workspace_dir(koan_root)` helper and routes the writer (handler), reader (discovery), and cache-invalidation mtime through it so a cloned repo always lands where discovery looks.

Closes https://github.com/Anantys-oss/koan/issues/2338

## Changes

- `workspace_discovery.resolve_workspace_dir(koan_root)` — single source of truth for the workspace location (prefers `instance/workspace`, else `workspace`); `discover_workspace_projects` now uses it.
- `add_project/handler.py` clones through `resolve_workspace_dir` (with `parents=True`) instead of hardcoding `<root>/workspace`.
- `projects_merged._get_workspace_mtime` watches the resolved dir so an add under `instance/workspace` invalidates the merged cache (no restart needed).
- Docs (user manual) + spec (skills component) record the shared workspace-resolution contract.

## Test plan

- New: resolver precedence/fallback/str+Path; handler clones into `instance/workspace` and is discoverable; cache invalidation on add under `instance/workspace`.
- Regression sweep (workspace_discovery, add_project ×2, projects_merged, dashboard_projects, command_handlers): 330 passed.
- `make lint` clean; `spec_change_guard` reports additive-only (no declaration needed).

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=50d7104c)_
