### PR TITLE
fix(docker): exclude koan dev tooling from the release image (#2383)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,3 +37,15 @@ claude-auth/
 
 # Workspace (mounted at runtime, not copied)
 workspace/
+
+# Repo dev tooling — koan's OWN contributor instructions and project skills.
+# These are for developing koan itself; they must never ship in the image, or a
+# CLI session with cwd inside /app could auto-load them (see issues #2379/#2383).
+# Both root and nested (**/) forms — koan/CLAUDE.md, koan/app/CLAUDE.md, etc.
+CLAUDE.md
+**/CLAUDE.md
+AGENTS.md
+**/AGENTS.md
+KOAN.md
+**/KOAN.md
+.claude/

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,6 @@ RUN pip install --no-cache-dir -r /app/koan/requirements.txt \
 COPY koan/ /app/koan/
 COPY instance.example/ /app/instance.example/
 COPY Makefile /app/
-COPY CLAUDE.md /app/
 COPY docs/ /app/docs/
 COPY projects.example.yaml /app/
 

--- a/docs/setup/docker.md
+++ b/docs/setup/docker.md
@@ -4,7 +4,7 @@ title: "Docker Setup"
 description: "Covers Docker Compose setup for Koan (pull vs. build from source), workspace project mounts, authentication (Claude/GitHub), volume layout, and troubleshooting common container issues."
 tags: [setup]
 created: 2026-05-28
-updated: 2026-07-12
+updated: 2026-07-18
 ---
 
 # Docker Setup
@@ -203,6 +203,21 @@ script:
 | `run.py` | Agent loop — picks missions, executes via Claude CLI |
 
 If either process crashes, the entrypoint restarts it automatically.
+
+### What the image deliberately excludes
+
+The published image contains koan's runtime and the `docs/` it needs, but **none
+of koan's own contributor tooling** — `CLAUDE.md`, `AGENTS.md`, `KOAN.md`, and
+`.claude/` (project skills, agents, settings) are kept out of the build context
+via `.dockerignore`. These files guide humans and agents *developing koan itself*;
+if they shipped, a CLI session whose `cwd` fell inside the image's `/app` checkout
+could auto-load them (the leak class addressed at runtime by isolating session
+`cwd`). Excluding them removes the material from the artifact entirely.
+
+This is enforced at build time: `docker-publish.yml` (the shared build/push
+workflow behind both the release and manual-publish flows) runs
+`scripts/verify_image_clean.sh` against the freshly built image and fails the
+build if any of that tooling is found under `/app`. See issue #2383.
 
 ### Recommended dev packages
 

--- a/koan/tests/test_docker.py
+++ b/koan/tests/test_docker.py
@@ -119,6 +119,14 @@ class TestDockerfile:
         assert "hasCompletedOnboarding" in self.dockerfile
         assert ".claude.json" in self.dockerfile
 
+    def test_does_not_copy_claude_md(self):
+        """CLAUDE.md must not be copied into the image (see #2379/#2383)."""
+        offending = [
+            ln for ln in self.dockerfile.splitlines()
+            if ln.strip().startswith("COPY") and "CLAUDE.md" in ln
+        ]
+        assert not offending, f"Dockerfile still copies CLAUDE.md: {offending}"
+
 
 class TestEntrypoint:
     """Validate docker-entrypoint.sh structure and correctness."""
@@ -420,6 +428,14 @@ class TestDockerIgnore:
         """claude-auth/ should not be in build context."""
         assert "claude-auth/" in self.patterns
 
+    def test_excludes_dev_tooling_root_and_nested(self):
+        """koan's own contributor tooling must be kept out of the build context."""
+        lines = {ln.strip() for ln in self.dockerignore.splitlines()}
+        for name in ("CLAUDE.md", "AGENTS.md", "KOAN.md"):
+            assert name in lines, f"{name} not excluded at root in .dockerignore"
+            assert f"**/{name}" in lines, f"**/{name} (nested) not excluded"
+        assert ".claude/" in lines, ".claude/ not excluded in .dockerignore"
+
 
 class TestDockerCompose:
     """Validate docker-compose.yml structure."""
@@ -621,3 +637,34 @@ class TestInstanceHydration:
             capture_output=True, text=True,
         )
         assert result.returncode == 0, result.stderr
+
+
+class TestImageCleanGuard:
+    """Issue #2383: live-image guard script exists and is wired into publish."""
+
+    def test_guard_script_exists_and_executable(self):
+        script = REPO_ROOT / "scripts" / "verify_image_clean.sh"
+        assert script.exists(), "scripts/verify_image_clean.sh missing"
+        assert os.access(script, os.X_OK), "verify_image_clean.sh not executable"
+        body = script.read_text()
+        for name in ("CLAUDE.md", "AGENTS.md", ".claude", "KOAN.md"):
+            assert name in body, f"guard does not check for {name}"
+
+    def test_guard_script_valid_bash(self):
+        result = subprocess.run(
+            ["bash", "-n", str(REPO_ROOT / "scripts" / "verify_image_clean.sh")],
+            capture_output=True, text=True,
+        )
+        assert result.returncode == 0, result.stderr
+
+    @pytest.mark.xfail(
+        strict=False,
+        reason="Wiring verify_image_clean.sh into docker-publish.yml requires a "
+        "token with the 'workflow' GitHub scope, which the automation account "
+        "lacks; a maintainer must apply the workflow diff from the PR body. "
+        "This test auto-XPASSes once wired — drop the marker then (#2383).",
+    )
+    def test_docker_publish_workflow_runs_the_guard(self):
+        wf = (REPO_ROOT / ".github" / "workflows" / "docker-publish.yml").read_text()
+        assert "verify_image_clean.sh" in wf, \
+            "docker-publish.yml does not invoke the image guard"

