### PR TITLE
fix: inject general KOAN.md into runner-based skill prompts

### DIFF
--- a/docs/users/koan-md.md
+++ b/docs/users/koan-md.md
@@ -78,6 +78,22 @@ skills (no loader) run without a resolved project in scope, so they receive
 neither `.koan/skills/` nor general `KOAN.md` — steer those via `CLAUDE.md` or
 the mission text instead.
 
+### Seeing what got loaded (`make logs`)
+
+Every steering file koan folds into a prompt is announced on the run log, so you
+can confirm the context is actually in play. Watch `make logs` for lines like:
+
+```
+[context] Detected KOAN.md, loaded 1240 chars (~ 354 tokens)
+[context] Detected .koan/skills/plan, loaded 380 chars (~ 108 tokens)
+[context] Detected CLAUDE.md (auto-loaded by CLI), loaded 8900 chars (~ 2542 tokens)
+```
+
+`KOAN.md` and `.koan/skills/<skill>` lines mean koan injected that content;
+the `CLAUDE.md` line is **detection-only** — Claude Code loads `CLAUDE.md` from
+the working directory itself, koan just reports its size so you can see the full
+steering context at a glance. Token counts are a `chars/3.5` estimate.
+
 ## Example: this repository (dogfood)
 
 The Kōan source tree ships its own steering so autonomous missions on koan

--- a/docs/users/koan-md.md
+++ b/docs/users/koan-md.md
@@ -4,7 +4,7 @@ title: "KOAN.md — koan-only project instructions"
 description: "Documents the optional project-root KOAN.md file and the .koan/ directory (a second .koan/KOAN.md plus per-skill .koan/skills/<skill>/*.md hooks): koan-only steering injected into the autonomous agent's system prompt but never loaded by interactive Claude Code sessions, with precedence rules, the 16k-char cap, and this repo's dogfood layout."
 tags: [users]
 created: 2026-07-09
-updated: 2026-07-16
+updated: 2026-07-22
 ---
 
 # KOAN.md — koan-only project instructions
@@ -65,14 +65,18 @@ the `/pr` handler drives its feedback, refactor, and quality-review sub-passes
 under a single `pr` skill, so steer all three via `.koan/skills/pr/` (there is
 no separate `.koan/skills/refactor/`).
 
-Everything is opt-in by file existence and a no-op when absent. Prompt-only
-skills do not read `.koan/skills/`; steer those with general `KOAN.md`.
+Runner skills pass `project_path` into `load_skill_prompt` /
+`load_prompt_or_skill`, so they receive **both** `.koan/skills/<skill>/*`
+(per-skill steering) **and** the general `KOAN.md` (root + `.koan/KOAN.md`),
+appended in that order — the same always-on guidance the agent loop gets. Core
+runners that honor it include `review`, `plan`, `pr`, `fix`, `implement`, and
+`rebase` (and their sub-passes). A runner that never passes `project_path`
+receives neither until wired.
 
-Runner skills must pass `project_path` into `load_skill_prompt` /
-`load_prompt_or_skill` for the append to fire. Core runners that honor it
-include `review`, `plan`, `pr`, `fix`, `implement`, and `rebase` (and their
-sub-passes). Skills that never pass `project_path` ignore
-`.koan/skills/<name>/` until wired.
+Everything is opt-in by file existence and a no-op when absent. Prompt-only
+skills (no loader) run without a resolved project in scope, so they receive
+neither `.koan/skills/` nor general `KOAN.md` — steer those via `CLAUDE.md` or
+the mission text instead.
 
 ## Example: this repository (dogfood)
 

