### PR TITLE
fix: redirect queued /fix on a PR URL to /rebase --fix (#2458)

### DIFF
--- a/docs/users/skills.md
+++ b/docs/users/skills.md
@@ -4,7 +4,7 @@ title: "Skills Reference"
 description: "Complete reference for all Koan slash commands (mission management, code/PR operations, scheduling, status, configuration, and system commands) usable via Telegram, Slack, or GitHub @mentions."
 tags: [users]
 created: 2026-05-28
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Skills Reference
@@ -52,7 +52,7 @@ Complete reference for all Koan slash commands. Use these via Telegram, Slack, o
 | `/plan [--iterations N] <desc>` | — | Deep-think an idea, create a tracker issue with task-level plan (file map, checkbox steps, code blocks, self-review). `--iterations N` (1-5) runs N critique+refine rounds. Loads project MCP servers when `plan` is in `mcp_roles` (default). | — |
 | `/deepplan <desc>` | `/deeplan` | Spec-first design: explore approaches, post spec, queue /plan | — |
 | `/implement <issue>` | `/impl` | Queue implementation for a GitHub or Jira issue; creates a draft PR, then privately reviews/fixes Important+ findings by default | Yes |
-| `/fix <issue>` | — | Diagnose → understand → plan → test → implement → submit PR, then privately reviews/fixes Important+ findings by default. Use `--skip-diagnose` to bypass the diagnostic. A PR URL is redirected to `/rebase --fix` (preserving `--now` and trailing context) so review feedback is addressed | Yes |
+| `/fix <issue>` | — | Diagnose → understand → plan → test → implement → submit PR, then privately reviews/fixes Important+ findings by default. Use `--skip-diagnose` to bypass the diagnostic. A PR URL is redirected to `/rebase --fix` (preserving `--now` and trailing context) so review feedback is addressed on the same branch — including a GitHub `@bot fix` on a PR, which force-pushes the existing branch and never opens a new PR | Yes |
 | `/debug <issue>` | `/dbg` | Structured 4-step debug loop: reproduce → hypothesize → minimal fix → verify. Auto-queued when `/fix` fails (opt-in via `debug_escalation.on_fix_failure` in config.yaml) | Yes |
 | `/review <PR> [PR ...] [--bot-comments]` | `/rv`, `/rereview`, `/re_review` | Review one or more pull requests; each URL queues a separate review mission. `--bot-comments` triages bot findings | Yes |
 | `/ultrareview <PR>` | `/urv` | Ultra-thorough review: architecture + silent-failure passes combined | Yes |

--- a/koan/app/skill_dispatch.py
+++ b/koan/app/skill_dispatch.py
@@ -445,7 +445,7 @@ def build_skill_command(
         "implement": lambda: _build_implement_cmd(
             base_cmd, args, project_name, project_path, instance_dir,
         ),
-        "fix": lambda: _build_implement_cmd(
+        "fix": lambda: _build_fix_cmd(
             base_cmd, args, project_name, project_path, instance_dir,
         ),
         "rebase": lambda: _build_rebase_cmd(base_cmd, args, project_path),
@@ -690,6 +690,38 @@ def _build_implement_cmd(
     GitHub's issues API works for PRs too, so both URL types are valid.
     """
     return _build_url_context_cmd(
+        base_cmd, args, project_name, project_path, instance_dir,
+    )
+
+
+def _build_fix_cmd(
+    base_cmd: List[str],
+    args: str,
+    project_name: str,
+    project_path: str,
+    instance_dir: str,
+) -> Optional[List[str]]:
+    """Build the /fix command, redirecting PR URLs to /rebase --fix.
+
+    /fix on an *issue* runs the full fix_runner pipeline (new branch + new
+    PR). /fix on a *PR* addresses review feedback on the SAME branch and
+    force-pushes — never opening a new PR — which is exactly what
+    /rebase --fix does. handler.py already does this on the bridge path,
+    but GitHub @mentions queue a raw ``/fix <url>`` mission that reaches the
+    agent loop through this chokepoint instead, so the redirect must live
+    here too. See specs/skills/fix.md (issue #2458).
+    """
+    if _PR_URL_RE.search(args):
+        # base_cmd targets fix_runner; rebuild it to invoke rebase_pr,
+        # reusing base_cmd[0] (the interpreter) so venv/Docker paths hold.
+        rebase_base = [base_cmd[0], "-m", "app.rebase_pr"]
+        cmd = _build_rebase_cmd(rebase_base, args, project_path)
+        # _build_rebase_cmd only appends --fix on trailing text/severity;
+        # /fix always wants the feedback leg, so force it for a bare URL.
+        if cmd and "--fix" not in cmd:
+            cmd.append("--fix")
+        return cmd
+    return _build_implement_cmd(
         base_cmd, args, project_name, project_path, instance_dir,
     )
 

--- a/koan/tests/test_skill_dispatch.py
+++ b/koan/tests/test_skill_dispatch.py
@@ -474,6 +474,44 @@ class TestBuildSkillCommand:
         cmd = self._build("fix", url)
         assert "--context" not in cmd
 
+    def test_fix_with_pr_url_redirects_to_rebase_fix(self):
+        """A queued /fix on a PR URL must dispatch rebase_pr with --fix,
+        never fix_runner — mirrors handler.py so GitHub @bot fix force-pushes
+        the same branch instead of opening a new PR (issue #2458)."""
+        url = "https://github.com/sukria/koan/pull/42"
+        cmd = self._build("fix", url)
+        assert cmd is not None
+        assert "app.rebase_pr" in cmd
+        assert "skills.core.fix.fix_runner" not in cmd
+        assert "--fix" in cmd
+        assert url in cmd
+        assert "--project-path" in cmd
+        assert self.PROJECT_PATH in cmd
+        # No new-PR machinery: issue-runner flags must be absent.
+        assert "--issue-url" not in cmd
+
+    def test_fix_with_pr_url_and_severity(self):
+        """Trailing severity after a PR URL threads through the rebase path."""
+        url = "https://github.com/sukria/koan/pull/42"
+        cmd = self._build("fix", f"{url} critical")
+        assert cmd is not None
+        assert "app.rebase_pr" in cmd
+        assert "--fix" in cmd
+        assert "--min-severity" in cmd
+        sev_idx = cmd.index("--min-severity")
+        assert cmd[sev_idx + 1] == "critical"
+
+    def test_fix_with_issue_url_still_uses_fix_runner(self):
+        """Regression: issue URLs keep the full fix_runner pipeline
+        (new branch + new PR)."""
+        url = "https://github.com/sukria/koan/issues/42"
+        cmd = self._build("fix", url)
+        assert cmd is not None
+        assert "skills.core.fix.fix_runner" in cmd
+        assert "--issue-url" in cmd
+        assert url in cmd
+        assert "app.rebase_pr" not in cmd
+
     def test_url_skill_command_resolves_project_name_from_path_when_missing(self):
         cmd = build_skill_command(
             command="fix",
@@ -525,6 +563,26 @@ class TestDispatchSkillMission:
         cmd = self._dispatch("/recreate https://github.com/sukria/koan/pull/42")
         assert cmd is not None
         assert "app.recreate_pr" in cmd
+
+    def test_fix_pr_url_dispatch_redirects_to_rebase(self):
+        """A GitHub-queued '/fix <PR-URL> 📬' mission dispatches to rebase_pr
+        with --fix, not fix_runner (issue #2458)."""
+        cmd = self._dispatch(
+            "[project:koan] /fix https://github.com/sukria/koan/pull/42 📬"
+        )
+        assert cmd is not None
+        assert "app.rebase_pr" in cmd
+        assert "--fix" in cmd
+        assert "skills.core.fix.fix_runner" not in cmd
+
+    def test_fix_issue_url_dispatch_uses_fix_runner(self):
+        """Regression: a /fix on an issue URL still dispatches fix_runner."""
+        cmd = self._dispatch(
+            "[project:koan] /fix https://github.com/sukria/koan/issues/42 📬"
+        )
+        assert cmd is not None
+        assert "skills.core.fix.fix_runner" in cmd
+        assert "app.rebase_pr" not in cmd
 
     def test_ai_dispatch(self):
         cmd = self._dispatch("/ai koan")

--- a/specs/skills/fix.md
+++ b/specs/skills/fix.md
@@ -4,7 +4,7 @@ title: "Skill Spec — fix"
 description: "Specifies the `/fix` skill, which fixes a tracker issue end-to-end (or batch-queues fixes for a repo) and redirects PR URLs to `/rebase --fix`, with eval coverage on its diagnostic output."
 tags: [skill]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-07-21
 ---
 
 # Skill Spec — `fix`
@@ -80,3 +80,9 @@ prompt MUST be reflected in the golden cases / baseline.
 
 - The issue-vs-PR branch is URL-shape-driven; `github_url_parser` is the single
   classifier — don't reimplement URL detection in the handler.
+- The PR-URL → `/rebase --fix` redirect must be enforced on **both** dispatch
+  paths: the in-process bridge handler (`handler.py`) *and* the queued-mission
+  chokepoint (`skill_dispatch._build_fix_cmd`). GitHub `@mention` `/fix`
+  missions are queued as raw `/fix <url>` and reach the agent loop through the
+  latter, never through `handler.py` — enforcing the redirect in only one place
+  reopens issue #2458 (a new PR is created instead of force-pushing the branch).


### PR DESCRIPTION
## Summary

A GitHub `@bot fix` on a PR opened a brand-new PR instead of addressing review feedback on the existing branch. The `/fix`→`/rebase --fix` redirect that prevents this lived only on the bridge handler path (`handler.py`); GitHub-triggered `/fix` missions are queued as raw `/fix <PR-URL>` and dispatched through `skill_dispatch`, bypassing it. This adds the same PR-URL redirect at the `skill_dispatch.build_skill_command` chokepoint so the documented invariant holds on **all** queued `/fix` paths.

Closes https://github.com/Anantys-oss/koan/issues/2458

## Changes

- `koan/app/skill_dispatch.py`: new `_build_fix_cmd()` — a PR URL routes to `app.rebase_pr … --fix` (forcing `--fix` even for a bare URL); an issue/Jira URL falls through to the existing `fix_runner` path. Repointed the `"fix"` builder.
- `koan/tests/test_skill_dispatch.py`: builder-level + dispatch-level tests for the PR-URL redirect (bare + severity) and the issue-URL regression.
- `docs/users/skills.md`, `specs/skills/fix.md`: note the redirect is enforced on both the bridge handler and the queued-dispatch chokepoint (non-normative watch-out; `spec_change_guard.py` reports no undeclared durable-contract change).

## Test plan

- `KOAN_ROOT=/tmp/test-koan .venv/bin/pytest koan/tests/test_skill_dispatch.py koan/tests/test_fix_runner.py koan/tests/test_pr_ownership.py` — 310 passed
- `make lint` — clean
- `python scripts/spec_change_guard.py` — passed (no undeclared contract change)

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=619d5ed7)_
