### PR TITLE
Implement: Repo dev tooling (.claude/skills, CLAUDE.md) leaks into dep

### DIFF
--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -67,6 +67,7 @@ from app.conversation_history import (
     format_conversation_history,
     compact_history,
 )
+from app.repo_tooling_guard import sanitize_repo_tooling
 from app.signals import HEARTBEAT_FILE, PAUSE_FILE, STOP_FILE
 from app.utils import (
     atomic_write_json,
@@ -1039,6 +1040,12 @@ def _bridge_loop():
 
     # Enforce single instance — abort if another awake process is running
     pidfile_lock = acquire_pidfile(KOAN_ROOT, "awake")
+
+    # Isolate koan's own repo-dev tooling out of KOAN_ROOT before any bridge
+    # chat/outbox-format session (which run with cwd=KOAN_ROOT) can start (#2379).
+    # After the pidfile lock so two bridge instances never race the move;
+    # before setup_github_auth / the poll loop so isolation precedes them.
+    sanitize_repo_tooling(KOAN_ROOT)
 
     setup_github_auth()
 

--- a/koan/app/repo_tooling_guard.py
+++ b/koan/app/repo_tooling_guard.py
@@ -1,0 +1,113 @@
+"""Isolate koan's own repo-development tooling from runtime CLI sessions.
+
+A deployed koan instance is a git clone of the koan repo, so the repo's
+contributor tooling — root CLAUDE.md / AGENTS.md and the .claude/ project-skills
+tree (brain, speckit-*) — lives at KOAN_ROOT. Several runtime CLI sessions
+(chat bridge, contemplative, rituals, outbox formatting) run with
+cwd=KOAN_ROOT, so Claude Code auto-loads that contributor context and it leaks
+into operator-facing output (e.g. advising operators to run /brain sync).
+
+This module relocates those artifacts out of the auto-load path and marks their
+tracked paths skip-worktree so `git status` stays clean and fast-forward
+self-updates don't fight the move. Idempotent; safe on every startup and after
+every self-update.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Union
+
+from app.git_utils import run_git
+from app.run_log import log
+
+QUARANTINE_DIRNAME = ".repo-tooling-quarantine"
+
+# Repo-root artifacts Claude Code auto-loads when cwd=KOAN_ROOT.
+# Relative to KOAN_ROOT. Nested CLAUDE.md files (koan/**/CLAUDE.md) are NOT
+# included: they only auto-load when a session reads files under that subtree,
+# which the four runtime session types never do (they read instance/ state).
+_ARTIFACTS = ("CLAUDE.md", "AGENTS.md", ".claude")
+
+
+def _is_git_repo(root: Path) -> bool:
+    rc, out, _ = run_git("rev-parse", "--is-inside-work-tree", cwd=str(root))
+    return rc == 0 and out.strip() == "true"
+
+
+def _tracked_files_under(root: Path, rel: str) -> list[str]:
+    """Tracked paths (files) at/under `rel`, relative to root. Empty if none."""
+    rc, out, _ = run_git("ls-files", "-z", "--", rel, cwd=str(root))
+    if rc != 0 or not out:
+        return []
+    return [p for p in out.split("\0") if p]
+
+
+def _set_skip_worktree(root: Path, files: list[str], skip: bool) -> None:
+    flag = "--skip-worktree" if skip else "--no-skip-worktree"
+    for f in files:
+        run_git("update-index", flag, "--", f, cwd=str(root))
+
+
+def sanitize_repo_tooling(koan_root: Union[str, Path]) -> list[str]:
+    """Relocate repo-dev artifacts out of KOAN_ROOT's Claude auto-load path.
+
+    Returns the list of artifact paths (relative to koan_root) relocated during
+    this call (empty when already isolated, untracked, or not a git repo).
+    """
+    root = Path(koan_root)
+    if not _is_git_repo(root):
+        return []
+
+    quarantine = root / "instance" / QUARANTINE_DIRNAME
+    relocated: list[str] = []
+    for rel in _ARTIFACTS:
+        src = root / rel
+        if not src.exists():
+            continue  # already relocated, or never present
+        tracked = _tracked_files_under(root, rel)
+        if not tracked:
+            continue  # untracked operator file — leave it alone
+        # Mark skip-worktree BEFORE moving so the physical absence reads as
+        # clean and ff-updates don't try to restore it.
+        _set_skip_worktree(root, tracked, skip=True)
+        dest = quarantine / rel
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        if dest.exists():
+            if dest.is_dir() and not dest.is_symlink():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
+        src.replace(dest)  # atomic within the same filesystem
+        relocated.append(rel)
+        log("guard", f"Isolated repo tooling: {rel} -> instance/{QUARANTINE_DIRNAME}/{rel}")
+    return relocated
+
+
+def restore_repo_tooling(koan_root: Union[str, Path]) -> list[str]:
+    """Inverse of sanitize_repo_tooling: move artifacts back and clear
+    skip-worktree. Returns the list restored. Best-effort; used for operators
+    who want to develop koan on this checkout again."""
+    root = Path(koan_root)
+    quarantine = root / "instance" / QUARANTINE_DIRNAME
+    if not quarantine.exists():
+        return []
+    restored: list[str] = []
+    for rel in _ARTIFACTS:
+        src = quarantine / rel
+        if not src.exists():
+            continue
+        dest = root / rel
+        if dest.exists():
+            if dest.is_dir() and not dest.is_symlink():
+                shutil.rmtree(dest)
+            else:
+                dest.unlink()
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        src.replace(dest)
+        if _is_git_repo(root):
+            _set_skip_worktree(root, _tracked_files_under(root, rel), skip=False)
+        restored.append(rel)
+        log("guard", f"Restored repo tooling: instance/{QUARANTINE_DIRNAME}/{rel} -> {rel}")
+    return restored

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -734,6 +734,12 @@ def run_startup(koan_root: str, instance: str, projects: list):
     from app.run import protected_phase
 
     with protected_phase("Startup checks"):
+        # Isolate koan's own repo-dev tooling (CLAUDE.md/AGENTS.md/.claude) out
+        # of KOAN_ROOT before any run-loop session starts (#2379). First so the
+        # leak is closed before config validation or any other step can run.
+        from app.repo_tooling_guard import sanitize_repo_tooling
+        _safe_run("Repo tooling isolation", sanitize_repo_tooling, koan_root)
+
         # Strict config validation runs outside _safe_run so errors
         # propagate (hard stop) and reach the operator via Telegram.
         try:

--- a/koan/app/update_manager.py
+++ b/koan/app/update_manager.py
@@ -320,6 +320,11 @@ def checkout_latest_tag(koan_root: Path, timeout: int = 120) -> UpdateResult:
 
     log("update", f"Checked out release tag {latest_tag} ({new_sha})")
 
+    # A checkout may have re-materialized koan's own repo-dev tooling into the
+    # worktree; re-isolate it immediately (#2379).
+    from app.repo_tooling_guard import sanitize_repo_tooling
+    sanitize_repo_tooling(koan_root)
+
     return UpdateResult(
         success=True,
         old_commit=old_sha,
@@ -477,6 +482,12 @@ def pull_upstream(koan_root: Path, timeout: int = 120) -> UpdateResult:
         _run_git(["checkout", current_branch], koan_root)
     if stashed:
         _run_git(["stash", "pop"], koan_root)
+
+    # A pull may have re-materialized koan's own repo-dev tooling into the
+    # worktree; re-isolate it immediately (belt-and-suspenders to the
+    # restart-triggered run_startup) (#2379).
+    from app.repo_tooling_guard import sanitize_repo_tooling
+    sanitize_repo_tooling(koan_root)
 
     return UpdateResult(
         success=True,

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -3860,3 +3860,41 @@ def test_read_sections_cached_expires_after_ttl():
     assert first == {"pending": ["a"]}
     assert second == {"pending": ["b"]}  # TTL expired → re-read
     assert mock_read.call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Test: repo-tooling isolation wiring (#2379)
+#
+# main() is a crash-recovery wrapper around _bridge_loop(); the guard call
+# lives in _bridge_loop after the pidfile lock and before setup_github_auth.
+# ---------------------------------------------------------------------------
+
+class _StopBridge(Exception):
+    pass
+
+
+def test_bridge_isolates_repo_tooling_before_github_auth(monkeypatch):
+    import app.awake as awake
+
+    # Everything that runs before the guard must succeed cheaply.
+    monkeypatch.setattr(awake, "check_config", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "app.migration_runner.run_pending_migrations", lambda *a, **k: []
+    )
+    monkeypatch.setattr(
+        "app.pid_manager.acquire_pidfile", lambda *a, **k: MagicMock()
+    )
+
+    # The guard aborts _bridge_loop right at its call site.
+    sanitize = MagicMock(side_effect=_StopBridge)
+    monkeypatch.setattr(awake, "sanitize_repo_tooling", sanitize)
+
+    # Anything that would run AFTER the guard must not be reached.
+    setup_auth = MagicMock()
+    monkeypatch.setattr("app.github_auth.setup_github_auth", setup_auth)
+
+    with pytest.raises(_StopBridge):
+        awake._bridge_loop()
+
+    sanitize.assert_called_once_with(awake.KOAN_ROOT)
+    setup_auth.assert_not_called()  # guard runs strictly before the rest of startup

--- a/koan/tests/test_repo_tooling_guard.py
+++ b/koan/tests/test_repo_tooling_guard.py
@@ -1,0 +1,98 @@
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from app.repo_tooling_guard import (
+    QUARANTINE_DIRNAME,
+    sanitize_repo_tooling,
+    restore_repo_tooling,
+)
+
+
+def _git(root, *args):
+    return subprocess.run(
+        ["git", *args], cwd=str(root), capture_output=True, text=True
+    )
+
+
+@pytest.fixture
+def repo(tmp_path):
+    root = tmp_path
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    (root / "CLAUDE.md").write_text("repo contributor guidance\n")
+    (root / "AGENTS.md").write_text("agents\n")
+    skills = root / ".claude" / "skills" / "brain"
+    skills.mkdir(parents=True)
+    (skills / "SKILL.md").write_text("brain\n")
+    (root / "README.md").write_text("hi\n")
+    # instance/ is gitignored in the real koan repo — the quarantine dir lives
+    # under it, so it must stay invisible to `git status`.
+    (root / ".gitignore").write_text("instance/\n")
+    (root / "instance").mkdir()
+    _git(root, "add", "-A")
+    _git(root, "commit", "-qm", "init")
+    return root
+
+
+def test_relocates_tracked_artifacts_out_of_root(repo):
+    moved = sanitize_repo_tooling(repo)
+    assert set(moved) == {"CLAUDE.md", "AGENTS.md", ".claude"}
+    assert not (repo / "CLAUDE.md").exists()
+    assert not (repo / "AGENTS.md").exists()
+    assert not (repo / ".claude").exists()
+    q = repo / "instance" / QUARANTINE_DIRNAME
+    assert (q / "CLAUDE.md").read_text() == "repo contributor guidance\n"
+    assert (q / ".claude" / "skills" / "brain" / "SKILL.md").exists()
+
+
+def test_git_status_clean_after_sanitize(repo):
+    sanitize_repo_tooling(repo)
+    status = _git(repo, "status", "--porcelain").stdout.strip()
+    assert status == "", f"expected clean tree, got:\n{status}"
+
+
+def test_idempotent_second_call_is_noop(repo):
+    sanitize_repo_tooling(repo)
+    moved_again = sanitize_repo_tooling(repo)
+    assert moved_again == []
+    assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_leaves_untracked_operator_files_alone(tmp_path):
+    root = tmp_path
+    _git(root, "init", "-b", "main")
+    _git(root, "config", "user.email", "t@t")
+    _git(root, "config", "user.name", "t")
+    (root / "instance").mkdir()
+    (root / "CLAUDE.md").write_text("operator's own untracked file\n")  # never committed
+    moved = sanitize_repo_tooling(root)
+    assert moved == []
+    assert (root / "CLAUDE.md").read_text() == "operator's own untracked file\n"
+
+
+def test_non_repo_is_noop(tmp_path):
+    (tmp_path / "instance").mkdir()
+    (tmp_path / "CLAUDE.md").write_text("x\n")
+    assert sanitize_repo_tooling(tmp_path) == []
+    assert (tmp_path / "CLAUDE.md").exists()
+
+
+def test_restore_round_trip(repo):
+    sanitize_repo_tooling(repo)
+    restored = restore_repo_tooling(repo)
+    assert set(restored) == {"CLAUDE.md", "AGENTS.md", ".claude"}
+    assert (repo / "CLAUDE.md").read_text() == "repo contributor guidance\n"
+    assert (repo / ".claude" / "skills" / "brain" / "SKILL.md").exists()
+    assert _git(repo, "status", "--porcelain").stdout.strip() == ""
+
+
+def test_regression_no_runtime_cwd_contains_claude_skills(repo):
+    """The guard's contract: after sanitize, KOAN_ROOT (the runtime cwd) has
+    no auto-loadable .claude/skills tree or root CLAUDE.md/AGENTS.md."""
+    sanitize_repo_tooling(repo)
+    assert not (repo / ".claude" / "skills").exists()
+    assert not (repo / "CLAUDE.md").exists()
+    assert not (repo / "AGENTS.md").exists()

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -1346,3 +1346,41 @@ class TestEnsureProjectsYaml:
         assert "Created projects.yaml" in msgs
         config = yaml.safe_load((tmp_path / "projects.yaml").read_text())
         assert "koan" not in config["projects"]
+
+
+# ---------------------------------------------------------------------------
+# Test: repo-tooling isolation wiring (#2379)
+# ---------------------------------------------------------------------------
+
+def test_run_startup_isolates_repo_tooling_first(monkeypatch, koan_root, instance, projects):
+    import contextlib
+    from unittest.mock import MagicMock
+
+    import app.startup_manager as sm
+    import app.repo_tooling_guard as guard
+
+    order = []
+
+    def fake_safe_run(step_name, fn, *args, **kwargs):
+        order.append((step_name, fn))
+        return None
+
+    # Replace _safe_run so no real startup step executes; we only assert wiring.
+    monkeypatch.setattr(sm, "_safe_run", fake_safe_run)
+    # Strict config validation runs outside _safe_run — stub it to pass.
+    monkeypatch.setattr(
+        "app.config_validator.validate_config_or_raise", lambda *_a, **_k: None
+    )
+    # protected_phase is a context manager pulled from run.py.
+    monkeypatch.setattr(
+        "app.run.protected_phase", lambda *_a, **_k: contextlib.nullcontext()
+    )
+    sanitize = MagicMock(return_value=[])
+    monkeypatch.setattr(guard, "sanitize_repo_tooling", sanitize)
+
+    sm.run_startup(str(koan_root), instance, projects)
+
+    assert order, "run_startup ran no _safe_run steps"
+    first_name, first_fn = order[0]
+    assert first_name == "Repo tooling isolation"
+    assert first_fn is sanitize  # the wired fn is the guard's sanitizer

--- a/koan/tests/test_update_manager.py
+++ b/koan/tests/test_update_manager.py
@@ -660,3 +660,58 @@ class TestCheckoutLatestTag:
         result = checkout_latest_tag(Path("/repo"))
         assert result.success is False
         assert "remote tags" in result.error.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: re-isolate repo tooling after successful self-update (#2379)
+# ---------------------------------------------------------------------------
+
+import app.update_manager as um
+
+
+def _ok(stdout=""):
+    return um._GitResult(0, stdout, "")
+
+
+def _fail(stderr="boom"):
+    return um._GitResult(1, "", stderr)
+
+
+def test_pull_upstream_resanitizes_on_success(monkeypatch, tmp_path):
+    monkeypatch.setattr(um, "find_upstream_remote", lambda root: "origin")
+    monkeypatch.setattr(um, "_is_dirty", lambda root: False)
+    # old != new so the pull counts as changed; all git calls succeed.
+    shas = iter(["aaaaaaa", "bbbbbbb"])
+    monkeypatch.setattr(um, "_get_short_sha", lambda root: next(shas))
+    monkeypatch.setattr(um, "_get_current_branch", lambda root: "main")
+    monkeypatch.setattr(um, "_run_git", lambda *a, **k: _ok())
+    monkeypatch.setattr(um, "_count_commits_between", lambda root, o, n: 1)
+
+    sanitize = MagicMock(return_value=["CLAUDE.md"])
+    monkeypatch.setattr("app.repo_tooling_guard.sanitize_repo_tooling", sanitize)
+
+    result = um.pull_upstream(tmp_path)
+    assert result.success
+    sanitize.assert_called_once_with(tmp_path)
+
+
+def test_pull_upstream_does_not_resanitize_on_failure(monkeypatch, tmp_path):
+    monkeypatch.setattr(um, "find_upstream_remote", lambda root: "origin")
+    monkeypatch.setattr(um, "_is_dirty", lambda root: False)
+    monkeypatch.setattr(um, "_get_short_sha", lambda root: "aaaaaaa")
+    monkeypatch.setattr(um, "_get_current_branch", lambda root: "main")
+
+    def run_git(args, cwd, timeout=60):
+        # fetch succeeds, the pull fails.
+        if args[:1] == ["pull"]:
+            return _fail("cannot fast-forward")
+        return _ok()
+
+    monkeypatch.setattr(um, "_run_git", run_git)
+
+    sanitize = MagicMock()
+    monkeypatch.setattr("app.repo_tooling_guard.sanitize_repo_tooling", sanitize)
+
+    result = um.pull_upstream(tmp_path)
+    assert not result.success
+    sanitize.assert_not_called()


### PR DESCRIPTION
## Summary

- Added `koan/app/repo_tooling_guard.py`, a module that relocates koan's own repo-dev tooling (root `CLAUDE.md`, `AGENTS.md`, `.claude/`) out of `KOAN_ROOT` into `instance/.repo-tooling-quarantine/` so runtime CLI sessions don't auto-load contributor context
- Wired `sanitize_repo_tooling()` into the bridge (`awake.py`, after the pidfile lock, before `setup_github_auth`) and into `run_startup()` (as the first startup step) so isolation happens on every process start
- Wired re-isolation into `update_manager.py`'s `checkout_latest_tag()` and `pull_upstream()` so a self-update that re-materializes those files gets cleaned up immediately after a successful pull/checkout
- Marks the relocated files `--skip-worktree` so `git status` stays clean and fast-forward updates don't fight the move; provided `restore_repo_tooling()` as the inverse for operators developing koan on the same checkout

## Why

A deployed koan instance is a git clone of the koan repo, so contributor-facing tooling (root `CLAUDE.md`/`AGENTS.md` and `.claude/` project skills like `brain`, `speckit-*`) lives at `KOAN_ROOT`. Several runtime CLI sessions (chat bridge, contemplative, rituals, outbox formatting) run with `cwd=KOAN_ROOT`, so Claude Code auto-loads that contributor context and leaks it into operator-facing output (e.g. advising operators to run `/brain sync`). This closes that leak at every point the tooling could reappear: fresh startup, bridge start, and post-self-update (#2379).

## How

- `sanitize_repo_tooling()` checks each artifact is git-tracked before moving it (untracked operator files are left alone), sets `--skip-worktree` before the move so the absence reads as clean, then atomically relocates it under `instance/.repo-tooling-quarantine/`
- Idempotent by design — if the artifact no longer exists at the source path, the call is a no-op, so it's safe to call unconditionally on every startup/update
- Nested `koan/**/CLAUDE.md` files are deliberately excluded from `_ARTIFACTS` since they only auto-load when a session reads files under that subtree, which runtime sessions never do
- `restore_repo_tooling()` mirrors the move in reverse and clears `--skip-worktree`, for operators who want to resume repo development on the same checkout
- Ordering enforced via explicit comments: bridge isolates after the pidfile lock (no race between two bridge instances) but before GitHub auth; startup isolates as the very first `_safe_run` step

## Testing

- New `test_repo_tooling_guard.py`: relocation, clean `git status`, idempotency, untracked-file preservation, non-repo no-op, restore round-trip, and a regression test asserting no auto-loadable `.claude/skills` or root `CLAUDE.md`/`AGENTS.md` remain post-sanitize
- New tests in `test_awake.py` and `test_startup_manager.py` assert call ordering — the guard runs before `setup_github_auth` and as the first startup step, respectively
- New tests in `test_update_manager.py` assert `sanitize_repo_tooling` is called after a successful `pull_upstream` and NOT called when the pull fails

Closes https://github.com/Anantys-oss/koan/issues/2379

---
_Generated by [Kōan](https://koan.anantys.com)_ _(Claude · model opus · HEAD=a62477f4 · 23m52s)_