### PR TITLE
Universal page-cache reclaim to cut billed memory.current (#2374)

### DIFF
--- a/docs/operations/memory-footprint.md
+++ b/docs/operations/memory-footprint.md
@@ -4,7 +4,7 @@ title: "Memory footprint: process RSS vs cgroup memory.current"
 description: "Why the container memory graph plateaus high after missions (page cache + slab, not a leak), the /tmp leftovers that inflate it, the post-mission sweep, and the anon-first triage rule."
 tags: [operations, memory, cgroup]
 created: 2026-07-13
-updated: 2026-07-13
+updated: 2026-07-14
 ---
 
 # Memory footprint: process RSS vs cgroup memory.current
@@ -81,6 +81,32 @@ not `memory.current`.** Where cheap, the cgroup breakdown is surfaced:
   `/health` endpoint.
 - `health_check.py` prints the same breakdown, tagging `anon` as the leak
   signal.
+
+## Page-cache reclaim (#2374)
+
+Railway bills the cgroup's `memory.current`, which includes the kernel page
+cache (`file`), not just process RSS (`anon`). Missions do heavy file I/O and
+the kernel keeps those clean pages warm absent memory pressure, so the billed
+baseline ratchets up (~550 MB → ~820 MB in a day) even though `anon` is flat.
+`/sys/fs/cgroup/memory.reclaim` is read-only on Railway, so Kōan uses
+unprivileged `posix_fadvise(POSIX_FADV_DONTNEED)` to drop clean pages
+(`app/page_cache.py`).
+
+- **When it runs:** after every mission (in `run_claude_task`'s `finally`, once
+  the CLI subprocess has exited) and periodically while idle
+  (`page_cache_reclaim.idle_interval_s`, default 900s; `0` disables the idle tick).
+- **What it touches:** project workdirs, `instance/`, the venv, the scratch dir,
+  plus `extra_roots`. Read-only; regular files only; symlinks and special files
+  skipped (`os.walk(followlinks=False)` + `os.lstat` + `stat.S_ISREG`); a soft
+  `time_budget_s` (default 10s) bounds each sweep so it never stalls the loop.
+- **Reading the numbers:** `read_cgroup_memory_stat()` returns `anon_mb`/`file_mb`.
+  Watch `file_mb` drop toward the hot-set floor post-mission; `anon` is the leak
+  signal. A single `Page cache reclaim: file X→Y MB (…)` health log fires when the
+  reclaimed delta is meaningful (≥3 MB).
+- **Platform:** no-op where `os.posix_fadvise` is absent (macOS dev boxes) —
+  every hook returns `ReclaimStats(supported=False)` and touches zero files.
+- **Config:** `page_cache_reclaim: { enabled, idle_interval_s, time_budget_s,
+  extra_roots }` — see `instance.example/config.yaml`. Default on.
 
 See also: [bridge-memory](../architecture/bridge-memory.md),
 [memory-watchdog](memory-watchdog.md).

--- a/docs/operations/memory-footprint.md
+++ b/docs/operations/memory-footprint.md
@@ -95,14 +95,19 @@ unprivileged `posix_fadvise(POSIX_FADV_DONTNEED)` to drop clean pages
 - **When it runs:** after every mission (in `run_claude_task`'s `finally`, once
   the CLI subprocess has exited) and periodically while idle
   (`page_cache_reclaim.idle_interval_s`, default 900s; `0` disables the idle tick).
-- **What it touches:** project workdirs, `instance/`, the venv, the scratch dir,
-  plus `extra_roots`. Read-only; regular files only; symlinks and special files
+- **What it touches:** the small, high-value roots first — `instance/`, the venv,
+  the scratch dir — then project workdirs, then `extra_roots`, so a budget-truncated
+  sweep still reclaims the cheap roots instead of burning the whole budget on one
+  large project tree. Read-only; regular files only; symlinks and special files
   skipped (`os.walk(followlinks=False)` + `os.lstat` + `stat.S_ISREG`); a soft
   `time_budget_s` (default 10s) bounds each sweep so it never stalls the loop.
 - **Reading the numbers:** `read_cgroup_memory_stat()` returns `anon_mb`/`file_mb`.
   Watch `file_mb` drop toward the hot-set floor post-mission; `anon` is the leak
   signal. A single `Page cache reclaim: file X→Y MB (…)` health log fires when the
-  reclaimed delta is meaningful (≥3 MB).
+  reclaimed delta is meaningful (≥3 MB), the sweep was truncated (`budget hit` —
+  raise `time_budget_s` or trim `extra_roots`), or per-file errors dominated (`N
+  errors`, i.e. systemic `os.open` denial). A small-delta success is the only case
+  suppressed, so no-op reclaims never hide behind silence.
 - **Platform:** no-op where `os.posix_fadvise` is absent (macOS dev boxes) —
   every hook returns `ReclaimStats(supported=False)` and touches zero files.
 - **Config:** `page_cache_reclaim: { enabled, idle_interval_s, time_budget_s,

--- a/docs/operations/memory-watchdog.md
+++ b/docs/operations/memory-watchdog.md
@@ -4,7 +4,7 @@ title: "Memory watchdog (#2232)"
 description: "Explains the memory watchdog that restarts the agent loop between missions when RSS stays over a threshold, its config knobs, and health-endpoint observability."
 tags: [operations]
 created: 2026-07-01
-updated: 2026-07-01
+updated: 2026-07-14
 ---
 
 # Memory watchdog (#2232)
@@ -85,3 +85,10 @@ A mid-session RSS read failure (`read_rss_mb` returns `0.0`, meaning "unknown")
 does **not** reset the overage counter — treating unknown as below-threshold
 would silently disable protection. The counter is held and the failure is
 logged to stderr once.
+
+## See also
+
+Restarting on RSS growth is a last resort. For the routine billing-hygiene
+mechanism that returns reclaimable kernel page cache (cgroup `file`) to the
+kernel after every mission and at idle — without a restart — see
+[memory-footprint § Page-cache reclaim](memory-footprint.md#page-cache-reclaim-2374).

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -787,6 +787,18 @@ memory_monitor:
     threshold_mb: 600        # Restart when RSS stays at/above this (MB)
     sustained_samples: 3     # Consecutive over-threshold poll cycles required
 
+# Universal page-cache reclaim (#2374). Billing on Railway tracks the cgroup's
+# memory.current, which counts reclaimable kernel page cache (file), not just
+# process RSS (anon). Missions do heavy file I/O and the kernel keeps those
+# clean pages warm with no memory pressure, so the billed baseline ratchets up.
+# After each mission (and periodically while idle) Kōan drops clean pages via
+# posix_fadvise(DONTNEED) — unprivileged, read-only, no-op on macOS dev boxes.
+page_cache_reclaim:
+  enabled: true          # Master switch (default: true — unattended billing hygiene)
+  idle_interval_s: 900   # Min seconds between idle reclaims; 0 disables the idle tick
+  time_budget_s: 10      # Soft wall-clock budget per sweep so it never stalls the loop
+  extra_roots: []        # Operator additions, e.g. large data dirs outside projects
+
 # Conversation history retention (#2354). Mid-session compaction of
 # conversation-history.jsonl so the append-only file stays bounded over long
 # bridge uptime. Floored at 300s; 0 disables mid-session compaction (startup

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -570,6 +570,28 @@ def get_memory_monitor_config() -> dict:
     }
 
 
+def get_page_cache_reclaim_config() -> dict:
+    """Page-cache reclaim config (#2374). Enabled by default.
+
+    Kernel page cache (cgroup ``file``) is billed but nothing returns it to the
+    kernel without pressure; this drives the post-mission + idle reclaim hooks.
+    ``idle_interval_s: 0`` disables the idle tick (post-mission hook remains).
+    Uses the module-local ``_safe_int`` coercion; never raises on bad input.
+    """
+    config = _load_config()
+    section = config.get("page_cache_reclaim", {})
+    if not isinstance(section, dict):
+        section = {}
+    raw_roots = section.get("extra_roots", [])
+    extra_roots = [str(r) for r in raw_roots] if isinstance(raw_roots, list) else []
+    return {
+        "enabled": bool(section.get("enabled", True)),
+        "idle_interval_s": _safe_int(section.get("idle_interval_s", 900), 900),
+        "time_budget_s": _safe_int(section.get("time_budget_s", 10), 10),
+        "extra_roots": extra_roots,
+    }
+
+
 def get_bridge_memory_monitor_config() -> dict:
     """Bridge (awake.py) memory watchdog config (#2354).
 

--- a/koan/app/page_cache.py
+++ b/koan/app/page_cache.py
@@ -1,0 +1,203 @@
+"""Universal kernel page-cache reclaim (#2374).
+
+Billing on Railway (and most container platforms) tracks the cgroup's
+``memory.current``, which counts reclaimable page cache (``file``) — not just
+process RSS (``anon``). Missions do heavy file I/O and the kernel keeps those
+clean pages warm with no memory pressure, so the billed baseline ratchets up.
+``/sys/fs/cgroup/memory.reclaim`` is read-only on Railway, but unprivileged
+``posix_fadvise(POSIX_FADV_DONTNEED)`` drops clean pages. This module is the
+single reclaim primitive; it is wired at the daemon's lifecycle choke points
+(post-mission ``finally`` + idle tick) so no future feature has to opt in.
+"""
+from __future__ import annotations
+
+import contextlib
+import os
+import stat
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable
+
+from app.config import get_page_cache_reclaim_config
+from app.memory_monitor import read_cgroup_memory_stat
+from app.run_log import log_safe as _log
+from app.utils import get_known_projects, koan_tmp_dir
+
+# Files checked between deadline re-checks inside one directory's file list.
+_BUDGET_CHECK_EVERY = 256
+# Suppress the health log when the reclaimed delta is below this (MB).
+_LOG_MIN_DELTA_MB = 3.0
+
+_last_idle_reclaim_ts: float = 0.0
+
+
+@dataclass
+class ReclaimStats:
+    supported: bool = True
+    files: int = 0
+    errors: int = 0
+    elapsed_s: float = 0.0
+    budget_hit: bool = False
+    file_mb_before: float | None = None
+    file_mb_after: float | None = None
+
+    @property
+    def delta_mb(self) -> float | None:
+        if self.file_mb_before is None or self.file_mb_after is None:
+            return None
+        return round(self.file_mb_before - self.file_mb_after, 1)
+
+
+def _reset_idle_throttle() -> None:
+    """Test seam: clear the module-level idle throttle."""
+    global _last_idle_reclaim_ts
+    _last_idle_reclaim_ts = 0.0
+
+
+def default_reclaim_roots() -> list[Path]:
+    """The known heavy page-cache contributors, resolved centrally (DRY anchor).
+
+    Every configured project workdir, ``KOAN_ROOT/instance/`` (logs + SQLite),
+    the venv, and the per-uid scratch dir. Non-existent roots are dropped;
+    operator ``extra_roots`` are appended. ``KOAN_ROOT`` is read from the
+    environment (not the import-time constant) so it stays correct if it changed.
+    """
+    roots: list[Path] = []
+    for _name, path in get_known_projects():
+        roots.append(Path(path))
+    koan_root = os.environ.get("KOAN_ROOT", "")
+    if koan_root:
+        roots.append(Path(koan_root) / "instance")
+    # Venv: sys.prefix points at the active interpreter's env.
+    roots.append(Path(sys.prefix))
+    with contextlib.suppress(OSError):
+        roots.append(Path(koan_tmp_dir()))
+    cfg = get_page_cache_reclaim_config()
+    roots.extend(Path(str(extra)) for extra in cfg.get("extra_roots", []))
+    # De-dupe on resolved path; keep only existing dirs.
+    seen: set[str] = set()
+    out: list[Path] = []
+    for r in roots:
+        try:
+            rp = r.resolve()
+        except OSError:
+            continue
+        key = str(rp)
+        if key in seen or not rp.is_dir():
+            continue
+        seen.add(key)
+        out.append(rp)
+    return out
+
+
+def reclaim_page_cache(
+    paths: Iterable[Path], *, budget_s: float = 10.0
+) -> ReclaimStats:
+    """Drop clean page-cache for every regular file under ``paths``.
+
+    ``os.open(O_RDONLY)`` + ``posix_fadvise(DONTNEED)`` + close each file.
+    Per-file ``OSError`` is swallowed (files vanish mid-walk). Symlinks and
+    special files are lstat-skipped so traversal never escapes the roots.
+    Honors a soft time budget so it can never stall the loop. No-op (with a
+    debug log) where ``os.posix_fadvise`` is unavailable (macOS).
+    """
+    stats = ReclaimStats()
+    fadvise = getattr(os, "posix_fadvise", None)
+    dontneed = getattr(os, "POSIX_FADV_DONTNEED", None)
+    if fadvise is None or dontneed is None:
+        stats.supported = False
+        _log("debug", "Page cache reclaim: posix_fadvise unavailable — skipping")
+        return stats
+
+    before = read_cgroup_memory_stat()
+    stats.file_mb_before = before.get("file_mb") if before else None
+
+    start = time.monotonic()
+    deadline = start + max(0.0, budget_s)
+    for root in paths:
+        if time.monotonic() >= deadline:
+            stats.budget_hit = True
+            break
+        for dirpath, _dirnames, filenames in os.walk(root, followlinks=False):
+            if time.monotonic() >= deadline:
+                stats.budget_hit = True
+                break
+            for idx, name in enumerate(filenames):
+                if idx % _BUDGET_CHECK_EVERY == 0 and time.monotonic() >= deadline:
+                    stats.budget_hit = True
+                    break
+                fp = os.path.join(dirpath, name)
+                try:
+                    st = os.lstat(fp)
+                    if not stat.S_ISREG(st.st_mode):
+                        continue  # skip symlinks, fifos, sockets, devices
+                    fd = os.open(fp, os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0))
+                    try:
+                        fadvise(fd, 0, 0, dontneed)
+                        stats.files += 1
+                    finally:
+                        os.close(fd)
+                except OSError:
+                    stats.errors += 1
+                    continue
+            if stats.budget_hit:
+                break
+        if stats.budget_hit:
+            break
+
+    after = read_cgroup_memory_stat()
+    stats.file_mb_after = after.get("file_mb") if after else None
+    stats.elapsed_s = round(time.monotonic() - start, 2)
+    return stats
+
+
+def _format_stats(stats: ReclaimStats) -> str:
+    files_k = f"{stats.files / 1000:.0f}k" if stats.files >= 1000 else str(stats.files)
+    if stats.file_mb_before is not None and stats.file_mb_after is not None:
+        head = f"file {stats.file_mb_before:.0f}→{stats.file_mb_after:.0f} MB"
+    else:
+        head = "cgroup stats unavailable"
+    return f"Page cache reclaim: {head} ({stats.elapsed_s}s, {files_k} files)"
+
+
+def run_reclaim(reason: str, *, budget_s: float | None = None) -> ReclaimStats:
+    """Reclaim over ``default_reclaim_roots()``, log the delta once at health level.
+
+    ``reason`` is a short tag ('post-mission' / 'idle') used only in the debug
+    trail. Logs at ``health`` only when the reclaimed delta is meaningful, to
+    avoid per-mission noise.
+    """
+    cfg = get_page_cache_reclaim_config()
+    if not cfg.get("enabled", True):
+        return ReclaimStats(supported=True)
+    budget = cfg.get("time_budget_s", 10) if budget_s is None else budget_s
+    stats = reclaim_page_cache(default_reclaim_roots(), budget_s=budget)
+    if not stats.supported:
+        return stats
+    delta = stats.delta_mb
+    if delta is None or delta >= _LOG_MIN_DELTA_MB:
+        _log("health", _format_stats(stats))
+    return stats
+
+
+def maybe_reclaim_page_cache_idle(now: float | None = None) -> ReclaimStats | None:
+    """Throttled idle reclaim: fire at most once per ``idle_interval_s``.
+
+    Called from every idle-sleep site; the module-level throttle makes wiring
+    it at more than one site idempotent. ``idle_interval_s == 0`` disables the
+    idle tick (the post-mission hook still runs).
+    """
+    global _last_idle_reclaim_ts
+    cfg = get_page_cache_reclaim_config()
+    if not cfg.get("enabled", True):
+        return None
+    interval = cfg.get("idle_interval_s", 900)
+    if interval <= 0:
+        return None
+    ts = time.monotonic() if now is None else now
+    if _last_idle_reclaim_ts and (ts - _last_idle_reclaim_ts) < interval:
+        return None
+    _last_idle_reclaim_ts = ts
+    return run_reclaim("idle")

--- a/koan/app/page_cache.py
+++ b/koan/app/page_cache.py
@@ -78,7 +78,7 @@ def default_reclaim_roots() -> list[Path]:
     roots.extend(Path(str(extra)) for extra in cfg.get("extra_roots", []))
     # De-dupe on resolved path; keep only existing dirs.
     seen: set[str] = set()
-    out: list[Path] = []
+    resolved: list[Path] = []
     for r in roots:
         try:
             rp = r.resolve()
@@ -88,6 +88,16 @@ def default_reclaim_roots() -> list[Path]:
         if key in seen or not rp.is_dir():
             continue
         seen.add(key)
+        resolved.append(rp)
+    # Drop roots nested under another kept root (e.g. the venv living inside a
+    # project workdir) so os.walk doesn't fadvise the same files twice and burn
+    # the time budget. Shortest paths first so ancestors are considered before
+    # their descendants.
+    resolved.sort(key=lambda p: len(p.parts))
+    out: list[Path] = []
+    for rp in resolved:
+        if any(anc in rp.parents for anc in out):
+            continue
         out.append(rp)
     return out
 

--- a/koan/app/page_cache.py
+++ b/koan/app/page_cache.py
@@ -63,20 +63,28 @@ def default_reclaim_roots() -> list[Path]:
     the venv, and the per-uid scratch dir. Non-existent roots are dropped;
     operator ``extra_roots`` are appended. ``KOAN_ROOT`` is read from the
     environment (not the import-time constant) so it stays correct if it changed.
+
+    Ordering matters: the small, high-value roots (``instance/``, venv, scratch)
+    are emitted **before** the large project workdirs so a truncated sweep (time
+    budget hit) still reclaims them rather than spending the whole budget walking
+    one big ``node_modules``/``.git`` tree.
     """
-    roots: list[Path] = []
-    for _name, path in get_known_projects():
-        roots.append(Path(path))
+    # Priority roots first — small + high-value, so they always get their turn
+    # within the time budget before the large project trees.
+    priority: list[Path] = []
     koan_root = os.environ.get("KOAN_ROOT", "")
     if koan_root:
-        roots.append(Path(koan_root) / "instance")
+        priority.append(Path(koan_root) / "instance")
     # Venv: sys.prefix points at the active interpreter's env.
-    roots.append(Path(sys.prefix))
+    priority.append(Path(sys.prefix))
     with contextlib.suppress(OSError):
-        roots.append(Path(koan_tmp_dir()))
+        priority.append(Path(koan_tmp_dir()))
+    project_roots = [Path(path) for _name, path in get_known_projects()]
     cfg = get_page_cache_reclaim_config()
-    roots.extend(Path(str(extra)) for extra in cfg.get("extra_roots", []))
-    # De-dupe on resolved path; keep only existing dirs.
+    extra = [Path(str(e)) for e in cfg.get("extra_roots", [])]
+    roots = priority + project_roots + extra
+    # De-dupe on resolved path; keep only existing dirs. Preserve the priority
+    # ordering above (do NOT re-sort).
     seen: set[str] = set()
     resolved: list[Path] = []
     for r in roots:
@@ -91,12 +99,12 @@ def default_reclaim_roots() -> list[Path]:
         resolved.append(rp)
     # Drop roots nested under another kept root (e.g. the venv living inside a
     # project workdir) so os.walk doesn't fadvise the same files twice and burn
-    # the time budget. Shortest paths first so ancestors are considered before
-    # their descendants.
-    resolved.sort(key=lambda p: len(p.parts))
+    # the time budget. Order-independent: a root is dropped when any of its
+    # parents is itself a kept root, which preserves the priority ordering above.
+    kept = {str(p) for p in resolved}
     out: list[Path] = []
     for rp in resolved:
-        if any(anc in rp.parents for anc in out):
+        if any(str(anc) in kept for anc in rp.parents):
             continue
         out.append(rp)
     return out
@@ -163,21 +171,39 @@ def reclaim_page_cache(
     return stats
 
 
+def _errors_notable(stats: ReclaimStats) -> bool:
+    """True when errors dominate — systemic denial, not the odd vanished file.
+
+    A handful of ``OSError``s while files churn under the walk is normal; errors
+    that equal or outnumber the files we actually reclaimed (in the limit, every
+    ``os.open`` denied by permissions/SELinux → ``files == 0``) means the sweep
+    did no real work and the operator needs to see it.
+    """
+    return stats.errors > 0 and stats.errors >= max(1, stats.files)
+
+
 def _format_stats(stats: ReclaimStats) -> str:
     files_k = f"{stats.files / 1000:.0f}k" if stats.files >= 1000 else str(stats.files)
     if stats.file_mb_before is not None and stats.file_mb_after is not None:
         head = f"file {stats.file_mb_before:.0f}→{stats.file_mb_after:.0f} MB"
     else:
         head = "cgroup stats unavailable"
-    return f"Page cache reclaim: {head} ({stats.elapsed_s}s, {files_k} files)"
+    parts = [f"{stats.elapsed_s}s", f"{files_k} files"]
+    if stats.errors:
+        parts.append(f"{stats.errors} errors")
+    if stats.budget_hit:
+        parts.append("budget hit — raise time_budget_s or trim extra_roots")
+    return f"Page cache reclaim: {head} ({', '.join(parts)})"
 
 
 def run_reclaim(reason: str, *, budget_s: float | None = None) -> ReclaimStats:
-    """Reclaim over ``default_reclaim_roots()``, log the delta once at health level.
+    """Reclaim over ``default_reclaim_roots()``, log the outcome once at health level.
 
     ``reason`` is a short tag ('post-mission' / 'idle') used only in the debug
-    trail. Logs at ``health`` only when the reclaimed delta is meaningful, to
-    avoid per-mission noise.
+    trail. Logs at ``health`` when the reclaimed delta is meaningful (to avoid
+    per-mission noise) OR when the sweep was truncated (``budget_hit``) or did no
+    real work (errors dominating) — a small-delta success is the only case
+    suppressed, so systemic failures never hide behind silence.
     """
     cfg = get_page_cache_reclaim_config()
     if not cfg.get("enabled", True):
@@ -187,7 +213,8 @@ def run_reclaim(reason: str, *, budget_s: float | None = None) -> ReclaimStats:
     if not stats.supported:
         return stats
     delta = stats.delta_mb
-    if delta is None or delta >= _LOG_MIN_DELTA_MB:
+    meaningful = delta is None or delta >= _LOG_MIN_DELTA_MB
+    if meaningful or stats.budget_hit or _errors_notable(stats):
         _log("health", _format_stats(stats))
     return stats
 

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -519,6 +519,15 @@ def run_claude_task(
                     f"Swept {len(removed)} stray tmp tree(s), freed {total_mb:.0f} MB")
         except Exception as e:
             log("error", f"stray tmp sweep failed: {e}")
+        # Universal page-cache reclaim (#2374): the CLI subprocess has exited,
+        # so dropping clean pages here returns mission file I/O (git objects,
+        # node_modules, venv, SQLite, logs) to the kernel and stops the billed
+        # baseline ratcheting up. Best-effort — never masks the mission result.
+        try:
+            from app.page_cache import run_reclaim
+            run_reclaim("post-mission")
+        except Exception as e:
+            log("error", f"post-mission page-cache reclaim failed: {e}")
         # Clear the liveness signal on every exit path — including exceptions
         # raised before the subprocess wait loop — so no stale .koan-active
         # survives to be misread as a live (then zombie) mission (#2086).
@@ -1523,6 +1532,13 @@ def _sleep_between_runs(
     else:
         set_status(koan_root, f"Idle — sleeping {interval}s{status_suffix}")
     log("koan", f"Sleeping {interval}s (checking for new missions every 10s)...")
+    # Idle page-cache reclaim (#2374): throttled to page_cache_reclaim.idle_interval_s
+    # so wiring it at more than one idle-sleep site cannot double-fire. Best-effort.
+    try:
+        from app.page_cache import maybe_reclaim_page_cache_idle
+        maybe_reclaim_page_cache_idle()
+    except Exception as e:
+        log("error", f"idle page-cache reclaim failed: {e}")
     with protected_phase("Sleeping between runs"):
         wake = interruptible_sleep(interval, koan_root, instance)
     if wake == "mission":
@@ -1836,6 +1852,12 @@ def _handle_contemplative(
     else:
         set_status(koan_root, f"Idle — post-contemplation sleep ({time.strftime('%H:%M')})")
         log("pause", f"Contemplative session complete. Sleeping {interval}s...")
+        # Idle page-cache reclaim (#2374): throttled + idempotent across sites.
+        try:
+            from app.page_cache import maybe_reclaim_page_cache_idle
+            maybe_reclaim_page_cache_idle()
+        except Exception as e:
+            log("error", f"idle page-cache reclaim failed: {e}")
         with protected_phase("Sleeping between runs"):
             wake = interruptible_sleep(interval, koan_root, instance)
         if wake == "mission":

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -2308,3 +2308,38 @@ class TestCleanupMinTmpAgeSeconds:
         from app.config import get_cleanup_min_tmp_age_seconds
         with _mock_config({"cleanup": {"min_tmp_age_seconds": -5}}):
             assert get_cleanup_min_tmp_age_seconds() == 0.0
+
+
+class TestGetPageCacheReclaimConfig:
+    def test_page_cache_reclaim_defaults(self):
+        from app.config import get_page_cache_reclaim_config
+        with _mock_config({}):
+            assert get_page_cache_reclaim_config() == {
+                "enabled": True,
+                "idle_interval_s": 900,
+                "time_budget_s": 10,
+                "extra_roots": [],
+            }
+
+    def test_page_cache_reclaim_overrides_and_bad_types(self):
+        from app.config import get_page_cache_reclaim_config
+        with _mock_config({
+            "page_cache_reclaim": {
+                "enabled": False,
+                "idle_interval_s": "0",
+                "time_budget_s": "not-an-int",
+                "extra_roots": ["/data", 42],
+            }
+        }):
+            cfg = get_page_cache_reclaim_config()
+        assert cfg["enabled"] is False
+        assert cfg["idle_interval_s"] == 0
+        assert cfg["time_budget_s"] == 10          # bad → default
+        assert cfg["extra_roots"] == ["/data", "42"]  # coerced to str
+
+    def test_page_cache_reclaim_malformed_section(self):
+        from app.config import get_page_cache_reclaim_config
+        with _mock_config({"page_cache_reclaim": "nope"}):
+            cfg = get_page_cache_reclaim_config()
+        assert cfg["enabled"] is True
+        assert cfg["extra_roots"] == []

--- a/koan/tests/test_page_cache.py
+++ b/koan/tests/test_page_cache.py
@@ -1,0 +1,108 @@
+import os
+from pathlib import Path
+
+import pytest
+from app import page_cache
+
+
+def _make_tree(root: Path, n: int) -> None:
+    for i in range(n):
+        (root / f"f{i}.bin").write_bytes(b"x" * 4096)
+
+
+def test_noop_when_fadvise_missing(tmp_path, monkeypatch):
+    _make_tree(tmp_path, 3)
+    monkeypatch.delattr(os, "posix_fadvise", raising=False)
+    stats = page_cache.reclaim_page_cache([tmp_path])
+    assert stats.supported is False
+    assert stats.files == 0
+
+
+@pytest.mark.skipif(not hasattr(os, "posix_fadvise"), reason="Linux-only")
+def test_counts_regular_files_and_swallows_errors(tmp_path):
+    _make_tree(tmp_path, 5)
+    # A dangling symlink must be skipped, not counted or raised on.
+    (tmp_path / "link").symlink_to(tmp_path / "missing.bin")
+    stats = page_cache.reclaim_page_cache([tmp_path], budget_s=5.0)
+    assert stats.files == 5
+    assert stats.errors == 0  # symlink is lstat-skipped, not an error
+
+
+@pytest.mark.skipif(not hasattr(os, "posix_fadvise"), reason="Linux-only")
+def test_budget_cutoff_stops_walk(tmp_path):
+    _make_tree(tmp_path, 50)
+    # Zero budget → deadline already passed → no files processed.
+    stats = page_cache.reclaim_page_cache([tmp_path], budget_s=0.0)
+    assert stats.budget_hit is True
+    assert stats.files == 0
+
+
+def test_default_roots_include_projects_and_instance(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    (tmp_path / "instance").mkdir()
+    monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        page_cache, "get_known_projects", lambda: [("proj", str(proj))]
+    )
+    roots = page_cache.default_reclaim_roots()
+    resolved = {str(Path(r).resolve()) for r in roots}
+    assert str(proj.resolve()) in resolved
+    assert str((tmp_path / "instance").resolve()) in resolved
+
+
+def test_idle_throttle_respects_interval(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        page_cache, "reclaim_page_cache",
+        lambda *a, **k: calls.append(1) or page_cache.ReclaimStats(supported=True),
+    )
+    monkeypatch.setattr(
+        page_cache, "get_page_cache_reclaim_config",
+        lambda: {"enabled": True, "idle_interval_s": 900, "time_budget_s": 10,
+                 "extra_roots": []},
+    )
+    monkeypatch.setattr(page_cache, "default_reclaim_roots", lambda: [])
+    page_cache._reset_idle_throttle()
+    page_cache.maybe_reclaim_page_cache_idle(now=1000.0)   # first call fires
+    page_cache.maybe_reclaim_page_cache_idle(now=1000.0 + 300)  # within → skip
+    page_cache.maybe_reclaim_page_cache_idle(now=1000.0 + 901)  # past → fires
+    assert len(calls) == 2
+
+
+def test_disabled_config_skips_reclaim(monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        page_cache, "reclaim_page_cache",
+        lambda *a, **k: calls.append(1) or page_cache.ReclaimStats(supported=True),
+    )
+    monkeypatch.setattr(
+        page_cache, "get_page_cache_reclaim_config",
+        lambda: {"enabled": False, "idle_interval_s": 900, "time_budget_s": 10,
+                 "extra_roots": []},
+    )
+    monkeypatch.setattr(page_cache, "default_reclaim_roots", lambda: [])
+    page_cache._reset_idle_throttle()
+    assert page_cache.maybe_reclaim_page_cache_idle(now=1000.0) is None
+    stats = page_cache.run_reclaim("post-mission")
+    assert stats.supported is True
+    assert not calls
+
+
+def test_log_suppressed_below_delta_threshold(monkeypatch):
+    logs = []
+    monkeypatch.setattr(page_cache, "_log", lambda cat, msg: logs.append((cat, msg)))
+    monkeypatch.setattr(
+        page_cache, "get_page_cache_reclaim_config",
+        lambda: {"enabled": True, "idle_interval_s": 900, "time_budget_s": 10,
+                 "extra_roots": []},
+    )
+    monkeypatch.setattr(page_cache, "default_reclaim_roots", lambda: [])
+    monkeypatch.setattr(
+        page_cache, "reclaim_page_cache",
+        lambda *a, **k: page_cache.ReclaimStats(
+            supported=True, file_mb_before=100.0, file_mb_after=99.0
+        ),
+    )
+    page_cache.run_reclaim("idle")  # delta 1.0 MB < 3.0 → no health log
+    assert not any(cat == "health" for cat, _ in logs)

--- a/koan/tests/test_page_cache.py
+++ b/koan/tests/test_page_cache.py
@@ -51,6 +51,20 @@ def test_default_roots_include_projects_and_instance(tmp_path, monkeypatch):
     assert str((tmp_path / "instance").resolve()) in resolved
 
 
+def test_nested_roots_deduped(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    venv = proj / ".venv"  # venv nested inside the project workdir
+    venv.mkdir(parents=True)
+    monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        page_cache, "get_known_projects", lambda: [("proj", str(proj))]
+    )
+    monkeypatch.setattr(page_cache.sys, "prefix", str(venv))
+    roots = {str(r) for r in page_cache.default_reclaim_roots()}
+    assert str(proj.resolve()) in roots
+    assert str(venv.resolve()) not in roots  # nested → dropped
+
+
 def test_idle_throttle_respects_interval(monkeypatch):
     calls = []
     monkeypatch.setattr(

--- a/koan/tests/test_page_cache.py
+++ b/koan/tests/test_page_cache.py
@@ -120,3 +120,53 @@ def test_log_suppressed_below_delta_threshold(monkeypatch):
     )
     page_cache.run_reclaim("idle")  # delta 1.0 MB < 3.0 → no health log
     assert not any(cat == "health" for cat, _ in logs)
+
+
+def test_priority_roots_ordered_before_projects(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    inst = tmp_path / "instance"
+    inst.mkdir()
+    venv = tmp_path / "venv"
+    venv.mkdir()
+    monkeypatch.setenv("KOAN_ROOT", str(tmp_path))
+    monkeypatch.setattr(
+        page_cache, "get_known_projects", lambda: [("proj", str(proj))]
+    )
+    monkeypatch.setattr(page_cache.sys, "prefix", str(venv))
+    roots = [str(r) for r in page_cache.default_reclaim_roots()]
+    # instance/ and venv (small, high-value) come before the project workdir.
+    assert roots.index(str(inst.resolve())) < roots.index(str(proj.resolve()))
+    assert roots.index(str(venv.resolve())) < roots.index(str(proj.resolve()))
+
+
+def _run_stats(monkeypatch, stats):
+    logs = []
+    monkeypatch.setattr(page_cache, "_log", lambda cat, msg: logs.append((cat, msg)))
+    monkeypatch.setattr(
+        page_cache, "get_page_cache_reclaim_config",
+        lambda: {"enabled": True, "idle_interval_s": 900, "time_budget_s": 10,
+                 "extra_roots": []},
+    )
+    monkeypatch.setattr(page_cache, "default_reclaim_roots", lambda: [])
+    monkeypatch.setattr(page_cache, "reclaim_page_cache", lambda *a, **k: stats)
+    page_cache.run_reclaim("idle")
+    return logs
+
+
+def test_budget_hit_logged_even_below_delta(monkeypatch):
+    logs = _run_stats(monkeypatch, page_cache.ReclaimStats(
+        supported=True, file_mb_before=100.0, file_mb_after=99.0, budget_hit=True,
+    ))
+    health = [msg for cat, msg in logs if cat == "health"]
+    assert health and "budget hit" in health[0]
+
+
+def test_dominant_errors_logged_even_below_delta(monkeypatch):
+    # files≈0, errors high → systemic denial, must not be silent.
+    logs = _run_stats(monkeypatch, page_cache.ReclaimStats(
+        supported=True, file_mb_before=100.0, file_mb_after=100.0,
+        files=0, errors=500,
+    ))
+    health = [msg for cat, msg in logs if cat == "health"]
+    assert health and "500 errors" in health[0]

--- a/koan/tests/test_run_finally_reclaim.py
+++ b/koan/tests/test_run_finally_reclaim.py
@@ -1,0 +1,47 @@
+"""Lifecycle wiring for universal page-cache reclaim (#2374)."""
+from unittest import mock
+
+import pytest
+from app import run
+
+
+def test_post_mission_reclaim_fires_even_when_body_raises(monkeypatch, tmp_path):
+    called = {}
+    monkeypatch.setattr(
+        "app.page_cache.run_reclaim",
+        lambda reason, **k: called.setdefault("reason", reason),
+    )
+    # Force the subprocess-launch path to raise so we exercise the finally,
+    # not the happy path. popen_cli is late-imported from app.cli_exec.
+    monkeypatch.setattr(
+        "app.cli_exec.popen_cli", mock.Mock(side_effect=RuntimeError("boom"))
+    )
+    monkeypatch.setattr("app.utils.create_mission_tmp_dir", lambda tag="": str(tmp_path))
+    monkeypatch.setattr("app.utils.cleanup_mission_tmp_dir", lambda p: None)
+    monkeypatch.setattr(run, "_start_stagnation_monitor", lambda *a, **k: None)
+    with pytest.raises(RuntimeError):
+        run.run_claude_task(
+            cmd=["true"], cwd=str(tmp_path),
+            stdout_file=str(tmp_path / "o"), stderr_file=str(tmp_path / "e"),
+            project_name="proj", run_num=1,
+        )
+    assert called.get("reason") == "post-mission"
+
+
+def test_sleep_between_runs_calls_idle_reclaim(monkeypatch):
+    monkeypatch.setattr(run, "check_pending_missions", lambda inst: False)
+    monkeypatch.setattr(run, "interruptible_sleep", lambda *a, **k: "timeout")
+    monkeypatch.setattr(run, "set_status", lambda *a, **k: None)
+    called = mock.Mock()
+    monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
+    run._sleep_between_runs("/root", "inst", interval=60)
+    called.assert_called_once()
+
+
+def test_pending_missions_skip_idle_reclaim(monkeypatch):
+    monkeypatch.setattr(run, "check_pending_missions", lambda inst: True)
+    monkeypatch.setattr(run, "set_status", lambda *a, **k: None)
+    called = mock.Mock()
+    monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
+    run._sleep_between_runs("/root", "inst", interval=60)
+    called.assert_not_called()

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -114,6 +114,23 @@ see it.
   `memory.current` (which counts reclaimable page cache + slab); the cgroup breakdown
   is surfaced via `get_memory_status`/`health_check` when `/sys/fs/cgroup/memory.stat`
   is readable. See `docs/operations/memory-footprint.md`.
+- **Kernel page cache is reclaimed universally, not just RSS (#2374).** Bounding
+  `anon` (per-mission `TMPDIR` reap + stray-tmp sweep, above) does not return the
+  reclaimable page cache (`file`) that mission file I/O leaves warm, and Railway's
+  `/sys/fs/cgroup/memory.reclaim` is read-only. The agent loop therefore runs a
+  single reclaim primitive (`app/page_cache.reclaim_page_cache`, over
+  `default_reclaim_roots()` = project workdirs + `instance/` + venv + scratch dir)
+  at exactly two non-bypassable choke points: the `run_claude_task` outer `finally`
+  (post-mission, after the CLI subprocess has exited) and the between-runs idle
+  sleep (`_sleep_between_runs` + contemplative sleep, throttled to
+  `page_cache_reclaim.idle_interval_s`). The sweep is `posix_fadvise(DONTNEED)` on
+  regular files only — strictly read-only, symlink- and non-regular-file-skipped,
+  time-budgeted (`time_budget_s`) so it never stalls the loop, and a no-op where
+  `os.posix_fadvise` is absent (macOS). It reuses `read_cgroup_memory_stat()` for
+  the before/after `file` delta; no new cgroup parser. No per-feature opt-in exists
+  by construction — a new provider or mission type inherits both hooks. Default on
+  (`page_cache_reclaim.enabled: true`); `idle_interval_s: 0` keeps only the
+  post-mission hook. See `docs/operations/memory-footprint.md`.
 - **`run.py` never commits to main and never merges.** This is a hard safety boundary
   enforced by prompt + convention; the loop's job is to host the subprocess, not to
   alter git state itself.


### PR DESCRIPTION
## Summary

On Railway (and most container platforms) billing tracks the cgroup's `memory.current`, which counts reclaimable kernel page cache (`file`), not just process RSS (`anon`). Missions do heavy file I/O so the billed baseline ratchets up mission after mission even though `anon` is flat. `/sys/fs/cgroup/memory.reclaim` is read-only on Railway, but unprivileged `posix_fadvise(POSIX_FADV_DONTNEED)` drops clean pages. This adds one generic reclaim primitive wired into two non-bypassable lifecycle choke points so `file` returns to its hot-set floor after every mission and at idle.

Closes https://github.com/Anantys-oss/koan/issues/2374

## Changes

- New `koan/app/page_cache.py`: `ReclaimStats`, `reclaim_page_cache()`, `default_reclaim_roots()`, `run_reclaim()`, throttled `maybe_reclaim_page_cache_idle()`. Read-only `posix_fadvise(DONTNEED)` over regular files, symlink/special-file skipped, time-budgeted, no-op without `os.posix_fadvise` (macOS). Reuses `read_cgroup_memory_stat()`.
- `config.py`: `get_page_cache_reclaim_config()` (default enabled), documented `page_cache_reclaim:` block in `instance.example/config.yaml`.
- `run.py`: post-mission hook in `run_claude_task()`'s outer `finally`; throttled idle hook in `_sleep_between_runs()` and the contemplative sleep. All best-effort `try/except`.
- Spec: additive page-cache-reclaim contract appended to the agent-loop "Mission scratch is bounded" bullet (spec-change guard: additive, no declaration required). Docs: `memory-footprint.md` rationale/hooks + `memory-watchdog.md` cross-link.

## Test plan

- `test_page_cache.py`: no-op without `posix_fadvise`, file counting + error swallow (dangling symlink skipped), zero-budget cutoff, root resolution, idle throttle, disabled-config short-circuit, log suppression below 3 MB delta.
- `test_config.py`: defaults, malformed-section fallback, `extra_roots` coercion.
- `test_run_finally_reclaim.py`: post-mission hook fires from the `finally` even when the mission body raises; idle hook called when idle, skipped when missions pending.
- `make lint` clean; `scripts/spec_change_guard.py` passes.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(provider claude · model claude-opus-4-8 · HEAD=e236d04b)_
