### PR TITLE
fix: suppress project tooling at CLI for KOAN_ROOT sessions

### DIFF
--- a/docs/architecture/providers.md
+++ b/docs/architecture/providers.md
@@ -26,7 +26,10 @@ Providers are responsible for:
   state such as rotating auth tokens;
 - normalizing output handling enough for mission execution code;
 - exposing provider capabilities without leaking provider details into unrelated
-  modules.
+  modules;
+- optionally suppressing project-scope tooling via `project_context=False`
+  (Claude: `--setting-sources user`) for KOAN_ROOT runtime sessions — see
+  [claude.md](../providers/claude.md) and `specs/components/providers.md`.
 
 Post-CLI text extraction is shared: `mission_runner.parse_claude_output()`
 unwraps provider stream/json envelopes (NDJSON `stream-json` /

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -341,9 +341,9 @@ This is a Claude-specific feature — other providers don't support it.
 ## Project context isolation (KOAN_ROOT sessions)
 
 A deployed instance is a git clone of the Koan repo. Several **runtime**
-CLI sessions intentionally use `cwd=KOAN_ROOT` (chat bridge, contemplative,
-rituals, outbox formatting). Without isolation, Claude Code would
-auto-load **project** scope from that directory:
+CLI sessions intentionally use `cwd=KOAN_ROOT` (Telegram chat bridge,
+dashboard web chat, contemplative, rituals, outbox formatting). Without
+isolation, Claude Code would auto-load **project** scope from that directory:
 
 - root `CLAUDE.md` / `AGENTS.md` (contributor instructions)
 - `.claude/skills/` (e.g. `brain`, `speckit-*`)

--- a/docs/providers/claude.md
+++ b/docs/providers/claude.md
@@ -4,7 +4,7 @@ title: "Claude Code CLI Provider"
 description: "Setup and configuration guide for Kōan's default Claude Code CLI provider, including models, tools, per-role CLI config, MCP, and devcontainer mode."
 tags: [providers]
 created: 2026-05-28
-updated: 2026-07-01
+updated: 2026-07-16
 ---
 
 # Claude Code CLI Provider
@@ -337,6 +337,42 @@ models:
 ```
 
 This is a Claude-specific feature — other providers don't support it.
+
+## Project context isolation (KOAN_ROOT sessions)
+
+A deployed instance is a git clone of the Koan repo. Several **runtime**
+CLI sessions intentionally use `cwd=KOAN_ROOT` (chat bridge, contemplative,
+rituals, outbox formatting). Without isolation, Claude Code would
+auto-load **project** scope from that directory:
+
+- root `CLAUDE.md` / `AGENTS.md` (contributor instructions)
+- `.claude/skills/` (e.g. `brain`, `speckit-*`)
+
+That leaks contributor-only advice into operator-facing replies (e.g.
+“run `/brain sync`”). See issue
+[#2379](https://github.com/Anantys-oss/koan/issues/2379).
+
+**Fix (CLI boundary, not filesystem quarantine):** those sessions pass
+`project_context=False` into `build_full_command`, which for Claude
+becomes:
+
+```bash
+claude … --setting-sources user
+```
+
+Omitting `project` (and `local`) skips project settings, project
+`CLAUDE.md`, and project `.claude` skills. User-level prefs under
+`~/.claude/` still apply.
+
+**Mission / project work is unchanged.** When `cwd` is a project under
+`workspace/` (normally its own git root), Claude loads **that** project's
+`CLAUDE.md` as usual (`project_context` defaults to true). Projects
+should be real git roots (or external checkouts); a non-git folder that
+is only a subdirectory of the Koan clone can still walk up to KOAN_ROOT
+and pick up contributor docs — keep projects as separate repos.
+
+This approach does **not** move files on disk or use `git skip-worktree`
+(contrast the alternative explored in PR #2384).
 
 ## Troubleshooting
 

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -4,7 +4,7 @@ title: "OpenAI Codex CLI Provider"
 description: "Setup and behavior guide for using OpenAI's Codex CLI as Kōan's provider, including quota/usage handling and troubleshooting."
 tags: [providers]
 created: 2026-05-28
-updated: 2026-07-01
+updated: 2026-07-16
 ---
 
 # OpenAI Codex CLI Provider
@@ -196,6 +196,16 @@ consider symlinking or adapting it:
 ```bash
 ln -s CLAUDE.md AGENTS.md
 ```
+
+### Project-context isolation (deferred)
+
+Koan's `project_context=False` path (used for KOAN_ROOT runtime sessions
+such as chat and contemplative — see [claude.md](claude.md) § Project
+context isolation) is a **no-op for Codex today**. Claude uses
+`--setting-sources user`; Codex AGENTS.md suppression is not wired yet.
+If contributor `AGENTS.md` at the instance root leaks into Codex-backed
+chat, prefer mission/`workspace/` project roots with their own docs, or
+track a follow-up to map isolation to a Codex config override.
 
 ## Troubleshooting
 

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -504,12 +504,15 @@ def handle_chat(text: str):
     # The prompt tells Claude where to look.
     chat_cwd = str(KOAN_ROOT)
 
+    # project_context=False: cwd is KOAN_ROOT; do not load contributor
+    # CLAUDE.md / .claude skills (issue #2379).
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=chat_tools_list,
         model=models["chat"],
         fallback=models["fallback"],
         max_turns=5,
+        project_context=False,
     )
 
     # Serialize chat CLI calls: Claude takes a per-cwd session lock, so two
@@ -553,6 +556,7 @@ def handle_chat(text: str):
                 model=models["chat"],
                 fallback=models["fallback"],
                 max_turns=5,
+                project_context=False,
             )
             try:
                 result = run_cli(

--- a/koan/app/contemplative_runner.py
+++ b/koan/app/contemplative_runner.py
@@ -79,12 +79,15 @@ def build_contemplative_command(
     # Contemplative sessions run on the lightweight role's provider (cli:
     # section); extra_flags supplies the matching lightweight model.
     provider = get_provider_for_role("lightweight", project_name)
+    # Contemplative runs at KOAN_ROOT; suppress contributor project tooling
+    # (issue #2379) while still using the lightweight provider/model.
     cmd = build_full_command(
         prompt=prompt,
         allowed_tools=allowed_tools,
         mcp_configs=mcp_configs,
         max_turns=get_contemplative_max_turns(),
         provider=provider,
+        project_context=False,
     )
     if extra_flags:
         cmd.extend(extra_flags)

--- a/koan/app/dashboard/chat.py
+++ b/koan/app/dashboard/chat.py
@@ -131,9 +131,15 @@ def chat_send():
         save_conversation_message(state.CONVERSATION_HISTORY_FILE, "user", text)
 
         prompt = _build_dashboard_prompt(text)
-        project_path = os.environ.get("KOAN_CURRENT_PROJECT_PATH", str(state.KOAN_ROOT))
+        koan_root = str(state.KOAN_ROOT)
+        project_path = os.environ.get("KOAN_CURRENT_PROJECT_PATH", koan_root)
         allowed_tools_list = get_allowed_tools().split(",")
         models = get_model_config()
+        # Operator chat at KOAN_ROOT must not load contributor CLAUDE.md /
+        # .claude skills (#2379). When a project path is selected, keep
+        # project_context so that project's docs still load (mission default).
+        at_koan_root = os.path.realpath(project_path) == os.path.realpath(koan_root)
+        project_context = not at_koan_root
 
         cmd = build_full_command(
             prompt=prompt,
@@ -141,6 +147,7 @@ def chat_send():
             model=models["chat"],
             fallback=models["fallback"],
             max_turns=1,
+            project_context=project_context,
         )
 
         try:
@@ -169,6 +176,7 @@ def chat_send():
                 model=models["chat"],
                 fallback=models["fallback"],
                 max_turns=1,
+                project_context=project_context,
             )
             try:
                 result = run_cli(

--- a/koan/app/format_outbox.py
+++ b/koan/app/format_outbox.py
@@ -178,7 +178,12 @@ def format_message(raw_content: str, soul: str, prefs: str,
         from app.cli_exec import run_cli
 
         models = get_model_config()
-        cmd = build_full_command(prompt=prompt, model=models["lightweight"])
+        # Outbox formatting runs at KOAN_ROOT — suppress contributor tooling (#2379).
+        cmd = build_full_command(
+            prompt=prompt,
+            model=models["lightweight"],
+            project_context=False,
+        )
         result = run_cli(
             cmd,
             cwd=koan_root,

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -481,6 +481,7 @@ def build_full_command(
     system_prompt_file: str = "",
     effort: str = "",
     resume_session_id: str = "",
+    project_context: bool = True,
     provider: Optional[CLIProvider] = None,
 ) -> List[str]:
     """Build a complete CLI command for the configured provider.
@@ -498,6 +499,10 @@ def build_full_command(
         resume_session_id: When set and the provider supports session
             resumption, continues the given session instead of starting
             fresh.
+        project_context: When False, ask the provider to suppress
+            project-scope tooling (Claude: ``--setting-sources user``).
+            Use for KOAN_ROOT runtime sessions (chat, contemplative,
+            rituals, outbox). Mission sessions leave the default True.
         provider: Explicit provider instance to build for. ``None`` (default)
             uses the global :func:`get_provider`. Pass a per-role instance
             (from :func:`get_provider_for_role`) to build a command for a
@@ -523,6 +528,7 @@ def build_full_command(
         system_prompt_file=system_prompt_file,
         effort=effort,
         resume_session_id=resume_session_id,
+        project_context=project_context,
     )
 
 
@@ -585,6 +591,7 @@ def build_full_command_managed(
     system_prompt: str = "",
     effort: str = "",
     resume_session_id: str = "",
+    project_context: bool = True,
     system_prompt_dir: Optional[str] = None,
     system_prompt_container_dir: Optional[str] = None,
     provider: Optional[CLIProvider] = None,
@@ -617,6 +624,7 @@ def build_full_command_managed(
         plugin_dirs=plugin_dirs,
         effort=effort,
         resume_session_id=resume_session_id,
+        project_context=project_context,
         provider=provider,
     )
     if system_prompt and (provider or get_provider()).supports_system_prompt_file():

--- a/koan/app/provider/base.py
+++ b/koan/app/provider/base.py
@@ -280,6 +280,20 @@ class CLIProvider:
         """
         return []
 
+    def build_project_context_args(self, project_context: bool = True) -> List[str]:
+        """Build args that control whether project-scope tooling is loaded.
+
+        When *project_context* is False, the provider should suppress
+        project-directory instructions (e.g. root ``CLAUDE.md`` /
+        ``AGENTS.md`` / ``.claude/skills``) so KOAN_ROOT runtime sessions
+        do not load contributor tooling. Mission sessions leave the default
+        True so the project's own guidance still applies.
+
+        Base implementation is a no-op — only providers with a first-class
+        switch (Claude Code ``--setting-sources``) override this.
+        """
+        return []
+
     def supports_session_resume(self) -> bool:
         """Return True if the provider supports resuming a previous session.
 
@@ -355,6 +369,7 @@ class CLIProvider:
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build a complete CLI command from generic parameters.
 
@@ -375,6 +390,10 @@ class CLIProvider:
             resume_session_id: When set and the provider supports session
                 resumption, continues the given session instead of starting
                 fresh. Saves tokens by reusing the prior conversation context.
+            project_context: When False, suppress project-scope tooling
+                (see :meth:`build_project_context_args`). KOAN_ROOT runtime
+                sessions pass False so contributor ``CLAUDE.md`` / skills do
+                not leak into operator chat. Mission sessions leave True.
 
         Returns a list of strings suitable for subprocess.run().
         """
@@ -392,6 +411,7 @@ class CLIProvider:
         if resume_session_id and self.supports_session_resume():
             cmd.extend(self.build_resume_args(resume_session_id))
         cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(self.build_project_context_args(project_context))
         cmd.extend(sys_args)
         cmd.extend(self.build_prompt_args(prompt))
         cmd.extend(self.build_tool_args(allowed_tools, disallowed_tools))

--- a/koan/app/provider/claude.py
+++ b/koan/app/provider/claude.py
@@ -132,6 +132,18 @@ class ClaudeProvider(CLIProvider):
             return ["--effort", effort]
         return []
 
+    def build_project_context_args(self, project_context: bool = True) -> List[str]:
+        """Suppress project CLAUDE.md / .claude skills when *project_context* is False.
+
+        Claude Code loads user / project / local setting sources by default.
+        ``--setting-sources user`` keeps user-level prefs but omits project
+        and local sources so KOAN_ROOT runtime sessions do not auto-load
+        contributor tooling (issue #2379).
+        """
+        if project_context:
+            return []
+        return ["--setting-sources", "user"]
+
     def build_thinking_args(
         self, enabled: bool = False, budget_tokens: int = 0,
     ) -> List[str]:

--- a/koan/app/provider/cline.py
+++ b/koan/app/provider/cline.py
@@ -164,6 +164,7 @@ class ClineProvider(CLIProvider):
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build a complete Cline CLI command.
 
@@ -187,6 +188,7 @@ class ClineProvider(CLIProvider):
 
         # Global flags come before the positional prompt
         cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(self.build_project_context_args(project_context))
         cmd.extend(self.build_model_args(model, fallback))
         cmd.extend(self.build_output_args(output_format))
         cmd.extend(self.build_max_turns_args(max_turns))

--- a/koan/app/provider/codex.py
+++ b/koan/app/provider/codex.py
@@ -339,6 +339,7 @@ class CodexProvider(CLIProvider):
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build a complete Codex CLI command.
 
@@ -351,6 +352,9 @@ class CodexProvider(CLIProvider):
         are ``exec`` subcommand flags in current Codex CLI (>= 0.1),
         so they must come *after* the ``exec`` keyword.  The prompt is
         the final positional argument.
+
+        *project_context* is accepted for API parity; AGENTS.md isolation
+        for Codex is deferred (no first-class flag wired in v1).
         """
         # Handle system prompt: Codex has no --append-system-prompt or
         # file-mode equivalent, so prepend to user prompt (base class
@@ -363,6 +367,7 @@ class CodexProvider(CLIProvider):
 
         # Exec-level flags (permission, model) come after 'exec'
         cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(self.build_project_context_args(project_context))
         cmd.extend(self.build_model_args(model, fallback))
         cmd.extend(self.build_output_args(output_format))
 

--- a/koan/app/provider/grok.py
+++ b/koan/app/provider/grok.py
@@ -363,12 +363,14 @@ class GrokProvider(CLIProvider):
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build ``grok [flags] -p <prompt>``.
 
         Prompt args stay last for readability and for prompt-file rewrite.
         When *system_prompt_file* is set, its contents are inlined via
         ``--rules`` (no dedicated file flag on Grok Build 0.2.x).
+        *project_context* is accepted for API parity (base no-op for grok).
         """
         sys_args: List[str] = []
         if system_prompt_file:
@@ -392,6 +394,7 @@ class GrokProvider(CLIProvider):
         cmd = [self.binary()]
         if resume_session_id and self.supports_session_resume():
             cmd.extend(self.build_resume_args(resume_session_id))
+        cmd.extend(self.build_project_context_args(project_context))
         cmd.extend(self.build_permission_args(skip_permissions))
         cmd.extend(sys_args)
         cmd.extend(self.build_tool_args(allowed_tools, disallowed_tools))

--- a/koan/app/provider/haze.py
+++ b/koan/app/provider/haze.py
@@ -230,12 +230,14 @@ class HazeProvider(CLIProvider):
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build ``haze [-m <sel>] [--output <fmt>] -p <prompt>``.
 
         Prompt args stay last so :meth:`rewrite_prompt_for_stdin` and human
         readers find them in a fixed position. Unsupported inputs are routed
         through their builders (which warn) rather than dropped here.
+        *project_context* is accepted for API parity (base no-op for haze).
         """
         if system_prompt_file:
             self._warn_unsupported_once(
@@ -263,6 +265,7 @@ class HazeProvider(CLIProvider):
             )
 
         cmd = [self.binary()]
+        cmd.extend(self.build_project_context_args(project_context))
         cmd.extend(self.build_tool_args(allowed_tools, disallowed_tools))
         cmd.extend(self.build_model_args(model, fallback))
         cmd.extend(self.build_output_args(output_format))

--- a/koan/app/provider/ollama_launch.py
+++ b/koan/app/provider/ollama_launch.py
@@ -105,6 +105,7 @@ class OllamaLaunchProvider(ClaudeProvider):
         system_prompt_file: str = "",
         effort: str = "",
         resume_session_id: str = "",
+        project_context: bool = True,
     ) -> List[str]:
         """Build: ollama launch claude --model X -- <claude-flags>.
 
@@ -112,7 +113,7 @@ class OllamaLaunchProvider(ClaudeProvider):
         Everything after ``--`` uses the same flag builders as
         :class:`ClaudeProvider` so feature parity is maintained
         (permissions, system prompts, resume, output format, max turns,
-        MCP, plugins, effort).
+        MCP, plugins, effort, project_context).
         """
         # Ollama part: binary + launch subcommand + model
         cmd = ["ollama", "launch", "claude"]
@@ -127,6 +128,7 @@ class OllamaLaunchProvider(ClaudeProvider):
         if resume_session_id and self.supports_session_resume():
             cmd.extend(self.build_resume_args(resume_session_id))
         cmd.extend(self.build_permission_args(skip_permissions))
+        cmd.extend(self.build_project_context_args(project_context))
 
         # System prompt: file mode takes precedence over inline content.
         if system_prompt_file and self.supports_system_prompt_file():

--- a/koan/app/rituals.py
+++ b/koan/app/rituals.py
@@ -76,10 +76,12 @@ def run_ritual(ritual_type: str, instance_dir: Path) -> bool:
         return False
 
     try:
+        # Rituals run at KOAN_ROOT — suppress contributor project tooling (#2379).
         cmd = build_full_command(
             prompt=prompt,
             allowed_tools=["Read", "Write", "Glob"],
             max_turns=7,
+            project_context=False,
         )
         result = run_cli(
             cmd,

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -2386,6 +2386,30 @@ class TestChatToolsSecurity:
         assert tools_arg == "Read,Glob,Grep"
         assert "Bash" not in tools_arg
 
+    @patch("app.awake.save_conversation_message")
+    @patch("app.awake.load_recent_history", return_value=[])
+    @patch("app.awake.format_conversation_history", return_value="")
+    @patch("app.awake.get_tools_description", return_value="")
+    @patch("app.awake.get_chat_tools", return_value="Read")
+    @patch("app.awake.send_telegram", return_value=True)
+    @patch("app.cli_exec.run_cli")
+    def test_handle_chat_suppresses_project_context(
+        self, mock_run, mock_send, mock_tools, mock_tools_desc, mock_fmt,
+        mock_hist, mock_save, tmp_path,
+    ):
+        """Chat runs at KOAN_ROOT — must not load contributor tooling (#2379)."""
+        mock_run.return_value = MagicMock(stdout="ok", returncode=0, stderr="")
+        with patch("app.awake.INSTANCE_DIR", tmp_path), \
+             patch("app.awake.KOAN_ROOT", tmp_path), \
+             patch("app.awake.PROJECT_PATH", ""), \
+             patch("app.awake.CONVERSATION_HISTORY_FILE", tmp_path / "history.jsonl"), \
+             patch("app.awake.SOUL", ""), \
+             patch("app.awake.SUMMARY", ""):
+            handle_chat("hello")
+        cmd = mock_run.call_args[0][0]
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "user"
+
 
 # ---------------------------------------------------------------------------
 # /mission command

--- a/koan/tests/test_cli_provider.py
+++ b/koan/tests/test_cli_provider.py
@@ -270,6 +270,41 @@ class TestClaudeProvider:
         cmd = self.provider.build_command(prompt="hello", skip_permissions=False)
         assert "--dangerously-skip-permissions" not in cmd
 
+    def test_project_context_false_adds_setting_sources_user(self):
+        """KOAN_ROOT sessions suppress project CLAUDE.md / .claude skills."""
+        cmd = self.provider.build_command(prompt="hello", project_context=False)
+        assert "--setting-sources" in cmd
+        idx = cmd.index("--setting-sources")
+        assert cmd[idx + 1] == "user"
+        # Default mission path must not inject the flag.
+        default_cmd = self.provider.build_command(prompt="hello")
+        assert "--setting-sources" not in default_cmd
+        assert self.provider.build_command(
+            prompt="hello", project_context=True,
+        ) == default_cmd
+
+    def test_build_full_command_forwards_project_context(self):
+        from app.provider import build_full_command
+        from app.provider.claude import ClaudeProvider
+
+        with patch("app.config.get_skip_permissions", return_value=False):
+            cmd = build_full_command(
+                prompt="hello",
+                project_context=False,
+                provider=ClaudeProvider(),
+            )
+        assert cmd[cmd.index("--setting-sources") + 1] == "user"
+
+    def test_codex_accepts_project_context_false_noop(self):
+        """Codex isolation is deferred; flag must not break build_command."""
+        from app.provider.codex import CodexProvider
+
+        p = CodexProvider()
+        cmd = p.build_command(prompt="hello", project_context=False)
+        assert cmd[0] == "codex"
+        assert "--setting-sources" not in cmd
+        assert "hello" in cmd
+
     def test_permission_args_under_root_drop_flag_and_warn_once(self, capsys, monkeypatch):
         import app.provider.claude as claude_module
 

--- a/koan/tests/test_contemplative_runner.py
+++ b/koan/tests/test_contemplative_runner.py
@@ -86,6 +86,9 @@ class TestBuildContemplativeCommand:
         assert "--allowedTools" in cmd
         assert "Read,Write,Glob,Grep" in cmd
         assert "--max-turns" in cmd
+        # KOAN_ROOT session: suppress contributor project tooling (#2379).
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "user"
 
     @patch("app.config.get_contemplative_tools")
     @patch("app.prompt_builder.build_contemplative_prompt")

--- a/koan/tests/test_dashboard.py
+++ b/koan/tests/test_dashboard.py
@@ -787,6 +787,55 @@ class TestChatSend:
         captured = capsys.readouterr()
         assert "model overloaded" in captured.out
 
+    @patch("app.dashboard.chat.get_allowed_tools", return_value="")
+    @patch("app.dashboard.chat.get_tools_description", return_value="")
+    @patch("app.dashboard.chat.save_conversation_message")
+    @patch("app.dashboard.chat.load_recent_history", return_value=[])
+    @patch("app.dashboard.chat.format_conversation_history", return_value="")
+    @patch("app.dashboard.chat.subprocess.run")
+    def test_chat_suppresses_project_context_at_koan_root(
+        self, mock_run, mock_fmt, mock_hist, mock_save,
+        mock_tools_desc, mock_tools, app_client, instance_dir, monkeypatch,
+    ):
+        """Default cwd is KOAN_ROOT — must not load contributor tooling (#2379)."""
+        mock_run.return_value = MagicMock(stdout="ok", returncode=0, stderr="")
+        monkeypatch.delenv("KOAN_CURRENT_PROJECT_PATH", raising=False)
+        with patch.object(dashboard.state, "CONVERSATION_HISTORY_FILE", instance_dir / "history.jsonl"), \
+             patch.object(dashboard.state, "SOUL_FILE", instance_dir / "soul.md"), \
+             patch.object(dashboard.state, "SUMMARY_FILE", instance_dir / "memory" / "summary.md"), \
+             patch.object(dashboard.state, "JOURNAL_DIR", instance_dir / "journal"):
+            resp = app_client.post("/chat/send", data={"message": "hello", "mode": "chat"})
+        assert resp.get_json()["ok"] is True
+        cmd = mock_run.call_args[0][0]
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "user"
+
+    @patch("app.dashboard.chat.get_allowed_tools", return_value="")
+    @patch("app.dashboard.chat.get_tools_description", return_value="")
+    @patch("app.dashboard.chat.save_conversation_message")
+    @patch("app.dashboard.chat.load_recent_history", return_value=[])
+    @patch("app.dashboard.chat.format_conversation_history", return_value="")
+    @patch("app.dashboard.chat.subprocess.run")
+    def test_chat_keeps_project_context_for_selected_project(
+        self, mock_run, mock_fmt, mock_hist, mock_save,
+        mock_tools_desc, mock_tools, app_client, instance_dir, tmp_path, monkeypatch,
+    ):
+        """When dashboard chat is scoped to a project path, keep project docs."""
+        mock_run.return_value = MagicMock(stdout="ok", returncode=0, stderr="")
+        project = tmp_path / "workspace" / "my-toolkit"
+        project.mkdir(parents=True)
+        monkeypatch.setenv("KOAN_CURRENT_PROJECT_PATH", str(project))
+        with patch.object(dashboard.state, "CONVERSATION_HISTORY_FILE", instance_dir / "history.jsonl"), \
+             patch.object(dashboard.state, "SOUL_FILE", instance_dir / "soul.md"), \
+             patch.object(dashboard.state, "SUMMARY_FILE", instance_dir / "memory" / "summary.md"), \
+             patch.object(dashboard.state, "JOURNAL_DIR", instance_dir / "journal"):
+            resp = app_client.post("/chat/send", data={"message": "hello", "mode": "chat"})
+        assert resp.get_json()["ok"] is True
+        cmd = mock_run.call_args[0][0]
+        # project_context=True → Claude should not force --setting-sources user
+        if "--setting-sources" in cmd:
+            assert cmd[cmd.index("--setting-sources") + 1] != "user"
+
     def test_chat_send_with_project_tag(self, app_client, instance_dir):
         with patch.object(dashboard.state, "MISSIONS_FILE", instance_dir / "missions.md"):
             resp = app_client.post("/chat/send", data={

--- a/koan/tests/test_format_outbox.py
+++ b/koan/tests/test_format_outbox.py
@@ -130,12 +130,17 @@ class TestFormatForTelegram:
         result = format_message("Raw", "soul", "")
         assert result == "Raw"
 
+    @staticmethod
+    def _prompt_from_cmd(cmd):
+        """Extract -p prompt regardless of leading isolation flags."""
+        return cmd[cmd.index("-p") + 1]
+
     @patch("app.cli_exec.run_cli")
     def test_prompt_includes_soul_and_prefs(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "my-soul", "my-prefs")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]  # ["claude", "-p", prompt]
+        cmd = mock_run.call_args[0][0]
+        prompt = self._prompt_from_cmd(cmd)
         assert "my-soul" in prompt
         assert "my-prefs" in prompt
 
@@ -143,16 +148,14 @@ class TestFormatForTelegram:
     def test_prompt_omits_prefs_when_empty(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]
+        prompt = self._prompt_from_cmd(mock_run.call_args[0][0])
         assert "Human preferences:" not in prompt
 
     @patch("app.cli_exec.run_cli")
     def test_prompt_includes_memory_context(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "prefs", memory_context="Session 61: tests")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]
+        prompt = self._prompt_from_cmd(mock_run.call_args[0][0])
         assert "Session 61: tests" in prompt
         assert "Recent memory context" in prompt
 
@@ -160,9 +163,17 @@ class TestFormatForTelegram:
     def test_prompt_omits_memory_when_empty(self, mock_run):
         mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
         format_message("content", "soul", "prefs", memory_context="")
-        call_args = mock_run.call_args[0][0]
-        prompt = call_args[2]
+        prompt = self._prompt_from_cmd(mock_run.call_args[0][0])
         assert "Recent memory context" not in prompt
+
+    @patch("app.cli_exec.run_cli")
+    def test_suppresses_project_context_for_koan_root(self, mock_run):
+        """Outbox formatting is a KOAN_ROOT session — no contributor tooling."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="ok", stderr="")
+        format_message("content", "soul", "")
+        cmd = mock_run.call_args[0][0]
+        assert "--setting-sources" in cmd
+        assert cmd[cmd.index("--setting-sources") + 1] == "user"
 
 
 class TestLoadMemoryContext:

--- a/koan/tests/test_rituals.py
+++ b/koan/tests/test_rituals.py
@@ -94,6 +94,9 @@ class TestRunRitual:
         call_args = mock_run.call_args[0][0]
         assert call_args[0] == "claude"
         assert "-p" in call_args
+        # KOAN_ROOT session: suppress contributor project tooling (#2379).
+        assert "--setting-sources" in call_args
+        assert call_args[call_args.index("--setting-sources") + 1] == "user"
 
     @patch("app.rituals.subprocess.run")
     def test_evening_calls_claude(self, mock_run, prompt_dir, instance_dir):

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -48,9 +48,17 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 | `effort:` config / `config.get_effort(mode, mission_type)` / `CLIProvider.build_effort_args()` | Reasoning-effort control for the Claude `--effort` flag (low/medium/high/max). `effort:` mapping keys are **mission types** (the `session_tracker.classify_mission_type` taxonomy: plan/review/implement/audit/…), not budget modes. Resolution in `get_effort()`: `effort.<mission_type>` → `effort.<autonomous_mode>` (legacy) → `_DEFAULT_EFFORT_MAP[mode]` (the dynamic default). The dynamic default — review→low, deep→high, else none — is preserved verbatim when `effort:` is absent; a per-type pin only layers on top. `build_mission_command()` classifies the mission type and passes it through, so a pin only reaches `get_effort()` for missions that run through the main agent loop — **not** for skill-dispatched commands (`/review`, `/plan`, …), which bypass `build_mission_command()` (see reach caveat below); `get_effort_for_mode()` is the type-unaware wrapper for callers outside the mission build path. `extended thinking` short-circuits effort to `max`. |
 | Provider resolution | Order: `KOAN_CLI_PROVIDER` env (fallback `CLI_PROVIDER`) → `projects.yaml`/`config.yaml` → default. Centralized in `utils.get_cli_provider_env()`. This resolves the GLOBAL provider; `cli.<role>` layers per-role selection on top via `get_provider_for_role`. |
 | `CLIProvider(binary_path="")` / `ClaudeProvider.binary()` | The base class takes an optional per-instance `binary_path` override (the replacement for the removed review ContextVar); `_resolve_binary_path()` is the shared resolver (absolute → as-is / relative → `normpath(join(KOAN_ROOT, …))` / bare name → PATH lookup). `ClaudeProvider.binary()`: `_binary_override` if set → else `KOAN_CLAUDE_CLI_PATH` → else `"claude"`. Every provider's `binary()` honors the override so `flavor:path` works uniformly. Relative paths root at `KOAN_ROOT` (not CWD — the agent runs from `KOAN_ROOT/koan`); bare names are never re-rooted. |
+| `build_command(..., project_context=True)` / `build_project_context_args` / `build_full_command(..., project_context=…)` | When `project_context=False`, the provider must suppress **project-scope** tooling loaded from cwd (Claude: `--setting-sources user`). Default `True` preserves mission/project CLAUDE.md / skills. Other providers may no-op. Callers that run with `cwd=KOAN_ROOT` (chat, contemplative, rituals, outbox formatting) **must** pass `False`. Do not implement isolation by mutating the worktree (`skip-worktree` / quarantine) on this path. |
 
 ## Invariants
 
+- **KOAN_ROOT runtime sessions must not load contributor project tooling.**
+  Chat, contemplative, rituals, and outbox formatting run with `cwd=KOAN_ROOT`
+  on a deployed clone. They must pass `project_context=False` so Claude does
+  not auto-load root `CLAUDE.md` / `AGENTS.md` / `.claude/skills` (e.g. `brain`,
+  `speckit-*`) into operator-facing output. Mission sessions keep the default
+  (`True`) so `workspace/` project guidance still loads. Isolation is at the
+  **CLI flag boundary**, not by relocating tracked files on disk.
 - **One invocation lock per uid.** Provider auth state is per-user, so the subprocess
   lock lives under `koan_tmp_dir()` (per-uid), not a fixed `/tmp` path.
 - **Provider resolution has a fixed precedence** (env → config → default) for the

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -48,14 +48,16 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 | `effort:` config / `config.get_effort(mode, mission_type)` / `CLIProvider.build_effort_args()` | Reasoning-effort control for the Claude `--effort` flag (low/medium/high/max). `effort:` mapping keys are **mission types** (the `session_tracker.classify_mission_type` taxonomy: plan/review/implement/audit/…), not budget modes. Resolution in `get_effort()`: `effort.<mission_type>` → `effort.<autonomous_mode>` (legacy) → `_DEFAULT_EFFORT_MAP[mode]` (the dynamic default). The dynamic default — review→low, deep→high, else none — is preserved verbatim when `effort:` is absent; a per-type pin only layers on top. `build_mission_command()` classifies the mission type and passes it through, so a pin only reaches `get_effort()` for missions that run through the main agent loop — **not** for skill-dispatched commands (`/review`, `/plan`, …), which bypass `build_mission_command()` (see reach caveat below); `get_effort_for_mode()` is the type-unaware wrapper for callers outside the mission build path. `extended thinking` short-circuits effort to `max`. |
 | Provider resolution | Order: `KOAN_CLI_PROVIDER` env (fallback `CLI_PROVIDER`) → `projects.yaml`/`config.yaml` → default. Centralized in `utils.get_cli_provider_env()`. This resolves the GLOBAL provider; `cli.<role>` layers per-role selection on top via `get_provider_for_role`. |
 | `CLIProvider(binary_path="")` / `ClaudeProvider.binary()` | The base class takes an optional per-instance `binary_path` override (the replacement for the removed review ContextVar); `_resolve_binary_path()` is the shared resolver (absolute → as-is / relative → `normpath(join(KOAN_ROOT, …))` / bare name → PATH lookup). `ClaudeProvider.binary()`: `_binary_override` if set → else `KOAN_CLAUDE_CLI_PATH` → else `"claude"`. Every provider's `binary()` honors the override so `flavor:path` works uniformly. Relative paths root at `KOAN_ROOT` (not CWD — the agent runs from `KOAN_ROOT/koan`); bare names are never re-rooted. |
-| `build_command(..., project_context=True)` / `build_project_context_args` / `build_full_command(..., project_context=…)` | When `project_context=False`, the provider must suppress **project-scope** tooling loaded from cwd (Claude: `--setting-sources user`). Default `True` preserves mission/project CLAUDE.md / skills. Other providers may no-op. Callers that run with `cwd=KOAN_ROOT` (chat, contemplative, rituals, outbox formatting) **must** pass `False`. Do not implement isolation by mutating the worktree (`skip-worktree` / quarantine) on this path. |
+| `build_command(..., project_context=True)` / `build_project_context_args` / `build_full_command(..., project_context=…)` | When `project_context=False`, the provider must suppress **project-scope** tooling loaded from cwd (Claude: `--setting-sources user`). Default `True` preserves mission/project CLAUDE.md / skills. Other providers may no-op. Callers that run with `cwd=KOAN_ROOT` (Telegram chat, **dashboard web chat**, contemplative, rituals, outbox formatting) **must** pass `False`. Do not implement isolation by mutating the worktree (`skip-worktree` / quarantine) on this path. |
 
 ## Invariants
 
 - **KOAN_ROOT runtime sessions must not load contributor project tooling.**
-  Chat, contemplative, rituals, and outbox formatting run with `cwd=KOAN_ROOT`
-  on a deployed clone. They must pass `project_context=False` so Claude does
-  not auto-load root `CLAUDE.md` / `AGENTS.md` / `.claude/skills` (e.g. `brain`,
+  Telegram chat, dashboard web chat, contemplative, rituals, and outbox
+  formatting run with `cwd=KOAN_ROOT` on a deployed clone (dashboard may
+  also target a selected project path — only the KOAN_ROOT case requires
+  `False`). They must pass `project_context=False` so Claude does not
+  auto-load root `CLAUDE.md` / `AGENTS.md` / `.claude/skills` (e.g. `brain`,
   `speckit-*`) into operator-facing output. Mission sessions keep the default
   (`True`) so `workspace/` project guidance still loads. Isolation is at the
   **CLI flag boundary**, not by relocating tracked files on disk.

--- a/wiki/index.md
+++ b/wiki/index.md
@@ -18,7 +18,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 - [`architecture/memory.md`](docs/architecture/memory.md) — Details Koan's Markdown+JSONL memory store, the SQLite FTS5 secondary index (confidence-weighted BM25 ranking, dual-write, fallback), entry schema, read/write paths, and compaction.
 - [`architecture/mission-lifecycle.md`](docs/architecture/mission-lifecycle.md) — Explains the mission queue format and lifecycle (Pending/In Progress/Done/Failed), org-wide missions, branch prep, direct skill dispatch, scheduling, recovery/retries, and missions.md integrity/size-bound safeguards.
 - [`architecture/overview.md`](docs/architecture/overview.md) — High-level architecture summary of Koan's two main processes (bridge and agent loop), major subsystems, and the human-decides safety model.
-- [`architecture/providers.md`](docs/architecture/providers.md) — Documents the CLI provider abstraction layer, provider responsibilities, resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Haze, Grok, Ollama-launch).
+- [`architecture/providers.md`](docs/architecture/providers.md) — Documents the CLI provider abstraction layer, provider responsibilities (including KOAN_ROOT `project_context` isolation), resolution flow, and the current supported providers (Claude, Cline, Codex, Copilot, Haze, Grok, Ollama-launch).
 - [`architecture/shared-state.md`](docs/architecture/shared-state.md) — Explains Koan's file-based (no-database) shared state under instance/, locking/atomic-write conventions, per-uid temp/scratch directories, and configuration sources.
 - [`architecture/skills-system.md`](docs/architecture/skills-system.md) — Describes the skill definition format, dispatch paths, the private implementation review gate (challenge loop, cost controls, dedup), and the documentation contract for skill changes.
 
@@ -59,7 +59,7 @@ This wiki spans two content roots — `docs/` (operational "how to use", see [`d
 
 ### Providers
 - [`providers/claude-cli-commands-official.md`](docs/providers/claude-cli-commands-official.md) — Official upstream Claude Code CLI reference listing all commands and flags.
-- [`providers/claude.md`](docs/providers/claude.md) — Setup and configuration guide for Kōan's default Claude Code CLI provider, including models, tools, per-role CLI config, MCP, and devcontainer mode.
+- [`providers/claude.md`](docs/providers/claude.md) — Setup and configuration guide for Kōan's default Claude Code CLI provider, including models, tools, per-role CLI config, MCP, KOAN_ROOT project-context isolation (`--setting-sources user`), and devcontainer mode.
 - [`providers/cline.md`](docs/providers/cline.md) — Setup and feature-mapping guide for using Cline CLI as Kōan's underlying multi-backend AI provider.
 - [`providers/codex.md`](docs/providers/codex.md) — Setup and behavior guide for using OpenAI's Codex CLI as Kōan's provider, including quota/usage handling and troubleshooting.
 - [`providers/copilot.md`](docs/providers/copilot.md) — Setup guide and feature/tool-mapping differences for using GitHub Copilot CLI as Kōan's provider.


### PR DESCRIPTION
## Summary

Stops contributor tooling (`CLAUDE.md`, `.claude/skills` like `brain` / `speckit-*`) from leaking into **operator-facing** Claude sessions that run with `cwd=KOAN_ROOT` (chat, contemplative, rituals, outbox formatting).

**How:** at the CLI boundary only — `project_context=False` → Claude `--setting-sources user`. **No** worktree mutation, **no** `skip-worktree`, **no** quarantine.

Fixes #2379  

Related / alternative approach: #2384 (quarantine + skip-worktree) — **kept open** for optional physical-absence / install-time packaging later. This PR is the simpler production fix discussed on that PR.

## Why not quarantine (#2384)

| Need | Quarantine + skip-worktree | This PR (`--setting-sources user`) |
|---|---|---|
| Skills not loaded in prod sessions | Yes | Yes |
| Git stays clean | By lying to the index | No mutation |
| Self-update re-isolation | Required | Not needed |
| Contributor clone still has `brain` / `speckit` | Needs restore | Unchanged |
| Blast radius | Lifecycle module + startup/update wiring | Provider hook + 4 call sites |

## What / why / how

### What
- New `project_context: bool = True` on `CLIProvider.build_command` / `build_full_command`
- Claude: `False` → `--setting-sources user` (omit project + local sources)
- Other providers: accept the flag as a **no-op** for v1 (Codex AGENTS.md isolation deferred — documented)
- Wire `project_context=False` at: `awake` chat, `contemplative_runner`, `rituals`, `format_outbox`
- Mission / project sessions unchanged (`True` default)

### Why
Deployed Koan **is** a git clone of the koan repo. Claude Code auto-loads project scope from cwd. Chat at `KOAN_ROOT` was absorbing contributor `CLAUDE.md` and advising operators to run `/brain sync` — a command they do not have.

### How (workspace missions still work)
Isolation is **session-flag based**, not path-auto. Missions use `cwd=workspace/<project>` (normally a separate git root), so Claude loads **that** project's docs, not KOAN_ROOT's contributor tooling. Edge case: a non-git folder nested under the KOAN_ROOT tree can still walk up to the instance clone — projects should remain real git checkouts (already typical).

## Architectural change

- [x] **This PR changes a durable design contract** (`specs/components/providers.md`)
  - Contract updated with conforming code: `project_context` / KOAN_ROOT isolation invariant
  - Why necessary: session isolation is a provider contract callers must honor
  - What breaks if ignored: contributor skills leak back into operator chat

## Test plan

- [x] `test_cli_provider` project_context unit tests (Claude flag + default parity + Codex no-op)
- [x] Call-site tests: chat, contemplative, rituals, outbox assert `--setting-sources user`
- [x] Related provider suites: **691 passed**
- [ ] Optional live: chat a docs question on a deploy with root `CLAUDE.md` present; expect no `/brain` advice

## Commits

1. Provider API + Claude mapping  
2. Wire four KOAN_ROOT call sites  
3. Docs + durable contract  