### PR TITLE
feat(agent-loop): degraded no-mission mode when CLI binary missing at startup

### DIFF
--- a/docs/architecture/daemon.md
+++ b/docs/architecture/daemon.md
@@ -4,7 +4,7 @@ title: "Daemon Runtime"
 description: "Describes how the Koan daemon is assembled: startup/process management, the bridge's chat/bg worker lanes, the agent loop's modular pieces, runtime modes, parallel sessions, and the bounded-memory model for CLI stdout capture."
 tags: [architecture]
 created: 2026-05-28
-updated: 2026-06-26
+updated: 2026-07-17
 ---
 
 # Daemon Runtime
@@ -137,6 +137,14 @@ Consequences and safeguards:
 - Pause mode uses `.koan-pause` state and can be time-bounded.
 - Focus mode narrows work to a project or focus area.
 - Passive mode keeps Koan alive but blocks execution.
+- CLI-unavailable degraded mode: if the primary provider binary is missing from
+  `PATH` at startup, the loop stays alive (chat and the GitHub/Jira inbox still
+  work) but starts **no** missions — running one would crash the provider
+  subprocess. Detected once at startup (`startup_manager.check_cli_binary` →
+  `cli_health.check_primary_cli`), advertised to the operator with one ⚠️ warning,
+  and held **in memory** (`app.cli_health`) with no signal file, so it clears only
+  on restart. Fix `PATH` / install the CLI, then `make stop && make start`. See
+  [troubleshooting](../operations/troubleshooting.md).
 - Restart signaling uses a file so the bridge can ask the runner to restart.
 - The stagnation monitor watches provider output, kills stuck subprocess groups,
   and requeues missions up to the configured retry limit.

--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 description: "Catalogs common operational issues (agent loop, git/worktrees, memory, bridge, GitHub, CLI provider, parallel sessions, config) and their fixes."
 tags: [operations]
 created: 2026-06-04
-updated: 2026-07-13
+updated: 2026-07-17
 ---
 
 # Troubleshooting
@@ -145,6 +145,29 @@ Messages queue in `instance/outbox.md`. The bridge flushes this to Telegram on e
 1. Verify the CLI is installed: `which claude` or `claude --version`.
 2. Check `KOAN_CLI_PROVIDER` in `.env` (default: `claude`).
 3. See [Provider Setup](../providers/) for provider-specific configuration.
+
+### CLI binary missing from PATH — "missions blocked" degraded mode
+
+If the daemon started without the provider binary on its `PATH` (a common cause is
+launching from a service manager or cron with a minimal environment), Kōan enters a
+**degraded, no-mission mode**: it stays alive so chat and the GitHub/Jira inbox keep
+working, but it starts **no** missions (running one would crash the provider). You'll
+see a one-time ⚠️ warning on Telegram/Slack at startup, and `/status` shows
+`⚠️ CLI unavailable — '<binary>' not on PATH; missions blocked`.
+
+This state is held **in memory** and clears **only on restart** — fixing `PATH` while
+the daemon runs is not picked up automatically (the `PATH` a long-lived process
+inherited cannot be changed from outside). To recover:
+
+1. Run `/doctor --full` (or `which claude`) to confirm which binary is missing.
+2. Fix the environment so the binary resolves — ensure the CLI is installed and its
+   directory is on the `PATH` the daemon runs with. For service-manager launches, see
+   [systemd PATH preservation](../setup/systemd-user.md) and
+   [launchd](../setup/launchd.md).
+3. Restart the stack: `make stop && make start`.
+
+`/doctor` resolves the *actual* configured provider binary (Claude, Codex, Grok, Haze,
+Cline, per-role `cli:` overrides, and `KOAN_CLAUDE_CLI_PATH`), not just `claude`.
 
 ### Provider quota / rate limit errors
 

--- a/koan/app/CLAUDE.md
+++ b/koan/app/CLAUDE.md
@@ -60,6 +60,7 @@ Communication between processes happens through shared files in `instance/` with
 - **`restart_manager.py`** — File-based restart signaling between bridge and run loop (`.koan-restart`)
 - **`focus_manager.py`** — Focus mode management (`.koan-focus` JSON); skips contemplative sessions when active
 - **`passive_manager.py`** — Passive mode management (`.koan-passive` JSON); read-only mode that blocks all execution while keeping loop alive
+- **`cli_health.py`** — Startup CLI-binary-on-PATH probe (`check_primary_cli()` wrapping `CLIProvider.is_available()`) + in-memory degraded (no-mission) state and warn throttle. Set by `startup_manager.check_cli_binary()`, gated in `iteration_manager.plan_iteration` (`cli_unavailable_wait`), surfaced by `/status` and `/doctor`. Restart clears it (no signal file).
 
 **CLI provider abstraction** (`koan/app/provider/`):
 

--- a/koan/app/cli_health.py
+++ b/koan/app/cli_health.py
@@ -19,6 +19,7 @@ accurate than a stale flag).
 
 from __future__ import annotations
 
+import sys
 import time
 from typing import NamedTuple, Optional
 
@@ -52,7 +53,8 @@ def check_primary_cli() -> CliCheck:
             binary=provider.binary() or "",
             provider_name=provider.name or "",
         )
-    except Exception:
+    except Exception as e:
+        print(f"[cli_health] primary CLI probe failed: {e}", file=sys.stderr)
         return CliCheck(available=True, binary="", provider_name="")
 
 

