### PR TITLE
fix(page_cache): idle reclaim moved inside interruptible_sleep — focus_wait & friends never reclaimed (#2374)

### DIFF
--- a/docs/operations/memory-footprint.md
+++ b/docs/operations/memory-footprint.md
@@ -95,6 +95,14 @@ unprivileged `posix_fadvise(POSIX_FADV_DONTNEED)` to drop clean pages
 - **When it runs:** after every mission (in `run_claude_task`'s `finally`, once
   the CLI subprocess has exited) and periodically while idle
   (`page_cache_reclaim.idle_interval_s`, default 900s; `0` disables the idle tick).
+  The idle hook lives *inside* `loop_manager.interruptible_sleep()` — the one
+  sleep primitive every idle path shares (between-runs sleep, contemplative
+  sleep, and all `_IDLE_WAIT_CONFIG` states: `focus_wait`, `passive_wait`,
+  `schedule_wait`, `exploration_wait`, `pr_limit_wait`,
+  `branch_saturated_wait`) — so new idle states inherit it automatically.
+  Do not wire it at individual call-sites: that is how `focus_wait` initially
+  shipped with no reclaim at all (850 MB flat billed `memory.current` on an
+  idle focus-mode instance, observed 2026-07-14).
 - **What it touches:** the small, high-value roots first — `instance/`, the venv,
   the scratch dir — then project workdirs, then `extra_roots`, so a budget-truncated
   sweep still reclaims the cheap roots instead of burning the whole budget on one

--- a/koan/app/loop_manager.py
+++ b/koan/app/loop_manager.py
@@ -1869,6 +1869,17 @@ def interruptible_sleep(
         from app.heartbeat import run_stale_mission_check, run_disk_space_check
         run_stale_mission_check(instance_dir)
         run_disk_space_check(koan_root)
+
+        # Idle page-cache reclaim (#2374). Wired HERE — inside the one sleep
+        # primitive every idle path shares — not at individual call-sites:
+        # per-site wiring is how focus_wait shipped with no reclaim at all.
+        # Throttled to page_cache_reclaim.idle_interval_s by the module, so
+        # calling it every check tick cannot double-fire. Best-effort.
+        try:
+            from app.page_cache import maybe_reclaim_page_cache_idle
+            maybe_reclaim_page_cache_idle()
+        except Exception as e:
+            _log_loop("error", f"idle page-cache reclaim failed: {e}")
         _maybe_sync_instance_repo(instance_dir)
 
         # Drain CI queue (throttled to once per 30s).

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -1532,13 +1532,7 @@ def _sleep_between_runs(
     else:
         set_status(koan_root, f"Idle — sleeping {interval}s{status_suffix}")
     log("koan", f"Sleeping {interval}s (checking for new missions every 10s)...")
-    # Idle page-cache reclaim (#2374): throttled to page_cache_reclaim.idle_interval_s
-    # so wiring it at more than one idle-sleep site cannot double-fire. Best-effort.
-    try:
-        from app.page_cache import maybe_reclaim_page_cache_idle
-        maybe_reclaim_page_cache_idle()
-    except Exception as e:
-        log("error", f"idle page-cache reclaim failed: {e}")
+    # Idle page-cache reclaim (#2374) fires inside interruptible_sleep itself.
     with protected_phase("Sleeping between runs"):
         wake = interruptible_sleep(interval, koan_root, instance)
     if wake == "mission":
@@ -1852,12 +1846,7 @@ def _handle_contemplative(
     else:
         set_status(koan_root, f"Idle — post-contemplation sleep ({time.strftime('%H:%M')})")
         log("pause", f"Contemplative session complete. Sleeping {interval}s...")
-        # Idle page-cache reclaim (#2374): throttled + idempotent across sites.
-        try:
-            from app.page_cache import maybe_reclaim_page_cache_idle
-            maybe_reclaim_page_cache_idle()
-        except Exception as e:
-            log("error", f"idle page-cache reclaim failed: {e}")
+        # Idle page-cache reclaim (#2374) fires inside interruptible_sleep itself.
         with protected_phase("Sleeping between runs"):
             wake = interruptible_sleep(interval, koan_root, instance)
         if wake == "mission":

--- a/koan/tests/test_run_finally_reclaim.py
+++ b/koan/tests/test_run_finally_reclaim.py
@@ -1,8 +1,17 @@
-"""Lifecycle wiring for universal page-cache reclaim (#2374)."""
+"""Lifecycle wiring for universal page-cache reclaim (#2374).
+
+The idle hook lives INSIDE loop_manager.interruptible_sleep — the one sleep
+primitive every idle path shares (between-runs, contemplative, and the whole
+_IDLE_WAIT_CONFIG family: focus_wait, passive_wait, ...). Wiring it at
+individual call-sites is the regression these tests guard against: focus_wait
+originally shipped with no reclaim at all.
+"""
+import os
 from unittest import mock
 
 import pytest
 from app import run
+from app import loop_manager
 
 
 def test_post_mission_reclaim_fires_even_when_body_raises(monkeypatch, tmp_path):
@@ -28,20 +37,72 @@ def test_post_mission_reclaim_fires_even_when_body_raises(monkeypatch, tmp_path)
     assert called.get("reason") == "post-mission"
 
 
-def test_sleep_between_runs_calls_idle_reclaim(monkeypatch):
-    monkeypatch.setattr(run, "check_pending_missions", lambda inst: False)
-    monkeypatch.setattr(run, "interruptible_sleep", lambda *a, **k: "timeout")
-    monkeypatch.setattr(run, "set_status", lambda *a, **k: None)
-    called = mock.Mock()
-    monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
-    run._sleep_between_runs("/root", "inst", interval=60)
-    called.assert_called_once()
+def _mk_dirs(tmp_path):
+    koan_root = str(tmp_path / "root")
+    instance = str(tmp_path / "instance")
+    os.makedirs(koan_root, exist_ok=True)
+    os.makedirs(instance, exist_ok=True)
+    return koan_root, instance
 
 
-def test_pending_missions_skip_idle_reclaim(monkeypatch):
-    monkeypatch.setattr(run, "check_pending_missions", lambda inst: True)
-    monkeypatch.setattr(run, "set_status", lambda *a, **k: None)
+def test_interruptible_sleep_calls_idle_reclaim(monkeypatch, tmp_path):
+    """Any idle path sleeping through the shared primitive reclaims."""
+    koan_root, instance = _mk_dirs(tmp_path)
     called = mock.Mock()
     monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
-    run._sleep_between_runs("/root", "inst", interval=60)
+    result = loop_manager.interruptible_sleep(
+        interval=1, koan_root=koan_root, instance_dir=instance, check_interval=1,
+    )
+    assert result == "timeout"
+    called.assert_called()
+
+
+def test_interruptible_sleep_reclaim_error_is_nonfatal(monkeypatch, tmp_path):
+    """A reclaim failure must never break the sleep loop."""
+    koan_root, instance = _mk_dirs(tmp_path)
+    monkeypatch.setattr(
+        "app.page_cache.maybe_reclaim_page_cache_idle",
+        mock.Mock(side_effect=RuntimeError("boom")),
+    )
+    result = loop_manager.interruptible_sleep(
+        interval=1, koan_root=koan_root, instance_dir=instance, check_interval=1,
+    )
+    assert result == "timeout"
+
+
+def test_pending_mission_wake_skips_idle_reclaim(monkeypatch, tmp_path):
+    """Waking for a mission is not idle — no reclaim before handing back."""
+    koan_root, instance = _mk_dirs(tmp_path)
+    monkeypatch.setattr(loop_manager, "check_pending_missions", lambda inst: True)
+    called = mock.Mock()
+    monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
+    result = loop_manager.interruptible_sleep(
+        interval=60, koan_root=koan_root, instance_dir=instance, check_interval=1,
+    )
+    assert result == "mission"
     called.assert_not_called()
+
+
+def test_focus_wait_reclaims_via_shared_primitive(monkeypatch, tmp_path):
+    """The focus_wait/_IDLE_WAIT_CONFIG family sleeps via the REAL
+    interruptible_sleep, so it inherits the idle reclaim with no wiring of
+    its own (#2374 regression: focus_wait shipped with no reclaim)."""
+    called = mock.Mock()
+    monkeypatch.setattr("app.page_cache.maybe_reclaim_page_cache_idle", called)
+    monkeypatch.setattr(run, "set_status", lambda *a, **k: None)
+    plan = {
+        "action": "focus_wait", "project_name": "koan",
+        "project_path": str(tmp_path), "autonomous_mode": "implement",
+        "available_pct": 50, "display_lines": [], "mission_title": "",
+        "focus_area": "", "decision_reason": "", "recurring_injected": [],
+        "focus_remaining": "1h",
+    }
+    monkeypatch.setattr(run, "plan_iteration", lambda *a, **k: plan)
+    instance = str(tmp_path / "instance")
+    os.makedirs(instance, exist_ok=True)
+    run._run_iteration(
+        koan_root=str(tmp_path), instance=instance,
+        projects=[("koan", str(tmp_path))],
+        count=0, max_runs=10, interval=1, git_sync_interval=5,
+    )
+    called.assert_called()

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -121,9 +121,17 @@ see it.
   single reclaim primitive (`app/page_cache.reclaim_page_cache`, over
   `default_reclaim_roots()` = project workdirs + `instance/` + venv + scratch dir)
   at exactly two non-bypassable choke points: the `run_claude_task` outer `finally`
-  (post-mission, after the CLI subprocess has exited) and the between-runs idle
-  sleep (`_sleep_between_runs` + contemplative sleep, throttled to
-  `page_cache_reclaim.idle_interval_s`). The sweep is `posix_fadvise(DONTNEED)` on
+  (post-mission, after the CLI subprocess has exited) and **inside
+  `loop_manager.interruptible_sleep()` itself** — the single sleep primitive every
+  idle path shares (between-runs sleep, contemplative sleep, and the whole
+  `_IDLE_WAIT_CONFIG` family: `focus_wait`, `passive_wait`, `schedule_wait`,
+  `exploration_wait`, `pr_limit_wait`, `branch_saturated_wait`) — throttled to
+  `page_cache_reclaim.idle_interval_s` by `maybe_reclaim_page_cache_idle()`'s
+  module-level timestamp, which makes the call idempotent per tick. Wiring the
+  idle hook at individual call-sites instead of inside the primitive is a
+  contract violation: it is exactly how `focus_wait` shipped with no reclaim at
+  all (observed live 2026-07-14: 850 MB flat billed `memory.current` on an idle
+  focus-mode instance). The sweep is `posix_fadvise(DONTNEED)` on
   regular files only — strictly read-only, symlink- and non-regular-file-skipped,
   time-budgeted (`time_budget_s`) so it never stalls the loop, and a no-op where
   `os.posix_fadvise` is absent (macOS). It reuses `read_cgroup_memory_stat()` for


### PR DESCRIPTION
## Summary

Follow-up to #2374 / #2375. The idle page-cache reclaim was wired at two individual call-sites in `run.py` (between-runs sleep and post-contemplative sleep), but the `_IDLE_WAIT_CONFIG` family — `focus_wait`, `passive_wait`, `schedule_wait`, `exploration_wait`, `pr_limit_wait`, `branch_saturated_wait` — sleeps through `loop_manager.interruptible_sleep()` directly and **never reclaimed**.

**Observed live (2026-07-14, koan0 on Railway):** an idle focus-mode instance sat at **850 MB flat** billed `memory.current` with `file` = 502 MB of reclaimable page cache and `anon` = 90 MB. The post-mission hook fired correctly (`Page cache reclaim: file 507→255 MB (0.8s, 124k files)`), but nothing ever ran during `focus_wait` idle.

## Fix

- Move the `maybe_reclaim_page_cache_idle()` call **inside `interruptible_sleep()` itself** — the one sleep primitive every idle path shares — so any current or future idle state inherits the reclaim with no wiring of its own. This is the "non-bypassable choke point" the original design intended; per-site wiring is exactly how `focus_wait` shipped without it.
- Delete the two per-site calls in `run.py` (now redundant — one wiring point, zero duplication).
- The module-level `idle_interval_s` throttle (default 900 s) makes the per-tick call idempotent; signal/mission checks still return *before* any reclaim, so waking for a mission never pays the sweep.

## Architectural change

- [x] **Architectural change declared** — `specs/components/agent-loop.md` updated contract-first: the idle choke point is now specified as *inside `interruptible_sleep()`*, with an explicit prohibition on per-call-site wiring (and the observed failure documented as rationale).

## Tests

`koan/tests/test_run_finally_reclaim.py` rewritten around the new contract (5 passed):
- post-mission `finally` still reclaims even when the body raises (unchanged);
- `interruptible_sleep` calls the idle reclaim, and a reclaim failure is non-fatal to the sleep loop;
- waking for a pending mission skips the reclaim;
- **regression test**: a `focus_wait` iteration through the real `interruptible_sleep` triggers the reclaim.

`make lint` clean; `test_loop_manager` / `test_page_cache` / `test_check_notifications` / `test_run` / `test_mission_executor` all pass (777 passed, 2 skipped).

## Docs

`docs/operations/memory-footprint.md` updated: idle hook location, the inherit-by-construction guarantee, and the do-not-wire-per-site warning.

Closes the gap reported in #2374.

🤖 Generated with [Claude Code](https://claude.com/claude-code)