### PR TITLE
feat(page-cache): reclaim stray /tmp mission trees to cut billed Railway footprint

### DIFF
--- a/docs/operations/memory-footprint.md
+++ b/docs/operations/memory-footprint.md
@@ -119,7 +119,34 @@ unprivileged `posix_fadvise(POSIX_FADV_DONTNEED)` to drop clean pages
 - **Platform:** no-op where `os.posix_fadvise` is absent (macOS dev boxes) —
   every hook returns `ReclaimStats(supported=False)` and touches zero files.
 - **Config:** `page_cache_reclaim: { enabled, idle_interval_s, time_budget_s,
-  extra_roots }` — see `instance.example/config.yaml`. Default on.
+  extra_roots }` — see `instance.example/config.yaml`. Default on. `idle_interval_s`
+  defaults to **180s** — short enough that boot/between-tick page cache never sits
+  billed for long.
+
+## Out-of-root residuals: the stray `/tmp` trees
+
+The reclaim only drops pages for files **under its roots**. Mission subprocesses
+read large files into the page cache from trees the standard roots
+(`instance/` + venv + scratch + project workdirs) never cover — chiefly the stray
+`/tmp` mission trees (`pytest-of-*`, `test-koan*`, `koan-*`, `jest_rs`). Those
+pages stay billed until the underlying files are **deleted** by the age-gated
+post-mission sweep, which can be hours away.
+
+Observed live (2026-07-19, fresh idle instance): `anon` 78 MB / per-process RSS
+~124 MB (healthy), but billed `memory.current` sat at ~600–900 MB. The reclaim
+log showed two floors — `file` dropping to **~95 MB** (everything reclaimed) or
+plateauing at **~663 MB** (a mission tree pinning ~570 MB of out-of-root cache).
+The high floor held **10:44→15:16 (~4.5h)** — this is the "stable at ~1 GB for
+hours" an operator sees — then fell to ~98 MB the instant the file was deleted.
+
+**Fix:** `default_reclaim_roots()` now also sweeps the same stray-`/tmp` trees the
+post-mission tmp sweep targets (`cleanup.extra_tmp_globs`, **own-uid dirs only** so
+it never churns on another user's `/tmp`). Reclaiming their clean pages decouples
+the billed baseline from the sweep's deletion latency. If a large residual persists
+elsewhere, add its dir to `page_cache_reclaim.extra_roots`; the ultimate backstop
+for *any* out-of-root cache is a **cgroup memory limit** on the service (Railway
+Resources), which forces the kernel to evict reclaimable page cache **and** slab
+under pressure — `fadvise` cannot touch slab.
 
 See also: [bridge-memory](../architecture/bridge-memory.md),
 [memory-watchdog](memory-watchdog.md).

--- a/instance.example/config.yaml
+++ b/instance.example/config.yaml
@@ -844,9 +844,13 @@ memory_monitor:
 # posix_fadvise(DONTNEED) — unprivileged, read-only, no-op on macOS dev boxes.
 page_cache_reclaim:
   enabled: true          # Master switch (default: true — unattended billing hygiene)
-  idle_interval_s: 900   # Min seconds between idle reclaims; 0 disables the idle tick
+  idle_interval_s: 180   # Min seconds between idle reclaims; 0 disables the idle tick
   time_budget_s: 10      # Soft wall-clock budget per sweep so it never stalls the loop
   extra_roots: []        # Operator additions, e.g. large data dirs outside projects
+  # The reclaim also sweeps the stray per-mission /tmp trees matched by
+  # cleanup.extra_tmp_globs (own-uid only) — those hold big out-of-root page-cache
+  # residuals (observed ~570 MB pinned for ~4.5h) until the age-gated sweep deletes
+  # them; reclaiming their clean pages decouples billed footprint from that latency.
 
 # Conversation history retention (#2354). Mid-session compaction of
 # conversation-history.jsonl so the append-only file stays bounded over long

--- a/koan/app/config.py
+++ b/koan/app/config.py
@@ -674,7 +674,7 @@ def get_page_cache_reclaim_config() -> dict:
     """
     defaults = {
         "enabled": True,
-        "idle_interval_s": 900,
+        "idle_interval_s": 180,
         "time_budget_s": 10,
         "extra_roots": [],
     }

--- a/koan/app/page_cache.py
+++ b/koan/app/page_cache.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Iterable
 
-from app.config import get_page_cache_reclaim_config
+from app.config import get_cleanup_extra_tmp_globs, get_page_cache_reclaim_config
 from app.memory_monitor import read_cgroup_memory_stat
 from app.run_log import log_safe as _log
 from app.utils import get_known_projects, koan_tmp_dir
@@ -56,18 +56,58 @@ def _reset_idle_throttle() -> None:
     _last_idle_reclaim_ts = 0.0
 
 
+def _stray_tmp_roots() -> list[Path]:
+    """Stray per-mission ``/tmp`` trees that hold big page-cache residuals
+    *outside* the project/instance/venv roots.
+
+    Mission subprocesses (pytest → ``/tmp/pytest-of-*``, koan test runs →
+    ``/tmp/test-koan*``, jest → ``/tmp/jest_rs``) read large files into the
+    kernel page cache from trees the standard roots never cover. Observed live
+    (2026-07-19): such a tree pinned ~570 MB of billed ``file`` cache for ~4.5h
+    until the age-gated post-mission sweep finally deleted it. Reclaiming the
+    same glob list (``cleanup.extra_tmp_globs``) drops those clean pages
+    immediately, decoupling billed footprint from the sweep's deletion latency.
+
+    Strictly read-only (the caller only ``fadvise(DONTNEED)``s), and restricted
+    to **own-uid** directories so it never churns on another user's ``/tmp``
+    trees with permission-denied noise (mirrors the sweep's own-uid guard).
+    """
+    import glob as _glob
+
+    try:
+        uid: int | None = os.getuid()
+    except AttributeError:  # non-POSIX; no uid concept
+        uid = None
+    roots: list[Path] = []
+    for pattern in get_cleanup_extra_tmp_globs():
+        if not pattern.startswith("/tmp/"):
+            continue  # sweep only honors /tmp/* patterns; stay in lockstep
+        for match in _glob.glob(pattern):
+            try:
+                st = os.lstat(match)
+                if not stat.S_ISDIR(st.st_mode):
+                    continue  # skip symlinks / non-dirs — never escape /tmp
+                if uid is not None and st.st_uid != uid:
+                    continue  # another user's tree — skip (no perms anyway)
+            except OSError:
+                continue
+            roots.append(Path(match))
+    return roots
+
+
 def default_reclaim_roots() -> list[Path]:
     """The known heavy page-cache contributors, resolved centrally (DRY anchor).
 
     Every configured project workdir, ``KOAN_ROOT/instance/`` (logs + SQLite),
-    the venv, and the per-uid scratch dir. Non-existent roots are dropped;
+    the venv, the per-uid scratch dir, and the stray per-mission ``/tmp`` trees
+    (``cleanup.extra_tmp_globs``, own-uid only). Non-existent roots are dropped;
     operator ``extra_roots`` are appended. ``KOAN_ROOT`` is read from the
     environment (not the import-time constant) so it stays correct if it changed.
 
-    Ordering matters: the small, high-value roots (``instance/``, venv, scratch)
-    are emitted **before** the large project workdirs so a truncated sweep (time
-    budget hit) still reclaims them rather than spending the whole budget walking
-    one big ``node_modules``/``.git`` tree.
+    Ordering matters: the small, high-value roots (``instance/``, venv, scratch,
+    stray-tmp) are emitted **before** the large project workdirs so a truncated
+    sweep (time budget hit) still reclaims them rather than spending the whole
+    budget walking one big ``node_modules``/``.git`` tree.
     """
     # Priority roots first — small + high-value, so they always get their turn
     # within the time budget before the large project trees.
@@ -79,6 +119,9 @@ def default_reclaim_roots() -> list[Path]:
     priority.append(Path(sys.prefix))
     with contextlib.suppress(OSError):
         priority.append(Path(koan_tmp_dir()))
+    # Stray per-mission /tmp residuals — the out-of-root page cache that made the
+    # billed baseline ratchet up; reclaim them before the big project trees.
+    priority.extend(_stray_tmp_roots())
     project_roots = [Path(path) for _name, path in get_known_projects()]
     cfg = get_page_cache_reclaim_config()
     extra = [Path(str(e)) for e in cfg.get("extra_roots", [])]
@@ -230,7 +273,7 @@ def maybe_reclaim_page_cache_idle(now: float | None = None) -> ReclaimStats | No
     cfg = get_page_cache_reclaim_config()
     if not cfg.get("enabled", True):
         return None
-    interval = cfg.get("idle_interval_s", 900)
+    interval = cfg.get("idle_interval_s", 180)
     if interval <= 0:
         return None
     ts = time.monotonic() if now is None else now

--- a/koan/tests/test_config.py
+++ b/koan/tests/test_config.py
@@ -2457,7 +2457,7 @@ class TestGetPageCacheReclaimConfig:
         with _mock_config({}):
             assert get_page_cache_reclaim_config() == {
                 "enabled": True,
-                "idle_interval_s": 900,
+                "idle_interval_s": 180,
                 "time_budget_s": 10,
                 "extra_roots": [],
             }

--- a/koan/tests/test_page_cache.py
+++ b/koan/tests/test_page_cache.py
@@ -45,6 +45,9 @@ def test_default_roots_include_projects_and_instance(tmp_path, monkeypatch):
     monkeypatch.setattr(
         page_cache, "get_known_projects", lambda: [("proj", str(proj))]
     )
+    # Neutralize ambient stray-/tmp trees (the pytest tmpdir itself matches
+    # /tmp/pytest-of-*) so this test only exercises the standard roots.
+    monkeypatch.setattr(page_cache, "_stray_tmp_roots", list)
     roots = page_cache.default_reclaim_roots()
     resolved = {str(Path(r).resolve()) for r in roots}
     assert str(proj.resolve()) in resolved
@@ -60,6 +63,7 @@ def test_nested_roots_deduped(tmp_path, monkeypatch):
         page_cache, "get_known_projects", lambda: [("proj", str(proj))]
     )
     monkeypatch.setattr(page_cache.sys, "prefix", str(venv))
+    monkeypatch.setattr(page_cache, "_stray_tmp_roots", list)
     roots = {str(r) for r in page_cache.default_reclaim_roots()}
     assert str(proj.resolve()) in roots
     assert str(venv.resolve()) not in roots  # nested → dropped
@@ -134,10 +138,48 @@ def test_priority_roots_ordered_before_projects(tmp_path, monkeypatch):
         page_cache, "get_known_projects", lambda: [("proj", str(proj))]
     )
     monkeypatch.setattr(page_cache.sys, "prefix", str(venv))
+    monkeypatch.setattr(page_cache, "_stray_tmp_roots", list)
     roots = [str(r) for r in page_cache.default_reclaim_roots()]
     # instance/ and venv (small, high-value) come before the project workdir.
     assert roots.index(str(inst.resolve())) < roots.index(str(proj.resolve()))
     assert roots.index(str(venv.resolve())) < roots.index(str(proj.resolve()))
+
+
+def test_stray_tmp_roots_ignores_non_tmp_patterns(tmp_path, monkeypatch):
+    # A matching dir outside /tmp must be ignored: the sweep only honors /tmp/*.
+    (tmp_path / "pytest-of-koan").mkdir()
+    monkeypatch.setattr(
+        page_cache, "get_cleanup_extra_tmp_globs",
+        lambda: [str(tmp_path / "pytest-of-*")],
+    )
+    assert page_cache._stray_tmp_roots() == []
+
+
+@pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only")
+def test_stray_tmp_roots_dir_and_uid_filters(monkeypatch):
+    import app.page_cache as pc
+
+    captured = {}
+
+    def fake_glob(pattern):
+        captured["pattern"] = pattern
+        return ["/tmp/pytest-of-me", "/tmp/pytest-of-other", "/tmp/pytest-file"]
+
+    def fake_lstat(path):
+        import stat as _stat
+        from types import SimpleNamespace
+        if path == "/tmp/pytest-file":
+            return SimpleNamespace(st_mode=_stat.S_IFREG, st_uid=os.getuid())
+        uid = os.getuid() if path == "/tmp/pytest-of-me" else os.getuid() + 1
+        return SimpleNamespace(st_mode=_stat.S_IFDIR, st_uid=uid)
+
+    monkeypatch.setattr(pc, "get_cleanup_extra_tmp_globs", lambda: ["/tmp/pytest-of-*"])
+    monkeypatch.setattr(pc.os, "lstat", fake_lstat)
+    import glob as _g
+    monkeypatch.setattr(_g, "glob", fake_glob)
+    roots = {str(r) for r in pc._stray_tmp_roots()}
+    # Only the own-uid directory survives (other-uid dir and regular file dropped).
+    assert roots == {"/tmp/pytest-of-me"}
 
 
 def _run_stats(monkeypatch, stats):

--- a/koan/tests/test_page_cache.py
+++ b/koan/tests/test_page_cache.py
@@ -145,14 +145,20 @@ def test_priority_roots_ordered_before_projects(tmp_path, monkeypatch):
     assert roots.index(str(venv.resolve())) < roots.index(str(proj.resolve()))
 
 
-def test_stray_tmp_roots_ignores_non_tmp_patterns(tmp_path, monkeypatch):
-    # A matching dir outside /tmp must be ignored: the sweep only honors /tmp/*.
-    (tmp_path / "pytest-of-koan").mkdir()
+def test_stray_tmp_roots_ignores_non_tmp_patterns(monkeypatch):
+    # A pattern outside /tmp must be skipped outright: the sweep only honors
+    # /tmp/* patterns. Use a fixed non-/tmp pattern (not tmp_path, which pytest
+    # roots under /tmp on CI) and spy on glob to prove the guard short-circuits
+    # before globbing rather than merely matching nothing.
+    globbed: list[str] = []
     monkeypatch.setattr(
         page_cache, "get_cleanup_extra_tmp_globs",
-        lambda: [str(tmp_path / "pytest-of-*")],
+        lambda: ["/var/tmp/pytest-of-*"],
     )
+    import glob as _glob
+    monkeypatch.setattr(_glob, "glob", lambda p: globbed.append(p) or [])
     assert page_cache._stray_tmp_roots() == []
+    assert globbed == []  # non-/tmp pattern never reached glob
 
 
 @pytest.mark.skipif(not hasattr(os, "getuid"), reason="POSIX-only")

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -119,14 +119,19 @@ see it.
   reclaimable page cache (`file`) that mission file I/O leaves warm, and Railway's
   `/sys/fs/cgroup/memory.reclaim` is read-only. The agent loop therefore runs a
   single reclaim primitive (`app/page_cache.reclaim_page_cache`, over
-  `default_reclaim_roots()` = project workdirs + `instance/` + venv + scratch dir)
+  `default_reclaim_roots()` = project workdirs + `instance/` + venv + scratch dir +
+  the stray per-mission `/tmp` trees matched by `cleanup.extra_tmp_globs`, own-uid
+  only — those hold big *out-of-root* page-cache residuals that the standard roots
+  never cover, observed live 2026-07-19 as ~570 MB of `file` pinned for ~4.5h until
+  the age-gated sweep deleted the files; reclaiming their clean pages decouples the
+  billed baseline from that deletion latency)
   at exactly two non-bypassable choke points: the `run_claude_task` outer `finally`
   (post-mission, after the CLI subprocess has exited) and **inside
   `loop_manager.interruptible_sleep()` itself** — the single sleep primitive every
   idle path shares (between-runs sleep, contemplative sleep, and the whole
   `_IDLE_WAIT_CONFIG` family: `focus_wait`, `passive_wait`, `schedule_wait`,
   `exploration_wait`, `pr_limit_wait`, `branch_saturated_wait`) — throttled to
-  `page_cache_reclaim.idle_interval_s` by `maybe_reclaim_page_cache_idle()`'s
+  `page_cache_reclaim.idle_interval_s` (default 180s) by `maybe_reclaim_page_cache_idle()`'s
   module-level timestamp, which makes the call idempotent per tick. Wiring the
   idle hook at individual call-sites instead of inside the primitive is a
   contract violation: it is exactly how `focus_wait` shipped with no reclaim at


### PR DESCRIPTION
## Summary

Since v0.8.0 the Railway memory graph plateaus near **1 GB** while real process memory is tiny. Root cause is **not a leak** — it is cgroup `memory.current` page-cache accounting.

Diagnosed live on a fresh idle instance (2026-07-19):

| Metric | Value |
|---|---|
| `anon` (real private RAM) | **78 MB** |
| per-process RSS (`ps`) | ~124 MB |
| billed `memory.current` | ~600–900 MB |

The reclaim log showed `file` dropping either to **~95 MB** (fully reclaimed) or plateauing at **~663 MB** — a single mission `/tmp` tree pinning ~570 MB of **out-of root** page cache that held for **~4.5h** until the age-gated post-mission sweep deleted the files. That is the "stable at 1 GB for hours" an operator observes.

The universal reclaim (#2374) only fadvises pages under its roots (`instance/` + venv + scratch + project workdirs); the stray `/tmp` mission trees (`pytest-of-*`, `test-koan*`, `koan-*`, `jest_rs`) were never covered.

## Changes

- **`default_reclaim_roots()` also sweeps the stray `/tmp` mission trees** matched
  by `cleanup.extra_tmp_globs` — **own-uid dirs only** (read-only `fadvise`; skip
  other users' `/tmp` to avoid permission-denied churn). Their clean pages are now
  dropped immediately, decoupling billed footprint from the sweep's deletion latency.
- **`page_cache_reclaim.idle_interval_s` default 900 → 180s** so boot and
  between-tick page cache never sits billed for long.
- Spec contract (`specs/components/agent-loop.md`), `instance.example/config.yaml`,
  and `docs/operations/memory-footprint.md` updated; new test coverage for the
  glob / dir-only / own-uid filters.

The ultimate backstop for *any* out-of-root cache (and for kernel `slab`, which `fadvise` cannot touch) remains a **cgroup memory limit** on the service — noted in the docs.

## Architectural declaration

This extends the durable `default_reclaim_roots()` contract in `specs/components/agent-loop.md` — changed **contract-first**, then the code made to conform.

## Checklist

- [x] **Architectural change** — modifies a durable design contract
  (`specs/components/agent-loop.md`), declared above and reviewed contract-first.
- [x] Tests pass (`test_page_cache.py`, `test_config.py`, `test_run_finally_reclaim.py`)
- [x] `make lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