--- a/koan/app/cli_health.py
+++ b/koan/app/cli_health.py
@@ -1,0 +1,112 @@
+"""CLI provider binary availability check + in-memory degraded state.
+
+At startup ``startup_manager.run_startup`` probes whether the configured CLI
+provider's binary is findable on PATH (``CLIProvider.is_available()``). When it
+is missing the agent loop must NOT start any missions — a mission would
+otherwise crash the provider subprocess with ``FileNotFoundError`` — but the
+loop and bridge stay alive so chat/inbox keep working.
+
+The degraded flag is held **in memory** for the process lifetime: the PATH must
+be fixed properly and the daemon restarted. There is deliberately no
+auto-recovery and no on-disk signal file (see the plan / decision: "restart to
+clear").
+
+``/status`` and ``/doctor`` run in the separate bridge process and cannot read
+this module's in-memory flag, so they re-probe via :func:`check_primary_cli` —
+the bridge shares PATH with the loop, so the result matches (and is more
+accurate than a stale flag).
+"""
+
+from __future__ import annotations
+
+import time
+from typing import NamedTuple, Optional
+
+
+class CliCheck(NamedTuple):
+    """Result of a primary-CLI availability probe."""
+
+    available: bool
+    binary: str
+    provider_name: str
+
+
+def check_primary_cli() -> CliCheck:
+    """Probe whether the primary (global) CLI provider binary is on PATH.
+
+    Pure probe — no side effects, no degraded-state mutation. Safe to call from
+    any process. Delegates to the provider abstraction so absolute /
+    bare-PATH / ``KOAN_ROOT``-relative paths and the ``KOAN_CLAUDE_CLI_PATH`` /
+    ``cli.<role>`` overrides are all honored (``CLIProvider.is_available`` is
+    ``shutil.which(self.binary())``).
+
+    On any provider-resolution error the probe reports ``available=True`` so an
+    unrelated failure never false-positives a degraded state.
+    """
+    try:
+        from app.provider import get_provider
+
+        provider = get_provider()
+        return CliCheck(
+            available=bool(provider.is_available()),
+            binary=provider.binary() or "",
+            provider_name=provider.name or "",
+        )
+    except Exception:
+        return CliCheck(available=True, binary="", provider_name="")
+
+
+def warning_message(binary: str, provider_name: str) -> str:
+    """The operator-facing warning shown at startup and (throttled) in the loop."""
+    b = binary or "(unknown)"
+    p = provider_name or "(default)"
+    return (
+        f"⚠️ CLI binary '{b}' (provider '{p}') not found on PATH — "
+        f"Kōan will keep chat & inbox running but will NOT start missions. "
+        f"Fix PATH / install the CLI, then restart: make stop && make start"
+    )
+
+
+# ---------------------------------------------------------------------------
+# In-memory degraded state (run.py loop process only)
+# ---------------------------------------------------------------------------
+
+_unavailable_info: Optional[dict] = None
+_last_warned_at: float = 0.0
+
+# Re-warn from the loop at most once per this window; startup sends the first one.
+WARN_COOLDOWN_S = 6 * 3600
+
+
+def set_unavailable(binary: str, provider_name: str) -> None:
+    """Mark the primary CLI as unavailable for the remainder of this process."""
+    global _unavailable_info
+    _unavailable_info = {"binary": binary, "provider": provider_name}
+
+
+def is_unavailable() -> bool:
+    """True when startup detected a missing primary CLI binary."""
+    return _unavailable_info is not None
+
+
+def get_unavailable_info() -> Optional[dict]:
+    """Return ``{"binary", "provider"}`` when degraded, else ``None``."""
+    return dict(_unavailable_info) if _unavailable_info is not None else None
+
+
+def clear() -> None:
+    """Reset degraded state + warn throttle. Primarily a test helper."""
+    global _unavailable_info, _last_warned_at
+    _unavailable_info = None
+    _last_warned_at = 0.0
+
+
+def should_warn(cooldown_s: float = WARN_COOLDOWN_S) -> bool:
+    """True when at least ``cooldown_s`` has elapsed since the last warning."""
+    return (time.time() - _last_warned_at) >= cooldown_s
+
+
+def mark_warned() -> None:
+    """Stamp the warn throttle (called right after sending a warning)."""
+    global _last_warned_at
+    _last_warned_at = time.time()