--- a/scripts/verify_image_clean.sh
+++ b/scripts/verify_image_clean.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Fail if koan's own repo-dev tooling shipped inside a built image.
+#
+# Regression guard for issue #2383 (packaging), complementing #2379's
+# runtime-cwd guard: even a future cwd=KOAN_ROOT code path then has nothing
+# to auto-load. Scoped to $ROOT (KOAN_ROOT=/app) so the CLI's legitimate
+# /home/koan/.claude runtime-state dir is NOT flagged.
+#
+# Usage: verify_image_clean.sh <image-ref> [root]
+set -euo pipefail
+
+IMAGE="${1:?usage: verify_image_clean.sh <image-ref> [root]}"
+ROOT="${2:-/app}"
+
+# Throwaway container with an overridden entrypoint — never launches koan.
+offenders="$(docker run --rm --entrypoint sh "$IMAGE" -c \
+  "find '$ROOT' \\( -name CLAUDE.md -o -name AGENTS.md -o -name .claude -o -name KOAN.md \\) -print 2>/dev/null" \
+  || true)"
+
+if [ -n "$offenders" ]; then
+  echo "::error::Repo dev tooling leaked into the image under $ROOT (#2383):"
+  printf '%s\n' "$offenders"
+  exit 1
+fi
+
+echo "✅ image clean: no CLAUDE.md / AGENTS.md / .claude / KOAN.md under $ROOT"


### PR DESCRIPTION
## Summary

The release Docker image shipped koan's own contributor tooling: the Dockerfile copied the root `CLAUDE.md`, and `COPY koan/` transitively pulled in `koan/CLAUDE.md`, `koan/app/CLAUDE.md`, `koan/skills/CLAUDE.md`. A CLI session with `cwd` inside the image's `/app` checkout could auto-load them — the leak class #2379 addresses at runtime. This removes the material from the shipped artifact and adds a build-time guard script.

Closes https://github.com/Anantys-oss/koan/issues/2383

## Changes

- **`.dockerignore`** — exclude `CLAUDE.md` / `AGENTS.md` / `KOAN.md` / `.claude/` (root **and** nested `**/` forms) from the build context, so `COPY koan/` no longer drags nested `CLAUDE.md` files in.
- **`Dockerfile`** — drop the now-invalid `COPY CLAUDE.md /app/` line (its source is ignored; leaving it would break the build). Verified no runtime code reads `$KOAN_ROOT/CLAUDE.md` — every CLAUDE.md read is *project/worktree*-scoped (`core_files.PROJECT_CORE_PATHS`, not the koan_root `CORE_PATHS`).
- **`scripts/verify_image_clean.sh`** — runs a built image and fails if any dev tooling survives under `/app`. Scoped to `/app` so the CLI's legitimate `/home/koan/.claude` runtime-state dir is not flagged; overrides the entrypoint so the throwaway container never launches koan.
- **`koan/tests/test_docker.py`** — contract tests for the exclusions, the removed `COPY`, and the guard script (exists / executable / valid bash / checks all names).
- **`docs/setup/docker.md`** — documents the exclusion and the build-time guard.

## ⚠️ Required maintainer follow-up — wire the guard into CI

The automation account's token lacks the **`workflow`** GitHub scope, so this PR **cannot** modify `.github/workflows/`. A maintainer must apply the following diff to `.github/workflows/docker-publish.yml` (insert between the metadata step and the existing push step). The `test_docker_publish_workflow_runs_the_guard` test is marked `xfail` and will auto-XPASS once applied (drop the marker then):

```yaml
      # Build once into the local daemon (no push) so the guard can inspect the
      # real assembled artifact before it is published. type=gha cache makes the
      # subsequent push build a cache hit, not a rebuild.
      - name: 🐳 Build image for verification (load, no push)
        uses: docker/build-push-action@v7
        with:
          context: .
          load: true
          push: false
          tags: koan:verify
          cache-from: type=gha
          cache-to: type=gha,mode=max

      - name: 🔒 Guard — no repo dev tooling in the image (#2383)
        run: ./scripts/verify_image_clean.sh koan:verify /app

      # (existing, unchanged) push build — reuses the cache from the verify build:
      - name: 🐳 Build and push Docker image
        uses: docker/build-push-action@v7
        ...
```

`docker-publish.yml` is the single `workflow_call` reusable workflow behind **both** `release.yml` and `publish-container.yml`, so this one step covers every publish path.

## Test plan

- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_docker.py -v` → 128 passed, 1 xfailed.
- `make lint` → clean.
- `python3 scripts/wiki_check.py --full` → no gaps.
- Guard behavior validated locally: `./scripts/verify_image_clean.sh koan:verify /app` exits 0 on a clean image; a planted `/app/CLAUDE.md` makes it exit non-zero with a `::error::` line.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=4ad18fc5)_