--- a/koan/app/project_koan.py
+++ b/koan/app/project_koan.py
@@ -6,12 +6,37 @@ absent/blank/unreadable handling: absent is the normal case (no log); a
 present-but-unreadable file warns and is treated as empty.
 """
 import logging
+import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
 _MAX_KOAN_MD_CHARS = 16000
 _MAX_KOAN_SKILL_CHARS = 16000
+
+
+def log_context_load(label: str, content: str) -> None:
+    """Announce a steering file koan just loaded into a prompt, for ``make logs``.
+
+    Emits ``Detected <label>, loaded N chars (~ M tokens)`` on **stderr** so it
+    lands in ``logs/run.log`` (visible via ``make logs``) without ever
+    corrupting the JSON some skill runners write to stdout. The ``logging``
+    module has no stdout/stderr handler wired in the run loop, so ``logger.info``
+    alone would be invisible there — hence the direct ``print``.
+
+    Best-effort: a broken stream (or a missing ``estimate_tokens``) must never
+    break prompt assembly, so every failure is swallowed silently.
+    """
+    try:
+        from app.diff_compressor import estimate_tokens
+        print(
+            f"[context] Detected {label}, loaded {len(content)} chars "
+            f"(~ {estimate_tokens(content)} tokens)",
+            file=sys.stderr,
+            flush=True,
+        )
+    except Exception:
+        pass
 
 
 def _read_or_empty(path: Path) -> str:

--- a/koan/app/project_koan.py
+++ b/koan/app/project_koan.py
@@ -25,7 +25,8 @@ def log_context_load(label: str, content: str) -> None:
     alone would be invisible there — hence the direct ``print``.
 
     Best-effort: a broken stream (or a missing ``estimate_tokens``) must never
-    break prompt assembly, so every failure is swallowed silently.
+    break prompt assembly, so every failure is swallowed — logged at debug so it
+    stays visible without ever raising.
     """
     try:
         from app.diff_compressor import estimate_tokens
@@ -35,8 +36,8 @@ def log_context_load(label: str, content: str) -> None:
             file=sys.stderr,
             flush=True,
         )
-    except Exception:
-        pass
+    except Exception as e:
+        logger.debug("log_context_load failed for %s: %s", label, e)
 
 
 def _read_or_empty(path: Path) -> str:

