### PR TITLE
Improve /rebase transition notice to prefer /fix

### DIFF
--- a/docs/users/user-manual.md
+++ b/docs/users/user-manual.md
@@ -688,7 +688,8 @@ the mission as extra focus context. A `/fix` invoked on a PR URL redirects here
 > **Transition (through 2026-08-17):** `/rebase` used to always apply review
 > feedback. Now a bare `/rebase` rebases only. During this window a bare
 > `/rebase` shows a temporary notice (in chat and as a PR comment) pointing you
-> to `/rebase --fix`; the notice disappears automatically after the deadline.
+> to `/fix` (or alternatively `/rebase --fix`); the notice disappears
+> automatically after the deadline.
 
 By default, Telegram `/rebase` only queues PRs created by this instance
 (branch prefix match). Set `allow_rebase_foreign_prs: true` in

--- a/koan/app/rebase_transition.py
+++ b/koan/app/rebase_transition.py
@@ -24,9 +24,10 @@ from typing import Optional
 FIX_NOTICE_DEADLINE = datetime(2026, 8, 17, tzinfo=timezone.utc)
 
 _NOTICE_BODY = (
-    "`/rebase` now only rebases the PR onto its base branch. To also address "
-    "review feedback (the previous default), use `/rebase --fix` — this is "
-    "implied when you add a focus area or severity after the URL."
+    "`/rebase` now only rebases the PR onto its base branch.\n"
+    "To also address review feedback (the previous default), use `/fix` "
+    "(or alternatively `/rebase --fix`) — you can also provide extra context "
+    "after `/rebase` or `/fix`."
 )
 
 

--- a/koan/tests/test_rebase_transition.py
+++ b/koan/tests/test_rebase_transition.py
@@ -22,10 +22,17 @@ class TestNoticeActive:
 class TestNoticeText:
     def test_chat_notice_mentions_fix(self):
         text = rebase_transition.chat_notice()
+        assert "`/fix`" in text
         assert "--fix" in text
         assert "Heads up" in text
+
+    def test_chat_notice_advertises_fix_before_rebase_fix(self):
+        # /fix is the simpler, preferred form; --fix is the alternative.
+        text = rebase_transition.chat_notice()
+        assert text.index("`/fix`") < text.index("`/rebase --fix`")
 
     def test_pr_comment_notice_is_note_alert(self):
         text = rebase_transition.pr_comment_notice()
         assert text.startswith("> [!NOTE]")
+        assert "`/fix`" in text
         assert "--fix" in text

--- a/specs/skills/rebase.md
+++ b/specs/skills/rebase.md
@@ -4,7 +4,7 @@ title: "Skill Spec — rebase"
 description: "Documents the `/rebase` skill that rebases a PR onto its current base by default and, with `--fix` (or any trailing context), also addresses review feedback, including its already-solved detection JSON scored by the eval harness."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-07-18
 ---
 
 # Skill Spec — `rebase`
@@ -76,7 +76,8 @@ See `docs/users/skills.md` for the end-user `/rebase` reference and
 
 The default flipped from "rebase + feedback" to "rebase only" on 2026-07-17. To
 avoid a silent surprise, a bare `/rebase` surfaces a temporary notice (chat reply
-+ PR comment via `build_alert("NOTE", …)`) pointing users to `/rebase --fix`.
++ PR comment via `build_alert("NOTE", …)`) pointing users to `/fix` (or
+alternatively `/rebase --fix`).
 The notice is date-gated by `rebase_transition.FIX_NOTICE_DEADLINE`
 (2026-08-17) and disappears automatically; the behavior change is permanent.
 After the deadline the notice code + `_FEEDBACK_ON_BY_DEFAULT` are removed


### PR DESCRIPTION
## Summary

The transitional notice shown on a bare `/rebase` pointed users to `/rebase --fix`. Since `/fix` already redirects PR URLs to `/rebase --fix`, this updates the notice (and the docs describing it) to advertise the simpler `/fix` form first, keeping `/rebase --fix` as the documented alternative.

Closes https://github.com/anantys-oss/koan/issues/2450

## Changes

- `koan/app/rebase_transition.py`: reworded `_NOTICE_BODY` to lead with `/fix`, list `/rebase --fix` as an alternative, and note that extra context can follow either command.
- `koan/tests/test_rebase_transition.py`: added regression coverage asserting the notice mentions `/fix` and advertises it before `/rebase --fix`.
- `specs/skills/rebase.md`, `docs/users/user-manual.md`: updated the transition-notice description to match the new wording.

## Test plan

- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_rebase_transition.py koan/tests/test_rebase_skill.py -v` — all pass
- `make lint` — passes
- Confirmed the two pre-existing failures in `koan/tests/test_rebase_pr.py::TestRebaseOutcomeGating` reproduce identically on `main` (unrelated to this change)

---
### Quality Report

**Changes**: 4 files changed, 16 insertions(+), 6 deletions(-)

**Code scan**: clean

**Tests**: failed (timeout (120s))

**Branch hygiene**: clean

- [x] **Architectural change**

_Generated by [Skuggi](https://skuggi.ai)_