### PR TITLE
feat: GitHub 'Running' indicator (koan:working label + koan/mission status)

### DIFF
--- a/docs/architecture/github-and-trackers.md
+++ b/docs/architecture/github-and-trackers.md
@@ -4,7 +4,7 @@ title: "GitHub And Trackers"
 description: "Covers GitHub/Jira notification flow, PR workflows (footer, receiving-code-review protocol), review issue-tracker enrichment, and the instance/ tracker files used to dedupe work."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-06-23
+updated: 2026-07-13
 ---
 
 # GitHub And Trackers
@@ -55,6 +55,41 @@ feedback takes a fast-path. The review-learning extraction additionally records
 pushback outcomes (validated vs. overridden) so the agent learns which pushbacks to
 trust.
 
+## Mission status indicators (`koan/mission`)
+
+While a GitHub-linked mission runs, Kōan surfaces a live "Running" indicator on
+GitHub with no GitHub App — a `koan:working` issue label plus a `koan/mission`
+commit status — reusing the existing `gh` auth. See
+`specs/components/git-github.md` (Mission status indicators) for the contract
+and [GitHub commands](../messaging/github-commands.md#running-indicator-koanmission)
+for the user-facing config.
+
+The orchestration lives in `koan/app/mission_status.py` and hangs off the
+mission lifecycle:
+
+1. **Start** — `_start_mission_in_file` (`run.py`) confirms the Pending→In
+   Progress transition, then `start_indicator` resolves the linked issue/repo
+   (from an issue URL in the mission text, else the project's `github_url`),
+   adds the `koan:working` label, and records a tracker entry.
+2. **First push** — `on_branch_pushed` (called from `pr_submit.py` right after
+   the branch is pushed) fills the head SHA into the tracker and posts the
+   `pending` commit status. The commit status is complementary: koan pushes
+   late, so the label is the primary live signal.
+3. **Finalize** — `resolve_indicator` (called from `_finalize_mission`) posts
+   the final `success`/`failure` status and removes the label on every terminal
+   path. A **stagnation requeue** deliberately leaves the indicator up (the
+   mission returns to Pending and is still "running").
+4. **Crash recovery** — a hard crash skips finalize, stranding a yellow
+   `pending`. `startup_manager.reconcile_running_indicators` (run right after
+   crash recovery) resolves any tracked mission no longer Pending/In Progress
+   as `error` and removes its label.
+
+Cross-stage state lives in `instance/.running-indicator.json`, keyed by mission
+title (mirroring `.stagnation-retries.json`). It carries `{repo, issue, sha,
+branch, project}` across the start → push → finalize gap. Local-only missions
+(no issue URL, no `github_url`) write nothing. Every entrypoint is best-effort:
+a `gh` failure is logged and never blocks the mission.
+
 ## Review Issue-Tracker Enrichment
 
 See `specs/components/issue-tracking.md` for the design contract behind the
@@ -93,6 +128,9 @@ Examples include:
 - CI dispatch fingerprints keyed by PR, SHA, and job.
 - Remote rename and default-branch tracking.
 - Burn-rate and quota-related state.
+- Running-indicator state (`.running-indicator.json`), keyed by mission title,
+  carrying the linked issue/repo/SHA across a mission's lifecycle. Stale entries
+  from a crashed run are reconciled at startup.
 
 Use the existing tracker module for a behavior when one exists. If a new tracker
 is needed, keep its state local to `instance/`, make keys stable, and document

--- a/docs/messaging/github-commands.md
+++ b/docs/messaging/github-commands.md
@@ -4,7 +4,7 @@ title: "GitHub Notification-Driven Commands"
 description: "Full reference for triggering Kōan via `@mention` commands in GitHub PR/issue comments, including config, dedup, security, and fallback scanning."
 tags: [messaging]
 created: 2026-05-28
-updated: 2026-06-24
+updated: 2026-07-13
 ---
 
 # GitHub Notification-Driven Commands
@@ -210,6 +210,62 @@ This is useful when the global config allows `["*"]` but a specific repo needs t
 |----------|---------|
 | `GH_TOKEN` | GitHub authentication for the `gh` CLI (required) |
 | `GITHUB_USER` | Override bot username for API calls (optional, falls back to `github.nickname`) |
+
+## Running indicator (`koan/mission`)
+
+While Kōan works a GitHub-linked mission, it surfaces a live "Running" signal
+directly on GitHub — **no GitHub App or Action required**, it reuses the same
+`gh` auth as everything else:
+
+- **Issue label** `koan:working` — added to the linked issue at mission start
+  and removed when the mission reaches a terminal state. This is the **primary
+  live signal**, because the issue is already known when the mission starts.
+- **Commit status** `context=koan/mission` — posted `pending` on the pushed
+  branch head at first push, then resolved to `success` / `failure` / `error`
+  when the mission finishes. This is the durable green/red on the PR.
+
+It is **on by default** and best-effort: a `gh` write failure (e.g. a PAT
+missing `repo:status` scope) is logged and never blocks the mission. It is a
+**no-op for local-only missions** — those with no issue URL in the mission text
+and no `github_url` configured for the project write nothing.
+
+Every terminal path tears the indicator down — normal completion, failure,
+abort, and stagnation-cap. A hard crash that skips teardown is reconciled at
+the next `run.py` startup (any stranded `pending` becomes `error` and the label
+is removed).
+
+### Global settings (`instance/config.yaml`)
+
+```yaml
+running_indicator:
+  enabled: true            # Master switch (default: true). Set false to opt out.
+  commit_status: true      # Post the koan/mission commit status (default: true)
+  issue_label: true        # Toggle the koan:working issue label (default: true)
+  label_name: "koan:working"  # Label text (default: koan:working)
+```
+
+A bare bool is also accepted as shorthand for `enabled`:
+
+```yaml
+running_indicator: false   # equivalent to { enabled: false }
+```
+
+### Per-project override (`projects.yaml`)
+
+Any subset of the global keys can be overridden per project; unset keys inherit
+the global values:
+
+```yaml
+projects:
+  my-toolkit:
+    path: "/path/to/my-toolkit"
+    running_indicator:
+      enabled: false       # disable the indicator for just this project
+```
+
+See also the sibling Telegram progress channel in
+[messaging-level.md](messaging-level.md), and the flow/tracker detail in
+[../architecture/github-and-trackers.md](../architecture/github-and-trackers.md).
 
 ## How It Works
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -828,6 +828,17 @@ memory_monitor:
 #   cooldown_minutes: 30       # Min time between checks per project (default: 30)
 #   log_snippet_bytes: 4096    # Max CI log snippet in mission text (default: 4096)
 
+# Running indicator: live "Kōan is working" signal on GitHub while a
+# GitHub-linked mission runs — a koan:working issue label plus a koan/mission
+# commit status on the pushed branch head. Reuses gh auth (no GitHub App).
+# On by default; best-effort; a no-op for local-only missions. Can be
+# overridden per-project under projects.<name>.running_indicator in projects.yaml.
+# running_indicator:
+#   enabled: true              # Master switch (default: true; set false to opt out)
+#   commit_status: true        # Post the koan/mission commit status (default: true)
+#   issue_label: true          # Toggle the koan:working issue label (default: true)
+#   label_name: "koan:working" # Label text (default: koan:working)
+
 
 # memory:
 #  learnings_max_lines: 100        # Target after semantic compaction

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -960,6 +960,35 @@ def is_ci_check_enabled() -> bool:
     return True
 
 
+def get_running_indicator_config() -> dict:
+    """Resolve the GitHub "Running" indicator config.
+
+    Controls the live indicator Kōan surfaces on GitHub while it works a
+    mission linked to an issue: a ``koan:working`` label on the issue plus a
+    ``koan/mission`` commit status on the pushed branch head.
+
+    Config key: ``running_indicator`` (a dict, or a bare bool for the
+    ``enabled`` toggle). Enabled by default — it is a no-op for local-only
+    missions and best-effort for GitHub ones, so there is no downside to
+    leaving it on. Set ``running_indicator.enabled: false`` to opt out.
+
+    Returns a dict with keys: ``enabled`` (bool), ``commit_status`` (bool),
+    ``issue_label`` (bool), ``label_name`` (str).
+    """
+    config = _load_config()
+    ri = config.get("running_indicator", {})
+    if isinstance(ri, bool):
+        ri = {"enabled": ri}
+    if not isinstance(ri, dict):
+        ri = {}
+    return {
+        "enabled": bool(ri.get("enabled", True)),
+        "commit_status": bool(ri.get("commit_status", True)),
+        "issue_label": bool(ri.get("issue_label", True)),
+        "label_name": str(ri.get("label_name", "koan:working")),
+    }
+
+
 def is_unlimited_quota() -> bool:
     """Return True when the operator declares the CLI provider has no quota limit.
 

--- a/koan/app/config_validator.py
+++ b/koan/app/config_validator.py
@@ -102,6 +102,7 @@ CONFIG_SCHEMA: Dict[str, Any] = {
     "stagnation": _NESTED,
     "optimizations": _NESTED,
     "ci_check": _NESTED,
+    "running_indicator": _NESTED,
 }
 
 # Top-level keys that are recognized but deprecated: they still work (honored
@@ -301,6 +302,14 @@ SECTION_SCHEMAS: Dict[str, Dict[str, str]] = {
         "max_fix_attempts_per_mission": "int",
         "idle_timeout": "int",
     },
+    # running_indicator also accepts a bare bool shorthand
+    # (``running_indicator: true``); the dict form carries the sub-toggles.
+    "running_indicator": {
+        "enabled": "bool",
+        "commit_status": "bool",
+        "issue_label": "bool",
+        "label_name": "str",
+    },
 }
 
 # Type name → Python type(s) for isinstance checks
@@ -416,6 +425,10 @@ def validate_config(config: dict) -> List[Tuple[str, str]]:
                 # ci_check accepts a bare bool shorthand (ci_check: true) in
                 # addition to the dict form — is_ci_check_enabled honors both.
                 if key == "ci_check" and isinstance(value, bool):
+                    continue
+                # running_indicator likewise accepts a bare bool shorthand
+                # (running_indicator: true) — get_running_indicator_config honors both.
+                if key == "running_indicator" and isinstance(value, bool):
                     continue
                 warnings.append((key, f"'{key}' should be a mapping, got {type(value).__name__}"))
                 continue
@@ -926,6 +939,8 @@ def validate_config_or_raise(koan_root: str) -> None:
             # to the dict form — is_ci_check_enabled honors both. Mirror the
             # warning validator so the strict startup path does not regress it.
             if key == "ci_check" and isinstance(value, bool):
+                continue
+            if key == "running_indicator" and isinstance(value, bool):
                 continue
             if not isinstance(value, dict):
                 errors.append(

--- a/koan/app/github.py
+++ b/koan/app/github.py
@@ -295,6 +295,50 @@ def issue_edit(number, body, cwd=None, repo=None):
     return run_gh(*args, cwd=cwd, idempotent=False)
 
 
+def set_commit_status(repo, sha, state, *, context="koan/mission",
+                      description="", target_url=None, cwd=None):
+    """POST a commit status on a branch head via ``gh api`` (raw JSON body).
+
+    Mirrors ``security_advisory_report``'s raw-body transport. ``description``
+    is capped at GitHub's 140-char limit. Lets ``RuntimeError`` propagate so
+    the best-effort caller can degrade.
+
+    Args:
+        repo: Repository in ``owner/repo`` format.
+        sha: Commit SHA the status is attached to.
+        state: One of ``pending``, ``success``, ``failure``, ``error``.
+        context: Status context label (default ``koan/mission``).
+        description: Short human-readable description (truncated to 140 chars).
+        target_url: Optional URL the status links to.
+        cwd: Optional working directory.
+    """
+    payload = {"state": state, "context": context,
+               "description": (description or "")[:140]}
+    if target_url:
+        payload["target_url"] = target_url
+    return api(f"repos/{repo}/statuses/{sha}", method="POST",
+               input_data=json.dumps(payload), raw_body=True, cwd=cwd)
+
+
+def add_issue_label(repo, number, label, cwd=None):
+    """Add a label to an issue via ``gh issue edit --add-label`` (idempotent)."""
+    return run_gh("issue", "edit", str(number), "--repo", repo,
+                  "--add-label", label, cwd=cwd)
+
+
+def remove_issue_label(repo, number, label, cwd=None):
+    """Remove a label from an issue via ``gh issue edit --remove-label``."""
+    return run_gh("issue", "edit", str(number), "--repo", repo,
+                  "--remove-label", label, cwd=cwd)
+
+
+def ensure_label(repo, label, *, color="fbca04",
+                 description="Kōan is working on this issue", cwd=None):
+    """Create-or-update a repo label idempotently via ``gh label create --force``."""
+    return run_gh("label", "create", label, "--repo", repo, "--color", color,
+                  "--description", description, "--force", cwd=cwd)
+
+
 def api(endpoint, method="GET", jq=None, input_data=None, cwd=None,
         extra_args=None, timeout=30, raw_body=False):
     """Call ``gh api`` for lower-level GitHub API access.

--- a/koan/app/mission_status.py
+++ b/koan/app/mission_status.py
@@ -42,12 +42,30 @@ def _tracker_path(instance: str) -> str:
 
 
 def _load(instance: str) -> dict:
+    path = _tracker_path(instance)
     try:
-        with open(_tracker_path(instance), encoding="utf-8") as fh:
+        with open(path, encoding="utf-8") as fh:
             data = json.load(fh)
-            return data if isinstance(data, dict) else {}
-    except (OSError, ValueError):
+    except FileNotFoundError:
         return {}
+    except OSError as e:
+        # Unreadable (permissions/IO): do not clobber — the file still exists,
+        # so a following _save would only overwrite a readable copy anyway. Log
+        # and treat as empty for this call.
+        log("koan", f"running-indicator tracker unreadable: {e}")
+        return {}
+    except ValueError as e:
+        # Corrupt JSON. Returning {} here would let the next _save silently
+        # clobber the file and permanently drop every other tracked mission
+        # (labels/statuses never torn down). Move the corrupt file aside first
+        # so its entries can be recovered by hand, then start fresh.
+        log("koan", f"running-indicator tracker corrupt, backing up: {e}")
+        try:
+            os.replace(path, path + ".corrupt")
+        except OSError as move_err:
+            log("koan", f"running-indicator tracker backup failed: {move_err}")
+        return {}
+    return data if isinstance(data, dict) else {}
 
 
 def _save(instance: str, data: dict) -> None:
@@ -65,7 +83,13 @@ def _resolve_config(project_name: str) -> dict:
         if cfg:
             return get_project_running_indicator(cfg, project_name)
     except Exception as e:
-        log("koan", f"running-indicator config fallback to global: {e}")
+        # Fail closed: the global default is enabled-by-default, so falling back
+        # to it on a transient projects.yaml read error would flip the indicator
+        # back ON for a project that explicitly opted out. Disable instead.
+        log("koan", f"running-indicator config resolve failed, disabling: {e}")
+        return {"enabled": False, "commit_status": False,
+                "issue_label": False, "label_name": "koan:working"}
+    # No projects.yaml at all (cfg falsy) — legitimately global, not a failure.
     from app.config import get_running_indicator_config
     return get_running_indicator_config()
 
@@ -176,25 +200,43 @@ def resolve_indicator(instance: str, mission_title: str, *,
     Posts the final commit status (green/red, or an explicit ``state``) when a
     SHA was recorded, removes the ``koan:working`` label, and drops the tracker
     entry. Best-effort — never blocks finalization.
+
+    The two GitHub writes are independent: one failing must not skip the other
+    or orphan the label. The tracker entry is dropped **only when both writes
+    that were required actually succeeded**, so a failed write is retried by the
+    next startup reconcile and never leaves a stale ``koan/mission`` status or
+    ``koan:working`` label on GitHub.
     """
     try:
         data = _load(instance)
-        entry = data.pop(mission_title, None)
+        entry = data.get(mission_title)
         if entry is None:
             return
-        _save(instance, data)
         cfg = _resolve_config(entry.get("project") or "")
         gh_state = state or ("success" if success else "failure")
+        all_ok = True
         if entry.get("sha") and cfg.get("commit_status"):
-            github.set_commit_status(entry["repo"], entry["sha"], gh_state,
-                                     context=_CONTEXT, description=_DESC)
+            try:
+                github.set_commit_status(entry["repo"], entry["sha"], gh_state,
+                                         context=_CONTEXT, description=_DESC)
+            except Exception as e:  # keep the entry so reconcile retries later
+                all_ok = False
+                log("koan", f"running-indicator resolve commit-status skipped: {e}")
         if entry.get("issue") and cfg.get("issue_label"):
             # The label lives on the issue's repo, which may differ from the
             # push-target repo recorded in ``repo`` (fork workflow). Fall back
             # to ``repo`` for entries persisted before ``issue_repo`` existed.
             issue_repo = entry.get("issue_repo") or entry["repo"]
-            github.remove_issue_label(issue_repo, entry["issue"],
-                                      cfg["label_name"])
+            try:
+                github.remove_issue_label(issue_repo, entry["issue"],
+                                          cfg["label_name"])
+            except Exception as e:  # independent of the commit-status write
+                all_ok = False
+                log("koan", f"running-indicator resolve label skipped: {e}")
+        if all_ok:
+            data = _load(instance)
+            data.pop(mission_title, None)
+            _save(instance, data)
     except Exception as e:
         log("koan", f"running-indicator resolve skipped: {e}")
 

--- a/koan/app/mission_status.py
+++ b/koan/app/mission_status.py
@@ -1,0 +1,215 @@
+"""GitHub "Running" indicator: koan:working label + koan/mission commit status.
+
+While a GitHub-linked mission runs, Kōan surfaces a live indicator with no
+GitHub App, reusing the existing ``gh`` auth:
+
+- an issue **label** (``koan:working``) toggled on the linked issue for the
+  whole run — the primary live signal, since the issue is known at start; and
+- a **commit status** (``context=koan/mission``) posted ``pending`` on the
+  pushed branch head at first push and resolved ``success``/``failure``/
+  ``error`` at finalize.
+
+This module owns the cross-stage bookkeeping (which SHA/issue a mission maps
+to, and what has already been posted) via ``instance/.running-indicator.json``,
+keyed by mission title. Every public entrypoint is best-effort: no failure
+escapes into the mission lifecycle. Local-only missions (no issue URL in the
+text and no ``github_url`` configured) are a silent no-op.
+
+See ``specs/components/git-github.md`` (Mission status indicators) for the
+contract, and ``docs/architecture/github-and-trackers.md`` for the flow.
+"""
+
+import json
+import os
+import re
+from pathlib import Path
+from typing import Optional
+
+from app import github, utils
+from app.github_url_parser import search_issue_url
+from app.run_log import log_safe as log
+
+_TRACKER = ".running-indicator.json"
+_CONTEXT = "koan/mission"
+_DESC = "Kōan is working on this mission"
+
+# owner/repo out of any github(.com|GHE) URL, ignoring a trailing path/.git
+_REPO_URL_RE = re.compile(r"https?://[^/]*github[^/]*/([^/\s]+)/([^/\s#?]+)")
+
+
+def _tracker_path(instance: str) -> str:
+    return os.path.join(instance, _TRACKER)
+
+
+def _load(instance: str) -> dict:
+    try:
+        with open(_tracker_path(instance), encoding="utf-8") as fh:
+            data = json.load(fh)
+            return data if isinstance(data, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _save(instance: str, data: dict) -> None:
+    utils.atomic_write_json(Path(_tracker_path(instance)), data)
+
+
+def _resolve_config(project_name: str) -> dict:
+    """Resolve the per-project running-indicator config, falling back to global."""
+    try:
+        from app.projects_config import (
+            get_project_running_indicator,
+            load_projects_config,
+        )
+        cfg = load_projects_config(os.environ.get("KOAN_ROOT", ""))
+        if cfg:
+            return get_project_running_indicator(cfg, project_name)
+    except Exception:
+        pass
+    from app.config import get_running_indicator_config
+    return get_running_indicator_config()
+
+
+def _repo_from_github_url(url: str) -> Optional[str]:
+    """Extract ``owner/repo`` from a project's configured github_url."""
+    if not url:
+        return None
+    match = _REPO_URL_RE.search(url)
+    if not match:
+        return None
+    repo = match.group(2)
+    if repo.endswith(".git"):
+        repo = repo[:-4]
+    return f"{match.group(1)}/{repo}"
+
+
+def _resolve_link(instance: str, mission_title: str,
+                  project_name: str) -> Optional[dict]:
+    """Derive ``{repo, issue}`` for a mission.
+
+    Priority: an issue URL embedded in the mission text (gives both repo and
+    issue number), then the project's ``github_url`` (repo only, no issue).
+    Returns ``None`` for local-only / non-GitHub missions.
+    """
+    try:
+        owner, name, num = search_issue_url(mission_title)
+        return {"repo": f"{owner}/{name}", "issue": num}
+    except ValueError:
+        pass
+    try:
+        from app.projects_config import get_project_config, load_projects_config
+        cfg = load_projects_config(os.environ.get("KOAN_ROOT", ""))
+        if cfg:
+            url = (get_project_config(cfg, project_name) or {}).get("github_url")
+            repo = _repo_from_github_url(url or "")
+            if repo:
+                return {"repo": repo, "issue": None}
+    except Exception:
+        pass
+    return None
+
+
+def start_indicator(instance: str, mission_title: str,
+                    project_name: str = "") -> None:
+    """Raise the live indicator at the confirmed Pending→In Progress transition.
+
+    Sets the ``koan:working`` label on the linked issue (when there is one) and
+    records a tracker entry so a later push / finalize can complete the flow.
+    Best-effort — never blocks the mission.
+    """
+    cfg = _resolve_config(project_name)
+    if not cfg.get("enabled"):
+        return
+    try:
+        link = _resolve_link(instance, mission_title, project_name)
+        if not link:
+            return  # local-only / non-GitHub mission
+        entry = {"repo": link["repo"], "issue": link["issue"],
+                 "sha": None, "branch": None, "project": project_name}
+        if cfg.get("issue_label") and link["issue"]:
+            github.ensure_label(link["repo"], cfg["label_name"])
+            github.add_issue_label(link["repo"], link["issue"], cfg["label_name"])
+        data = _load(instance)
+        data[mission_title] = entry
+        _save(instance, data)
+    except Exception as e:  # best-effort — never block the mission
+        log("koan", f"running-indicator start skipped: {e}")
+
+
+def on_branch_pushed(instance: str, project_name: str, repo: str,
+                     branch: str, sha: str) -> None:
+    """Post the ``pending`` commit status when a mission branch is first pushed.
+
+    The tracker entry created at start has no SHA yet (koan pushes late); this
+    fills it in, matched by project (only one main-loop mission runs at a time).
+    """
+    cfg = _resolve_config(project_name)
+    if not cfg.get("enabled") or not cfg.get("commit_status"):
+        return
+    try:
+        data = _load(instance)
+        # Match the single active main-loop mission for this project that has
+        # not yet had a SHA recorded.
+        title = next(
+            (t for t, e in data.items()
+             if e.get("project") == project_name and not e.get("sha")),
+            None,
+        )
+        if title is None:
+            return
+        data[title].update(sha=sha, branch=branch, repo=repo)
+        _save(instance, data)
+        github.set_commit_status(repo, sha, "pending", context=_CONTEXT,
+                                 description=_DESC)
+    except Exception as e:
+        log("koan", f"running-indicator push skipped: {e}")
+
+
+def resolve_indicator(instance: str, mission_title: str, *,
+                      success: bool, state: Optional[str] = None) -> None:
+    """Lower the indicator on a terminal transition.
+
+    Posts the final commit status (green/red, or an explicit ``state``) when a
+    SHA was recorded, removes the ``koan:working`` label, and drops the tracker
+    entry. Best-effort — never blocks finalization.
+    """
+    try:
+        data = _load(instance)
+        entry = data.pop(mission_title, None)
+        if entry is None:
+            return
+        _save(instance, data)
+        cfg = _resolve_config(entry.get("project") or "")
+        gh_state = state or ("success" if success else "failure")
+        if entry.get("sha") and cfg.get("commit_status"):
+            github.set_commit_status(entry["repo"], entry["sha"], gh_state,
+                                     context=_CONTEXT, description=_DESC)
+        if entry.get("issue") and cfg.get("issue_label"):
+            github.remove_issue_label(entry["repo"], entry["issue"],
+                                      cfg["label_name"])
+    except Exception as e:
+        log("koan", f"running-indicator resolve skipped: {e}")
+
+
+def reconcile_stale_indicators(instance: str, active_titles) -> None:
+    """Resolve any tracked mission no longer active as an ``error`` (crash net).
+
+    A hard crash skips ``resolve_indicator``, stranding a yellow ``pending``.
+    Called at startup with the set of currently Pending/In Progress mission
+    keys (canonicalized); anything tracked but not active is torn down.
+    """
+    try:
+        from app.missions import canonical_mission_key
+    except Exception:
+        canonical_mission_key = None
+
+    def _key(title: str) -> str:
+        if canonical_mission_key is None:
+            return re.sub(r"\s+", " ", title).strip()
+        return re.sub(r"\s+", " ", canonical_mission_key(title)).strip()
+
+    active = {_key(t) for t in (active_titles or set())}
+    data = _load(instance)
+    for title in [t for t in data if _key(t) not in active]:
+        log("koan", f"running-indicator: reconciling orphan {title[:50]!r}")
+        resolve_indicator(instance, title, success=False, state="error")

--- a/koan/app/mission_status.py
+++ b/koan/app/mission_status.py
@@ -64,8 +64,8 @@ def _resolve_config(project_name: str) -> dict:
         cfg = load_projects_config(os.environ.get("KOAN_ROOT", ""))
         if cfg:
             return get_project_running_indicator(cfg, project_name)
-    except Exception:
-        pass
+    except Exception as e:
+        log("koan", f"running-indicator config fallback to global: {e}")
     from app.config import get_running_indicator_config
     return get_running_indicator_config()
 
@@ -104,8 +104,8 @@ def _resolve_link(instance: str, mission_title: str,
             repo = _repo_from_github_url(url or "")
             if repo:
                 return {"repo": repo, "issue": None}
-    except Exception:
-        pass
+    except Exception as e:
+        log("koan", f"running-indicator link resolve skipped: {e}")
     return None
 
 
@@ -208,7 +208,9 @@ def reconcile_stale_indicators(instance: str, active_titles) -> None:
     """
     try:
         from app.missions import canonical_mission_key
-    except Exception:
+    except Exception as e:
+        log("koan", f"running-indicator: canonical key unavailable, "
+                    f"using raw titles: {e}")
         canonical_mission_key = None
 
     def _key(title: str) -> str:

--- a/koan/app/mission_status.py
+++ b/koan/app/mission_status.py
@@ -124,8 +124,9 @@ def start_indicator(instance: str, mission_title: str,
         link = _resolve_link(instance, mission_title, project_name)
         if not link:
             return  # local-only / non-GitHub mission
-        entry = {"repo": link["repo"], "issue": link["issue"],
-                 "sha": None, "branch": None, "project": project_name}
+        entry = {"repo": link["repo"], "issue_repo": link["repo"],
+                 "issue": link["issue"], "sha": None, "branch": None,
+                 "project": project_name}
         if cfg.get("issue_label") and link["issue"]:
             github.ensure_label(link["repo"], cfg["label_name"])
             github.add_issue_label(link["repo"], link["issue"], cfg["label_name"])
@@ -157,6 +158,9 @@ def on_branch_pushed(instance: str, project_name: str, repo: str,
         )
         if title is None:
             return
+        # ``repo`` here is the push-target repo (used for the commit status);
+        # leave ``issue_repo`` untouched so the label is removed from the
+        # issue's repo at finalize even when they differ (fork workflow).
         data[title].update(sha=sha, branch=branch, repo=repo)
         _save(instance, data)
         github.set_commit_status(repo, sha, "pending", context=_CONTEXT,
@@ -185,7 +189,11 @@ def resolve_indicator(instance: str, mission_title: str, *,
             github.set_commit_status(entry["repo"], entry["sha"], gh_state,
                                      context=_CONTEXT, description=_DESC)
         if entry.get("issue") and cfg.get("issue_label"):
-            github.remove_issue_label(entry["repo"], entry["issue"],
+            # The label lives on the issue's repo, which may differ from the
+            # push-target repo recorded in ``repo`` (fork workflow). Fall back
+            # to ``repo`` for entries persisted before ``issue_repo`` existed.
+            issue_repo = entry.get("issue_repo") or entry["repo"]
+            github.remove_issue_label(issue_repo, entry["issue"],
                                       cfg["label_name"])
     except Exception as e:
         log("koan", f"running-indicator resolve skipped: {e}")

--- a/koan/app/pr_submit.py
+++ b/koan/app/pr_submit.py
@@ -383,6 +383,23 @@ def submit_draft_pr(
     # Resolve where to submit
     target = resolve_submit_target(project_path, project_name, owner, repo)
 
+    # Post the pending "koan/mission" commit status on the freshly-pushed head.
+    # Best-effort: a failure here must never abort PR submission.
+    try:
+        from app.mission_status import on_branch_pushed
+
+        koan_root = os.environ.get("KOAN_ROOT", "")
+        if koan_root:
+            instance_dir = os.path.join(koan_root, "instance")
+            head_sha = run_git_strict(
+                "rev-parse", "HEAD", cwd=project_path, timeout=15,
+            ).strip()
+            on_branch_pushed(
+                instance_dir, project_name, target["repo"], branch, head_sha,
+            )
+    except Exception as e:
+        logger.warning("running-indicator push hook skipped: %s", e)
+
     if footer_enabled:
         from app.pr_footer import append_koan_footer, build_pr_footer
 

--- a/koan/app/projects_config.py
+++ b/koan/app/projects_config.py
@@ -371,6 +371,29 @@ def get_project_auto_merge(config: dict, project_name: str) -> dict:
     }
 
 
+def get_project_running_indicator(config: dict, project_name: str) -> dict:
+    """Per-project override for the GitHub "Running" indicator.
+
+    Merges the global ``running_indicator`` config (see
+    ``app.config.get_running_indicator_config``) with a per-project
+    ``running_indicator`` block from projects.yaml. Only keys explicitly set
+    (non-None) on the project override the global values, so a project can flip
+    ``enabled`` without restating ``label_name``.
+
+    Returns a dict with the same keys as the global resolver.
+    """
+    from app.config import get_running_indicator_config
+
+    base = get_running_indicator_config()
+    project_cfg = get_project_config(config, project_name)
+    ri = project_cfg.get("running_indicator", {})
+    if isinstance(ri, bool):
+        ri = {"enabled": ri}
+    if not isinstance(ri, dict):
+        ri = {}
+    return {**base, **{k: v for k, v in ri.items() if v is not None}}
+
+
 def resolve_base_branch(
     project_name: str, project_path: Optional[str] = None
 ) -> str:

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -3050,6 +3050,15 @@ def _finalize_mission(instance: str, mission_title: str, project_name: str,
     _update_mission_in_file(
         instance, mission_title, failed=failed, cause_tag=cause_tag,
     )
+    # Lower the GitHub "Running" indicator now that the mission has reached a
+    # terminal state. The stagnation-requeue path returns early above (mission
+    # goes back to Pending), so it deliberately leaves the indicator up.
+    # Best-effort — never block finalization.
+    try:
+        from app.mission_status import resolve_indicator
+        resolve_indicator(instance, mission_title, success=(not failed))
+    except Exception as e:
+        log("error", f"running-indicator resolve error: {e}")
     # Record the authoritative terminal outcome for the REST API. Best-effort:
     # a log hiccup must not block finalization. record_outcome is imported
     # locally (matches the record_execution convention below) — tests patch it

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -2805,6 +2805,13 @@ def _start_mission_in_file(instance: str, mission_title: str, project_name: str 
                         f"recover.py missed them "
                         f"(see _flush_in_progress_to_failed): {titles}"
                     ))
+                # Raise the GitHub "Running" indicator now that the transition
+                # is confirmed. Best-effort — never block the mission start.
+                try:
+                    from app.mission_status import start_indicator
+                    start_indicator(instance, mission_title, project_name)
+                except Exception as e:
+                    log("error", f"running-indicator start error: {e}")
                 return True
         log("warning", f"Mission transition unconfirmed — '{clean_title[:60]}' "
             "not found in In Progress after start_mission(). "

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -94,6 +94,48 @@ def recover_crashed_missions(instance: str):
     recover_missions(instance)
 
 
+def _current_active_titles(instance: str):
+    """Titles currently Pending or In Progress in the mission export.
+
+    Returns a set of mission-line strings, or ``None`` if the export cannot be
+    read/parsed — the caller then skips reconciliation (fail-open) rather than
+    treating "couldn't read" as "nothing active" and wrongly clearing every
+    live indicator. Called after crash recovery, so a requeued mission is back
+    in Pending and correctly keeps its indicator until it re-runs.
+    """
+    import os
+
+    from app import missions
+
+    path = os.path.join(instance, "missions.md")
+    if not os.path.exists(path):
+        return set()
+    try:
+        with open(path, encoding="utf-8") as fh:
+            content = fh.read()
+        sections = missions.parse_sections(content)
+        titles = set()
+        for key in ("pending", "in_progress"):
+            titles.update(sections.get(key, []))
+        return titles
+    except (OSError, ValueError):
+        return None
+
+
+def reconcile_running_indicators(instance: str) -> None:
+    """Tear down stale GitHub 'Running' indicators left by a hard crash.
+
+    A SIGKILL / power loss skips ``_finalize_mission``'s teardown, stranding a
+    yellow ``pending`` status and a ``koan:working`` label. Resolve any tracked
+    mission that is no longer active as an ``error``.
+    """
+    active = _current_active_titles(instance)
+    if active is None:
+        return  # could not read active set — do not wrongly clear
+    from app.mission_status import reconcile_stale_indicators
+    reconcile_stale_indicators(instance, active)
+
+
 def run_migrations(koan_root: str):
     """Auto-migrate env vars to projects.yaml (one-shot, idempotent)."""
     from app.projects_migration import run_migration
@@ -708,6 +750,7 @@ def run_startup(koan_root: str, instance: str, projects: list):
 
         _safe_run("Config validation", validate_config, koan_root)
         _safe_run("Crash recovery", recover_crashed_missions, instance)
+        _safe_run("Running-indicator reconcile", reconcile_running_indicators, instance)
         _safe_run("Projects migration", run_migrations, koan_root)
         msgs = _safe_run("Ensure projects.yaml", ensure_projects_yaml, koan_root)
         if msgs:

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -1931,6 +1931,49 @@ class TestCiCheckConfig:
         assert "unexpected type" in capsys.readouterr().err
 
 
+class TestRunningIndicatorConfig:
+    """Tests for get_running_indicator_config()."""
+
+    def test_defaults_on(self):
+        from app.config import get_running_indicator_config
+        with _mock_config({}):
+            cfg = get_running_indicator_config()
+        assert cfg == {
+            "enabled": True,
+            "commit_status": True,
+            "issue_label": True,
+            "label_name": "koan:working",
+        }
+
+    def test_explicit_block_overrides(self):
+        from app.config import get_running_indicator_config
+        with _mock_config(
+            {"running_indicator": {"enabled": False, "commit_status": False}}
+        ):
+            cfg = get_running_indicator_config()
+        assert cfg["enabled"] is False
+        assert cfg["commit_status"] is False
+        assert cfg["issue_label"] is True
+        assert cfg["label_name"] == "koan:working"
+
+    def test_custom_label_name(self):
+        from app.config import get_running_indicator_config
+        with _mock_config({"running_indicator": {"label_name": "wip"}}):
+            cfg = get_running_indicator_config()
+        assert cfg["label_name"] == "wip"
+
+    def test_bare_bool(self):
+        from app.config import get_running_indicator_config
+        with _mock_config({"running_indicator": False}):
+            assert get_running_indicator_config()["enabled"] is False
+
+    def test_non_dict_non_bool_uses_defaults(self):
+        from app.config import get_running_indicator_config
+        with _mock_config({"running_indicator": "yes"}):
+            cfg = get_running_indicator_config()
+        assert cfg["enabled"] is True
+
+
 # --- get_review_verdict_config ---
 
 

--- a/koan/tests/test_github.py
+++ b/koan/tests/test_github.py
@@ -1688,3 +1688,80 @@ class TestDetectEcosystem:
         from app.github import detect_ecosystem
 
         assert detect_ecosystem(str(tmp_path)) == "other"
+
+
+# ---------------------------------------------------------------------------
+# Mission status indicators (koan/mission)
+# ---------------------------------------------------------------------------
+
+
+class TestSetCommitStatus:
+    def test_posts_raw_json(self, monkeypatch):
+        import app.github as github
+
+        calls = {}
+
+        def fake_api(endpoint, method="GET", input_data=None,
+                     raw_body=False, cwd=None, **kw):
+            calls.update(endpoint=endpoint, method=method,
+                         body=json.loads(input_data), raw_body=raw_body)
+            return "{}"
+
+        monkeypatch.setattr(github, "api", fake_api)
+        github.set_commit_status("o/r", "abc123", "pending",
+                                 description="Kōan is working on this mission")
+        assert calls["endpoint"] == "repos/o/r/statuses/abc123"
+        assert calls["method"] == "POST"
+        assert calls["raw_body"] is True
+        assert calls["body"]["state"] == "pending"
+        assert calls["body"]["context"] == "koan/mission"
+
+    def test_description_truncated_to_140(self, monkeypatch):
+        import app.github as github
+
+        captured = {}
+        monkeypatch.setattr(
+            github, "api",
+            lambda endpoint, **kw: captured.update(
+                body=json.loads(kw["input_data"])) or "{}",
+        )
+        github.set_commit_status("o/r", "sha", "success", description="x" * 300)
+        assert len(captured["body"]["description"]) == 140
+
+    def test_target_url_included(self, monkeypatch):
+        import app.github as github
+
+        captured = {}
+        monkeypatch.setattr(
+            github, "api",
+            lambda endpoint, **kw: captured.update(
+                body=json.loads(kw["input_data"])) or "{}",
+        )
+        github.set_commit_status("o/r", "sha", "success",
+                                 target_url="https://pr/1")
+        assert captured["body"]["target_url"] == "https://pr/1"
+
+
+class TestIssueLabelToggle:
+    def test_add_and_remove_label(self, monkeypatch):
+        import app.github as github
+
+        seen = []
+        monkeypatch.setattr(github, "run_gh",
+                            lambda *a, **k: seen.append(a) or "")
+        github.add_issue_label("o/r", 42, "koan:working")
+        github.remove_issue_label("o/r", 42, "koan:working")
+        assert seen[0] == ("issue", "edit", "42", "--repo", "o/r",
+                           "--add-label", "koan:working")
+        assert seen[1][5] == "--remove-label"
+
+    def test_ensure_label_uses_force(self, monkeypatch):
+        import app.github as github
+
+        seen = []
+        monkeypatch.setattr(github, "run_gh",
+                            lambda *a, **k: seen.append(a) or "")
+        github.ensure_label("o/r", "koan:working")
+        assert seen[0][:5] == ("label", "create", "koan:working",
+                               "--repo", "o/r")
+        assert "--force" in seen[0]

--- a/koan/tests/test_mission_status.py
+++ b/koan/tests/test_mission_status.py
@@ -174,6 +174,50 @@ def test_resolve_posts_status_and_removes_label(tmp_path, monkeypatch):
     assert json.loads(_tracker(tmp_path).read_text()) == {}
 
 
+def test_resolve_fork_removes_label_from_issue_repo(tmp_path, monkeypatch):
+    """Fork workflow: label removed from the issue's repo, status on the fork.
+
+    ``start`` records the upstream issue repo; ``on_branch_pushed`` overwrites
+    ``repo`` with the fork push-target. Finalize must remove the label from the
+    upstream issue repo, not the fork (which has no such issue).
+    """
+    import app.github as github
+    import app.mission_status as ms
+
+    # Emulate the persisted entry after start + push in a fork workflow:
+    # issue_repo = upstream, repo = fork push-target.
+    _tracker(tmp_path).write_text(json.dumps(
+        {"fix the bug": {"repo": "me/fork", "issue_repo": "upstream/proj",
+                         "issue": "7", "sha": "deadbee", "project": "proj"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted, removed = [], []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda r, s, st, **k: posted.append((r, s, st)))
+    monkeypatch.setattr(github, "remove_issue_label",
+                        lambda r, n, label, **k: removed.append((r, n, label)))
+    ms.resolve_indicator(str(tmp_path), "fix the bug", success=True)
+    assert posted == [("me/fork", "deadbee", "success")]
+    assert removed == [("upstream/proj", "7", "koan:working")]
+
+
+def test_start_then_push_preserves_issue_repo(tmp_path, monkeypatch):
+    """A fork push must not clobber the issue repo recorded at start."""
+    import app.github as github
+    import app.mission_status as ms
+
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    monkeypatch.setattr(ms, "_resolve_link",
+                        lambda i, t, p: {"repo": "upstream/proj", "issue": "7"})
+    monkeypatch.setattr(github, "ensure_label", lambda *a, **k: "")
+    monkeypatch.setattr(github, "add_issue_label", lambda *a, **k: None)
+    monkeypatch.setattr(github, "set_commit_status", lambda *a, **k: None)
+    ms.start_indicator(str(tmp_path), "fix the bug", "proj")
+    ms.on_branch_pushed(str(tmp_path), "proj", "me/fork", "koan/x", "deadbee")
+    entry = json.loads(_tracker(tmp_path).read_text())["fix the bug"]
+    assert entry["issue_repo"] == "upstream/proj"
+    assert entry["repo"] == "me/fork"
+
+
 def test_resolve_failure_posts_red(tmp_path, monkeypatch):
     import app.github as github
     import app.mission_status as ms

--- a/koan/tests/test_mission_status.py
+++ b/koan/tests/test_mission_status.py
@@ -278,6 +278,55 @@ def test_reconcile_marks_orphan_as_error(tmp_path, monkeypatch):
     assert json.loads(_tracker(tmp_path).read_text()) == {}
 
 
+def test_resolve_keeps_entry_when_commit_status_fails(tmp_path, monkeypatch):
+    """A failed commit-status write must keep the entry for reconcile retry and
+    still attempt the independent label removal (no orphaned label)."""
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"m": {"repo": "o/r", "issue": "7", "sha": "abc", "project": "p"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    removed = []
+
+    def boom(*a, **k):
+        raise RuntimeError("no repo:status scope")
+
+    monkeypatch.setattr(github, "set_commit_status", boom)
+    monkeypatch.setattr(github, "remove_issue_label",
+                        lambda r, n, label, **k: removed.append((n, label)))
+    ms.resolve_indicator(str(tmp_path), "m", success=True)
+    # Label still removed despite the commit-status failure...
+    assert removed == [("7", "koan:working")]
+    # ...and the entry is retained so the next startup reconcile can retry.
+    assert "m" in json.loads(_tracker(tmp_path).read_text())
+
+
+def test_load_backs_up_corrupt_tracker(tmp_path, monkeypatch):
+    """Corrupt JSON is moved aside (not clobbered) so entries can be recovered."""
+    import app.mission_status as ms
+
+    tracker = _tracker(tmp_path)
+    tracker.write_text("{not valid json")
+    assert ms._load(str(tmp_path)) == {}
+    assert not tracker.exists()
+    assert (tmp_path / ".running-indicator.json.corrupt").read_text() == \
+        "{not valid json"
+
+
+def test_resolve_config_fails_closed_on_error(tmp_path, monkeypatch):
+    """A projects.yaml read error disables the indicator (fail-closed) instead
+    of reverting to the enabled-by-default global config."""
+    import app.mission_status as ms
+
+    def boom(_root):
+        raise RuntimeError("transient read error")
+
+    monkeypatch.setattr("app.projects_config.load_projects_config", boom)
+    cfg = ms._resolve_config("proj")
+    assert cfg["enabled"] is False
+
+
 def test_reconcile_keeps_active(tmp_path, monkeypatch):
     import app.github as github
     import app.mission_status as ms

--- a/koan/tests/test_mission_status.py
+++ b/koan/tests/test_mission_status.py
@@ -1,0 +1,251 @@
+"""Tests for app.mission_status — GitHub 'Running' indicator orchestrator."""
+
+import json
+
+import pytest
+
+
+def _cfg(**over):
+    base = {"enabled": True, "commit_status": True,
+            "issue_label": True, "label_name": "koan:working"}
+    base.update(over)
+    return base
+
+
+def _tracker(tmp_path):
+    return tmp_path / ".running-indicator.json"
+
+
+# ---------------------------------------------------------------------------
+# Config gating
+# ---------------------------------------------------------------------------
+
+
+def test_start_disabled_is_noop(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg(enabled=False))
+    monkeypatch.setattr(ms, "_resolve_link",
+                        lambda i, t, p: {"repo": "o/r", "issue": "7"})
+    ms.start_indicator(str(tmp_path), "mission", "proj")
+    assert not _tracker(tmp_path).exists()
+
+
+def test_start_local_only_is_noop(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    monkeypatch.setattr(ms, "_resolve_link", lambda i, t, p: None)
+    ms.start_indicator(str(tmp_path), "local mission", "proj")
+    assert not _tracker(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# Linkage resolution
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_link_from_issue_url(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    text = "Fix https://github.com/acme/widgets/issues/12 please"
+    link = ms._resolve_link(str(tmp_path), text, "proj")
+    assert link == {"repo": "acme/widgets", "issue": "12"}
+
+
+def test_resolve_link_from_github_url(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    def fake_load(_root):
+        return {"projects": {"proj": {"github_url": "https://github.com/acme/tool.git"}}}
+
+    monkeypatch.setattr("app.projects_config.load_projects_config", fake_load)
+    monkeypatch.setattr("app.projects_config.get_project_config",
+                        lambda cfg, name: cfg["projects"][name])
+    link = ms._resolve_link(str(tmp_path), "no issue url here", "proj")
+    assert link == {"repo": "acme/tool", "issue": None}
+
+
+def test_resolve_link_none_for_local(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    monkeypatch.setattr("app.projects_config.load_projects_config",
+                        lambda _root: {"projects": {"proj": {}}})
+    monkeypatch.setattr("app.projects_config.get_project_config",
+                        lambda cfg, name: {})
+    assert ms._resolve_link(str(tmp_path), "just text", "proj") is None
+
+
+# ---------------------------------------------------------------------------
+# start -> track
+# ---------------------------------------------------------------------------
+
+
+def test_start_sets_label_and_tracks(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    monkeypatch.setattr(ms, "_resolve_link",
+                        lambda i, t, p: {"repo": "o/r", "issue": "7"})
+    added = []
+    monkeypatch.setattr(github, "ensure_label", lambda *a, **k: "")
+    monkeypatch.setattr(github, "add_issue_label",
+                        lambda r, n, label, **k: added.append((r, n, label)))
+    ms.start_indicator(str(tmp_path), "fix the bug", "proj")
+    assert added == [("o/r", "7", "koan:working")]
+    tracker = json.loads(_tracker(tmp_path).read_text())
+    assert tracker["fix the bug"]["issue"] == "7"
+    assert tracker["fix the bug"]["sha"] is None
+
+
+def test_start_without_issue_skips_label(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    monkeypatch.setattr(ms, "_resolve_link",
+                        lambda i, t, p: {"repo": "o/r", "issue": None})
+    called = []
+    monkeypatch.setattr(github, "add_issue_label",
+                        lambda *a, **k: called.append(a))
+    ms.start_indicator(str(tmp_path), "analysis mission", "proj")
+    assert called == []
+    tracker = json.loads(_tracker(tmp_path).read_text())
+    assert tracker["analysis mission"]["issue"] is None
+
+
+# ---------------------------------------------------------------------------
+# on_branch_pushed
+# ---------------------------------------------------------------------------
+
+
+def test_on_branch_pushed_posts_pending(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"fix the bug": {"repo": "o/r", "issue": "7",
+                         "sha": None, "project": "proj"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda r, s, st, **k: posted.append((r, s, st)))
+    ms.on_branch_pushed(str(tmp_path), "proj", "o/r", "koan/x", "deadbee")
+    assert posted == [("o/r", "deadbee", "pending")]
+    tracker = json.loads(_tracker(tmp_path).read_text())
+    assert tracker["fix the bug"]["sha"] == "deadbee"
+
+
+def test_on_branch_pushed_no_match_is_noop(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps({}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda *a, **k: posted.append(a))
+    ms.on_branch_pushed(str(tmp_path), "proj", "o/r", "koan/x", "sha")
+    assert posted == []
+
+
+# ---------------------------------------------------------------------------
+# resolve
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_posts_status_and_removes_label(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"fix the bug": {"repo": "o/r", "issue": "7",
+                         "sha": "deadbee", "project": "proj"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted, removed = [], []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda r, s, st, **k: posted.append((s, st)))
+    monkeypatch.setattr(github, "remove_issue_label",
+                        lambda r, n, label, **k: removed.append((n, label)))
+    ms.resolve_indicator(str(tmp_path), "fix the bug", success=True)
+    assert posted == [("deadbee", "success")]
+    assert removed == [("7", "koan:working")]
+    assert json.loads(_tracker(tmp_path).read_text()) == {}
+
+
+def test_resolve_failure_posts_red(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"m": {"repo": "o/r", "issue": "7", "sha": "abc", "project": "p"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda r, s, st, **k: posted.append(st))
+    monkeypatch.setattr(github, "remove_issue_label", lambda *a, **k: None)
+    ms.resolve_indicator(str(tmp_path), "m", success=False)
+    assert posted == ["failure"]
+
+
+def test_resolve_no_sha_skips_status(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"m": {"repo": "o/r", "issue": "7", "sha": None, "project": "p"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    posted = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda *a, **k: posted.append(a))
+    monkeypatch.setattr(github, "remove_issue_label", lambda *a, **k: None)
+    ms.resolve_indicator(str(tmp_path), "m", success=True)
+    assert posted == []
+
+
+def test_resolve_unknown_title_is_noop(tmp_path, monkeypatch):
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps({}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    # Must not raise.
+    ms.resolve_indicator(str(tmp_path), "absent", success=True)
+
+
+# ---------------------------------------------------------------------------
+# reconcile
+# ---------------------------------------------------------------------------
+
+
+def test_reconcile_marks_orphan_as_error(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"orphan": {"repo": "o/r", "issue": "7", "sha": "abc", "project": "p"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    states = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda r, s, st, **k: states.append(st))
+    monkeypatch.setattr(github, "remove_issue_label", lambda *a, **k: None)
+    ms.reconcile_stale_indicators(str(tmp_path), active_titles=set())
+    assert states == ["error"]
+    assert json.loads(_tracker(tmp_path).read_text()) == {}
+
+
+def test_reconcile_keeps_active(tmp_path, monkeypatch):
+    import app.github as github
+    import app.mission_status as ms
+
+    _tracker(tmp_path).write_text(json.dumps(
+        {"still running": {"repo": "o/r", "issue": "7",
+                           "sha": "abc", "project": "p"}}))
+    monkeypatch.setattr(ms, "_resolve_config", lambda p: _cfg())
+    states = []
+    monkeypatch.setattr(github, "set_commit_status",
+                        lambda *a, **k: states.append(a))
+    ms.reconcile_stale_indicators(str(tmp_path),
+                                  active_titles={"still running"})
+    assert states == []
+    assert "still running" in json.loads(_tracker(tmp_path).read_text())

--- a/koan/tests/test_pr_submit.py
+++ b/koan/tests/test_pr_submit.py
@@ -329,6 +329,44 @@ class TestSubmitDraftPr:
             )
             assert kw["draft"] is True
 
+    def test_posts_running_indicator_on_push(self, monkeypatch):
+        """After a successful push, the pending koan/mission commit status is
+        posted on the resolved head SHA via mission_status.on_branch_pushed."""
+        import app.mission_status as ms
+
+        monkeypatch.setenv("KOAN_ROOT", "/tmp/test-koan")
+        seen = {}
+        monkeypatch.setattr(
+            ms, "on_branch_pushed",
+            lambda instance, project, repo, branch, sha: seen.update(
+                instance=instance, project=project, repo=repo,
+                branch=branch, sha=sha),
+        )
+
+        def fake_git(*args, **kwargs):
+            if args[:1] == ("rev-parse",):
+                return "deadbeef\n"
+            return ""
+
+        with patch(f"{_M}.get_current_branch", return_value="koan/feat"), \
+             patch(f"{_M}.resolve_base_branch", return_value="main"), \
+             patch(f"{_M}.run_gh", side_effect=["", ""]), \
+             patch(f"{_M}.get_commit_subjects", return_value=["c1"]), \
+             patch(f"{_M}.run_git_strict", side_effect=fake_git), \
+             patch(f"{_M}.resolve_submit_target",
+                   return_value={"repo": "o/r", "is_fork": False}), \
+             patch(f"{_M}.pr_create", return_value="https://pr/99"):
+            result = submit_draft_pr(
+                "/p", "proj", "o", "r", "42",
+                pr_title="fix: bug", pr_body="## Summary\nFixed.",
+                footer_enabled=False,
+            )
+        assert result == "https://pr/99"
+        assert seen == {
+            "instance": "/tmp/test-koan/instance", "project": "proj",
+            "repo": "o/r", "branch": "koan/feat", "sha": "deadbeef",
+        }
+
     def test_replaces_existing_koan_footer(self):
         old_body = (
             "## Summary\nFixed.\n\n---\n"

--- a/koan/tests/test_projects_config.py
+++ b/koan/tests/test_projects_config.py
@@ -18,6 +18,7 @@ from app.projects_config import (
     get_project_models,
     get_project_review_history,
     get_project_review_verdict,
+    get_project_running_indicator,
     get_project_submit_to_repository,
     get_project_tools,
     resolve_base_branch,
@@ -478,6 +479,64 @@ class TestGetProjectAutoMerge:
         }
         result = get_project_auto_merge(config, "unknown")
         assert result["enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# get_project_running_indicator
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectRunningIndicator:
+    """Tests for get_project_running_indicator()."""
+
+    def test_running_indicator_defaults_on(self):
+        # Global default is enabled with the canonical label name.
+        with patch("app.config._load_config", return_value={}):
+            config = {"projects": {"my-toolkit": {"path": "/p"}}}
+            ri = get_project_running_indicator(config, "my-toolkit")
+        assert ri["enabled"] is True
+        assert ri["commit_status"] is True
+        assert ri["issue_label"] is True
+        assert ri["label_name"] == "koan:working"
+
+    def test_project_can_opt_out(self):
+        with patch("app.config._load_config", return_value={}):
+            config = {
+                "projects": {
+                    "my-toolkit": {
+                        "path": "/p",
+                        "running_indicator": {"enabled": False},
+                    }
+                }
+            }
+            ri = get_project_running_indicator(config, "my-toolkit")
+        assert ri["enabled"] is False
+        # Unset keys still inherit the global defaults.
+        assert ri["label_name"] == "koan:working"
+
+    def test_project_override_partial(self):
+        with patch("app.config._load_config", return_value={}):
+            config = {
+                "defaults": {},
+                "projects": {
+                    "my-toolkit": {
+                        "running_indicator": {
+                            "commit_status": False,
+                            "label_name": "wip",
+                        }
+                    }
+                },
+            }
+            ri = get_project_running_indicator(config, "my-toolkit")
+        assert ri["enabled"] is True  # inherited
+        assert ri["commit_status"] is False  # overridden
+        assert ri["label_name"] == "wip"  # overridden
+
+    def test_bare_bool_override(self):
+        with patch("app.config._load_config", return_value={}):
+            config = {"projects": {"my-toolkit": {"running_indicator": False}}}
+            ri = get_project_running_indicator(config, "my-toolkit")
+        assert ri["enabled"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -122,6 +122,69 @@ class TestClearIfCapHit:
             assert run._clear_if_cap_hit(str(tmp_path), "Fix bug", "tight") is False
 
 
+class TestFinalizeRunningIndicator:
+    """_finalize_mission lowers the GitHub 'Running' indicator on terminal
+    paths, and deliberately leaves it up on a stagnation requeue."""
+
+    def _patch_downstream(self, monkeypatch):
+        from app import run
+        monkeypatch.setattr(run, "_update_mission_in_file", lambda *a, **k: True)
+        monkeypatch.setattr("app.mission_outcome.record_outcome",
+                            lambda *a, **k: True)
+        monkeypatch.setattr("app.mission_outcome.classify_failure",
+                            lambda *a, **k: None)
+        monkeypatch.setattr("app.mission_history.record_execution",
+                            lambda *a, **k: None)
+
+    def test_terminal_success_resolves_green(self, tmp_path, monkeypatch):
+        from app import run
+        import app.mission_status as ms
+        run._last_mission_stagnated.clear()
+        self._patch_downstream(monkeypatch)
+        got = {}
+        monkeypatch.setattr(ms, "resolve_indicator",
+                            lambda i, t, *, success: got.update(t=t, ok=success))
+        run._finalize_mission(str(tmp_path), "mission", "proj", 0)
+        assert got == {"t": "mission", "ok": True}
+
+    def test_terminal_failure_resolves_red(self, tmp_path, monkeypatch):
+        from app import run
+        import app.mission_status as ms
+        run._last_mission_stagnated.clear()
+        self._patch_downstream(monkeypatch)
+        got = {}
+        monkeypatch.setattr(ms, "resolve_indicator",
+                            lambda i, t, *, success: got.update(t=t, ok=success))
+        run._finalize_mission(str(tmp_path), "mission", "proj", 1)
+        assert got == {"t": "mission", "ok": False}
+
+    def test_stagnation_requeue_does_not_resolve(self, tmp_path, monkeypatch):
+        from app import run
+        import app.mission_status as ms
+        run._last_mission_stagnated.set()
+        monkeypatch.setattr(
+            "app.config.get_stagnation_config",
+            lambda project_name="": {"max_retry_on_stagnation": 3,
+                                     "max_total_retries": 0},
+        )
+        monkeypatch.setattr("app.stagnation_monitor.get_retry_count",
+                            lambda i, t: 0)
+        monkeypatch.setattr("app.stagnation_monitor.get_total_attempts",
+                            lambda i, t: 0)
+        monkeypatch.setattr("app.stagnation_monitor.increment_retry_count",
+                            lambda *a, **k: 1)
+        monkeypatch.setattr(run, "_requeue_mission_in_file", lambda *a, **k: None)
+        monkeypatch.setattr(run, "_notify_stagnation_retry", lambda *a, **k: None)
+        monkeypatch.setattr("app.mission_history.record_execution",
+                            lambda *a, **k: None)
+        called = []
+        monkeypatch.setattr(ms, "resolve_indicator",
+                            lambda *a, **k: called.append(1))
+        run._finalize_mission(str(tmp_path), "m", "proj", 1)
+        assert called == []
+        run._last_mission_stagnated.clear()
+
+
 # ---------------------------------------------------------------------------
 # Test: Colored logging
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -6756,6 +6756,46 @@ class TestStartMissionSanityFlushLog:
         assert "leftover stale" not in "\n".join(sections.get("failed", []))
 
 
+class TestStartMissionRunningIndicator:
+    """The confirmed Pending→In Progress transition raises the GitHub
+    'Running' indicator via mission_status.start_indicator."""
+
+    def test_start_fires_indicator_on_confirmed_transition(self, tmp_path):
+        import app.mission_status as ms
+        from app.run import _start_mission_in_file
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n- do the thing\n\n"
+            "## In Progress\n\n## Done\n"
+        )
+        called = {}
+        with patch.object(ms, "start_indicator",
+                          lambda i, t, p: called.update(i=i, t=t, p=p)):
+            assert _start_mission_in_file(
+                str(missions.parent), "do the thing", "proj") is True
+        assert called == {"i": str(missions.parent),
+                          "t": "do the thing", "p": "proj"}
+
+    def test_start_does_not_fire_on_unconfirmed_transition(self, tmp_path):
+        import app.mission_status as ms
+        from app.run import _start_mission_in_file
+
+        missions = tmp_path / "instance" / "missions.md"
+        missions.parent.mkdir(parents=True)
+        # Mission absent from Pending → transition not confirmed.
+        missions.write_text(
+            "# Missions\n\n## Pending\n\n## In Progress\n\n## Done\n"
+        )
+        called = []
+        with patch.object(ms, "start_indicator",
+                          lambda *a, **k: called.append(a)):
+            assert _start_mission_in_file(
+                str(missions.parent), "absent", "proj") is False
+        assert called == []
+
+
 class TestStartMissionComplexityTagTOCTOU:
     """Regression for #2087: a [complexity:X] tag injected into the Pending
     line *after* the mission title was captured must not break the transition

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -56,6 +56,45 @@ class TestRecoverCrashedMissions:
 
 
 # ---------------------------------------------------------------------------
+# Test: running-indicator reconciliation
+# ---------------------------------------------------------------------------
+
+class TestReconcileRunningIndicators:
+    def test_reconciles_orphan_at_startup(self, instance):
+        import json
+
+        from app import mission_status, startup_manager
+        Path(instance, ".running-indicator.json").write_text(json.dumps(
+            {"dead mission": {"repo": "o/r", "issue": "7",
+                              "sha": "abc", "project": "p"}}))
+        with patch.object(startup_manager, "_current_active_titles",
+                          return_value=set()), \
+             patch.object(mission_status, "reconcile_stale_indicators") as recon:
+            startup_manager.reconcile_running_indicators(instance)
+        recon.assert_called_once_with(instance, set())
+
+    def test_skips_when_active_titles_unreadable(self, instance):
+        from app import mission_status, startup_manager
+        with patch.object(startup_manager, "_current_active_titles",
+                          return_value=None), \
+             patch.object(mission_status, "reconcile_stale_indicators") as recon:
+            startup_manager.reconcile_running_indicators(instance)
+        recon.assert_not_called()
+
+    def test_current_active_titles_collects_pending_and_in_progress(self, instance):
+        from app.startup_manager import _current_active_titles
+        Path(instance, "missions.md").write_text(
+            "# Missions\n\n## Pending\n\n- pending one\n\n"
+            "## In Progress\n\n- running two\n\n## Done\n\n- done three\n"
+        )
+        titles = _current_active_titles(instance)
+        joined = "\n".join(titles)
+        assert "pending one" in joined
+        assert "running two" in joined
+        assert "done three" not in joined
+
+
+# ---------------------------------------------------------------------------
 # Test: run_migrations
 # ---------------------------------------------------------------------------
 

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -63,6 +63,31 @@ workflows.
   remote base anyway. A **conflict-free** dirty tree is never discarded — the
   stash data-loss guard still holds for genuine uncommitted work.
 
+### Mission status indicators (koan/mission)
+
+While a GitHub-linked mission runs, Kōan surfaces a live indicator with no
+GitHub App:
+
+- **Issue label** `koan:working` — toggled on the linked issue for the whole
+  run (primary live signal; the issue is known at mission start).
+- **Commit status** `context=koan/mission` — posted `pending` on the pushed
+  branch head at first push, resolved `success`/`failure`/`error` at finalize.
+
+**Invariants**
+
+- All writes go through `github.run_gh()`/`github.api()` (gh-only transport),
+  honoring the existing `gh`-only invariant above.
+- Indicators are best-effort: a write failure logs and degrades, never blocks
+  the mission.
+- Every terminal path (success, failure, abort, stagnation-cap, crash
+  recovery) resolves the commit status and removes the label. A hard crash is
+  reconciled at next startup (`mission_status.reconcile_stale_indicators`).
+- Cross-stage state lives in `instance/.running-indicator.json`, keyed by
+  mission title; local-only missions (no issue URL, no `github_url`) write
+  nothing.
+- Gated by a global `running_indicator` config block plus a per-project
+  override; on by default, opt-out via `running_indicator.enabled: false`.
+
 ## Integration points
 
 - Notifications wired into `loop_manager.process_github_notifications()`, which also

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -80,8 +80,13 @@ GitHub App:
 - Indicators are best-effort: a write failure logs and degrades, never blocks
   the mission.
 - Every terminal path (success, failure, abort, stagnation-cap, crash
-  recovery) resolves the commit status and removes the label. A hard crash is
-  reconciled at next startup (`mission_status.reconcile_stale_indicators`).
+  recovery) resolves the commit status and removes the label. The two writes
+  are independent (one failing never skips the other or orphans the label), and
+  the tracker entry is dropped **only when both required writes succeed** — a
+  failed teardown retains the entry so the next startup reconcile retries it,
+  guaranteeing no stale `koan/mission` status or `koan:working` label is left on
+  GitHub. A hard crash is likewise reconciled at next startup
+  (`mission_status.reconcile_stale_indicators`).
 - Cross-stage state lives in `instance/.running-indicator.json`, keyed by
   mission title; local-only missions (no issue URL, no `github_url`) write
   nothing.

--- a/specs/components/git-github.md
+++ b/specs/components/git-github.md
@@ -4,7 +4,7 @@ title: "Component Spec — Git & GitHub"
 description: "Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows."
 tags: [git-github]
 created: 2026-06-27
-updated: 2026-07-11
+updated: 2026-07-13
 ---
 
 # Component Spec — Git & GitHub


### PR DESCRIPTION
## Summary

Surfaces a live "Running" indicator on GitHub while Kōan works a GitHub-linked mission — a `koan:working` issue label plus a `koan/mission` commit status — with zero new infrastructure (no GitHub App/Action), reusing the existing `gh` auth. On by default; best-effort; a no-op for local-only missions.

Closes https://github.com/Anantys-oss/koan/issues/2364

## Architectural change

- [x] **Architectural change** — declares a new GitHub write surface in `specs/components/git-github.md` (Mission status indicators), landed contract-first per the specs discipline.

## Changes

- **Contract-first spec** (`specs/components/git-github.md`): new commit-status + issue-label write surface with its `gh`-only, best-effort, always-torn-down invariants.
- **Config** (`config.py`, `projects_config.py`, `config_validator.py`, `instance.example/config.yaml`): `running_indicator` block (global + per-project override), **on by default**, opt-out via `running_indicator.enabled: false`.
- **GitHub primitives** (`github.py`): `set_commit_status` (raw-body `gh api`), `add_issue_label`, `remove_issue_label`, `ensure_label` (`--force` upsert).
- **Orchestrator** (`mission_status.py`, new): link resolution (issue URL in text → project `github_url`), `.running-indicator.json` tracker, and `start_indicator` / `on_branch_pushed` / `resolve_indicator` / `reconcile_stale_indicators`. Every path is exception-swallowing.
- **Lifecycle wiring**: label raised at `_start_mission_in_file` (confirmed transition); `pending` status at `pr_submit` first push; resolved green/red + label removed at `_finalize_mission` (stagnation requeue deliberately left up); stale entries reconciled at startup after crash recovery.
- **Docs**: `docs/messaging/github-commands.md` (config schema) + `docs/architecture/github-and-trackers.md` (flow + tracker).

### Refinement vs. the plan

The plan shipped **off by default**; per the confirmed answer to the open question, this ships **on by default** (no external risk, clear UX upgrade, customer-requested). The label is the primary live signal (set at start); the commit status is the complementary durable green/red.

## Test plan

- New unit tests: `test_mission_status.py` (15), `test_github.py` (4 primitives), config/projects_config/config_validator readers, and wiring tests in `test_run.py` / `test_pr_submit.py` / `test_startup_manager.py`. All mock at the `gh`/`api` boundary.
- End-to-end runtime smoke: start→push→finalize emits label add → `pending` → `success` → label remove, and clears the tracker.
- `make lint` passes; targeted suites green (906 + 5 passed). The 12 pre-existing `KOAN_SUPPRESS_RUNNER_OUTCOME` failures are an ambient sandbox env var, unrelated to this change (pass once unset).

---
_Generated by [Kōan](https://koan.anantys.com)_ _(Claude · model claude-opus-4-8 · HEAD=c339a022)_
