### PR TITLE
feat(koan-md): dogfood .koan skill quality gates on this repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Kōan instance data (private to each user)
 instance
-.koan*
+# Runtime signal files (.koan-status, .koan-stop, …) — not the project
+# steering directory `.koan/` (KOAN.md + skills/*.md), which is committed.
+.koan-*
 .claude/*
 !.claude/settings.json
 !.claude/skills

--- a/.koan/skills/fix/quality-gates.md
+++ b/.koan/skills/fix/quality-gates.md
@@ -1,0 +1,20 @@
+# Koan-repo fix gates
+
+Extra must-checks for `/fix` on this repository.
+
+## Do
+
+- Prefer a **failing regression test first** when the bug is reproducible in unit/integration form.
+- Run tests with `KOAN_ROOT` set to a temp dir (e.g. `/tmp/test-koan`).
+- Mock external boundaries: `run_gh` / `api`, Telegram `format_and_send`, provider CLIs. Never hit real Claude/Telegram in tests.
+- For `run_gh` error-path tests, mock at `run_gh` or `api` — not raw `subprocess.run` (avoids real retry backoff sleeps).
+- Stay on a `koan/*` (or configured prefix) branch; never commit to `main`.
+- If the fix touches a component with a durable spec under `specs/components/` or a skill under `specs/skills/`: **read the spec first**. Do not bend the durable contract to match code after the fact; contract-first + declare architectural change when intentional.
+- Put LLM prompt text in `.md` files, not Python string literals.
+- Keep system prompts generic (no private owner/operator names).
+
+## Don’t
+
+- Ship private identifiers in source, tests, fixtures, docs, or commit messages.
+- Skip `make lint` for Python changes (3.11+ only; no post-3.11 syntax).
+- Leave core skill behavior changed without user-manual / skills.md updates.

--- a/.koan/skills/implement/quality-gates.md
+++ b/.koan/skills/implement/quality-gates.md
@@ -1,0 +1,19 @@
+# Koan-repo implement gates
+
+Extra must-checks for `/implement` on this repository.
+
+## Do
+
+- Consult `wiki/index.md` then relevant `docs/` / durable `specs/` before designing non-trivial work. State what you found (or that coverage is missing).
+- Create a `koan/*` (or configured prefix) branch; never commit to `main`.
+- Tests: set `KOAN_ROOT` to a temp path; mock Claude/Telegram/`gh` at the documented boundaries.
+- Python 3.11+ only; changes must pass `make lint`.
+- LLM prompts live in `.md` files loaded via `load_prompt` / `load_skill_prompt`.
+- Durable-contract work: contract-first under `specs/components/**` or `specs/skills/**`, rare, and declared on the PR.
+- After user-visible or skill surface changes: update matching docs in the same branch. Core skills → `docs/users/user-manual.md` + `docs/users/skills.md`. REST routes → `make openapi`.
+
+## Don’t
+
+- Expand scope beyond the issue/plan without saying so.
+- Duplicate large chunks of `CLAUDE.md` into new prompts — follow existing patterns.
+- Leak private operator identifiers into the public tree or commit subjects.

--- a/.koan/skills/plan/quality-gates.md
+++ b/.koan/skills/plan/quality-gates.md
@@ -1,0 +1,14 @@
+# Koan-repo plan gates
+
+Extra must-checks for `/plan` on this repository.
+
+## Context section must include
+
+- What `wiki/index.md` / docs / durable specs said for this topic, **or** an explicit “nothing relevant found”.
+- Whether the work would touch `specs/components/**` or `specs/skills/**` (architectural surface).
+
+## Plan quality
+
+- Prefer the smallest change that satisfies the issue; call out out-of-scope ideas separately.
+- Call out test strategy (`KOAN_ROOT`, mock boundaries) for code-changing plans.
+- Never plan to commit private identifiers into the public tree.

--- a/.koan/skills/pr/quality-gates.md
+++ b/.koan/skills/pr/quality-gates.md
@@ -1,0 +1,14 @@
+# Koan-repo PR pipeline gates
+
+Extra must-checks for `/pr` (feedback → refactor → quality review) on this repository.
+
+## Scope
+
+- Address review feedback; avoid unrelated drive-by changes.
+- Do not force-push unless the human asked or the pipeline’s normal update requires it.
+
+## Before claiming done
+
+- Re-check privacy on **added** lines.
+- Python changes: lint-clean mindset; no new inline LLM prompts.
+- If feedback required API or core-skill doc updates, include them in the same push.

--- a/.koan/skills/rebase/quality-gates.md
+++ b/.koan/skills/rebase/quality-gates.md
@@ -1,0 +1,19 @@
+# Koan-repo rebase / conflict gates
+
+Extra must-checks for `/rebase` (feedback apply, conflict resolution, CI fix) on this repository.
+
+## Conflicts
+
+- Do **not** “resolve” by deleting or emptying `specs/`, tests, workflows, or wiki bookkeeping without explicitly reporting what was dropped.
+- Preserve both sides’ intent when possible; if policy forces a side, surface the choice in the actions log / PR comment.
+- Prefer keeping durable contracts and test coverage over convenience.
+
+## Commits and privacy
+
+- Commit subjects and bodies: no private slash commands, bot names, Jira prefixes, or customer project names.
+- Keep conventional, English subjects consistent with the repo.
+
+## After rebase / CI fix
+
+- Do not invent drive-by refactors unrelated to the conflict or CI failure.
+- If CI fix touches API routes or core skills, remember OpenAPI regen and user-manual/skills.md obligations.

--- a/.koan/skills/review/quality-gates.md
+++ b/.koan/skills/review/quality-gates.md
@@ -1,0 +1,23 @@
+# Koan-repo review gates
+
+Extra must-checks for `/review` on this repository. Append-only: do not ignore the built-in review prompt.
+
+## Always flag when present
+
+- **Undeclared durable-contract change** — edits under `specs/components/**` or `specs/skills/**` without the PR declaring an architectural change.
+- **Privacy leak on added lines** — private slash-command names, bot handles, Jira key prefixes, customer project names, concrete private case numbers. Placeholders only in public artifacts.
+- **Tests that call real boundaries** — Claude/Telegram/provider subprocesses, or unmocked `gh` that would sleep on retry. Prefer mocks at `run_gh` / `api` / `format_and_send`.
+- **Missing `KOAN_ROOT`** in new tests that import app modules which require it.
+- **Inline LLM prompts** in Python — prompts belong in `.md` files (`load_prompt` / `load_skill_prompt`).
+- **Core skill surface drift** — skill add/remove/rename without updating `docs/users/user-manual.md` and `docs/users/skills.md`.
+- **REST API drift** — route/method/auth changes without regenerating `koan/openapi.yaml` (`make openapi`).
+- **Specs/docs ignored** — non-trivial design change with no consult of `wiki/index.md` / relevant docs (note when the PR should have done so).
+
+## Severity calibration (this repo)
+
+- Undeclared durable-spec edits, privacy leaks, and real external calls in tests → **critical** or **warning**, never suggestion-only.
+- Do not set `lgtm: false` on suggestion-only findings.
+
+## Verify before asserting
+
+Use Read/Grep on surrounding code. Unverified claims about callers, mocks, or existing helpers → mark unverified or drop.

--- a/KOAN.md
+++ b/KOAN.md
@@ -1,0 +1,16 @@
+# KOAN.md — autonomous-agent guidance for this repository
+
+Interactive Claude Code sessions load `CLAUDE.md` / `AGENTS.md`, not this file.
+These rules apply only when Kōan runs missions here.
+
+## Priorities
+
+1. **The agent proposes. The human decides.** Never merge to `main` unsupervised.
+2. **Docs/specs first** for non-trivial work: start at `wiki/index.md`, then the matching pages under `docs/` and durable `specs/components/` / `specs/skills/`. Trust current code if docs disagree; update docs in the same change.
+3. **Branches:** create `<prefix>/*` (default `koan/`); never commit directly to `main`.
+4. **Privacy:** the public tree must not contain private operator identifiers (private slash commands, bot display names, Jira key prefixes, customer project names). Use placeholders (`my_fix`, `@koan-bot`, `PROJ-NNN`, `my-toolkit`) in tests, docs, examples, and commit messages.
+5. **After behavior changes:** update the matching `docs/` page (and durable specs only contract-first, declared as architectural). Core skill add/remove/change → `docs/users/user-manual.md` + `docs/users/skills.md`. REST route changes → `make openapi` and commit `koan/openapi.yaml`.
+
+## Per-skill quality gates
+
+Mission skills load extra checklists from `.koan/skills/<skill>/` (review, fix, implement, rebase, plan, pr). Prefer those for skill-specific must-checks; keep this file short.

--- a/docs/users/koan-md.md
+++ b/docs/users/koan-md.md
@@ -1,9 +1,10 @@
 ---
 type: doc
 title: "KOAN.md — koan-only project instructions"
+description: "Documents the optional project-root KOAN.md file and the .koan/ directory (a second .koan/KOAN.md plus per-skill .koan/skills/<skill>/*.md hooks): koan-only steering injected into the autonomous agent's system prompt but never loaded by interactive Claude Code sessions, with precedence rules, the 16k-char cap, and this repo's dogfood layout."
 tags: [users]
 created: 2026-07-09
-updated: 2026-07-11
+updated: 2026-07-16
 ---
 
 # KOAN.md — koan-only project instructions
@@ -67,6 +68,37 @@ no separate `.koan/skills/refactor/`).
 Everything is opt-in by file existence and a no-op when absent. Prompt-only
 skills do not read `.koan/skills/`; steer those with general `KOAN.md`.
 
+Runner skills must pass `project_path` into `load_skill_prompt` /
+`load_prompt_or_skill` for the append to fire. Core runners that honor it
+include `review`, `plan`, `pr`, `fix`, `implement`, and `rebase` (and their
+sub-passes). Skills that never pass `project_path` ignore
+`.koan/skills/<name>/` until wired.
+
+## Example: this repository (dogfood)
+
+The Kōan source tree ships its own steering so autonomous missions on koan
+itself apply repo-specific quality gates:
+
+```
+KOAN.md                              # thin always-on priorities
+.koan/skills/
+  review/quality-gates.md
+  fix/quality-gates.md
+  implement/quality-gates.md
+  rebase/quality-gates.md
+  plan/quality-gates.md
+  pr/quality-gates.md
+```
+
+Content is intentionally short: unique failure modes (specs discipline,
+privacy, `KOAN_ROOT` / mock boundaries, OpenAPI, skill docs) — not a copy of
+`CLAUDE.md`. Keep fragments under the 16k per-skill cap; prefer one
+`quality-gates.md` per skill.
+
+**Gitignore note:** runtime signal files (`.koan-status`, `.koan-stop`, …)
+stay ignored via `.koan-*`. The project directory `.koan/` is **not** ignored
+so skill hooks can be committed like any other project file.
+
 ## Discoverability
 
 Kōan advertises this feature once, unprompted: the first idle period after the
@@ -82,3 +114,6 @@ never repeats.
 - Always run `make lint` and `make test` before opening a PR.
 - Never touch files under `vendor/`.
 ```
+
+See also the committed `KOAN.md` and `.koan/skills/*/quality-gates.md` at the
+root of this repository for a full dogfood example.

--- a/koan/app/claude_step.py
+++ b/koan/app/claude_step.py
@@ -1963,6 +1963,7 @@ def _build_pr_prompt(
     skill_dir: Optional[Path] = None,
     max_diff_chars: int = 80_000,
     commit_conventions: str = "",
+    project_path: str = "",
 ) -> str:
     """Build a prompt for Claude to process PR feedback.
 
@@ -1978,6 +1979,8 @@ def _build_pr_prompt(
         commit_conventions: Project commit convention guidance to include
             in the prompt. When non-empty, also loads the commit subject
             instruction fragment.
+        project_path: Target checkout; enables ``.koan/skills/<skill>/``
+            append when the skill package is real.
     """
     diff = context.get("diff", "")
     if len(diff) > max_diff_chars:
@@ -2012,7 +2015,11 @@ def _build_pr_prompt(
         COMMIT_CONVENTIONS=commit_conventions,
         COMMIT_SUBJECT_INSTRUCTION=commit_subject_instruction,
     )
-    return load_prompt_or_skill(skill_dir, prompt_name, **kwargs)
+    return load_prompt_or_skill(
+        skill_dir, prompt_name,
+        project_path=project_path or None,
+        **kwargs,
+    )
 
 
 def _sanitize_commit_subject(subject: str) -> str:

--- a/koan/app/rebase_pr.py
+++ b/koan/app/rebase_pr.py
@@ -1166,6 +1166,7 @@ def _check_if_already_solved(
 
     prompt = load_prompt_or_skill(
         skill_dir, "already_solved",
+        project_path=project_path or None,
         TITLE=pr_context.get("title", ""),
         BODY=pr_context.get("body", ""),
         BRANCH=pr_context.get("branch", ""),
@@ -1426,6 +1427,7 @@ def _resolve_rebase_conflicts(
         print(f"[rebase] Resolving conflicts via Claude (round {round_num})", flush=True)
         prompt = _build_conflict_resolution_prompt(
             context, conflicted, base, skill_dir=skill_dir,
+            project_path=project_path,
         )
 
         # Invoke Claude to resolve conflicts
@@ -1495,6 +1497,7 @@ def _build_conflict_resolution_prompt(
     conflicted_files: List[str],
     base: str,
     skill_dir: Optional[Path] = None,
+    project_path: str = "",
 ) -> str:
     """Build a prompt for Claude to resolve merge conflicts."""
     kwargs = dict(
@@ -1504,7 +1507,11 @@ def _build_conflict_resolution_prompt(
         BASE=base,
         CONFLICTED_FILES="\n".join(f"- `{f}`" for f in conflicted_files),
     )
-    return load_prompt_or_skill(skill_dir, "conflict_resolution", **kwargs)
+    return load_prompt_or_skill(
+        skill_dir, "conflict_resolution",
+        project_path=project_path or None,
+        **kwargs,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1593,6 +1600,7 @@ def _fix_existing_ci_failures(
     ci_fix_prompt = _build_ci_fix_prompt(
         context, ci_logs, diff, skill_dir=skill_dir,
         commit_conventions=commit_conventions,
+        project_path=project_path,
     )
 
     fixed, timed_out, attempts_used = _run_ci_fix_step_with_timeout_retry(
@@ -1723,6 +1731,7 @@ def _run_ci_check_and_fix(
         return _build_ci_fix_prompt(
             context, logs, diff, skill_dir=skill_dir,
             commit_conventions=commit_conventions,
+            project_path=project_path,
         )
 
     # Delegate the shared diff -> fix -> push -> recheck loop to the canonical
@@ -1799,6 +1808,7 @@ def _build_ci_fix_prompt(
     diff: str,
     skill_dir: Optional[Path] = None,
     commit_conventions: str = "",
+    project_path: str = "",
 ) -> str:
     """Build a prompt for Claude to fix CI failures."""
     from app.claude_step import _load_commit_subject_instruction
@@ -1816,7 +1826,11 @@ def _build_ci_fix_prompt(
         COMMIT_CONVENTIONS=commit_conventions,
         COMMIT_SUBJECT_INSTRUCTION=commit_subject_instruction,
     )
-    return load_prompt_or_skill(skill_dir, "ci_fix", **kwargs)
+    return load_prompt_or_skill(
+        skill_dir, "ci_fix",
+        project_path=project_path or None,
+        **kwargs,
+    )
 
 
 def _emit_phase_heartbeat(
@@ -1948,11 +1962,13 @@ def _build_rebase_prompt(
     skill_dir: Optional[Path] = None,
     commit_conventions: str = "",
     min_severity: Optional[str] = None,
+    project_path: str = "",
 ) -> str:
     """Build a prompt for Claude to analyze and apply review feedback."""
     prompt = _build_pr_prompt(
         "rebase", context, skill_dir=skill_dir,
         commit_conventions=commit_conventions,
+        project_path=project_path,
     )
 
     if min_severity and min_severity != "suggestion":
@@ -2004,6 +2020,7 @@ def _apply_review_feedback(
         context, skill_dir=skill_dir,
         commit_conventions=commit_conventions,
         min_severity=min_severity,
+        project_path=project_path,
     )
 
     try:

--- a/koan/skills/core/fix/fix_diagnose.py
+++ b/koan/skills/core/fix/fix_diagnose.py
@@ -47,7 +47,11 @@ def run_diagnostic(
         CONTEXT=context or "No additional context.",
     )
     try:
-        prompt = load_prompt_or_skill(skill_dir, "fix-diagnose", **template_vars)
+        prompt = load_prompt_or_skill(
+            skill_dir, "fix-diagnose",
+            project_path=project_path,
+            **template_vars,
+        )
         output = run_command_streaming(
             prompt,
             project_path,

--- a/koan/skills/core/fix/fix_runner.py
+++ b/koan/skills/core/fix/fix_runner.py
@@ -381,6 +381,7 @@ def _execute_fix(
         base_branch=effective_base,
         existing_branch=existing_branch,
         diagnostic=diagnostic,
+        project_path=project_path,
     )
 
     from app.claude_step import run_skill_loop
@@ -420,6 +421,7 @@ def _build_prompt(
     base_branch: str = "main",
     existing_branch: Optional[str] = None,
     diagnostic: str = "",
+    project_path: str = "",
 ) -> str:
     """Build the fix prompt from the issue content."""
     branch_section = _build_branch_section(
@@ -441,7 +443,9 @@ def _build_prompt(
         DIAGNOSTIC=diagnostic,
     )
 
-    return load_prompt_or_skill(skill_dir, "fix", **template_vars)
+    return load_prompt_or_skill(
+        skill_dir, "fix", project_path=project_path or None, **template_vars,
+    )
 
 
 def _build_branch_section(

--- a/koan/skills/core/implement/implement_runner.py
+++ b/koan/skills/core/implement/implement_runner.py
@@ -620,6 +620,7 @@ def _build_prompt(
     issue_number: str = "",
     project_memory: str = "",
     base_branch: str = "main",
+    project_path: str = "",
 ) -> str:
     """Build the implementation prompt from the issue and plan."""
     template_vars = dict(
@@ -633,7 +634,11 @@ def _build_prompt(
         BASE_BRANCH=base_branch,
     )
 
-    return load_prompt_or_skill(skill_dir, "implement", **template_vars)
+    return load_prompt_or_skill(
+        skill_dir, "implement",
+        project_path=project_path or None,
+        **template_vars,
+    )
 
 
 def _generate_pr_summary(
@@ -654,6 +659,7 @@ def _generate_pr_summary(
     try:
         prompt = load_prompt_or_skill(
             skill_dir, "pr_summary",
+            project_path=project_path or None,
             ISSUE_URL=issue_url,
             ISSUE_TITLE=issue_title,
             COMMIT_SUBJECTS=commits_text,
@@ -705,7 +711,10 @@ def _execute_implementation(
 
     effective_context = context
     if escalate:
-        escalation_preamble = load_prompt_or_skill(skill_dir, "implement_retry_context")
+        escalation_preamble = load_prompt_or_skill(
+            skill_dir, "implement_retry_context",
+            project_path=project_path or None,
+        )
         effective_context = escalation_preamble + "\n\n" + context
 
     prompt = _build_prompt(
@@ -714,6 +723,7 @@ def _execute_implementation(
         issue_number=issue_number,
         project_memory=project_memory,
         base_branch=effective_base,
+        project_path=project_path,
     )
 
     from app.claude_step import run_skill_loop

--- a/koan/tests/test_claude_step.py
+++ b/koan/tests/test_claude_step.py
@@ -1999,6 +1999,13 @@ class TestBuildPrPrompt:
         assert "+small change" in kwargs["DIFF"]
         assert "BEGIN EXTERNAL DATA" in kwargs["DIFF"]
 
+    @patch("app.claude_step.load_prompt_or_skill", return_value="ok")
+    def test_passes_project_path_for_koan_skill_injection(self, mock_lp, context):
+        from app.claude_step import _build_pr_prompt
+        _build_pr_prompt("rebase", context, project_path="/repo/koan")
+        _, kwargs = mock_lp.call_args
+        assert kwargs["project_path"] == "/repo/koan"
+
 
 # ---------- _force_push / _owner_token_push ----------
 

--- a/koan/tests/test_fix_runner.py
+++ b/koan/tests/test_fix_runner.py
@@ -156,6 +156,23 @@ class TestBuildPrompt:
         assert "{KOAN_PYTHON}" not in prompt
         assert " -m app.issue_cli" in prompt
 
+    def test_injects_project_skill_instructions(self, tmp_path):
+        """When project_path has .koan/skills/fix/*.md, append them to the prompt."""
+        skill_dir = Path(__file__).resolve().parent.parent / "skills" / "core" / "fix"
+        d = tmp_path / ".koan" / "skills" / "fix"
+        d.mkdir(parents=True)
+        (d / "quality-gates.md").write_text("KOAN_FIX_EXTRA_RULE")
+        prompt = _build_prompt(
+            issue_url="https://github.com/o/r/issues/1",
+            issue_title="Bug",
+            issue_body="Body",
+            context="ctx",
+            skill_dir=skill_dir,
+            project_path=str(tmp_path),
+        )
+        assert "KOAN_FIX_EXTRA_RULE" in prompt
+        assert "fix skill" in prompt
+
 
 class TestExecuteFix:
     def test_uses_mission_model_key(self):

--- a/koan/tests/test_implement_runner.py
+++ b/koan/tests/test_implement_runner.py
@@ -806,6 +806,7 @@ class TestBuildPrompt:
             )
             mock_load.assert_called_once_with(
                 skill_dir, "implement",
+                project_path=None,
                 ISSUE_URL="http://url",
                 ISSUE_TITLE="Title",
                 PLAN="Plan",
@@ -824,6 +825,7 @@ class TestBuildPrompt:
             )
             mock_load.assert_called_once_with(
                 None, "implement",
+                project_path=None,
                 ISSUE_URL="http://url",
                 ISSUE_TITLE="Title",
                 PLAN="Plan",
@@ -834,6 +836,17 @@ class TestBuildPrompt:
                 BASE_BRANCH="main",
             )
             assert result == "prompt"
+
+    def test_passes_project_path_for_koan_skill_injection(self):
+        """project_path must reach the loader so .koan/skills/implement/*.md applies."""
+        skill_dir = Path("/fake/skill/dir")
+        with patch(f"{_IMPL_MODULE}.load_prompt_or_skill", return_value="prompt") as mock_load:
+            _build_prompt(
+                "http://url", "Title", "Plan", "Context",
+                skill_dir=skill_dir,
+                project_path="/repo/koan",
+            )
+            assert mock_load.call_args.kwargs["project_path"] == "/repo/koan"
 
     def test_base_branch_propagates_into_prompt_template_vars(self):
         """BASE_BRANCH must reach load_prompt_or_skill so the rendered prompt

--- a/koan/tests/test_rebase_pr.py
+++ b/koan/tests/test_rebase_pr.py
@@ -1933,6 +1933,51 @@ class TestBuildRebasePrompt:
         with pytest.raises(FileNotFoundError):
             _build_rebase_prompt(context, skill_dir=None)
 
+    def test_injects_project_skill_instructions(self, tmp_path):
+        """project_path enables .koan/skills/rebase/*.md append on rebase prompts."""
+        d = tmp_path / ".koan" / "skills" / "rebase"
+        d.mkdir(parents=True)
+        (d / "quality-gates.md").write_text("KOAN_REBASE_EXTRA_RULE")
+        context = {
+            "title": "T", "body": "", "branch": "br", "base": "main",
+            "diff": "", "review_comments": "", "reviews": "", "issue_comments": "",
+        }
+        prompt = _build_rebase_prompt(
+            context, skill_dir=REBASE_SKILL_DIR, project_path=str(tmp_path),
+        )
+        assert "KOAN_REBASE_EXTRA_RULE" in prompt
+        assert "rebase skill" in prompt
+
+
+class TestBuildConflictAndCiFixPrompts:
+    def test_conflict_prompt_injects_project_skill(self, tmp_path):
+        from app.rebase_pr import _build_conflict_resolution_prompt
+
+        d = tmp_path / ".koan" / "skills" / "rebase"
+        d.mkdir(parents=True)
+        (d / "quality-gates.md").write_text("KOAN_CONFLICT_EXTRA")
+        context = {
+            "title": "T", "body": "B", "branch": "br", "base": "main",
+        }
+        prompt = _build_conflict_resolution_prompt(
+            context, ["a.py"], "main",
+            skill_dir=REBASE_SKILL_DIR,
+            project_path=str(tmp_path),
+        )
+        assert "KOAN_CONFLICT_EXTRA" in prompt
+
+    def test_ci_fix_prompt_injects_project_skill(self, tmp_path):
+        d = tmp_path / ".koan" / "skills" / "rebase"
+        d.mkdir(parents=True)
+        (d / "quality-gates.md").write_text("KOAN_CI_FIX_EXTRA")
+        context = {"title": "T", "branch": "br", "base": "main"}
+        prompt = _build_ci_fix_prompt(
+            context, "log fail", "+diff",
+            skill_dir=REBASE_SKILL_DIR,
+            project_path=str(tmp_path),
+        )
+        assert "KOAN_CI_FIX_EXTRA" in prompt
+
 
 # ---------------------------------------------------------------------------
 # _apply_review_feedback

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -85,7 +85,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 - [`setup/systemd-user.md`](docs/setup/systemd-user.md) — Describes running Koan as a per-user (rootless) systemd service on Linux, covering unit installation, linger for boot persistence, and PATH preservation for CLI providers.
 
 ### Users
-- [`users/koan-md.md`](docs/users/koan-md.md) — Documents the optional project-root `KOAN.md` file and the `.koan/` directory (a second `.koan/KOAN.md` plus per-skill `.koan/skills/<skill>/*.md` hooks): koan-only steering injected into the autonomous agent's system prompt but never loaded by interactive Claude Code sessions, with precedence rules and the 16k-char cap.
+- [`users/koan-md.md`](docs/users/koan-md.md) — Documents the optional project-root `KOAN.md` file and the `.koan/` directory (a second `.koan/KOAN.md` plus per-skill `.koan/skills/<skill>/*.md` hooks): koan-only steering for the autonomous agent, 16k caps, runner `project_path` wiring, and this repo's dogfood quality-gate layout.
 - [`users/model-configuration.md`](docs/users/model-configuration.md) — Explains how to configure which model handles each Koan role (mission, chat, lightweight, fallback, etc.) per provider via `config.yaml`, including resolution order and CLI-provider-per-role routing.
 - [`users/onboarding.md`](docs/users/onboarding.md) — Documents the interactive 12-step onboarding wizard that sets up a new Koan instance, its resumability, personality presets, and non-interactive/CI mode.
 - [`users/quickstart.md`](docs/users/quickstart.md) — A 5-minute guide to the commands for driving Koan from GitHub PRs/issues, Jira, and messaging apps (Telegram/Slack), with minimal and context-augmented examples for each.


### PR DESCRIPTION
## Why

Autonomous missions on the **Koan repository itself** currently get the same generic skill prompts as any customer project. This codebase has unique failure modes that generic prompts miss:

- durable **specs discipline** (contract-first, architectural declaration)
- **privacy** scrub on public artifacts
- test isolation (`KOAN_ROOT`, mock `run_gh` / Telegram / providers)
- **OpenAPI** regen and core-skill user-manual updates
- rebase conflict policy that must not silently drop `specs/` or tests

The product already supports per-skill steering via `.koan/skills/<skill>/*.md` (see `docs/users/koan-md.md`), but:

1. This repo did not ship any `.koan/` content
2. **`.gitignore` used `.koan*`, which ignored the entire `.koan/` directory** — dogfooding was impossible
3. **`fix` / `implement` / `rebase` never passed `project_path`** into the prompt loader, so even a present hook was a no-op

## What

| Area | Change |
|---|---|
| Gitignore | Ignore runtime signals with `.koan-*` (and existing explicit entries); **track** project `.koan/` |
| Wiring | Pass `project_path` through fix, implement, and rebase (including diagnose, conflict, CI-fix, already-solved, shared `_build_pr_prompt`) |
| Content | Thin root `KOAN.md` + six short `quality-gates.md` files under `.koan/skills/{review,fix,implement,rebase,plan,pr}/` |
| Docs | Dogfood layout + runner wiring notes in `docs/users/koan-md.md`; wiki index line refreshed |
| Tests | Injection + kwargs assertions for the new wiring |

**Not architectural:** no durable `specs/components/**` or `specs/skills/**` contract change — wiring fulfills the existing “runner skills should pass `project_path`” convention.

## How

1. `read_skill_instructions` + `_maybe_append_project_skill_instructions` already append framed blocks when `project_path` is set and `SKILL.md` exists.
2. Runners now pass that path; content is opt-in by file presence for any project.
3. Checklists stay short (append-only additions, not replacements of built-in skill prompts) to stay under the 16k per-skill cap.

## Skills we deliberately skipped

Low signal for this pass: `ask`, `magic`, status/config skills, creative skills (`brainstorm`, `deepplan`). General `KOAN.md` covers non-skill missions.

## Test plan

- [x] `git check-ignore` — `.koan/skills/...` not ignored; `.koan-status` / `.koan-*` still ignored
- [x] Targeted pytest: fix/implement/rebase/claude_step build-prompt injection + existing project_koan/prompts suites (40 passed)
- [x] `make lint`
- [ ] Optional: run `/review` or `/fix` against this repo in a real instance and confirm the framed block appears in the agent prompt log