### PR TITLE
Add Grok Build CLI provider (cli_provider: grok)

### DIFF
--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -1,10 +1,10 @@
 ---
 type: doc
 title: "Provider Architecture"
-description: "Documents the CLI provider abstraction layer, provider responsibilities, resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Local)."
+description: "Documents the CLI provider abstraction layer, provider responsibilities, resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Haze, Grok, Ollama-launch)."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-06-09
+updated: 2026-07-15
 ---
 
 # Provider Architecture
@@ -44,6 +44,9 @@ prefer importing from `koan.app.provider`.
 - Cline provider: Cline CLI multi-backend integration.
 - Codex provider: OpenAI Codex CLI integration.
 - Copilot provider: GitHub Copilot CLI integration with tool-name mapping.
-- Local provider: local model server integration.
+- Haze provider: multi-backend agentic CLI with stream-json.
+- Grok provider: xAI Grok Build CLI (`cli_provider: grok`) with headless
+  `streaming-json`.
+- Ollama Launch provider: Claude CLI driven via `ollama launch claude`.
 
 Setup details live in [Provider Setup](../providers/).

--- a/docs/providers/grok.md
+++ b/docs/providers/grok.md
@@ -1,0 +1,147 @@
+---
+type: doc
+title: "Grok Build CLI Provider"
+description: "Setup and behavior guide for using xAI's Grok Build CLI as Kōan's provider, including headless streaming-json, auth, models, and limitations."
+tags: [providers]
+created: 2026-07-15
+updated: 2026-07-15
+---
+
+# Grok Build CLI Provider
+
+The Grok provider lets Kōan use [xAI Grok Build](https://x.ai/cli) as the
+underlying AI coding agent. Grok Build is xAI's terminal coding agent (TUI +
+headless), powered by Grok models (e.g. Grok 4.5).
+
+**Official docs:** [Grok Build overview](https://docs.x.ai/build/overview) ·
+[Headless & scripting](https://docs.x.ai/build/cli/headless-scripting)
+
+**Minimum verified version:** Grok Build **0.2.101** (stable). Other versions
+with the same headless flags should work; re-capture stream samples if the
+NDJSON schema changes.
+
+## Quick Setup
+
+### 1. Install Grok Build
+
+```bash
+curl -fsSL https://x.ai/cli/install.sh | bash
+grok --version
+```
+
+### 2. Authenticate
+
+```bash
+# Browser login (interactive)
+grok
+
+# Or API key for headless / servers
+export XAI_API_KEY="xai-..."
+```
+
+### 3. Configure Kōan
+
+**Option A: `instance/config.yaml`**
+
+```yaml
+cli_provider: "grok"
+```
+
+**Option B: environment**
+
+```bash
+export KOAN_CLI_PROVIDER=grok
+```
+
+The env var overrides `config.yaml` when both are set.
+
+### 4. Model selection (optional)
+
+```yaml
+cli_provider: "grok"
+models:
+  grok:
+    mission: "grok-4.5"
+    chat: "grok-4.5"
+    lightweight: "grok-4.5"
+    review_mode: "grok-4.5"
+    fallback: ""   # ignored — Grok Build has no fallback-model flag
+```
+
+When unset, Grok Build uses its own default model (`~/.grok/config.toml` /
+interactive `/model`). Confirm available models with `grok inspect` after
+install.
+
+Per-role binary pin (same pattern as other flavors):
+
+```yaml
+cli:
+  default:
+    review_mode: grok:/path/to/custom-grok
+```
+
+## How Kōan drives Grok
+
+Kōan invokes headless Grok Build with streaming output:
+
+```text
+grok --always-approve|--permission-mode acceptEdits \
+     [--tools …] [-m <model>] --output-format streaming-json \
+     [--max-turns N] [-p "<prompt>"]
+```
+
+| Concern | Behavior |
+|---|---|
+| Prompt | `-p` / `--single` (argv). Stdin prompt passing is not used. |
+| Stream | `--output-format streaming-json` → NDJSON `thought` / `text` / `end` |
+| Final text | Concatenated `text` deltas (`data` fields); `end` has usage, not body |
+| Usage | Snake_case `usage` on `end` + optional `modelUsage` map |
+| Permissions | `skip_permissions: true` → `--always-approve`; otherwise `--permission-mode acceptEdits` (avoids interactive hangs) |
+| Tools | `--tools` / `--disallowed-tools` (comma-separated) |
+| System prompt | `--rules` (append). File paths are inlined into `--rules` |
+| Effort | `--reasoning-effort` when configured |
+| Sessions | `--resume <id>` when resume is requested |
+| Concurrency | Invocation lock `grok-cli` (shared `~/.grok/` state) |
+
+Live progress lines appear as `[cli] …` in `make logs` (thinking, text
+previews, terminal `end`).
+
+## Capabilities and limitations
+
+**Supported (MVP):**
+
+- Headless missions and skill runners via `run_command` / `run_command_streaming`
+- Stream progress + token usage accounting
+- Model override (`-m`)
+- Tool allow/deny lists (as supported by Grok Build)
+- Max turns, reasoning effort, session resume
+- Quota / auth detection (stderr + failed stdout); soft pre-flight probe
+
+**Not supported / ignored with a notice:**
+
+- Fallback model (`models.*.fallback`)
+- MCP config via CLI flags
+- Plugin directory flags
+- Claude-identical tool vocabulary (pass Claude names; Grok maps or ignores unknown tool ids)
+
+**Safety note:** `--always-approve` auto-approves tool execution. Prefer
+restricting tools for read-only roles (e.g. `/review` already passes
+`Read,Glob,Grep` only). Headless without skip still uses `acceptEdits` so the
+agent does not block forever on permission prompts.
+
+## Troubleshooting
+
+| Symptom | Check |
+|---|---|
+| `Unknown CLI provider: grok` | Update to a build that includes the Grok provider; restart `run`/`awake` |
+| Provider not ready / not installed | `which grok` and reinstall from https://x.ai/cli |
+| Auth failures | `export XAI_API_KEY=…` or run interactive `grok` login once |
+| Rate limits pause Koan | Expected; wait or switch provider / raise quota |
+| Empty skill output | Confirm `--output-format streaming-json` events still match samples in `koan/tests/grok_samples.py` |
+
+## Related
+
+- Design contract: `specs/components/providers.md` (Grok Build headless contract)
+- Architecture: [Provider Architecture](../architecture/providers.md)
+- Recorded fixtures: `koan/tests/grok_samples.py`
+- Issue: https://github.com/Anantys-oss/koan/issues/2400

--- a/docs/providers/index.md
+++ b/docs/providers/index.md
@@ -6,6 +6,7 @@
 * [OpenAI Codex CLI Provider](codex.md) - Setup and behavior guide for using OpenAI's Codex CLI as Kōan's provider, including quota/usage handling and troubleshooting.
 * [GitHub Copilot CLI Provider](copilot.md) - Setup guide and feature/tool-mapping differences for using GitHub Copilot CLI as Kōan's provider.
 * [Haze CLI Provider](haze.md) - Setup and behavior guide for using haze (multi-backend agentic CLI) as Kōan's provider, including stream-json integration, usage accounting, capabilities and limitations.
+* [Grok Build CLI Provider](grok.md) - Setup and behavior guide for using xAI's Grok Build CLI as Kōan's provider, including headless streaming-json, auth, models, and limitations.
 * [Local LLM Provider (removed)](local.md) - Explains that the `local` Ollama provider was removed and points to `ollama-launch` or a custom Claude CLI endpoint as the supported replacements.
 * [Ollama Launch Provider](ollama-launch.md) - Documents the `ollama-launch` provider, which runs the Claude Code CLI through `ollama launch claude` for full tool-use/streaming parity with native Claude.
 * [Local Ollama via the Claude CLI](ollama-wrapper.md) - Describes the `bin/ollama-claude` wrapper that routes Koan's default `claude` provider through a local Ollama model via `ollama launch claude`, without changing `cli_provider`.

--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -1591,7 +1591,7 @@ projects:
 ```
 
 Key per-project settings:
-- **`cli_provider`** — `claude`, `cline`, `codex`, `copilot`, `haze`, `local`, or `ollama-launch`
+- **`cli_provider`** — `claude`, `cline`, `codex`, `copilot`, `haze`, `grok`, `local`, or `ollama-launch`
 - **`models`** — Override model selection per role
 - **`tools`** — Restrict available tools
 - **`git_auto_merge`** — Auto-merge completed PRs (strategy: squash/merge/rebase)
@@ -1777,6 +1777,7 @@ Kōan supports multiple CLI backends. Configure globally via `KOAN_CLI_PROVIDER`
 | **OpenAI Codex** | ChatGPT users who want Codex models | [codex.md](../providers/codex.md) |
 | **GitHub Copilot** | Teams with existing Copilot licenses | [copilot.md](../providers/copilot.md) |
 | **Haze** | Minimal multi-backend agentic CLI (OpenAI, OpenRouter, local endpoints) — [official docs](https://denizokcu.github.io/haze/) | [haze.md](../providers/haze.md) |
+| **Grok Build** | xAI Grok Build CLI (`grok`) with headless streaming-json | [grok.md](../providers/grok.md) |
 | **Ollama Launch** | Local/offline models behind the Claude CLI harness | [ollama-launch.md](../providers/ollama-launch.md) |
 | **OpenRouter** (via Claude CLI) | Claude CLI behavior with OpenRouter's model catalog/billing | [openrouter.md](../providers/openrouter.md) |
 

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -425,7 +425,8 @@ tools:
 
 # CLI provider — which AI CLI to use as the backend
 # Options: "claude" (default), "codex" (OpenAI Codex CLI), "copilot" (GitHub Copilot CLI),
-#          "local" (local LLM via OpenAI-compatible API), "ollama-launch" (Ollama-managed Claude CLI)
+#          "haze", "grok" (xAI Grok Build CLI), "ollama-launch" (Ollama-managed Claude CLI)
+#          ("local" was removed — use ollama-launch)
 # Can also be set via KOAN_CLI_PROVIDER env var (overrides this)
 cli_provider: "claude"
 

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -2125,7 +2125,7 @@ def get_cli_binary_for_shell() -> str:
 def get_cli_provider_name() -> str:
     """Get the configured CLI provider name for display.
 
-    Returns "claude", "codex", "copilot", or "ollama-launch".
+    Returns a registered provider flavor (e.g. "claude", "codex", "grok").
     """
     from app.cli_provider import get_provider_name
     return get_provider_name()

--- a/koan/app/onboarding.py
+++ b/koan/app/onboarding.py
@@ -572,6 +572,7 @@ PROVIDER_TOOLS = {
     "codex": "codex",
     "copilot": "gh",
     "haze": "haze",
+    "grok": "grok",
     "ollama-launch": "ollama",
 }
 
@@ -581,6 +582,7 @@ PROVIDERS = [
     ("codex", "OpenAI Codex CLI"),
     ("copilot", "GitHub Copilot CLI"),
     ("haze", "haze (multi-backend agentic CLI)"),
+    ("grok", "Grok Build CLI (xAI)"),
     ("ollama-launch", "Ollama Launch (local models via ollama)"),
 ]
 

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -45,6 +45,7 @@ from app.provider.cline import ClineProvider  # noqa: F401
 from app.provider.codex import CodexProvider  # noqa: F401
 from app.provider.copilot import CopilotProvider  # noqa: F401
 from app.provider.haze import HazeProvider  # noqa: F401
+from app.provider.grok import GrokProvider  # noqa: F401
 from app.provider.ollama_launch import OllamaLaunchProvider  # noqa: F401
 
 
@@ -118,6 +119,7 @@ _PROVIDERS = {
     "codex": CodexProvider,
     "copilot": CopilotProvider,
     "haze": HazeProvider,
+    "grok": GrokProvider,
     "ollama-launch": OllamaLaunchProvider,
 }
 
@@ -924,6 +926,26 @@ def _summarize_stream_event(event: Dict[str, Any]) -> str:
         # marker above. See quota_handler._rate_limit_exhausted.
         return f"[cli] rate_limit_ok: {status or 'unknown'}{label}"
 
+    # Grok Build-style NDJSON (streaming-json): thought/text deltas + terminal
+    # ``end`` envelope. Shape-keyed on type + ``data`` / stopReason — no
+    # provider-name checks. See tests/grok_samples.py.
+    if etype == "thought" and isinstance(event.get("data"), str):
+        return "[cli] assistant — thinking"
+    if etype == "text" and isinstance(event.get("data"), str):
+        preview = _first_line(event.get("data"))
+        if preview:
+            return f"[cli] assistant — text: {_drop_part_sep(preview)}"
+        return "[cli] assistant — streaming"
+    if etype == "end":
+        stop = str(event.get("stopReason") or event.get("stop_reason") or "").strip()
+        turns = event.get("num_turns")
+        parts = ["end"]
+        if stop:
+            parts.append(stop)
+        if isinstance(turns, int):
+            parts.append(f"{turns} turns")
+        return f"[cli] result: {', '.join(parts)}"
+
     item = event.get("item")
     if isinstance(item, dict):
         item_type = item.get("type", "")
@@ -976,6 +998,15 @@ def _extract_assistant_text_chunks(event: Dict[str, Any]) -> List[str]:
                 text = block.get("text")
                 if isinstance(text, str) and text:
                     chunks.append(text)
+
+    # Grok Build-style assistant text deltas: {"type":"text","data":"…"}.
+    # These are token/word deltas that must be concatenated with "" (see
+    # run_command_streaming delta flush). Not the same as Claude content
+    # blocks or haze message_end segments.
+    if event.get("type") == "text":
+        data = event.get("data")
+        if isinstance(data, str) and data:
+            chunks.append(data)
 
     # Haze-style segment completion: ``message_end`` carries the finalized
     # text for one assistant segment (one event per segment id). Cumulative
@@ -1041,15 +1072,21 @@ def _extract_result_text(event: Dict[str, Any]) -> Optional[str]:
                 "task.completed",
                 "turn_complete",
                 "task_complete",
+                # Grok Build terminal envelope carries usage/stopReason but not
+                # the assistant text — return None so callers fall back to
+                # accumulated text deltas.
+                "end",
             }
         ):
             return None
-        for key in ("output_text", "last_agent_message"):
+        if etype == "end":
+            return None
+        for key in ("output_text", "last_agent_message", "text"):
             result = event.get(key)
             if isinstance(result, str) and result:
                 return result
         return None
-    for key in ("result", "output_text", "last_agent_message"):
+    for key in ("result", "output_text", "last_agent_message", "text"):
         result = event.get(key)
         if isinstance(result, str) and result:
             return result
@@ -1107,16 +1144,31 @@ def _usage_snapshot_from_event(event: Dict[str, Any]) -> Optional[Dict[str, Any]
 
         input_tokens = int(usage.get("input_tokens", 0) or 0)
         output_tokens = int(usage.get("output_tokens", 0) or 0)
-        cached_input = int(usage.get("cached_input_tokens", 0) or 0)
-        if cached_input > 0:
-            input_tokens = max(0, input_tokens - cached_input)
+        # Claude/Codex: ``cached_input_tokens`` is a subset of input — subtract.
+        # Grok Build: ``cache_read_input_tokens`` may exceed ``input_tokens`` on
+        # multi-turn runs (cache spans prior turns). Only subtract when cache
+        # is a subset of input so we never zero out a real input count.
+        if "cached_input_tokens" in usage:
+            cached_input = int(usage.get("cached_input_tokens", 0) or 0)
+            if cached_input > 0:
+                input_tokens = max(0, input_tokens - cached_input)
+        else:
+            cached_input = int(usage.get("cache_read_input_tokens", 0) or 0)
+            if 0 < cached_input <= input_tokens:
+                input_tokens = max(0, input_tokens - cached_input)
         if input_tokens or output_tokens or cached_input:
+            model = str(event.get("model") or "")
+            if not model:
+                # Grok Build puts the model id in modelUsage keys, not event.model.
+                model_usage = event.get("modelUsage")
+                if isinstance(model_usage, dict) and model_usage:
+                    model = str(next(iter(model_usage)))
             return {
                 "input_tokens": input_tokens,
                 "output_tokens": output_tokens,
                 "cache_read_input_tokens": cached_input,
                 "cache_creation_input_tokens": 0,
-                "model": str(event.get("model") or "unknown"),
+                "model": model or "unknown",
             }
 
     payload = event.get("payload")
@@ -1263,11 +1315,22 @@ def run_command_streaming(
     raw_lines = deque(maxlen=2000)  # for error reporting (terminal lines)
     # text_lines IS the fallback return value when no result event arrives —
     # it must stay unbounded or long sessions would silently lose output.
+    # Block-style providers (Claude, Haze segments) append full segments and
+    # are joined with newlines. Delta-style providers (Grok Build text/data)
+    # buffer into text_delta_parts and flush as one segment so "hel"+"lo"
+    # becomes "hello", not "hel\\nlo".
     text_lines: List[str] = []  # fallback return value when no result event
+    text_delta_parts: List[str] = []
     final_result: Optional[str] = None
     usage_snapshot: Optional[Dict[str, Any]] = None
     saw_max_turns_event = False
     stderr_text = ""
+
+    def _flush_text_deltas() -> None:
+        if text_delta_parts:
+            text_lines.append("".join(text_delta_parts))
+            text_delta_parts.clear()
+
     try:
         proc, cleanup = popen_cli(
             cmd,
@@ -1305,7 +1368,15 @@ def run_command_streaming(
                     # before the final ``result`` event (timeout, watchdog
                     # kill, SIGPIPE) still returns whatever the provider managed
                     # to print, instead of silently returning "".
-                    text_lines.extend(_extract_assistant_text_chunks(event))
+                    chunks = _extract_assistant_text_chunks(event)
+                    if (
+                        event.get("type") == "text"
+                        and isinstance(event.get("data"), str)
+                    ):
+                        text_delta_parts.extend(chunks)
+                    else:
+                        _flush_text_deltas()
+                        text_lines.extend(chunks)
                     result_text = _extract_result_text(event)
                     if result_text is not None:
                         final_result = result_text
@@ -1314,8 +1385,10 @@ def run_command_streaming(
                 else:
                     # Non-JSON: provider doesn't speak stream-json or a stray
                     # warning slipped in. Print and remember for the fallback.
+                    _flush_text_deltas()
                     print(stripped, flush=True)
                     text_lines.append(stripped)
+            _flush_text_deltas()
             stderr_text = proc.stderr.read() if proc.stderr else ""
             proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired as e:

--- a/koan/app/provider/grok.py
+++ b/koan/app/provider/grok.py
@@ -1,0 +1,365 @@
+"""xAI Grok Build CLI provider implementation."""
+
+import re
+import shutil
+import subprocess
+from typing import List, Optional, Tuple
+
+from app.provider.base import CLIProvider
+from app.run_log import log_safe
+
+# Grok Build fronts the xAI API (and optional custom model endpoints). Quota
+# and auth wording is API-ish; patterns stay backend-agnostic.
+_GROK_QUOTA_PATTERNS = [
+    r"rate[_\s-]?limit(?:ed|_error| exceeded)?",
+    r"insufficient[_\s-]?quota",
+    r"\bquota\b.*(?:exceeded|reached|exhausted|insufficient)",
+    r"(?:exceeded|reached|exhausted|insufficient).*\bquota\b",
+    r"usage.*(?:limit|cap).*(?:reached|exceeded|hit)",
+    r"billing.*(?:limit|quota|credit)",
+    r"HTTP\s*429",
+    r"status[\s:]+429",
+    r"too many requests",
+    r"retry[\s-]+after",
+]
+_GROK_QUOTA_RE = re.compile("|".join(_GROK_QUOTA_PATTERNS), re.IGNORECASE)
+
+_GROK_AUTH_PATTERNS = [
+    r"\b401\s+Unauthorized\b",
+    r"unexpected\s+status\s+401",
+    r"authentication\s+failed",
+    r"invalid\s+api\s+key",
+    r"api\s+key.*(?:invalid|missing|expired)",
+    r"not\s+authenticated",
+    r"run\s+`?grok\s+login`?",
+    r"XAI_API_KEY",
+]
+_GROK_AUTH_RE = re.compile("|".join(_GROK_AUTH_PATTERNS), re.IGNORECASE)
+
+_STDOUT_ERROR_MARKERS = ("error", "rate", "limit", "quota", "http", "status", "api", "auth")
+
+# Unsupported inputs: warn once per process (Haze two-tier precedent).
+# - "info"    → Koan-default static capabilities the operator cannot act on
+# - "warning" → operator-actionable config
+_WARNED_UNSUPPORTED: set = set()
+
+# Reasoning effort values accepted by ``--reasoning-effort`` / ``--effort``.
+# Unknown values are dropped with a notice rather than passed through.
+_EFFORT_LEVELS = frozenset({"low", "medium", "high", "max", "xhigh"})
+
+
+class GrokProvider(CLIProvider):
+    """xAI Grok Build CLI provider (https://x.ai/cli, https://docs.x.ai/build).
+
+    Targets headless Grok Build (verified against 0.2.101):
+
+    - Prompt: ``grok -p <prompt>`` (``--single``)
+    - Model: ``-m <model>``
+    - Output: ``--output-format streaming-json`` (NDJSON: thought/text/end)
+      or ``json`` (single object with ``text`` + ``usage``)
+    - Permissions: ``--always-approve`` when skip_permissions is set;
+      otherwise ``--permission-mode acceptEdits`` so headless runs do not
+      block on interactive prompts
+    - Tools: ``--tools`` / ``--disallowed-tools`` (comma-separated)
+    - Max turns: ``--max-turns``
+    - System prompt: ``--rules`` (append) / ``--system-prompt-override``
+    - Effort: ``--reasoning-effort``
+    - Session: ``--resume`` when supported
+
+    Stream samples: ``koan/tests/grok_samples.py``.
+    Configuration: ``cli_provider: "grok"`` or ``KOAN_CLI_PROVIDER=grok``.
+    Auth: prior ``grok`` login, or ``XAI_API_KEY``.
+    """
+
+    name = "grok"
+
+    def binary(self) -> str:
+        if self._binary_override:
+            return self._resolve_binary_path(self._binary_override)
+        return "grok"
+
+    def is_available(self) -> bool:
+        return shutil.which(self.binary()) is not None
+
+    def invocation_lock_name(self) -> str:
+        # Sessions and config live under ~/.grok/; serialize concurrent invokes
+        # so auth/session files do not race.
+        return "grok-cli"
+
+    def supports_stream_json(self) -> bool:
+        return True
+
+    def supports_session_resume(self) -> bool:
+        return True
+
+    def build_resume_args(self, session_id: str) -> List[str]:
+        if session_id:
+            return ["--resume", session_id]
+        return []
+
+    # ------------------------------------------------------------------
+    # Prompt delivery
+    # ------------------------------------------------------------------
+
+    def build_prompt_args(self, prompt: str) -> List[str]:
+        return ["-p", prompt]
+
+    def supports_stdin_prompt_passing(self) -> bool:
+        # Headless path is ``-p`` / ``--prompt-file``; stdin is not a documented
+        # prompt channel for Grok Build headless mode.
+        return False
+
+    def supports_system_prompt_file(self) -> bool:
+        # No dedicated file flag; callers may still pass inline system_prompt
+        # via --rules. File content is inlined in build_command when needed.
+        return False
+
+    def build_system_prompt_args(self, system_prompt: str) -> List[str]:
+        # Append extra rules to Grok's system prompt (closest to Claude's
+        # --append-system-prompt).
+        if system_prompt:
+            return ["--rules", system_prompt]
+        return []
+
+    # ------------------------------------------------------------------
+    # Flag builders
+    # ------------------------------------------------------------------
+
+    def build_model_args(self, model: str = "", fallback: str = "") -> List[str]:
+        if fallback:
+            self._warn_unsupported_once(
+                "fallback",
+                "fallback model is not supported by Grok Build; ignored",
+                level="info",
+            )
+        return ["-m", model] if model else []
+
+    def build_output_args(self, fmt: str = "") -> List[str]:
+        # Koan internal name is stream-json; Grok CLI spelling is streaming-json.
+        if fmt == "stream-json":
+            return ["--output-format", "streaming-json"]
+        if fmt == "json":
+            return ["--output-format", "json"]
+        if fmt == "plain":
+            return ["--output-format", "plain"]
+        return []
+
+    def build_permission_args(self, skip_permissions: bool = False) -> List[str]:
+        if skip_permissions:
+            return ["--always-approve"]
+        # Headless Koan cannot answer interactive permission prompts. Prefer
+        # acceptEdits (workspace edits without full bypass) over hanging.
+        return ["--permission-mode", "acceptEdits"]
+
+    def build_tool_args(
+        self,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+    ) -> List[str]:
+        flags: List[str] = []
+        if allowed_tools:
+            flags.extend(["--tools", ",".join(allowed_tools)])
+        if disallowed_tools:
+            flags.extend(["--disallowed-tools", ",".join(disallowed_tools)])
+        return flags
+
+    def build_max_turns_args(self, max_turns: int = 0) -> List[str]:
+        if max_turns > 0:
+            return ["--max-turns", str(max_turns)]
+        return []
+
+    def build_mcp_args(self, configs: Optional[List[str]] = None) -> List[str]:
+        if configs:
+            self._warn_unsupported_once(
+                "mcp",
+                "MCP config is not supported via CLI flags for Grok Build; ignored",
+            )
+        return []
+
+    def build_plugin_args(self, plugin_dirs: Optional[List[str]] = None) -> List[str]:
+        if plugin_dirs:
+            self._warn_unsupported_once(
+                "plugins",
+                "plugin directories are not supported via CLI flags; ignored",
+            )
+        return []
+
+    def build_effort_args(self, effort: str = "") -> List[str]:
+        if not effort:
+            return []
+        level = effort.strip().lower()
+        if level not in _EFFORT_LEVELS:
+            self._warn_unsupported_once(
+                f"effort:{level}",
+                f"unknown reasoning effort {effort!r}; ignored "
+                f"(valid: {', '.join(sorted(_EFFORT_LEVELS))})",
+            )
+            return []
+        return ["--reasoning-effort", level]
+
+    def build_thinking_args(
+        self, enabled: bool = False, budget_tokens: int = 0,
+    ) -> List[str]:
+        if not enabled:
+            return []
+        # Grok has no separate thinking toggle; map to high effort.
+        return ["--reasoning-effort", "high"]
+
+    def _warn_unsupported_once(
+        self, feature: str, message: str, level: str = "warning",
+    ) -> None:
+        if feature in _WARNED_UNSUPPORTED:
+            return
+        _WARNED_UNSUPPORTED.add(feature)
+        log_safe(level, f"[{self.name}] {message}")
+
+    # ------------------------------------------------------------------
+    # Command assembly
+    # ------------------------------------------------------------------
+
+    def build_command(
+        self,
+        prompt: str,
+        allowed_tools: Optional[List[str]] = None,
+        disallowed_tools: Optional[List[str]] = None,
+        model: str = "",
+        fallback: str = "",
+        output_format: str = "",
+        max_turns: int = 0,
+        mcp_configs: Optional[List[str]] = None,
+        plugin_dirs: Optional[List[str]] = None,
+        skip_permissions: bool = False,
+        system_prompt: str = "",
+        system_prompt_file: str = "",
+        effort: str = "",
+        resume_session_id: str = "",
+    ) -> List[str]:
+        """Build ``grok [flags] -p <prompt>``.
+
+        Prompt args stay last for readability and for any future stdin rewrite.
+        When *system_prompt_file* is set, its contents are inlined via
+        ``--rules`` (no dedicated file flag on Grok Build 0.2.x).
+        """
+        sys_args: List[str] = []
+        if system_prompt_file:
+            try:
+                with open(system_prompt_file, encoding="utf-8") as fh:
+                    file_prompt = fh.read().strip()
+            except OSError as exc:
+                self._warn_unsupported_once(
+                    "system_prompt_file_read",
+                    f"could not read system prompt file {system_prompt_file!r}: {exc}",
+                )
+                file_prompt = ""
+            if file_prompt:
+                # File path wins over inline when both are provided.
+                sys_args = ["--rules", file_prompt]
+            elif system_prompt:
+                sys_args = self.build_system_prompt_args(system_prompt)
+        elif system_prompt:
+            sys_args = self.build_system_prompt_args(system_prompt)
+
+        cmd = [self.binary()]
+        if resume_session_id and self.supports_session_resume():
+            cmd.extend(self.build_resume_args(resume_session_id))
+        cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(sys_args)
+        cmd.extend(self.build_tool_args(allowed_tools, disallowed_tools))
+        cmd.extend(self.build_model_args(model, fallback))
+        cmd.extend(self.build_output_args(output_format))
+        cmd.extend(self.build_max_turns_args(max_turns))
+        cmd.extend(self.build_mcp_args(mcp_configs))
+        cmd.extend(self.build_plugin_args(plugin_dirs))
+        cmd.extend(self.build_effort_args(effort))
+        cmd.extend(self.build_prompt_args(prompt))
+        return cmd
+
+    # ------------------------------------------------------------------
+    # Failure classification & quota probing
+    # ------------------------------------------------------------------
+
+    def detect_quota_exhaustion(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect quota/rate-limit failures from Grok Build output."""
+        if _GROK_QUOTA_RE.search(stderr_text or ""):
+            return True
+        if exit_code == 0:
+            return False
+        for line in (stdout_text or "").splitlines():
+            stripped = line.strip()
+            if not stripped or not self._line_has_error_marker(
+                stripped, _STDOUT_ERROR_MARKERS
+            ):
+                continue
+            if _GROK_QUOTA_RE.search(stripped):
+                return True
+        return False
+
+    def detect_auth_failure(
+        self,
+        stdout_text: str = "",
+        stderr_text: str = "",
+        exit_code: int = 0,
+    ) -> bool:
+        """Detect authentication failures (missing login / API key)."""
+        if exit_code == 0:
+            return False
+        if _GROK_AUTH_RE.search(stderr_text or ""):
+            return True
+        return any(
+            _GROK_AUTH_RE.search(line)
+            for line in (stdout_text or "").splitlines()
+            if line.strip()
+        )
+
+    def check_quota_available(self, project_path: str, timeout: int = 15) -> Tuple[bool, str]:
+        """Best-effort quota/auth probe via a minimal headless 'ok' run.
+
+        Uses ``--output-format json`` and an empty scratch cwd so project
+        context files do not inflate token cost (Haze/Cline precedent).
+        Probe errors never block real work.
+        """
+        import tempfile
+
+        from app.cli_exec import run_cli
+        from app.utils import koan_tmp_dir
+
+        cmd = [
+            self.binary(),
+            "--always-approve",
+            "--max-turns", "1",
+            "--output-format", "json",
+            "-p", "ok",
+        ]
+        probe_dir = tempfile.mkdtemp(prefix="grok-probe-", dir=koan_tmp_dir())
+        try:
+            result = run_cli(
+                cmd,
+                provider=self,
+                capture_output=True,
+                text=True,
+                timeout=timeout,
+                cwd=probe_dir,
+            )
+        except subprocess.TimeoutExpired:
+            return True, ""
+        except Exception as e:
+            log_safe("error", f"[{self.name}] quota probe error: {e}")
+            return True, ""
+        finally:
+            shutil.rmtree(probe_dir, ignore_errors=True)
+
+        stdout_text = result.stdout or ""
+        stderr_text = result.stderr or ""
+        for detect in (self.detect_quota_exhaustion, self.detect_auth_failure):
+            if detect(
+                stdout_text=stdout_text,
+                stderr_text=stderr_text,
+                exit_code=result.returncode,
+            ):
+                return False, (stderr_text + "\n" + stdout_text).strip()
+        return True, ""

--- a/koan/tests/grok_samples.py
+++ b/koan/tests/grok_samples.py
@@ -1,0 +1,161 @@
+"""Recorded Grok Build CLI output samples for the Grok provider tests.
+
+Captured against ``grok 0.2.101`` (stable) headless mode on 2026-07-15:
+
+- ``grok -p … --output-format streaming-json --always-approve --max-turns N``
+- ``grok -p … --output-format json --always-approve --max-turns N``
+
+These are the "recorded samples" the providers component-spec change protocol
+expects usage/text extraction to be verified against. Content is generic
+placeholder material only (no private identifiers).
+
+## Stream schema (streaming-json) — shape notes
+
+NDJSON events observed:
+
+| type | shape | meaning |
+|---|---|---|
+| ``thought`` | ``{"type":"thought","data":"<delta>"}`` | Reasoning token deltas (display only) |
+| ``text`` | ``{"type":"text","data":"<delta>"}`` | Assistant text **deltas** (concatenate with ``""``, not newlines) |
+| ``end`` | ``{"type":"end","stopReason", "sessionId", "requestId", "usage", "num_turns", "modelUsage"}`` | Terminal envelope; **no** final text field — text comes from accumulated ``text`` deltas |
+
+``usage`` on ``end`` is **snake_case** API-style:
+
+```json
+{"input_tokens": N, "output_tokens": N, "cache_read_input_tokens": N,
+ "reasoning_tokens": N, "total_tokens": N}
+```
+
+``modelUsage`` is a per-model map with **camelCase** counters (Claude-like):
+
+```json
+{"grok-4.5": {"inputTokens": N, "outputTokens": N,
+              "cacheReadInputTokens": N, "modelCalls": N}}
+```
+
+No separate ``tool_start`` / ``tool_end`` events were observed on a short
+shell-tool turn in 0.2.101 — tools appear to run without NDJSON tool events
+(only thought/text/end). Treat tool progress as best-effort.
+
+## json mode (single object)
+
+``--output-format json`` emits **one** JSON object (pretty-printed), not a
+``type: result`` envelope:
+
+```json
+{"text": "…", "stopReason": "EndTurn", "sessionId": "…", "requestId": "…",
+ "thought": "…", "usage": {…snake_case…}, "num_turns": 1, "modelUsage": {…}}
+```
+
+## Capability notes (Grok Build 0.2.101 help)
+
+Supported flags useful to Koan:
+
+- ``-p`` / ``--single`` headless prompt
+- ``--output-format`` ``plain`` | ``json`` | ``streaming-json``
+- ``-m`` / ``--model``
+- ``--max-turns``
+- ``--always-approve``
+- ``--permission-mode`` (default|acceptEdits|auto|dontAsk|bypassPermissions|plan)
+- ``--tools`` / ``--disallowed-tools`` (comma-separated built-ins)
+- ``--allow`` / ``--deny`` (permission rules)
+- ``--rules`` (append to system prompt)
+- ``--system-prompt-override``
+- ``--reasoning-effort`` / ``--effort``
+- ``-r`` / ``--resume``, ``-c`` / ``--continue``, ``-s`` / ``--session-id``
+- ``--cwd``, ``--prompt-file``
+
+Not observed / not used in MVP:
+
+- ``--no-auto-update`` (mentioned in online docs; not present in 0.2.101 ``--help``)
+- Claude-style ``--output-format stream-json`` spelling (Grok uses ``streaming-json``)
+"""
+
+# ---------------------------------------------------------------------------
+# streaming-json: simple success (ping/pong). Real capture, redacted session IDs
+# replaced with stable placeholders for fixtures.
+# ---------------------------------------------------------------------------
+STREAM_SUCCESS = """\
+{"type":"thought","data":"The"}
+{"type":"thought","data":" user"}
+{"type":"thought","data":" wants"}
+{"type":"thought","data":" a"}
+{"type":"thought","data":" simple"}
+{"type":"thought","data":" reply"}
+{"type":"thought","data":"."}
+{"type":"text","data":"pong"}
+{"type":"end","stopReason":"EndTurn","sessionId":"sess-fixture-001","requestId":"req-fixture-001","usage":{"input_tokens":21415,"cache_read_input_tokens":6016,"output_tokens":28,"reasoning_tokens":23,"total_tokens":27459},"num_turns":1,"modelUsage":{"grok-4.5":{"inputTokens":21415,"outputTokens":28,"cacheReadInputTokens":6016,"modelCalls":1}}}
+"""
+
+STREAM_SUCCESS_RESULT_TEXT = "pong"
+
+# Usage accounting target after snake_case extraction + cache-read subtract:
+# input_tokens effective = 21415 - 6016 = 15399
+STREAM_SUCCESS_USAGE = {
+    "input_tokens": 15399,
+    "output_tokens": 28,
+    "cache_read_input_tokens": 6016,
+    "cache_creation_input_tokens": 0,
+}
+
+# ---------------------------------------------------------------------------
+# streaming-json: multi-delta assistant text (tool-assisted reply).
+# ---------------------------------------------------------------------------
+STREAM_MULTI_DELTA = """\
+{"type":"thought","data":"Run"}
+{"type":"thought","data":" the"}
+{"type":"thought","data":" command"}
+{"type":"thought","data":"."}
+{"type":"text","data":"hello"}
+{"type":"text","data":"-"}
+{"type":"text","data":"from"}
+{"type":"text","data":"-"}
+{"type":"text","data":"tool"}
+{"type":"end","stopReason":"EndTurn","sessionId":"sess-fixture-002","requestId":"req-fixture-002","usage":{"input_tokens":21550,"cache_read_input_tokens":33408,"output_tokens":71,"reasoning_tokens":59,"total_tokens":55029},"num_turns":2,"modelUsage":{"grok-4.5":{"inputTokens":21550,"outputTokens":71,"cacheReadInputTokens":33408,"modelCalls":2}}}
+"""
+
+STREAM_MULTI_DELTA_RESULT_TEXT = "hello-from-tool"
+
+# ---------------------------------------------------------------------------
+# streaming-json: truncated mid-stream (no end event) — partial fallback.
+# ---------------------------------------------------------------------------
+STREAM_TRUNCATED = """\
+{"type":"thought","data":"Working"}
+{"type":"text","data":"Partial"}
+{"type":"text","data":" progress"}
+{"type":"text","data":" so"}
+{"type":"text","data":" far"}
+"""
+
+STREAM_TRUNCATED_PARTIAL_TEXT = "Partial progress so far"
+
+# ---------------------------------------------------------------------------
+# --output-format json single object (probe / non-stream mode).
+# ---------------------------------------------------------------------------
+JSON_OBJECT_SUCCESS = """\
+{
+  "text": "ok",
+  "stopReason": "EndTurn",
+  "sessionId": "sess-fixture-003",
+  "requestId": "req-fixture-003",
+  "thought": "Short acknowledgement.",
+  "usage": {
+    "input_tokens": 21414,
+    "cache_read_input_tokens": 6016,
+    "output_tokens": 19,
+    "reasoning_tokens": 14,
+    "total_tokens": 27449
+  },
+  "num_turns": 1,
+  "modelUsage": {
+    "grok-4.5": {
+      "inputTokens": 21414,
+      "outputTokens": 19,
+      "cacheReadInputTokens": 6016,
+      "modelCalls": 1
+    }
+  }
+}
+"""
+
+JSON_OBJECT_SUCCESS_TEXT = "ok"

--- a/koan/tests/test_grok_provider.py
+++ b/koan/tests/test_grok_provider.py
@@ -1,0 +1,428 @@
+"""Tests for the Grok Build CLI provider (issue #2400).
+
+All stream/usage behavior is exercised against recorded samples in
+``tests/grok_samples.py`` — never a live ``grok`` subprocess.
+"""
+
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+import app.provider.grok as grok_module
+from app.provider import (
+    _extract_assistant_text_chunks,
+    _extract_result_text,
+    _summarize_stream_event,
+    _usage_snapshot_from_event,
+)
+from app.provider.grok import GrokProvider
+from tests import grok_samples
+
+
+@pytest.fixture(autouse=True)
+def _fresh_warn_state(monkeypatch):
+    """Isolate the once-per-process unsupported-feature warning set."""
+    monkeypatch.setattr(grok_module, "_WARNED_UNSUPPORTED", set())
+
+
+def _parse_ndjson(blob: str):
+    events = []
+    for line in blob.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        events.append(json.loads(stripped))
+    return events
+
+
+def _join_stream_text(events) -> str:
+    """Mirror run_command_streaming delta/block accumulation for fixtures."""
+    text_lines: list[str] = []
+    deltas: list[str] = []
+    for event in events:
+        chunks = _extract_assistant_text_chunks(event)
+        if event.get("type") == "text" and isinstance(event.get("data"), str):
+            deltas.extend(chunks)
+        else:
+            if deltas:
+                text_lines.append("".join(deltas))
+                deltas.clear()
+            text_lines.extend(chunks)
+        result = _extract_result_text(event)
+        if result is not None:
+            # Prefer explicit result text when present (Claude/Haze shapes).
+            return result
+    if deltas:
+        text_lines.append("".join(deltas))
+    return "\n".join(text_lines)
+
+
+# ---------------------------------------------------------------------------
+# Package structure
+# ---------------------------------------------------------------------------
+
+class TestGrokPackageStructure:
+    def test_import_from_provider_package(self):
+        from app.provider import GrokProvider as PackageGrok
+        assert PackageGrok.name == "grok"
+
+    def test_grok_in_provider_registry(self):
+        from app.provider import _PROVIDERS
+        assert "grok" in _PROVIDERS
+
+    def test_registry_creates_grok_instance(self):
+        from app.provider import _PROVIDERS
+        provider = _PROVIDERS["grok"]()
+        assert isinstance(provider, GrokProvider)
+        assert provider.name == "grok"
+
+    def test_known_providers_includes_grok(self):
+        from app.provider import known_providers
+        assert "grok" in known_providers()
+
+
+# ---------------------------------------------------------------------------
+# Provider basics & capability profile
+# ---------------------------------------------------------------------------
+
+class TestGrokProviderBasics:
+    def setup_method(self):
+        self.provider = GrokProvider()
+
+    def test_binary_default(self):
+        assert self.provider.binary() == "grok"
+
+    def test_binary_override_absolute(self):
+        provider = GrokProvider(binary_path="/opt/tools/grok-nightly")
+        assert provider.binary() == "/opt/tools/grok-nightly"
+
+    def test_binary_override_bare_name_stays_path_lookup(self):
+        provider = GrokProvider(binary_path="grok-nightly")
+        assert provider.binary() == "grok-nightly"
+
+    def test_is_available_uses_which(self):
+        with patch("app.provider.grok.shutil.which", return_value="/usr/bin/grok"):
+            assert self.provider.is_available() is True
+        with patch("app.provider.grok.shutil.which", return_value=None):
+            assert self.provider.is_available() is False
+
+    def test_invocation_lock_name(self):
+        assert self.provider.invocation_lock_name() == "grok-cli"
+
+    def test_capability_profile(self):
+        assert self.provider.supports_stream_json() is True
+        assert self.provider.supports_stdin_prompt_passing() is False
+        assert self.provider.supports_session_resume() is True
+        assert self.provider.supports_system_prompt_file() is False
+        assert self.provider.supports_last_message_file() is False
+        assert self.provider.has_api_quota() is True
+
+
+# ---------------------------------------------------------------------------
+# Command construction
+# ---------------------------------------------------------------------------
+
+class TestGrokCommandConstruction:
+    def setup_method(self):
+        self.provider = GrokProvider()
+
+    def test_build_prompt_args(self):
+        assert self.provider.build_prompt_args("do it") == ["-p", "do it"]
+
+    def test_build_model_args(self):
+        assert self.provider.build_model_args("grok-4.5") == ["-m", "grok-4.5"]
+        assert self.provider.build_model_args("") == []
+
+    def test_build_model_args_fallback_notes_once_at_info(self):
+        with patch("app.provider.grok.log_safe") as log:
+            flags = self.provider.build_model_args("grok-4.5", fallback="grok-3")
+            self.provider.build_model_args("grok-4.5", fallback="grok-3")
+        assert flags == ["-m", "grok-4.5"]
+        fallback_notes = [c for c in log.call_args_list if "fallback" in c.args[1]]
+        assert len(fallback_notes) == 1
+        assert fallback_notes[0].args[0] == "info"
+
+    def test_build_output_args_mapping(self):
+        assert self.provider.build_output_args("stream-json") == [
+            "--output-format", "streaming-json",
+        ]
+        assert self.provider.build_output_args("json") == [
+            "--output-format", "json",
+        ]
+        assert self.provider.build_output_args("plain") == [
+            "--output-format", "plain",
+        ]
+        assert self.provider.build_output_args("") == []
+
+    def test_build_permission_args(self):
+        assert self.provider.build_permission_args(True) == ["--always-approve"]
+        assert self.provider.build_permission_args(False) == [
+            "--permission-mode", "acceptEdits",
+        ]
+
+    def test_build_tool_args(self):
+        assert self.provider.build_tool_args(
+            allowed_tools=["Read", "Grep"],
+            disallowed_tools=["Bash"],
+        ) == ["--tools", "Read,Grep", "--disallowed-tools", "Bash"]
+
+    def test_build_max_turns_args(self):
+        assert self.provider.build_max_turns_args(12) == ["--max-turns", "12"]
+        assert self.provider.build_max_turns_args(0) == []
+
+    def test_build_effort_args(self):
+        assert self.provider.build_effort_args("high") == [
+            "--reasoning-effort", "high",
+        ]
+        assert self.provider.build_effort_args("") == []
+
+    def test_build_effort_args_unknown_warns(self):
+        with patch("app.provider.grok.log_safe") as log:
+            assert self.provider.build_effort_args("turbo") == []
+        assert any("unknown reasoning effort" in c.args[1] for c in log.call_args_list)
+
+    def test_build_command_minimal_stream(self):
+        cmd = self.provider.build_command("hello world", output_format="stream-json")
+        assert cmd[0] == "grok"
+        assert "--permission-mode" in cmd
+        assert "acceptEdits" in cmd
+        assert cmd[-4:] == ["--output-format", "streaming-json", "-p", "hello world"]
+
+    def test_build_command_with_model_and_tools(self):
+        cmd = self.provider.build_command(
+            "hello",
+            model="grok-4.5",
+            output_format="stream-json",
+            allowed_tools=["Read", "Glob"],
+            skip_permissions=True,
+            max_turns=8,
+        )
+        assert cmd == [
+            "grok",
+            "--always-approve",
+            "--tools", "Read,Glob",
+            "-m", "grok-4.5",
+            "--output-format", "streaming-json",
+            "--max-turns", "8",
+            "-p", "hello",
+        ]
+
+    def test_build_command_prompt_args_last(self):
+        cmd = self.provider.build_command(
+            "hello", model="grok-4.5", output_format="stream-json",
+        )
+        assert cmd[-2:] == ["-p", "hello"]
+
+    def test_build_command_system_prompt_via_rules(self):
+        cmd = self.provider.build_command(
+            "user ask", system_prompt="be brief", output_format="stream-json",
+        )
+        assert "--rules" in cmd
+        assert "be brief" in cmd
+        assert cmd[-1] == "user ask"
+
+    def test_build_command_system_prompt_file_inlined(self, tmp_path):
+        path = tmp_path / "sys.md"
+        path.write_text("from file", encoding="utf-8")
+        cmd = self.provider.build_command(
+            "user ask",
+            system_prompt="inline",
+            system_prompt_file=str(path),
+        )
+        assert "--rules" in cmd
+        idx = cmd.index("--rules")
+        assert cmd[idx + 1] == "from file"
+        assert "inline" not in cmd
+
+    def test_build_resume_args(self):
+        assert self.provider.build_resume_args("sess-1") == ["--resume", "sess-1"]
+        cmd = self.provider.build_command("hi", resume_session_id="sess-1")
+        assert cmd[1:3] == ["--resume", "sess-1"]
+
+    def test_mcp_and_plugins_warn_once(self):
+        with patch("app.provider.grok.log_safe") as log:
+            self.provider.build_mcp_args(["cfg.json"])
+            self.provider.build_mcp_args(["cfg.json"])
+            self.provider.build_plugin_args(["/plugins"])
+            self.provider.build_plugin_args(["/plugins"])
+        mcp_notes = [c for c in log.call_args_list if "MCP" in c.args[1]]
+        plugin_notes = [c for c in log.call_args_list if "plugin" in c.args[1]]
+        assert len(mcp_notes) == 1
+        assert len(plugin_notes) == 1
+
+
+# ---------------------------------------------------------------------------
+# Registry / env resolution
+# ---------------------------------------------------------------------------
+
+class TestGrokProviderResolution:
+    def setup_method(self):
+        from app.provider import reset_provider
+        reset_provider()
+
+    def teardown_method(self):
+        from app.provider import reset_provider
+        reset_provider()
+
+    @patch.dict(os.environ, {"KOAN_CLI_PROVIDER": "grok"}, clear=False)
+    def test_env_var_grok(self):
+        from app.provider import get_provider, get_provider_name
+        assert get_provider_name() == "grok"
+        assert isinstance(get_provider(), GrokProvider)
+
+
+# ---------------------------------------------------------------------------
+# Stream samples — text, summary, usage
+# ---------------------------------------------------------------------------
+
+class TestGrokStreamSamples:
+    def test_stream_success_text(self):
+        events = _parse_ndjson(grok_samples.STREAM_SUCCESS)
+        assert _join_stream_text(events) == grok_samples.STREAM_SUCCESS_RESULT_TEXT
+
+    def test_stream_multi_delta_concatenates_without_newlines(self):
+        events = _parse_ndjson(grok_samples.STREAM_MULTI_DELTA)
+        assert _join_stream_text(events) == grok_samples.STREAM_MULTI_DELTA_RESULT_TEXT
+
+    def test_stream_truncated_partial(self):
+        events = _parse_ndjson(grok_samples.STREAM_TRUNCATED)
+        assert _join_stream_text(events) == grok_samples.STREAM_TRUNCATED_PARTIAL_TEXT
+
+    def test_end_event_has_no_result_text(self):
+        end = {
+            "type": "end",
+            "stopReason": "EndTurn",
+            "usage": {"input_tokens": 1, "output_tokens": 1},
+        }
+        assert _extract_result_text(end) is None
+
+    def test_summarize_thought_text_end(self):
+        assert "thinking" in _summarize_stream_event({"type": "thought", "data": "x"})
+        assert "text:" in _summarize_stream_event({"type": "text", "data": "hello"})
+        summary = _summarize_stream_event({
+            "type": "end",
+            "stopReason": "EndTurn",
+            "num_turns": 2,
+        })
+        assert "result:" in summary
+        assert "EndTurn" in summary
+
+    def test_usage_snapshot_from_stream_success(self):
+        events = _parse_ndjson(grok_samples.STREAM_SUCCESS)
+        usage = None
+        for event in events:
+            snap = _usage_snapshot_from_event(event)
+            if snap is not None:
+                usage = snap
+        assert usage is not None
+        assert usage["input_tokens"] == grok_samples.STREAM_SUCCESS_USAGE["input_tokens"]
+        assert usage["output_tokens"] == grok_samples.STREAM_SUCCESS_USAGE["output_tokens"]
+        assert (
+            usage["cache_read_input_tokens"]
+            == grok_samples.STREAM_SUCCESS_USAGE["cache_read_input_tokens"]
+        )
+        assert usage["model"] == "grok-4.5"
+
+    def test_usage_when_cache_exceeds_input_keeps_input(self):
+        """Multi-turn Grok usage can report cache_read > input_tokens."""
+        events = _parse_ndjson(grok_samples.STREAM_MULTI_DELTA)
+        usage = None
+        for event in events:
+            snap = _usage_snapshot_from_event(event)
+            if snap is not None:
+                usage = snap
+        assert usage is not None
+        assert usage["input_tokens"] == 21550
+        assert usage["cache_read_input_tokens"] == 33408
+        assert usage["model"] == "grok-4.5"
+
+    def test_json_object_text_field(self):
+        data = json.loads(grok_samples.JSON_OBJECT_SUCCESS)
+        assert data["text"] == grok_samples.JSON_OBJECT_SUCCESS_TEXT
+        # Non-stream path: usage extractable from the object shape.
+        snap = _usage_snapshot_from_event(data)
+        assert snap is not None
+        assert snap["output_tokens"] == 19
+        assert snap["model"] == "grok-4.5"
+
+
+# ---------------------------------------------------------------------------
+# Quota / auth detection
+# ---------------------------------------------------------------------------
+
+class TestGrokFailureDetection:
+    def setup_method(self):
+        self.provider = GrokProvider()
+
+    def test_quota_on_stderr(self):
+        assert self.provider.detect_quota_exhaustion(
+            stderr_text="Error: rate limit exceeded",
+            exit_code=1,
+        )
+
+    def test_quota_ignores_success_stdout_prose(self):
+        assert not self.provider.detect_quota_exhaustion(
+            stdout_text="We should avoid rate limits in the design.",
+            exit_code=0,
+        )
+
+    def test_auth_on_stderr(self):
+        assert self.provider.detect_auth_failure(
+            stderr_text="not authenticated — run `grok login` or set XAI_API_KEY",
+            exit_code=1,
+        )
+
+    def test_auth_ignores_success(self):
+        assert not self.provider.detect_auth_failure(
+            stderr_text="invalid api key",
+            exit_code=0,
+        )
+
+
+class TestGrokQuotaProbe:
+    def setup_method(self):
+        self.provider = GrokProvider()
+
+    def test_probe_available_on_success(self):
+        fake = subprocess.CompletedProcess(
+            args=["grok"], returncode=0, stdout='{"text":"ok"}', stderr="",
+        )
+        with patch("app.cli_exec.run_cli", return_value=fake):
+            ok, detail = self.provider.check_quota_available("/tmp/project")
+        assert ok is True
+        assert detail == ""
+
+    def test_probe_unavailable_on_auth_failure(self):
+        fake = subprocess.CompletedProcess(
+            args=["grok"],
+            returncode=1,
+            stdout="",
+            stderr="invalid api key",
+        )
+        with patch("app.cli_exec.run_cli", return_value=fake):
+            ok, detail = self.provider.check_quota_available("/tmp/project")
+        assert ok is False
+        assert "invalid api key" in detail
+
+    def test_probe_timeout_reports_available(self):
+        with patch(
+            "app.cli_exec.run_cli",
+            side_effect=subprocess.TimeoutExpired(cmd="grok", timeout=1),
+        ):
+            ok, detail = self.provider.check_quota_available("/tmp/project")
+        assert ok is True
+        assert detail == ""
+
+
+# ---------------------------------------------------------------------------
+# Onboarding wiring
+# ---------------------------------------------------------------------------
+
+class TestGrokOnboarding:
+    def test_provider_tools_and_list(self):
+        from app.onboarding import PROVIDER_TOOLS, PROVIDERS
+        assert PROVIDER_TOOLS.get("grok") == "grok"
+        assert any(p[0] == "grok" for p in PROVIDERS)

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -625,12 +625,18 @@ class TestProviderRegistry:
         assert "claude" in _PROVIDERS
         assert "copilot" in _PROVIDERS
         assert "haze" in _PROVIDERS
+        assert "grok" in _PROVIDERS
         assert "ollama-launch" in _PROVIDERS
 
     def test_haze_is_known_provider(self):
         from app.provider import is_known_provider, known_providers
         assert is_known_provider("haze")
         assert "haze" in known_providers()
+
+    def test_grok_is_known_provider(self):
+        from app.provider import is_known_provider, known_providers
+        assert is_known_provider("grok")
+        assert "grok" in known_providers()
 
     @patch("app.provider.get_provider_name", return_value="claude")
     def test_get_provider_claude(self, mock_name):

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -1,16 +1,16 @@
 ---
 type: component-spec
 title: "Component Spec — CLI Provider Abstraction"
-description: "Design contract for the CLI provider abstraction that decouples the agent loop from any single AI coding CLI (Claude, Cline, Codex, Copilot, Haze) behind one `CLIProvider` contract."
+description: "Design contract for the CLI provider abstraction that decouples the agent loop from any single AI coding CLI (Claude, Cline, Codex, Copilot, Haze, Grok) behind one `CLIProvider` contract."
 tags: [providers]
 created: 2026-06-27
-updated: 2026-07-14
+updated: 2026-07-15
 ---
 
 # Component Spec — CLI Provider Abstraction
 
 **Package:** `koan/app/provider/` (`base.py`, `claude.py`, `cline.py`, `codex.py`,
-`copilot.py`, `haze.py`, `__init__.py`) + `cli_provider.py` (legacy re-export facade)
+`copilot.py`, `haze.py`, `grok.py`, `__init__.py`) + `cli_provider.py` (legacy re-export facade)
 
 ## Purpose
 
@@ -28,7 +28,8 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
        ├─ cline.py     → ClineProvider
        ├─ codex.py     → CodexProvider (quota via stream-json summary only)
        ├─ copilot.py   → CopilotProvider (with tool-name mapping)
-       └─ haze.py      → HazeProvider (haze ≥0.7.0 headless stream-json)
+       ├─ haze.py      → HazeProvider (haze ≥0.7.0 headless stream-json)
+       └─ grok.py      → GrokProvider (xAI Grok Build headless streaming-json)
 ```
 
 ## Key types & functions
@@ -119,8 +120,11 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
   `modelUsage` (no top-level `model` field); codex surfaces quota only via the
   stream-json summary (`rate_limit_rejected`, stdout JSONL — never stderr); haze
   reports usage only in its terminal result envelope with **camelCase** fields
-  (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheWriteTokens`/`reasoningTokens`).
-  Detectors read the summary stream, not assistant text.
+  (`inputTokens`/`outputTokens`/`cacheReadTokens`/`cacheWriteTokens`/`reasoningTokens`);
+  Grok Build reports **snake_case** `usage` on the terminal ``end`` event
+  (`input_tokens`/`output_tokens`/`cache_read_input_tokens`/…) plus optional
+  `modelUsage` map (camelCase per model id). Shared extractors are shape-keyed
+  on field names. Detectors read the summary stream, not assistant text.
 - **`tool_use` summary grammar carries an optional input preview.**
   `_summarize_stream_event()` renders a `tool_use` block as
   `[cli] assistant — tool_use: <name>[: <input-preview>]`. The optional
@@ -173,6 +177,26 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
   project dir, whose CLAUDE.md/AGENTS.md context haze would ingest (~12K
   tokens per probe); probe errors never block work. Invocation lock:
   `haze-cli` (shared `~/.haze/settings.json` state).
+- **Grok Build headless contract (verified 0.2.101).** `GrokProvider` targets
+  xAI Grok Build headless mode: `grok -p <prompt> --output-format streaming-json`
+  (Koan internal name `stream-json` maps to CLI spelling `streaming-json`).
+  NDJSON event vocabulary is shape-keyed: `thought`/`text` carry incremental
+  `data` deltas; terminal `end` carries `stopReason`, `usage` (snake_case),
+  `num_turns`, and optional `modelUsage` — **not** the final assistant body.
+  Final text is the concatenation of `text.data` deltas (joined with `""`, not
+  newlines). `--output-format json` returns a single object with top-level
+  `text` + `usage` (probe mode). Permissions: `skip_permissions` →
+  `--always-approve`; otherwise `--permission-mode acceptEdits` so headless
+  runs never block on interactive prompts. Tools map to `--tools` /
+  `--disallowed-tools`; max turns to `--max-turns`; system prompt append to
+  `--rules` (file prompts are inlined); effort to `--reasoning-effort`; resume
+  to `--resume`. Unsupported inputs (MCP flags, plugin dirs, fallback model)
+  warn once and are skipped — never silently accepted. Stdin prompt passing is
+  off. Quota/auth: stderr trusted; stdout only on non-zero exit with an
+  error-marker gate. Pre-flight probe uses `--output-format json -p ok` from an
+  empty scratch dir. Invocation lock: `grok-cli` (shared `~/.grok/` state).
+  Recorded samples: `koan/tests/grok_samples.py`. Operator docs:
+  `docs/providers/grok.md`.
 
 ## Integration points
 

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,7 +18,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 - [`architecture/memory.md`](docs/architecture/memory.md) — Details Koan's Markdown+JSONL memory store, the SQLite FTS5 secondary index (confidence-weighted BM25 ranking, dual-write, fallback), entry schema, read/write paths, and compaction.
 - [`architecture/mission-lifecycle.md`](docs/architecture/mission-lifecycle.md) — Explains the mission queue format and lifecycle (Pending/In Progress/Done/Failed), org-wide missions, branch prep, direct skill dispatch, scheduling, recovery/retries, and missions.md integrity/size-bound safeguards.
 - [`architecture/overview.md`](docs/architecture/overview.md) — High-level architecture summary of Koan's two main processes (bridge and agent loop), major subsystems, and the human-decides safety model.
-- [`architecture/providers.md`](docs/architecture/providers.md) — Documents the CLI provider abstraction layer, provider responsibilities, resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Local).
+- [`architecture/providers.md`](docs/architecture/providers.md) — Documents the CLI provider abstraction layer, provider responsibilities, resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Haze, Grok, Ollama-launch).
 - [`architecture/shared-state.md`](docs/architecture/shared-state.md) — Explains Koan's file-based (no-database) shared state under instance/, locking/atomic-write conventions, per-uid temp/scratch directories, and configuration sources.
 - [`architecture/skills-system.md`](docs/architecture/skills-system.md) — Describes the skill definition format, dispatch paths, the private implementation review gate (challenge loop, cost controls, dedup), and the documentation contract for skill changes.
 
@@ -64,6 +64,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 - [`providers/codex.md`](docs/providers/codex.md) — Setup and behavior guide for using OpenAI's Codex CLI as Kōan's provider, including quota/usage handling and troubleshooting.
 - [`providers/copilot.md`](docs/providers/copilot.md) — Setup guide and feature/tool-mapping differences for using GitHub Copilot CLI as Kōan's provider.
 - [`providers/haze.md`](docs/providers/haze.md) — Setup and behavior guide for using haze (multi-backend agentic CLI) as Kōan's provider, including stream-json integration, usage accounting, capabilities and limitations.
+- [`providers/grok.md`](docs/providers/grok.md) — Setup and behavior guide for using xAI's Grok Build CLI as Kōan's provider, including headless streaming-json, auth, models, and limitations.
 - [`providers/local.md`](docs/providers/local.md) — Explains that the `local` Ollama provider was removed and points to `ollama-launch` or a custom Claude CLI endpoint as the supported replacements.
 - [`providers/ollama-launch.md`](docs/providers/ollama-launch.md) — Documents the `ollama-launch` provider, which runs the Claude Code CLI through `ollama launch claude` for full tool-use/streaming parity with native Claude.
 - [`providers/ollama-wrapper.md`](docs/providers/ollama-wrapper.md) — Describes the `bin/ollama-claude` wrapper that routes Koan's default `claude` provider through a local Ollama model via `ollama launch claude`, without changing `cli_provider`.
@@ -105,7 +106,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 - [`components/core.md`](specs-components/core.md) — Design contract for the foundation layer (mission queue contract, config resolution, atomic-write/lock primitives) that every other Kōan component depends on.
 - [`components/git-github.md`](specs-components/git-github.md) — Design contract for everything touching git history or the GitHub API: branch/PR creation, sync, webhook/notification handling, and rebase/recreate/CI-fix workflows.
 - [`components/issue-tracking.md`](specs-components/issue-tracking.md) — Design contract for the provider-neutral issue-tracker abstraction (GitHub/Jira) that routes fetch/comment/create calls through one service layer.
-- [`components/providers.md`](specs-components/providers.md) — Design contract for the CLI provider abstraction that decouples the agent loop from any single AI coding CLI (Claude, Cline, Codex, Copilot) behind one `CLIProvider` contract.
+- [`components/providers.md`](specs-components/providers.md) — Design contract for the CLI provider abstraction that decouples the agent loop from any single AI coding CLI (Claude, Cline, Codex, Copilot, Haze, Grok) behind one `CLIProvider` contract.
 - [`components/skills.md`](specs-components/skills.md) — Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness).
 - [`components/web.md`](specs-components/web.md) — Documents the Flask dashboard and token-gated REST API, their shared `dashboard_service`/`usage_service`/`log_reader` logic, and the invariants keeping the two surfaces from drifting.
 


### PR DESCRIPTION
## Summary

Adds a first-class **Grok Build** CLI provider so Koan can run missions and skills via xAI's official `grok` agent CLI with headless **streaming-json**, on the same path as Claude / Codex / Haze.

- `cli_provider: "grok"` / `KOAN_CLI_PROVIDER=grok`
- `GrokProvider` maps prompt, model, tools, max-turns, permissions, effort, rules, resume
- Shared stream parsers extended **by shape** for Grok NDJSON (`thought`/`text`/`end`) and snake_case usage — no `if provider == "grok"` branches
- Recorded fixtures + unit tests (no live `grok` in CI)
- Operator docs + durable providers contract update

Fixes #2400

## Architectural change

- [x] **This PR changes a durable design contract** (`specs/components/**` and/or `specs/skills/**`)
  - Contract updated **first** (or in the same commit as conforming code): yes — `specs/components/providers.md` Grok Build headless contract
  - Why this contract change is necessary: new CLI provider flavor requires documented stream schema, permissions mapping, and usage field shapes so future changes do not break shape-based parsers
  - What breaks if the new contract is ignored: empty skill output (text deltas joined wrong), wrong usage accounting, interactive permission hangs in headless mode

## Phases landed

1. Recorded stream samples (`grok_samples.py`) from Grok Build 0.2.101
2. `GrokProvider` + registry + stream/usage shape support + onboarding
3. Unit tests (`test_grok_provider.py`)
4. Docs (`docs/providers/grok.md`) + user-manual + wiki + component spec

## Test plan

- [x] `KOAN_ROOT=/tmp/test-koan pytest koan/tests/test_grok_provider.py` (43 tests)
- [x] Related provider suite: haze + cli_provider + provider_modules (487 passed together)
- [ ] Operator smoke (optional): install `grok`, set `XAI_API_KEY` or login, `KOAN_CLI_PROVIDER=grok`, run a tiny mission

## How to use

```yaml
cli_provider: "grok"
models:
  grok:
    mission: "grok-4.5"
```

- [x] **Architectural change** — this PR modifies a durable design contract (`specs/components/**` or `specs/skills/**`). The new architecture needs review before approval. Rationale: Adding a new provider 

See `docs/providers/grok.md`.