--- a/koan/app/iteration_manager.py
+++ b/koan/app/iteration_manager.py
@@ -1387,7 +1387,7 @@ def plan_iteration(
     Returns:
         dict with iteration plan:
         {
-            "action": "mission" | "autonomous" | "contemplative" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "error",
+            "action": "mission" | "autonomous" | "contemplative" | "cli_unavailable_wait" | "passive_wait" | "focus_wait" | "schedule_wait" | "exploration_wait" | "pr_limit_wait" | "wait_pause" | "error",
             "project_name": str,
             "project_path": str,
             "mission_title": str (empty for autonomous/contemplative),
@@ -1527,6 +1527,32 @@ def plan_iteration(
             f"Mission picked: [{mission_project}] {mission_title[:80]}")
     else:
         _log_iteration("koan", "No pending mission — entering autonomous mode")
+
+    # Step 4a2: CLI-unavailable gate — block all execution.
+    # The primary provider binary was missing at startup (app.cli_health, set
+    # by startup_manager.check_cli_binary). Running a mission would crash the
+    # provider subprocess with FileNotFoundError, so block ALL execution;
+    # missions stay Pending and the inbox is still polled. Must check before
+    # start_mission(). In-memory only — restart to clear.
+    from app import cli_health
+    if cli_health.is_unavailable():
+        _log_iteration("koan",
+            "CLI binary unavailable — skipping execution (missions stay pending)")
+        return _make_result(
+            action="cli_unavailable_wait",
+            project_name=mission_project or (projects[0][0] if projects else "default"),
+            project_path="",
+            mission_title="",
+            autonomous_mode=autonomous_mode,
+            focus_area="CLI unavailable: missions blocked",
+            available_pct=available_pct,
+            decision_reason="CLI binary not on PATH — missions blocked (fix PATH & restart)",
+            display_lines=display_lines,
+            recurring_injected=recurring_injected,
+            focus_remaining=None,
+            schedule_mode=schedule_state.mode if schedule_state else "normal",
+            tracker_error=tracker_error,
+        )
 
     # Step 4b: Passive mode gate — block all execution
     # Missions stay Pending, no autonomous work. Must check before start_mission().

--- a/koan/app/mission_executor.py
+++ b/koan/app/mission_executor.py
@@ -850,7 +850,8 @@ def _run_iteration(
 
     # Display usage — skip for idle-wait iterations (nothing to spend on)
     _IDLE_ACTIONS = {"exploration_wait", "passive_wait", "focus_wait",
-                     "schedule_wait", "pr_limit_wait", "branch_saturated_wait"}
+                     "schedule_wait", "pr_limit_wait", "branch_saturated_wait",
+                     "cli_unavailable_wait"}
     if plan["action"] not in _IDLE_ACTIONS:
         log("quota", "Usage (token estimate — may differ from real API quota):")
         if plan["display_lines"]:
@@ -916,6 +917,10 @@ def _run_iteration(
             p.get("decision_reason") or "Project branch-saturated — waiting for reviews/merges",
             f"Branch-saturated — waiting ({time.strftime('%H:%M')})",
         ),
+        "cli_unavailable_wait": lambda p: (
+            p.get("decision_reason") or "CLI binary not on PATH — missions blocked (fix PATH & restart)",
+            "⚠️ CLI unavailable — missions blocked (fix PATH & restart)",
+        ),
     }
     if action in _IDLE_WAIT_CONFIG:
         global _last_idle_msg
@@ -924,6 +929,18 @@ def _run_iteration(
             log("koan", log_msg)
             _last_idle_msg = log_msg
         _run.set_status(koan_root, status_msg)
+        # Remind the operator (throttled) that missions can't start. Startup
+        # already sent the first warning and stamped the throttle, so this fires
+        # at most once per cooldown — never per iteration.
+        if action == "cli_unavailable_wait":
+            from app import cli_health
+            if cli_health.should_warn():
+                info = cli_health.get_unavailable_info() or {}
+                _run._notify_raw(
+                    instance,
+                    cli_health.warning_message(info.get("binary", ""), info.get("provider", "")),
+                )
+                cli_health.mark_warned()
         idle_interval = _run._resolve_idle_wait_interval(
             interval, github_enabled, jira_enabled,
         )
@@ -933,7 +950,11 @@ def _run_iteration(
         # blocked state. Wait the full interval for PR count to change.
         # passive_wait: passive mode blocks all execution, so waking on
         # a pending mission tight-loops (logs flood in make logs).
-        wake_on_mission = action not in ("branch_saturated_wait", "passive_wait")
+        # cli_unavailable_wait: same — missions are blocked until restart, so
+        # waking on a queued mission would just tight-loop the gate.
+        wake_on_mission = action not in (
+            "branch_saturated_wait", "passive_wait", "cli_unavailable_wait",
+        )
         with _run.protected_phase(status_msg):
             wake = interruptible_sleep(
                 idle_interval, koan_root, instance,

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -1394,15 +1394,25 @@ def run_command_streaming(
             text_delta_parts.clear()
 
     try:
-        proc, cleanup = popen_cli(
-            cmd,
-            provider=provider,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-            encoding="utf-8",
-            errors="replace",
-            cwd=project_path,
-        )
+        try:
+            proc, cleanup = popen_cli(
+                cmd,
+                provider=provider,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                encoding="utf-8",
+                errors="replace",
+                cwd=project_path,
+            )
+        except FileNotFoundError as e:
+            executable = e.filename or str(cmd[0])
+            if executable != str(cmd[0]):
+                raise
+            raise RuntimeError(
+                f"CLI executable not found: {executable!r} "
+                f"(provider {provider.name!r}). Ensure it is on PATH or "
+                f"configure cli.{model_key}: {provider.name}:/absolute/path."
+            ) from e
         # Every print() in this loop is the load-bearing watchdog signal —
         # run.py's skill-runner liveness watchdog (600s) resets on each line
         # emitted to stdout. Do not silence these prints; doing so reintroduces

--- a/koan/app/provider/__init__.py
+++ b/koan/app/provider/__init__.py
@@ -1306,6 +1306,25 @@ def _persist_stream_usage_snapshot(snapshot: Optional[Dict[str, Any]]) -> None:
         print(f"[provider] WARNING: stream usage sidecar write failed: {exc}", file=sys.stderr)
 
 
+def missing_binary_message(err: "FileNotFoundError", cmd, provider_name: str, model_key: str) -> str:
+    """Actionable message for a provider launch that failed with FileNotFoundError.
+
+    Only fires when the missing executable IS the provider binary (``cmd[0]``);
+    a FileNotFoundError for some other file the CLI tried to open is re-raised
+    unchanged so it is never masked. Shared by ``run_command_streaming`` (skill
+    path, raises RuntimeError) and ``run.run_claude_task`` (mission path,
+    returns exit 127 + writes this to stderr).
+    """
+    executable = err.filename or str(cmd[0])
+    if executable != str(cmd[0]):
+        raise err
+    return (
+        f"CLI executable not found: {executable!r} "
+        f"(provider {provider_name!r}). Ensure it is on PATH or "
+        f"configure cli.{model_key}: {provider_name}:/absolute/path."
+    )
+
+
 def run_command_streaming(
     prompt: str,
     project_path: str,
@@ -1405,13 +1424,8 @@ def run_command_streaming(
                 cwd=project_path,
             )
         except FileNotFoundError as e:
-            executable = e.filename or str(cmd[0])
-            if executable != str(cmd[0]):
-                raise
             raise RuntimeError(
-                f"CLI executable not found: {executable!r} "
-                f"(provider {provider.name!r}). Ensure it is on PATH or "
-                f"configure cli.{model_key}: {provider.name}:/absolute/path."
+                missing_binary_message(e, cmd, provider.name, model_key)
             ) from e
         # Every print() in this loop is the load-bearing watchdog signal —
         # run.py's skill-runner liveness watchdog (600s) resets on each line

--- a/koan/app/run.py
+++ b/koan/app/run.py
@@ -389,15 +389,31 @@ def run_claude_task(
                     child_env.get("PYTEST_ADDOPTS", ""), mission_tmp
                 )
                 popen_kwargs["env"] = child_env
-            proc, cleanup = popen_cli(
-                cmd,
-                provider=provider,
-                stdout=out_f,
-                stderr=err_f,
-                cwd=cwd,
-                start_new_session=True,
-                **popen_kwargs,
-            )
+            try:
+                proc, cleanup = popen_cli(
+                    cmd,
+                    provider=provider,
+                    stdout=out_f,
+                    stderr=err_f,
+                    cwd=cwd,
+                    start_new_session=True,
+                    **popen_kwargs,
+                )
+            except FileNotFoundError as e:
+                # The provider binary vanished mid-session (the startup check +
+                # planner gate handle the common case). Fail this mission
+                # cleanly with an actionable message rather than a raw
+                # FileNotFoundError: write it to stderr and return exit 127 so
+                # the normal failure/fallback path handles it. A different
+                # missing file is re-raised unchanged by missing_binary_message.
+                from app.provider import missing_binary_message
+                msg = missing_binary_message(e, cmd, _provider_name, "mission")
+                log("error", msg)
+                with contextlib.suppress(Exception):
+                    err_f.write(msg + "\n")
+                    err_f.flush()
+                exit_code = 127
+                return exit_code
             _sig.claude_proc = proc
 
             # Record the live provider PID so status consumers can report

--- a/koan/app/startup_manager.py
+++ b/koan/app/startup_manager.py
@@ -699,6 +699,33 @@ def _safe_run(step_name: str, fn, *args, **kwargs):
         return None
 
 
+def check_cli_binary() -> None:
+    """Enter degraded (no-mission) mode if the primary CLI binary is missing.
+
+    Runs at startup. On a missing binary this logs, sends ONE operator warning
+    (⚠️, routed to whichever messaging backend is configured), and sets the
+    in-memory degraded flag so the agent loop blocks mission execution while
+    chat/inbox keep working. It deliberately does NOT hard-stop: the loop and
+    bridge must stay alive. The PATH must be fixed and the daemon restarted to
+    clear the state (see ``app.cli_health``).
+    """
+    from app import cli_health
+
+    check = cli_health.check_primary_cli()
+    if check.available:
+        return
+
+    msg = cli_health.warning_message(check.binary, check.provider_name)
+    log("error", f"CLI binary check failed: {msg}")
+    try:
+        from app.notify import send_telegram
+        send_telegram(msg)
+    except Exception as exc:
+        log("warn", f"Failed to send CLI-binary warning: {exc}")
+    cli_health.set_unavailable(check.binary, check.provider_name)
+    cli_health.mark_warned()
+
+
 # ---------------------------------------------------------------------------
 # Main orchestrator
 # ---------------------------------------------------------------------------
@@ -749,6 +776,10 @@ def run_startup(koan_root: str, instance: str, projects: list):
             raise
 
         _safe_run("Config validation", validate_config, koan_root)
+        # Verify the CLI provider binary is on PATH before any mission runs.
+        # Missing → degraded (no-mission) mode + one operator warning; never
+        # a hard stop, so chat/inbox keep working.
+        _safe_run("CLI binary check", check_cli_binary)
         _safe_run("Crash recovery", recover_crashed_missions, instance)
         _safe_run("Running-indicator reconcile", reconcile_running_indicators, instance)
         _safe_run("Projects migration", run_migrations, koan_root)

--- a/koan/diagnostics/connectivity_check.py
+++ b/koan/diagnostics/connectivity_check.py
@@ -104,27 +104,28 @@ def run(koan_root: str, instance_dir: str, full: bool = False) -> List[CheckResu
             message=f"GitHub CLI check failed: {e}",
         ))
 
-    # --- Claude CLI ---
+    # --- CLI provider binary ---
+    # Probe the real provider binary via the provider abstraction (covers all
+    # providers, per-role cli.<role> paths, and KOAN_CLAUDE_CLI_PATH), not a
+    # hardcoded provider→binary map.
     try:
-        from app.utils import get_cli_provider_env
-        provider = get_cli_provider_env()
-        cli_binary = "claude"
-        if provider == "copilot":
-            cli_binary = "gh"
+        from app.cli_health import check_primary_cli
+        cli = check_primary_cli()
+        provider = cli.provider_name or "default"
+        cli_binary = cli.binary or "claude"
 
-        import shutil
-        if shutil.which(cli_binary):
+        if cli.available:
             results.append(CheckResult(
                 name="cli_provider",
                 severity="ok",
-                message=f"CLI provider '{provider}' binary found",
+                message=f"CLI provider '{provider}' binary found: {cli_binary}",
             ))
         else:
             results.append(CheckResult(
                 name="cli_provider",
                 severity="error",
                 message=f"CLI provider '{provider}' binary not found: {cli_binary}",
-                hint=f"Install {cli_binary}",
+                hint=f"Install {cli_binary} / fix PATH, then restart",
             ))
     except Exception as e:
         results.append(CheckResult(

--- a/koan/diagnostics/environment_check.py
+++ b/koan/diagnostics/environment_check.py
@@ -32,15 +32,15 @@ def run(koan_root: str, instance_dir: str) -> List[CheckResult]:
         ))
 
     # --- Required binaries ---
-    # Determine which CLI binary to check based on configured provider
+    # Resolve the actual provider binary via the provider abstraction so ALL
+    # providers (codex/grok/haze/cline/…), per-role cli.<role> paths, and the
+    # KOAN_CLAUDE_CLI_PATH override are covered — not a hardcoded partial map.
     cli_binary = "claude"
     try:
-        from app.utils import get_cli_provider_env
-        provider = get_cli_provider_env()
-        if provider == "copilot":
-            cli_binary = "gh"  # Copilot uses gh CLI
-        elif provider == "ollama-launch":
-            cli_binary = "ollama"
+        from app.cli_health import check_primary_cli
+        cli = check_primary_cli()
+        if cli.binary:
+            cli_binary = cli.binary
     except Exception:
         pass
 

--- a/koan/skills/core/status/handler.py
+++ b/koan/skills/core/status/handler.py
@@ -235,6 +235,21 @@ def _handle_status(ctx) -> str:
         except Exception:
             parts.append(f"  🟢 Active{queue_suffix}")
 
+    # CLI provider binary availability — surfaced regardless of pause/active,
+    # since a missing binary blocks ALL missions until PATH is fixed + restart.
+    # Re-probed here (bridge process) rather than read from the loop's in-memory
+    # flag; the bridge shares PATH with the loop, so the result matches.
+    try:
+        from app.cli_health import check_primary_cli
+        cli = check_primary_cli()
+        if not cli.available:
+            parts.append(
+                f"  ⚠️ CLI unavailable — '{cli.binary}' not on PATH; "
+                "missions blocked (fix PATH & restart)"
+            )
+    except Exception:
+        pass
+
     # System info: IP │ hostname │ service manager on one compact line
     info_items = []
     server_ip = _get_server_ip()

--- a/koan/tests/test_cli_health.py
+++ b/koan/tests/test_cli_health.py
@@ -1,0 +1,88 @@
+"""Tests for app.cli_health — CLI binary availability + in-memory degraded state."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import cli_health
+
+
+@pytest.fixture(autouse=True)
+def _clean_state():
+    cli_health.clear()
+    yield
+    cli_health.clear()
+
+
+def _fake_provider(available, binary="claude", name="claude"):
+    p = MagicMock()
+    p.is_available.return_value = available
+    p.binary.return_value = binary
+    p.name = name
+    return p
+
+
+class TestCheckPrimaryCli:
+    def test_available(self):
+        with patch("app.provider.get_provider", return_value=_fake_provider(True)):
+            check = cli_health.check_primary_cli()
+        assert check == cli_health.CliCheck(True, "claude", "claude")
+
+    def test_missing(self):
+        with patch("app.provider.get_provider",
+                   return_value=_fake_provider(False, "codex", "codex")):
+            check = cli_health.check_primary_cli()
+        assert check.available is False
+        assert check.binary == "codex"
+        assert check.provider_name == "codex"
+
+    def test_probe_error_reports_available(self):
+        # A provider-resolution error must never false-positive a degraded state.
+        with patch("app.provider.get_provider", side_effect=RuntimeError("boom")):
+            check = cli_health.check_primary_cli()
+        assert check.available is True
+
+
+class TestDegradedState:
+    def test_set_is_get_clear(self):
+        assert cli_health.is_unavailable() is False
+        assert cli_health.get_unavailable_info() is None
+        cli_health.set_unavailable("claude", "claude")
+        assert cli_health.is_unavailable() is True
+        assert cli_health.get_unavailable_info() == {"binary": "claude", "provider": "claude"}
+        cli_health.clear()
+        assert cli_health.is_unavailable() is False
+        assert cli_health.get_unavailable_info() is None
+
+    def test_get_returns_copy(self):
+        cli_health.set_unavailable("claude", "claude")
+        info = cli_health.get_unavailable_info()
+        info["binary"] = "mutated"
+        assert cli_health.get_unavailable_info()["binary"] == "claude"
+
+
+class TestThrottle:
+    def test_should_warn_initially_true(self):
+        assert cli_health.should_warn() is True
+
+    def test_mark_warned_suppresses_within_cooldown(self):
+        cli_health.mark_warned()
+        assert cli_health.should_warn() is False
+
+    def test_should_warn_true_after_cooldown(self):
+        cli_health.mark_warned()
+        assert cli_health.should_warn(cooldown_s=0) is True
+
+
+class TestWarningMessage:
+    def test_contains_binary_provider_and_restart_hint(self):
+        msg = cli_health.warning_message("claude", "claude")
+        assert "claude" in msg
+        assert "PATH" in msg
+        assert "restart" in msg.lower()
+        assert msg.startswith("⚠️")
+
+    def test_handles_empty_values(self):
+        msg = cli_health.warning_message("", "")
+        assert "(unknown)" in msg
+        assert "(default)" in msg

--- a/koan/tests/test_diagnostics.py
+++ b/koan/tests/test_diagnostics.py
@@ -176,6 +176,17 @@ class TestEnvironmentCheck:
         pkg_results = [r for r in results if r.name.startswith("package_")]
         assert len(pkg_results) >= 1
 
+    def test_uses_provider_binary_not_hardcoded_map(self, tmp_path):
+        """The CLI binary check resolves the real provider binary (covers codex/grok/…)."""
+        from app import cli_health
+        from diagnostics.environment_check import run
+
+        with patch("app.cli_health.check_primary_cli",
+                   return_value=cli_health.CliCheck(False, "codex", "codex")):
+            results = run(str(tmp_path), str(tmp_path))
+        names = [r.name for r in results]
+        assert "binary_codex" in names
+
 
 # ---------------------------------------------------------------------------
 # instance_check
@@ -408,6 +419,20 @@ class TestConnectivityCheck:
             results = run(str(tmp_path), str(tmp_path), full=True)
             gh_results = [r for r in results if r.name == "github_cli"]
             assert any(r.severity == "warn" for r in gh_results)
+
+    def test_cli_provider_binary_missing(self, tmp_path, monkeypatch):
+        """cli_provider check reports the real provider binary as an error when missing."""
+        from app import cli_health
+        from diagnostics.connectivity_check import run
+
+        monkeypatch.delenv("TELEGRAM_BOT_TOKEN", raising=False)
+        with patch("app.cli_health.check_primary_cli",
+                   return_value=cli_health.CliCheck(False, "codex", "codex")):
+            results = run(str(tmp_path), str(tmp_path), full=True)
+        cli_results = [r for r in results if r.name == "cli_provider"]
+        assert len(cli_results) == 1
+        assert cli_results[0].severity == "error"
+        assert "codex" in cli_results[0].message
 
 
 # ---------------------------------------------------------------------------

--- a/koan/tests/test_iteration_manager.py
+++ b/koan/tests/test_iteration_manager.py
@@ -856,6 +856,29 @@ class TestPlanIteration:
 
     @patch("app.pick_mission.pick_mission", return_value="koan:Fix auth bug")
     @patch("app.usage_estimator.cmd_refresh")
+    @patch("app.cli_health.is_unavailable", return_value=True)
+    def test_cli_unavailable_gate(self, mock_cli, mock_refresh, mock_pick,
+                                  instance_dir, koan_root, usage_state):
+        """A missing CLI binary blocks execution — cli_unavailable_wait, no mission runs."""
+        usage_md = instance_dir / "usage.md"
+        usage_md.write_text("Session (5hr) : 30% (reset in 3h)\nWeekly (7 day) : 20% (Resets in 5d)\n")
+
+        result = plan_iteration(
+            instance_dir=str(instance_dir),
+            koan_root=str(koan_root),
+            run_num=2,
+            count=1,
+            projects=PROJECTS_LIST,
+            last_project="koan",
+            usage_state_path=str(usage_state),
+        )
+
+        # The gate fires even though a mission was picked (before start_mission).
+        assert result["action"] == "cli_unavailable_wait"
+        assert result["mission_title"] == ""
+
+    @patch("app.pick_mission.pick_mission", return_value="koan:Fix auth bug")
+    @patch("app.usage_estimator.cmd_refresh")
     @patch("app.usage_tracker.UsageTracker", side_effect=ValueError("budget DB corrupted"))
     def test_tracker_error_propagates_to_plan_result(self, mock_tracker, mock_refresh, mock_pick,
                                                       instance_dir, koan_root, usage_state):

--- a/koan/tests/test_provider_modules.py
+++ b/koan/tests/test_provider_modules.py
@@ -1004,6 +1004,23 @@ class TestRunCommandStreaming:
         call_kwargs = mock_popen.call_args[1]
         assert call_kwargs.get("errors") == "replace"
 
+    def test_missing_executable_raises_actionable_error(self):
+        """A missing provider binary must not crash a skill runner."""
+        from app.provider import run_command_streaming
+
+        with patch("app.config.get_model_config", return_value={"chat": "m", "fallback": "f"}), \
+             patch("app.provider.get_provider_name", return_value="codex"), \
+             patch("app.provider.build_full_command", return_value=["codex", "exec", "prompt"]), \
+             patch(
+                 "app.cli_exec.popen_cli",
+                 side_effect=FileNotFoundError(2, "No such file or directory", "codex"),
+             ):
+            with pytest.raises(RuntimeError, match="CLI executable not found: 'codex'") as exc:
+                run_command_streaming("hi", "/tmp", [])
+
+        assert "provider 'codex'" in str(exc.value)
+        assert "cli.chat: codex:/absolute/path" in str(exc.value)
+
     def test_failure_raises(self):
         from app.provider import run_command_streaming
         proc = self._make_proc(["oops\n"], stderr="err", returncode=1)

--- a/koan/tests/test_review_runner.py
+++ b/koan/tests/test_review_runner.py
@@ -2541,6 +2541,23 @@ class TestRunClaudeReview:
     @patch("app.cli_provider.run_command_streaming")
     @patch("app.config.get_model_config", return_value={"review_mode": "review-model", "mission": "mission-model"})
     @patch("app.config.get_skill_max_turns", return_value=200)
+    def test_missing_executable_returns_error_detail(
+        self, mock_max_turns, mock_models, mock_run,
+    ):
+        """A provider launch error is returned as a failed review, not raised."""
+        from app.review_runner import _run_claude_review
+
+        mock_run.side_effect = RuntimeError(
+            "CLI executable not found: 'codex' (provider 'codex')."
+        )
+        output, error = _run_claude_review("prompt", "/tmp/project")
+
+        assert output == ""
+        assert "CLI executable not found" in error
+
+    @patch("app.cli_provider.run_command_streaming")
+    @patch("app.config.get_model_config", return_value={"review_mode": "review-model", "mission": "mission-model"})
+    @patch("app.config.get_skill_max_turns", return_value=200)
     def test_failure_logs_to_stderr(
         self, mock_max_turns, mock_models, mock_run, capsys,
     ):

--- a/koan/tests/test_run.py
+++ b/koan/tests/test_run.py
@@ -1338,6 +1338,48 @@ class TestRunClaudeTask:
 
         assert exit_code != 0
 
+    def test_missing_binary_returns_127_with_actionable_stderr(self, tmp_path):
+        """A missing provider binary fails the mission cleanly (exit 127) with an
+        actionable message on stderr — not a raw FileNotFoundError."""
+        from app.run import run_claude_task, _sig
+        _sig.task_running = False
+
+        stdout_f = str(tmp_path / "out.txt")
+        stderr_f = str(tmp_path / "err.txt")
+
+        err = FileNotFoundError(2, "No such file or directory", "koan-missing-cli")
+        with patch("app.cli_exec.popen_cli", side_effect=err):
+            exit_code = run_claude_task(
+                cmd=["koan-missing-cli"],
+                stdout_file=stdout_f,
+                stderr_file=stderr_f,
+                cwd=str(tmp_path),
+            )
+
+        assert exit_code == 127
+        stderr_text = Path(stderr_f).read_text()
+        assert "CLI executable not found" in stderr_text
+        assert "koan-missing-cli" in stderr_text
+        assert _sig.task_running is False
+
+    def test_missing_other_file_propagates(self, tmp_path):
+        """A FileNotFoundError for a file other than the provider binary is not masked."""
+        from app.run import run_claude_task, _sig
+        _sig.task_running = False
+
+        stdout_f = str(tmp_path / "out.txt")
+        stderr_f = str(tmp_path / "err.txt")
+
+        err = FileNotFoundError(2, "No such file or directory", "/some/other/file")
+        with patch("app.cli_exec.popen_cli", side_effect=err):
+            with pytest.raises(FileNotFoundError):
+                run_claude_task(
+                    cmd=["claude"],
+                    stdout_file=stdout_f,
+                    stderr_file=stderr_f,
+                    cwd=str(tmp_path),
+                )
+
     def test_sets_and_reaps_per_mission_tmpdir(self, tmp_path, monkeypatch):
         """The child runs with a private TMPDIR that is removed afterwards."""
         from app import utils
@@ -2421,6 +2463,49 @@ class TestIdleWaitConfig:
         mock_sleep.assert_called_once()
         status_calls = [c for c in mock_status.call_args_list if "PR limit" in str(c)]
         assert len(status_calls) >= 1
+
+    @patch("app.run._notify_raw")
+    @patch("app.run.interruptible_sleep", return_value=None)
+    @patch("app.run.set_status")
+    @patch("app.run.log")
+    @patch("app.run.plan_iteration")
+    def test_cli_unavailable_wait_action(
+        self, mock_plan, mock_log, mock_status, mock_sleep, mock_notify, tmp_path,
+    ):
+        """cli_unavailable_wait blocks missions, never wakes on missions, warns (throttled)."""
+        import app.mission_executor as _me
+        _me._last_idle_msg = ""
+        from app import cli_health
+        cli_health.clear()
+        cli_health.set_unavailable("claude", "claude")
+        from app.run import _run_iteration
+        mock_plan.return_value = self._make_plan(
+            "cli_unavailable_wait",
+            decision_reason="CLI binary not on PATH — missions blocked (fix PATH & restart)",
+        )
+        instance = str(tmp_path / "instance")
+        os.makedirs(instance, exist_ok=True)
+        (tmp_path / ".koan-project").write_text("koan")
+
+        try:
+            _run_iteration(
+                koan_root=str(tmp_path),
+                instance=instance,
+                projects=[("koan", "/tmp/koan")],
+                count=0, max_runs=10, interval=60, git_sync_interval=5,
+            )
+        finally:
+            cli_health.clear()
+
+        # Missions must not wake this idle wait (would tight-loop until restart).
+        mock_sleep.assert_called_once_with(
+            60, str(tmp_path), instance, wake_on_mission=False,
+        )
+        status_calls = [c for c in mock_status.call_args_list if "CLI unavailable" in str(c)]
+        assert len(status_calls) >= 1
+        # A throttled reminder is sent exactly once (should_warn() True after clear()).
+        path_warnings = [c for c in mock_notify.call_args_list if "PATH" in str(c)]
+        assert len(path_warnings) == 1
 
     @patch("app.run.interruptible_sleep", return_value=None)
     @patch("app.run.set_status")

--- a/koan/tests/test_startup_manager.py
+++ b/koan/tests/test_startup_manager.py
@@ -1346,3 +1346,49 @@ class TestEnsureProjectsYaml:
         assert "Created projects.yaml" in msgs
         config = yaml.safe_load((tmp_path / "projects.yaml").read_text())
         assert "koan" not in config["projects"]
+
+
+class TestCheckCliBinary:
+    """Startup CLI-binary-on-PATH check (app.startup_manager.check_cli_binary)."""
+
+    def test_available_no_warning_no_flag(self):
+        from app import cli_health, startup_manager
+        cli_health.clear()
+        try:
+            with patch("app.cli_health.check_primary_cli",
+                       return_value=cli_health.CliCheck(True, "claude", "claude")), \
+                 patch("app.notify.send_telegram") as mock_send:
+                startup_manager.check_cli_binary()
+            assert mock_send.call_count == 0
+            assert cli_health.is_unavailable() is False
+        finally:
+            cli_health.clear()
+
+    def test_missing_warns_and_sets_flag(self):
+        from app import cli_health, startup_manager
+        cli_health.clear()
+        try:
+            with patch("app.cli_health.check_primary_cli",
+                       return_value=cli_health.CliCheck(False, "codex", "codex")), \
+                 patch("app.notify.send_telegram") as mock_send:
+                startup_manager.check_cli_binary()
+            assert mock_send.call_count == 1
+            assert "PATH" in mock_send.call_args[0][0]
+            assert cli_health.is_unavailable() is True
+            assert cli_health.get_unavailable_info()["binary"] == "codex"
+            # Throttle stamped so the loop doesn't immediately re-warn.
+            assert cli_health.should_warn() is False
+        finally:
+            cli_health.clear()
+
+    def test_missing_does_not_raise_when_send_fails(self):
+        from app import cli_health, startup_manager
+        cli_health.clear()
+        try:
+            with patch("app.cli_health.check_primary_cli",
+                       return_value=cli_health.CliCheck(False, "claude", "claude")), \
+                 patch("app.notify.send_telegram", side_effect=RuntimeError("net down")):
+                startup_manager.check_cli_binary()  # must not raise
+            assert cli_health.is_unavailable() is True
+        finally:
+            cli_health.clear()

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -4,7 +4,7 @@ title: "Component Spec — Agent Loop Pipeline"
 description: "Design contract for the core mission pipeline (iteration manager, mission executor/runner, quota handling, stagnation monitor) that pulls missions, invokes the CLI provider, and finalizes lifecycle state."
 tags: [agent-loop]
 created: 2026-06-27
-updated: 2026-07-13
+updated: 2026-07-17
 ---
 
 # Component Spec — Agent Loop Pipeline
@@ -142,6 +142,24 @@ see it.
 - **`run.py` never commits to main and never merges.** This is a hard safety boundary
   enforced by prompt + convention; the loop's job is to host the subprocess, not to
   alter git state itself.
+- **A missing CLI binary at startup enters an in-memory degraded (no-mission) mode.**
+  `startup_manager.check_cli_binary()` probes the primary provider once via
+  `cli_health.check_primary_cli()` (which wraps `CLIProvider.is_available()` /
+  `shutil.which(binary())`, honoring absolute / bare-PATH / `KOAN_ROOT`-relative paths and
+  the `KOAN_CLAUDE_CLI_PATH` / `cli.<role>` overrides). On a miss it logs, sends ONE ⚠️
+  operator warning (all messaging backends, via `send_telegram`), and sets the in-memory
+  `cli_health` flag — **never a hard stop** (chat/inbox must keep working) and **no on-disk
+  signal**: the flag lives for the process lifetime and clears only on restart (PATH must
+  be fixed properly). `iteration_manager.plan_iteration` gates on `cli_health.is_unavailable()`
+  **before** mission/autonomous/contemplative selection (next to the passive gate),
+  returning the `cli_unavailable_wait` idle action so **no** execution starts, missions stay
+  Pending, and GitHub/Jira notification polling (which runs before planning) still queues
+  work. The loop reminder is throttled (`cli_health.should_warn`/`mark_warned`, ~6h) so the
+  operator is never flooded. Defense-in-depth for a mid-session vanish: `run.run_claude_task`
+  converts a provider-binary `FileNotFoundError` into an actionable exit-127 failure (shared
+  `provider.missing_binary_message`, also used by `run_command_streaming`), routing through
+  the normal failure/fallback path rather than crashing the loop. `cli_unavailable_wait` sets
+  `wake_on_mission=False` (like `passive_wait`) so a queued mission cannot tight-loop the gate.
 - **Skill-dispatch stdout is DATA, not CLI error output.** `_classify_and_handle_cli_error`
   is called with `trust_stdout=False` for skill dispatches so a transcript is not
   mistaken for a quota/auth message. Keep that default for new dispatch pathways.

--- a/specs/components/providers.md
+++ b/specs/components/providers.md
@@ -4,7 +4,7 @@ title: "Component Spec — CLI Provider Abstraction"
 description: "Design contract for the CLI provider abstraction that decouples the agent loop from any single AI coding CLI (Claude, Cline, Codex, Copilot, Haze, Grok) behind one `CLIProvider` contract."
 tags: [providers]
 created: 2026-06-27
-updated: 2026-07-16
+updated: 2026-07-17
 ---
 
 # Component Spec — CLI Provider Abstraction
@@ -255,6 +255,14 @@ provider/__init__.py  → registry + resolution (env → config → default) + c
 
 ## Integration points
 
+- **Startup availability gate.** `app.cli_health.check_primary_cli()` wraps
+  `get_provider().is_available()` (`shutil.which(binary())`) as the single probe used by
+  `startup_manager.check_cli_binary()` (enters an in-memory degraded/no-mission mode on a
+  miss — see `specs/components/agent-loop.md`), the `/status` skill, and the `/doctor`
+  diagnostics (`environment_check` / `connectivity_check`, which resolve the real
+  `provider.binary()` rather than a hardcoded provider→binary map). `provider.missing_binary_message()`
+  is the shared constructor for the actionable "CLI executable not found" error raised by
+  `run_command_streaming` and (as an exit-127 failure) by `run.run_claude_task`.
 - Invoked by `run.run_claude_task()` and skill runners.
 - Usage flows to `usage_tracker.py` / `burn_rate.py` via the `record_usage()` hook.
   Structured per-call events are written to `instance/usage/*.jsonl` by


### PR DESCRIPTION
The daemon was recently started without the provider binary on PATH; missions
then crashed because run_claude_task had no missing-binary handler and there was
no startup check. Continue https://github.com/atoomic/koan/commit/dd8afcb56dce8d77f6cec97a5e69c092bbf7745d by detecting this at startup and refusing to
start missions while keeping chat/inbox alive.

- app.cli_health (new): check_primary_cli() wraps CLIProvider.is_available()
  (shutil.which(binary)), plus an in-memory degraded flag and warn throttle.
- startup_manager.check_cli_binary(): probe at startup; on a miss log, send ONE
  warning to the operator (all messaging backends), and set the in-memory flag.
  Never a hard stop — chat and the GitHub/Jira inbox keep working.
- iteration_manager.plan_iteration: gate on cli_health before mission/autonomous/
  contemplative selection, returning a new cli_unavailable_wait idle action so no
  execution starts, missions stay Pending, and notification polling still queues
  work. The loop reminder is throttled so the operator is never flooded.
- run.run_claude_task: convert a mid-session provider-binary FileNotFoundError
  into an actionable exit-127 failure via shared provider.missing_binary_message
  (extracted from run_command_streaming), routing through the normal
  failure/fallback path instead of crashing the loop.
- /status surfaces the degraded state; /doctor diagnostics now probe the real
  provider.binary() (covers codex/grok/haze/cline, per-role cli.<role>, and
  KOAN_CLAUDE_CLI_PATH) instead of a hardcoded partial provider->binary map.
- In-memory only: PATH must be fixed properly and the daemon restarted to clear.

Specs updated additively (agent-loop.md, providers.md); docs updated
(daemon.md, troubleshooting.md). Tests cover cli_health, the startup check, the
planner gate, the throttled idle reminder, the mission-path guard, and diagnostics.