### PR TITLE
fix(logs): collapse system: task_progress heartbeat to a tick

### DIFF
--- a/docs/operations/log-formatting.md
+++ b/docs/operations/log-formatting.md
@@ -20,7 +20,7 @@ presentational — the log **files** and the `[cli]` grammar emitted by
 
 | Raw `[cli]` line                    | Shown as        |
 |-------------------------------------|-----------------|
-| `assistant — thinking`, `system: thinking_tokens` | dim `•`, one per event, **accumulated** into a growing run (`••••`) — rewritten in place on a TTY, emitted as one `•×N` line when piped |
+| `assistant — thinking`, `system: thinking_tokens`, `system: task_progress` | dim `•`, one per event, **accumulated** into a growing run (`••••`) — rewritten in place on a TTY, emitted as one `•×N` line when piped |
 | `assistant — text: <preview>`       | `🧠 <preview>` (preview skips leading code fences / bare brackets, e.g. ```` ```json ```` → first real line) |
 | `assistant — tool_use: Bash: <cmd>` | `💻 Bash <cmd…>` (per-tool icon + dim, first-line input preview: command / file path / pattern / url, truncated with `…`; `🔧` default) |
 | `tool_result …`                     | *(suppressed — adds no signal)* |

--- a/koan/app/log_fmt.py
+++ b/koan/app/log_fmt.py
@@ -41,6 +41,12 @@ _TICK_BODIES = frozenset({
     "assistant — (empty)", "assistant — (hidden)", "user turn",
 })
 
+# system-event subtypes that are pure liveness heartbeats carrying no display
+# signal — collapse to a thinking tick instead of surfacing verbatim. The
+# provider keeps emitting the raw ``[cli] system: …`` line (run.py's liveness
+# watchdog needs the heartbeat); only the display formatter suppresses it.
+_TICK_SYSTEM_PREFIXES = ("system: thinking", "system: task_progress")
+
 # Split ", "-joined assistant parts ONLY before a known part keyword, so a
 # text preview that itself contains ", " is not broken mid-sentence.
 _PART_SEP = re.compile(r", (?=tool_use: |text(?:: |$)|thinking$)")
@@ -110,7 +116,7 @@ def classify_cli(body: str) -> list[dict]:
             "is_tick": is_tick,
         }
 
-    if body in _TICK_BODIES or body.startswith("system: thinking"):
+    if body in _TICK_BODIES or body.startswith(_TICK_SYSTEM_PREFIXES):
         return [_row("thinking", label="thinking", is_tick=True)]
 
     if body.startswith("assistant — "):
@@ -182,7 +188,7 @@ def render_cli(body: str, pal: "_Palette") -> Tuple[Optional[str], bool]:
     """
     tick = pal.dim(_TICK)
 
-    if body in _TICK_BODIES or body.startswith("system: thinking"):
+    if body in _TICK_BODIES or body.startswith(_TICK_SYSTEM_PREFIXES):
         return tick, True
 
     if body.startswith("assistant — "):

--- a/koan/tests/test_log_fmt.py
+++ b/koan/tests/test_log_fmt.py
@@ -26,6 +26,25 @@ def test_system_thinking_tokens_is_tick():
     assert is_tick("system: thinking_tokens") is True
 
 
+def test_system_task_progress_is_tick():
+    assert r("system: task_progress") == "•"
+    assert is_tick("system: task_progress") is True
+
+
+def test_run_collapses_task_progress_into_dot_run():
+    # Interleaved as it appears live: a real tool line, then heartbeats.
+    src = io.StringIO(
+        "[cli] assistant — tool_use: Grep: achievement|journey\n"
+        "[cli] system: task_progress\n"
+        "[cli] system: task_progress\n"
+    )
+    out = io.StringIO()  # not a TTY → buffered dot-run path
+    run(src, out)
+    result = out.getvalue()
+    assert "system: task_progress" not in result   # never verbatim
+    assert result == "🔎 Grep achievement|journey\n••\n"
+
+
 def test_text_preview_gets_brain_glyph():
     assert r("assistant — text: Now run.py — inject PYTEST_ADDOPTS") == \
         "🧠 Now run.py — inject PYTEST_ADDOPTS"
@@ -151,6 +170,13 @@ from app.log_fmt import classify_cli
 
 def test_classify_thinking_is_tick():
     rows = classify_cli("assistant — thinking")
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "thinking"
+    assert rows[0]["is_tick"] is True
+
+
+def test_classify_task_progress_is_tick():
+    rows = classify_cli("system: task_progress")
     assert len(rows) == 1
     assert rows[0]["kind"] == "thinking"
     assert rows[0]["is_tick"] is True


### PR DESCRIPTION
## Summary

`make logs` and the dashboard `/progress` timeline leaked a raw `system: task_progress` liveness heartbeat dozens of times per mission because the display formatter had no rule for that subtype and fell through to its verbatim escape hatch. This collapses it to the same dim `•` thinking tick as `system: thinking_tokens`, in both display surfaces, keeping them in sync.

Closes https://github.com/Anantys-oss/koan/issues/2432

## Changes

- `log_fmt.py`: add shared `_TICK_SYSTEM_PREFIXES` tuple; use it in `render_cli` (make logs) and `classify_cli` (dashboard timeline) so `system: task_progress` ticks instead of printing verbatim. Provider still emits the raw line so run.py's liveness watchdog keeps its heartbeat.
- `test_log_fmt.py`: cover `render_cli`, `classify_cli`, and the streaming dot-accumulation path.
- `docs/operations/log-formatting.md`: add `system: task_progress` to the accumulating-dots legend row.

## Test plan

- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_log_fmt.py` — 28 passed
- `make lint` — clean

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=6a044fdc)_
