### PR TITLE
feat(ci): manual GHCR publish + shared build workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: 🐳 Container Build
+
+on:
+  workflow_call:
+    inputs:
+      tags:
+        description: "docker/metadata-action tags block (newline-separated tag rules)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    name: publish
+
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1   # metadata uses the passed tags block, not git tags — shallow is fine
+
+      - name: 🐳 Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: 🔑 Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 🏷️ Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: ${{ inputs.tags }}
+
+      - name: 🐳 Build and push Docker image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -1,0 +1,40 @@
+name: 🐳 Publish Container
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Docker tag to publish (default: devel)"
+        required: false
+        type: string
+        default: devel
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    name: validate
+    outputs:
+      tag: ${{ steps.check.outputs.tag }}
+    steps:
+      - name: 🔍 Validate tag
+        id: check
+        run: |
+          TAG="${{ inputs.tag }}"
+          if ! printf '%s' "$TAG" | grep -qE '^[a-z0-9][a-z0-9._-]{0,127}$'; then
+            echo "::error::Invalid Docker tag '$TAG'. Use lowercase alphanumerics, '.', '-', '_' (max 128 chars; must start alnum). Examples: devel, test, pr-123."
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  publish:
+    needs: validate
+    name: publish
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tags: type=raw,value=${{ needs.validate.outputs.tag }}
+    secrets: inherit

--- a/.github/workflows/publish-container.yml
+++ b/.github/workflows/publish-container.yml
@@ -23,8 +23,9 @@ jobs:
     steps:
       - name: 🔍 Validate tag
         id: check
+        env:
+          TAG: ${{ inputs.tag }}   # bound as data, never interpolated into the shell
         run: |
-          TAG="${{ inputs.tag }}"
           if ! printf '%s' "$TAG" | grep -qE '^[a-z0-9][a-z0-9._-]{0,127}$'; then
             echo "::error::Invalid Docker tag '$TAG'. Use lowercase alphanumerics, '.', '-', '_' (max 128 chars; must start alnum). Examples: devel, test, pr-123."
             exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,33 +86,13 @@ jobs:
             --notes-file /tmp/release-notes.md \
             --latest
 
-      - name: 🐳 Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: 🔑 Log in to GHCR
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 🏷️ Extract Docker metadata
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository }}
-          tags: |
-            type=semver,pattern={{version}},value=${{ inputs.version }}
-            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
-            type=raw,value=latest
-            type=raw,value=stable,enable=${{ inputs.update_stable }}
-
-      - name: 🐳 Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+  publish-image:
+    needs: release
+    uses: ./.github/workflows/docker-publish.yml
+    with:
+      tags: |
+        type=semver,pattern={{version}},value=${{ inputs.version }}
+        type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+        type=raw,value=latest
+        type=raw,value=stable,enable=${{ inputs.update_stable }}
+    secrets: inherit

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -4,7 +4,7 @@ title: "Docker Setup"
 description: "Covers Docker Compose setup for Koan (pull vs. build from source), workspace project mounts, authentication (Claude/GitHub), volume layout, and troubleshooting common container issues."
 tags: [setup]
 created: 2026-05-28
-updated: 2026-07-08
+updated: 2026-07-12
 ---
 
 # Docker Setup
@@ -84,7 +84,19 @@ make docker-pull-up
 > make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:1.0   # major.minor
 > ```
 >
-> Available tags: `latest`, `stable`, and per-version (`X.Y` / `X.Y.Z`).
+> Available tags: `latest`, `stable`, per-version (`X.Y` / `X.Y.Z`), and a rolling
+> `devel` tag (see below).
+
+> **Rolling `:devel` image.** A fresh image can be published on demand — **without
+> cutting a release** — via the **🐳 Publish Container** workflow (repo Actions →
+> "Run workflow", tag defaults to `devel`). It is built by the same job that produces
+> release images, but pushes **only** the requested tag: `:devel` is a moving target
+> (overwritten on each manual publish) and never updates `:latest` or `:stable`,
+> which move only on a real release.
+>
+> ```bash
+> make docker-pull-up KOAN_IMAGE=ghcr.io/anantys-oss/koan:devel
+> ```
 
 > **UID/GID on the prebuilt image.** The published image runs as UID/GID
 > **1000**. On Linux hosts whose user isn't 1000, bind-mounted `instance/` and


### PR DESCRIPTION
## Summary

Allow publishing a GHCR image **without cutting a release**, while keeping the build code DRY between the release and manual flows.

Today `release.yml` is the only place that builds/pushes the container, and its 4 Docker steps (buildx → login → metadata → build-push) are inlined in the release job. This PR extracts those steps into a reusable `workflow_call` builder and adds a manual `workflow_dispatch` entry point:

- **`docker-publish.yml`** (new, `workflow_call`) — the shared builder. Takes the `metadata-action` tags block from the caller, so it is agnostic to which tags are produced.
- **`publish-container.yml`** (new, `workflow_dispatch`) — the manual entry. `tag` input (default `devel`), a fast `validate` job (lowercase-alnum, max 128), then calls the builder with `type=raw,value=<tag>`.
- **`release.yml`** — the `release` job keeps only release orchestration (git tag + GitHub release); a new `publish-image` job (`needs: release`) calls the builder with the **same** semver/`latest`/`stable` tag block, so release output is unchanged.
- **`docs/setup/docker.md`** — documents the rolling `:devel` tag and the manual publish workflow.

**Behavior guarantees:**
- Manual publish pushes **only** the requested tag (e.g. `:devel`). `:latest`/`:stable` move **only** on a release, so a dev build can never silently repoint what users pull as "current".
- Tag input is validated and fails fast with a clear error.
- Pure `workflow_dispatch` — no auto-publish on push (can be added later without touching the build code).

## Testing

- YAML validity: `python3 -c yaml.safe_load` across all three workflows — OK.
- Structural check (parsed job graph): `release.yml` → `publish-image` (`needs: release`, `uses: ./.github/workflows/docker-publish.yml`); `publish-container.yml` → `publish` (`needs: validate`, same `uses:`); `docker-publish.yml` is `workflow_call`-only.
- Triggers confirmed: `release.yml` and `publish-container.yml` = `workflow_dispatch`; `docker-publish.yml` = `workflow_call` (correctly has no "Run workflow" button).
- The release tag block passed to the builder is byte-for-byte the original inline rules → release image tags (`:X.Y.Z`, `:X.Y`, `:latest`, `:stable`) are unchanged.
- **Not yet run end-to-end** (can't trigger GitHub Actions from here). Recommended pre/post-merge check: trigger *🐳 Publish Container* with default `devel`, then `docker pull ghcr.io/anantys-oss/koan:devel`; and a release regression to confirm `:latest`/`:stable` still land via the builder.

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

> Not an architectural change — touches only CI workflows (`.github/workflows/**`) and a setup doc. No `specs/components/**` or `specs/skills/**` contract is added or changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