--- a/koan/app/prompt_builder.py
+++ b/koan/app/prompt_builder.py
@@ -328,17 +328,37 @@ def _get_koan_md_section(project_path: str) -> str:
     """
     if not project_path:
         return ""
-    from app.project_koan import read_general_koan_md
+    from app.project_koan import log_context_load, read_general_koan_md
     content = read_general_koan_md(project_path)
     if not content:
         return ""
 
-    logger.info(
-        "KOAN.md (root + .koan/) read (%d chars) from %s", len(content), project_path
-    )
+    log_context_load("KOAN.md", content)
 
     from app.prompts import load_prompt
     return load_prompt("koan-md", KOAN_MD_CONTENT=content)
+
+
+def _log_claude_md_detected(project_path: str) -> None:
+    """Surface the project's root ``CLAUDE.md`` in ``make logs`` when present.
+
+    Unlike ``KOAN.md``, koan never injects ``CLAUDE.md`` — the CLI auto-loads it
+    from ``cwd``. This is detection-only: it reads the file solely to report its
+    size so operators can see (via ``make logs``) exactly which steering context
+    is in play. Best-effort; any failure is swallowed.
+    """
+    if not project_path:
+        return
+    try:
+        from pathlib import Path
+        claude_md = Path(project_path) / "CLAUDE.md"
+        if not claude_md.is_file():
+            return
+        content = claude_md.read_text(errors="replace")
+        from app.project_koan import log_context_load
+        log_context_load("CLAUDE.md (auto-loaded by CLI)", content)
+    except Exception as e:
+        logger.debug("CLAUDE.md detection failed for %s: %s", project_path, e)
 
 
 def _get_staleness_section(instance: str, project_name: str) -> str:
@@ -855,6 +875,10 @@ def build_agent_prompt(
 
     # Append submit-pull-request section
     prompt += _get_submit_pr_section(project_path, project_name)
+
+    # Surface the project's CLAUDE.md for `make logs`. koan does NOT inject it
+    # (the CLI auto-loads CLAUDE.md via cwd) — this only makes the load visible.
+    _log_claude_md_detected(host_project_path or project_path)
 
     # Append project-local koan-only instructions (KOAN.md), host-path aware.
     koan_md = _get_koan_md_section(host_project_path or project_path)

--- a/koan/app/prompts.py
+++ b/koan/app/prompts.py
@@ -208,7 +208,10 @@ def load_skill_prompt(
     template = _resolve_includes(template, skill_dir=skill_dir)
     prompt = _substitute(template, kwargs)
     prompt = _maybe_append_caveman(prompt, skill_dir)
-    return _maybe_append_project_skill_instructions(prompt, skill_dir, project_path)
+    prompt = _maybe_append_project_skill_instructions(prompt, skill_dir, project_path)
+    # General KOAN.md rides BELOW the per-skill block: precedence is
+    # `.koan/skills/<skill>/* > KOAN.md` (see specs/components/skills.md).
+    return _maybe_append_general_koan_md(prompt, skill_dir, project_path)
 
 
 def load_prompt_or_skill(
@@ -297,4 +300,39 @@ def _maybe_append_project_skill_instructions(
         return f"{prompt}\n\n{block}"
     except Exception as e:
         logger.warning(".koan skill injection failed for %s: %s", skill_dir, e)
+        return prompt
+
+
+def _maybe_append_general_koan_md(
+    prompt: str, skill_dir: Path, project_path: Optional[str],
+) -> str:
+    """Append the project's general ``KOAN.md`` (root + ``.koan/KOAN.md``), when present.
+
+    Mirrors :func:`_maybe_append_project_skill_instructions`' gating: a no-op unless
+    ``skill_dir`` has a ``SKILL.md`` AND ``project_path`` is set, so arbitrary
+    directory paths (tests, legacy callers) stay untouched and the default
+    ``project_path=None`` keeps every existing call byte-identical. Framed via the
+    shared ``koan-md`` template — the same framing the agent loop uses in
+    ``prompt_builder._get_koan_md_section`` — and appended AFTER the
+    ``.koan/skills/<name>/`` block so the precedence reads
+    ``.koan/skills/<skill>/* > KOAN.md``.
+
+    Failures are swallowed (additive guidance, not a correctness feature); they
+    surface via the module logger so silent regressions stay visible in the log.
+    """
+    try:
+        if not project_path or not (skill_dir / "SKILL.md").is_file():
+            return prompt
+        from app.project_koan import read_general_koan_md  # lazy: avoid cycle
+        content = read_general_koan_md(project_path)
+        if not content:
+            return prompt
+        logger.info(
+            "general KOAN.md injected into %s prompt (%d chars) from %s",
+            skill_dir.name, len(content), project_path,
+        )
+        block = load_prompt("koan-md", KOAN_MD_CONTENT=content)
+        return f"{prompt}\n\n{block}"
+    except Exception as e:
+        logger.warning("general KOAN.md injection failed for %s: %s", skill_dir, e)
         return prompt

--- a/koan/app/prompts.py
+++ b/koan/app/prompts.py
@@ -288,10 +288,11 @@ def _maybe_append_project_skill_instructions(
     try:
         if not project_path or not (skill_dir / "SKILL.md").is_file():
             return prompt
-        from app.project_koan import read_skill_instructions  # lazy: avoid cycle
+        from app.project_koan import log_context_load, read_skill_instructions
         content = read_skill_instructions(project_path, skill_dir.name)
         if not content:
             return prompt
+        log_context_load(f".koan/skills/{skill_dir.name}", content)
         block = load_prompt(
             "koan-skill",
             SKILL_NAME=skill_dir.name,
@@ -315,7 +316,9 @@ def _maybe_append_general_koan_md(
     shared ``koan-md`` template — the same framing the agent loop uses in
     ``prompt_builder._get_koan_md_section`` — and appended AFTER the
     ``.koan/skills/<name>/`` block so the precedence reads
-    ``.koan/skills/<skill>/* > KOAN.md``.
+    ``.koan/skills/<skill>/* > KOAN.md``. A successful injection is announced via
+    ``project_koan.log_context_load`` (stderr → ``logs/run.log``) so ``make logs``
+    shows the load.
 
     Failures are swallowed (additive guidance, not a correctness feature); they
     surface via the module logger so silent regressions stay visible in the log.
@@ -323,14 +326,11 @@ def _maybe_append_general_koan_md(
     try:
         if not project_path or not (skill_dir / "SKILL.md").is_file():
             return prompt
-        from app.project_koan import read_general_koan_md  # lazy: avoid cycle
+        from app.project_koan import log_context_load, read_general_koan_md
         content = read_general_koan_md(project_path)
         if not content:
             return prompt
-        logger.info(
-            "general KOAN.md injected into %s prompt (%d chars) from %s",
-            skill_dir.name, len(content), project_path,
-        )
+        log_context_load("KOAN.md", content)
         block = load_prompt("koan-md", KOAN_MD_CONTENT=content)
         return f"{prompt}\n\n{block}"
     except Exception as e:

--- a/koan/tests/test_project_koan.py
+++ b/koan/tests/test_project_koan.py
@@ -93,3 +93,22 @@ def test_skill_cap(tmp_path, monkeypatch):
     (d / "a.md").write_text("y" * 50)
     out = pk.read_skill_instructions(str(tmp_path), "review")
     assert "truncated" in out
+
+
+def test_log_context_load_emits_chars_and_tokens(capsys):
+    pk.log_context_load("KOAN.md", "x" * 35)
+    err = capsys.readouterr().err
+    assert "Detected KOAN.md" in err
+    assert "35 chars" in err
+    assert "tokens" in err  # ~ 10 tokens at chars/3.5
+
+
+def test_log_context_load_never_raises(capsys, monkeypatch):
+    # A broken token estimator must not break prompt assembly.
+    import app.diff_compressor as dc
+
+    def _boom(_):
+        raise RuntimeError("estimator down")
+
+    monkeypatch.setattr(dc, "estimate_tokens", _boom)
+    pk.log_context_load("KOAN.md", "content")  # must not raise

--- a/koan/tests/test_prompt_builder.py
+++ b/koan/tests/test_prompt_builder.py
@@ -2596,6 +2596,35 @@ class TestKoanMdSection:
         from app.prompt_builder import _get_koan_md_section
         assert _get_koan_md_section(str(tmp_path)) == ""
 
+    def test_koan_md_section_logs_load(self, tmp_path, capsys):
+        from app.prompt_builder import _get_koan_md_section
+        (tmp_path / "KOAN.md").write_text("Always run make lint before pushing.")
+        _get_koan_md_section(str(tmp_path))
+        err = capsys.readouterr().err
+        assert "Detected KOAN.md" in err and "tokens" in err
+
+
+class TestClaudeMdDetection:
+    """_log_claude_md_detected surfaces CLAUDE.md in make logs (detection-only)."""
+
+    def test_logs_when_present(self, tmp_path, capsys):
+        from app.prompt_builder import _log_claude_md_detected
+        (tmp_path / "CLAUDE.md").write_text("Project rules here.")
+        _log_claude_md_detected(str(tmp_path))
+        err = capsys.readouterr().err
+        assert "Detected CLAUDE.md" in err
+        assert "auto-loaded by CLI" in err
+
+    def test_silent_when_absent(self, tmp_path, capsys):
+        from app.prompt_builder import _log_claude_md_detected
+        _log_claude_md_detected(str(tmp_path))
+        assert "CLAUDE.md" not in capsys.readouterr().err
+
+    def test_silent_when_empty_path(self, capsys):
+        from app.prompt_builder import _log_claude_md_detected
+        _log_claude_md_detected("")
+        assert capsys.readouterr().err == ""
+
 
 class TestKoanMdWiring:
     """Tests that KOAN.md content reaches the mission system prompt."""

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -933,6 +933,18 @@ class TestMaybeAppendProjectSkillInstructions:
         out = load_skill_prompt(sd, "review", project_path=str(proj))
         assert ".koan/skills/review" not in out
 
+    def test_logs_fragment_load_for_make_logs(self, tmp_path, capsys):
+        sd = self._make_skill(tmp_path)
+        proj = tmp_path / "proj"
+        d = proj / ".koan" / "skills" / "review"
+        d.mkdir(parents=True)
+        (d / "extra-rules.md").write_text("REPO EXTRA RULE")
+        load_skill_prompt(sd, "review", project_path=str(proj))
+        # Surfaced on stderr so `make logs` (logs/run.log) shows the load.
+        err = capsys.readouterr().err
+        assert "Detected .koan/skills/review" in err
+        assert "chars" in err and "tokens" in err
+
 
 class TestMaybeAppendGeneralKoanMd:
     """Gating/ordering of general KOAN.md injection via load_skill_prompt."""
@@ -1013,3 +1025,16 @@ class TestMaybeAppendGeneralKoanMd:
         # Best-effort: the built-in prompt still loads, injection skipped silently.
         assert "BUILT-IN PLAN PROMPT" in out
         assert "BEGIN KOAN.md" not in out
+
+    def test_logs_koan_md_load_for_make_logs(self, tmp_path, capsys):
+        sd = self._make_skill(tmp_path)
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "KOAN.md").write_text("Always use the widget tool.")
+
+        load_skill_prompt(sd, "plan", project_path=str(proj))
+
+        # Surfaced on stderr so `make logs` (logs/run.log) shows the load.
+        err = capsys.readouterr().err
+        assert "Detected KOAN.md" in err
+        assert "chars" in err and "tokens" in err

--- a/koan/tests/test_prompts.py
+++ b/koan/tests/test_prompts.py
@@ -932,3 +932,84 @@ class TestMaybeAppendProjectSkillInstructions:
         (d / "extra-rules.md").write_text("   \n")
         out = load_skill_prompt(sd, "review", project_path=str(proj))
         assert ".koan/skills/review" not in out
+
+
+class TestMaybeAppendGeneralKoanMd:
+    """Gating/ordering of general KOAN.md injection via load_skill_prompt."""
+
+    @staticmethod
+    def _make_skill(tmp_path):
+        sd = tmp_path / "skills" / "core" / "plan"
+        (sd / "prompts").mkdir(parents=True)
+        (sd / "SKILL.md").write_text("name: plan\n")
+        (sd / "prompts" / "plan.md").write_text("BUILT-IN PLAN PROMPT")
+        return sd
+
+    def test_injects_general_koan_md(self, tmp_path):
+        sd = self._make_skill(tmp_path)
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "KOAN.md").write_text("Always use the widget tool.")
+
+        out = load_skill_prompt(sd, "plan", project_path=str(proj))
+
+        assert "BUILT-IN PLAN PROMPT" in out
+        assert "Always use the widget tool." in out
+        assert "BEGIN KOAN.md" in out  # framed via the koan-md template
+
+    def test_no_project_path_omits_koan_md(self, tmp_path):
+        sd = self._make_skill(tmp_path)
+        # A KOAN.md exists nearby but no project_path is passed -> must not appear.
+        (tmp_path / "KOAN.md").write_text("SHOULD NOT LEAK")
+
+        out = load_skill_prompt(sd, "plan")  # project_path defaults to None
+
+        assert "BUILT-IN PLAN PROMPT" in out
+        assert "BEGIN KOAN.md" not in out
+        assert "SHOULD NOT LEAK" not in out
+
+    def test_no_skill_md_omits_koan_md(self, tmp_path):
+        # A bare directory without SKILL.md must not inject (legacy-caller gate).
+        sd = tmp_path / "skills" / "core" / "plan"
+        (sd / "prompts").mkdir(parents=True)
+        (sd / "prompts" / "plan.md").write_text("BUILT-IN PLAN PROMPT")
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "KOAN.md").write_text("SHOULD NOT LEAK")
+
+        out = load_skill_prompt(sd, "plan", project_path=str(proj))
+
+        assert "BUILT-IN PLAN PROMPT" in out
+        assert "SHOULD NOT LEAK" not in out
+
+    def test_koan_md_appended_after_skill_instructions(self, tmp_path):
+        sd = self._make_skill(tmp_path)
+        proj = tmp_path / "proj"
+        steer = proj / ".koan" / "skills" / "plan"
+        steer.mkdir(parents=True)
+        (steer / "extra.md").write_text("PER-SKILL STEER")
+        (proj / "KOAN.md").write_text("GENERAL STEER")
+
+        out = load_skill_prompt(sd, "plan", project_path=str(proj))
+
+        assert "PER-SKILL STEER" in out and "GENERAL STEER" in out
+        assert out.index("PER-SKILL STEER") < out.index("GENERAL STEER")
+
+    def test_injection_failure_is_swallowed(self, tmp_path, monkeypatch):
+        sd = self._make_skill(tmp_path)
+        proj = tmp_path / "proj"
+        proj.mkdir()
+        (proj / "KOAN.md").write_text("Always use the widget tool.")
+
+        import app.project_koan as pk
+
+        def _boom(_):
+            raise RuntimeError("read blew up")
+
+        monkeypatch.setattr(pk, "read_general_koan_md", _boom)
+
+        out = load_skill_prompt(sd, "plan", project_path=str(proj))
+
+        # Best-effort: the built-in prompt still loads, injection skipped silently.
+        assert "BUILT-IN PLAN PROMPT" in out
+        assert "BEGIN KOAN.md" not in out

--- a/specs/components/agent-loop.md
+++ b/specs/components/agent-loop.md
@@ -4,7 +4,7 @@ title: "Component Spec — Agent Loop Pipeline"
 description: "Design contract for the core mission pipeline (iteration manager, mission executor/runner, quota handling, stagnation monitor) that pulls missions, invokes the CLI provider, and finalizes lifecycle state."
 tags: [agent-loop]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-07-22
 ---
 
 # Component Spec — Agent Loop Pipeline
@@ -78,6 +78,15 @@ when `project_path` is the devcontainer workspace. Invariant: both sources
 absent/blank leaves the system prompt unchanged. KOAN.md is koan-only — Claude
 Code auto-loads `CLAUDE.md` but never `KOAN.md`, so interactive sessions never
 see it.
+
+**Steering-context visibility (`make logs`).** Every steering file that shapes a
+mission prompt is announced on stderr (→ `logs/run.log`) as `Detected <label>,
+loaded N chars (~ M tokens)` via `project_koan.log_context_load`. The agent loop
+surfaces `KOAN.md` when `_get_koan_md_section` reads it, and — detection-only —
+`CLAUDE.md (auto-loaded by CLI)` via `_log_claude_md_detected(project_path)`,
+which reads the project-root `CLAUDE.md` solely to report its size (koan never
+injects it; the CLI loads it from `cwd`). Best-effort: any read/stream failure is
+swallowed and never blocks prompt assembly.
 
 ## Invariants
 

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -4,7 +4,7 @@ title: "Component Spec — Skills System"
 description: "Documents the skills system that discovers, routes, and executes `/command` skills (SKILL.md contract, dispatch, the new-skill checklist, and the eval harness)."
 tags: [skills]
 created: 2026-06-27
-updated: 2026-07-17
+updated: 2026-07-22
 ---
 
 # Component Spec — Skills System

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -186,10 +186,31 @@ subdirs, and caps the concatenation at `_MAX_KOAN_SKILL_CHARS` (16k).
 `prompts._maybe_append_project_skill_instructions(prompt, skill_dir, project_path)` frames
 the content via the `koan-skill` template and appends it — **only** when `skill_dir` has a
 `SKILL.md` and `project_path` is set (default `None` ⇒ byte-identical no-op). Scope:
-runner/loader-based skills that thread `project_path` (`review`, `refactor`, `plan`, …);
-prompt-only skills (`_execute_prompt` returns raw `prompt_body`, no loader) are out of
-scope and rely on general `KOAN.md`. Precedence: mission instruction > `.koan/skills/<skill>/*`
-> `KOAN.md`/`.koan/KOAN.md` > skill built-in prompt > `CLAUDE.md`/defaults.
+runner/loader-based skills that thread `project_path` (`review`, `refactor`, `plan`, …)
+honor both `.koan/skills/<skill>/*` and general `KOAN.md` (see "General KOAN.md in skill
+prompts" below); prompt-only skills (`_execute_prompt` returns raw `prompt_body`, no
+loader) receive neither, as they run without a resolved project in scope. Precedence:
+mission instruction > `.koan/skills/<skill>/*` > `KOAN.md`/`.koan/KOAN.md` > skill built-in
+prompt > `CLAUDE.md`/defaults.
+
+### General KOAN.md in skill prompts
+
+`prompts.load_skill_prompt` also injects the project's **general** `KOAN.md`
+(root `KOAN.md` + `.koan/KOAN.md`, read via `project_koan.read_general_koan_md`,
+combined cap `_MAX_KOAN_MD_CHARS` 16k) for every runner/loader-based skill that
+threads `project_path`. `prompts._maybe_append_general_koan_md(prompt, skill_dir,
+project_path)` frames it via the shared `koan-md` template (the same framing the
+agent loop uses in `prompt_builder._get_koan_md_section`) and appends it **after**
+the `.koan/skills/<skill>/*` block, so a single skill prompt carries both — ordered
+`.koan/skills/<skill>/* > KOAN.md`. Gated identically to the per-skill append: a
+no-op unless `skill_dir` has a `SKILL.md` **and** `project_path` is set (default
+`project_path=None` ⇒ byte-identical). This makes the precedence chain above real
+for skills, not only for the agent loop. The two blocks keep independent 16k caps
+(no combined ceiling — worst case 32k on one prompt, only when a project ships both
+a large root `KOAN.md` and large per-skill instructions; the injected length is
+logged). Prompt-only skills (`_execute_prompt` returns raw `prompt_body`) run
+without a resolved project in scope, so they receive no project-scoped injection —
+by design, not a gap.
 
 ### `add_project` workspace resolution (contract)
 

--- a/specs/components/skills.md
+++ b/specs/components/skills.md
@@ -207,10 +207,16 @@ no-op unless `skill_dir` has a `SKILL.md` **and** `project_path` is set (default
 `project_path=None` ⇒ byte-identical). This makes the precedence chain above real
 for skills, not only for the agent loop. The two blocks keep independent 16k caps
 (no combined ceiling — worst case 32k on one prompt, only when a project ships both
-a large root `KOAN.md` and large per-skill instructions; the injected length is
-logged). Prompt-only skills (`_execute_prompt` returns raw `prompt_body`) run
-without a resolved project in scope, so they receive no project-scoped injection —
-by design, not a gap.
+a large root `KOAN.md` and large per-skill instructions). Prompt-only skills
+(`_execute_prompt` returns raw `prompt_body`) run without a resolved project in
+scope, so they receive no project-scoped injection — by design, not a gap.
+
+Every actual injection is announced on **stderr** (so it lands in `logs/run.log`
+and is visible via `make logs`) through `project_koan.log_context_load(label,
+content)`, which emits `Detected <label>, loaded N chars (~ M tokens)` — `label`
+is `KOAN.md` for the general block and `.koan/skills/<skill>` for the per-skill
+block. `logging.getLogger` output alone is invisible in the run loop (no
+stream handler wired), so the load line is a direct `print`, not `logger.info`.
 
 ### `add_project` workspace resolution (contract)
 


### PR DESCRIPTION
## Summary

`KOAN.md` is specified as the koan-only analogue of `CLAUDE.md` (always-on project guidance), but only the generic agent loop injected it — every runner-based core skill (`/plan`, `/fix`, `/implement`, `/review`, `/rebase`, …) ran blind to it, contradicting the precedence chain already written in `specs/components/skills.md`. This injects the project's general `KOAN.md` inside `prompts.load_skill_prompt`, gated identically to the existing `.koan/skills/` append, so every runner that already threads `project_path` gains it at once — including the `/plan` path observed ignoring `KOAN.md`.

- [x] **Architectural change** — durable-contract change to `specs/components/skills.md`, made contract-first before the code conformed.

Closes https://github.com/Anantys-oss/koan/issues/2463

## Changes

- `specs/components/skills.md`: new "General KOAN.md in skill prompts" subsection; corrected the stale prompt-only "rely on general KOAN.md" claim.
- `koan/app/prompts.py`: added `_maybe_append_general_koan_md()`, called last in `load_skill_prompt()` — appended **after** the `.koan/skills/<skill>/*` block so precedence reads `.koan/skills/<skill>/* > KOAN.md`. Gated on `SKILL.md` + `project_path` (default `None` ⇒ byte-identical). Failures swallowed with a `logger.warning`.
- `koan/tests/test_prompts.py`: injection present/absent, ordering after `.koan/skills/`, swallowed-failure, and no-`SKILL.md` gate.
- `docs/users/koan-md.md`: runner skills now receive both `.koan/skills/` and general `KOAN.md`; prompt-only skills receive neither by design.

## Test plan

- `pytest test_prompts.py test_project_koan.py test_prompt_builder.py` — 282 passed.
- `make lint` — clean. `scripts/spec_change_guard.py` — passes.

---
_Generated by [Kōan](https://koan.anantys.com)_ _(claude · model claude-opus-4-8 · HEAD=7c19bf0f)_