### PR TITLE
fix(worktree): reclaim leaked review worktrees registered outside the…

### DIFF
--- a/docs/operations/troubleshooting.md
+++ b/docs/operations/troubleshooting.md
@@ -4,7 +4,7 @@ title: "Troubleshooting"
 description: "Catalogs common operational issues (agent loop, git/worktrees, memory, bridge, GitHub, CLI provider, parallel sessions, config) and their fixes."
 tags: [operations]
 created: 2026-06-04
-updated: 2026-07-17
+updated: 2026-07-30
 ---
 
 # Troubleshooting
@@ -68,6 +68,11 @@ git worktree prune         # Remove stale references
 ```
 
 Kōan cleans up worktrees on startup during crash recovery. If you see stale worktrees, restarting the agent loop should clear them.
+
+The bridge also sweeps hourly for leaked worktrees registered outside the project, such
+as temporary review checkouts. It keeps locked worktrees, worktrees with recent
+non-ignored file activity, tracking branches with commits missing upstream, and
+detached commits missing every durable branch, remote, or tag.
 
 ### Branch conflicts (can't checkout, can't push)
 

--- a/koan/app/awake.py
+++ b/koan/app/awake.py
@@ -816,6 +816,49 @@ def _bridge_should_restart(monitor) -> bool:
     return _workers_idle()
 
 
+# How often to sweep for leaked agent-created worktrees. Hourly: a stray worktree costs
+# disk, not correctness, and reap_foreign_worktrees() ignores anything touched in the last
+# two days anyway, so sweeping more often would find nothing new.
+WORKTREE_REAP_INTERVAL = 3600
+
+
+def _maybe_reap_worktrees(last_reap: float, interval: int = WORKTREE_REAP_INTERVAL) -> float:
+    """Reclaim leaked review worktrees across known projects, every ``interval`` seconds.
+
+    Agents check revisions out ad hoc during PR review (`git worktree add /tmp/review-<sha>`)
+    and never remove them. On a large checkout each is hundreds of megabytes, so they fill
+    the disk; on 2026-07-30 this took the `koan` host's root filesystem to 100% and
+    crash-looped this service. reap_foreign_worktrees() only touches worktrees registered
+    outside the project, unlocked, untouched for days, and free of unpushed commits.
+
+    Returns the (possibly updated) last-reap timestamp.
+    """
+    if not interval:
+        return last_reap
+    now = time.time()
+    if (now - last_reap) < interval:
+        return last_reap
+    try:
+        from app.project_explorer import get_projects
+        from app.worktree_manager import reap_foreign_worktrees
+
+        projects = get_projects()
+    except Exception as e:
+        log("error", f"periodic worktree reap failed: {e}")
+        return now
+
+    # Per-project isolation: one unreadable repo must not stop the others being swept.
+    for _name, path in projects:
+        try:
+            reaped = reap_foreign_worktrees(path)
+        except Exception as e:
+            log("error", f"worktree reap failed for {path}: {e}")
+            continue
+        if reaped:
+            log("health", f"Reclaimed {len(reaped)} leaked worktree(s) in {path}")
+    return now
+
+
 def _maybe_periodic_compact(last_compact: float, interval: int) -> float:
     """Run compact_history if ``interval`` seconds elapsed since last_compact.
 
@@ -1113,6 +1156,9 @@ def _bridge_loop():
     bridge_monitor = _build_bridge_memory_monitor()
     compact_interval = get_conversation_compact_interval()
     last_compact = startup_time
+    # Reap on the first cycle rather than after a full interval, so a restart triggered by
+    # a full disk reclaims space immediately instead of an hour later.
+    last_worktree_reap = 0.0
 
     # Purge stale heartbeat so health_check doesn't report STALE on restart
     heartbeat_file = KOAN_ROOT / HEARTBEAT_FILE
@@ -1304,6 +1350,9 @@ def _bridge_loop():
 
             # --- Periodic conversation-history compaction (#2354) ---
             last_compact = _maybe_periodic_compact(last_compact, compact_interval)
+
+            # --- Reclaim leaked agent-created review worktrees ---
+            last_worktree_reap = _maybe_reap_worktrees(last_worktree_reap)
 
             # --- Bridge memory watchdog (#2354) ---
             # Sample once per cycle; restart only when idle so an in-flight

--- a/koan/app/session_manager.py
+++ b/koan/app/session_manager.py
@@ -30,6 +30,7 @@ from app.worktree_manager import (
     create_worktree,
     inject_worktree_claude_md,
     prune_worktrees,
+    reap_foreign_worktrees,
     remove_worktree,
     setup_shared_deps,
 )
@@ -502,6 +503,24 @@ def recover_stale_sessions(registry: SessionRegistry):
         if session.project_path and session.project_path not in pruned_projects:
             pruned_projects.add(session.project_path)
             prune_worktrees(session.project_path)
+            # Also reclaim worktrees an agent checked out ad hoc outside the project
+            # (typically under /tmp during a PR review) and never removed. These are
+            # invisible to prune_worktrees() while their directory still exists, and on a
+            # large checkout they are hundreds of megabytes each.
+            try:
+                reaped = reap_foreign_worktrees(session.project_path)
+                if reaped:
+                    print(
+                        f"[session_manager] reclaimed {len(reaped)} leaked worktree(s) "
+                        f"for {session.project_path}",
+                        file=sys.stderr,
+                    )
+            except Exception as e:
+                print(
+                    f"[session_manager] foreign worktree reap error for "
+                    f"{session.project_path}: {e}",
+                    file=sys.stderr,
+                )
 
     for session in registry.get_active():
         if session.pid <= 0:

--- a/koan/app/worktree_manager.py
+++ b/koan/app/worktree_manager.py
@@ -33,6 +33,11 @@ GIT_RETRY_MAX_DELAY = 0.5
 # Default worktree directory name (relative to project root)
 WORKTREE_DIR = ".worktrees"
 
+# How long a worktree registered outside the project must sit untouched before
+# reap_foreign_worktrees() will remove it. Two days is comfortably longer than any single
+# review run, so a live job is never stripped of its working tree.
+FOREIGN_WORKTREE_MAX_AGE_DAYS = 2.0
+
 
 @dataclass
 class WorktreeInfo:
@@ -43,6 +48,9 @@ class WorktreeInfo:
     project_path: str
     commit: str = ""
     is_main: bool = False
+    # True when git reports the worktree as `locked` — someone else's live workspace
+    # (e.g. a Claude Code agent worktree). Never reap these.
+    locked: bool = False
 
 
 def _get_branch_prefix() -> str:
@@ -309,6 +317,8 @@ def list_worktrees(project_path: str) -> List[WorktreeInfo]:
             current["branch"] = line[7:]
         elif line == "bare":
             current["bare"] = True
+        elif line == "locked" or line.startswith("locked "):
+            current["locked"] = True
         elif line == "":
             if current:
                 worktrees.append(_parse_worktree_entry(current, project_path))
@@ -352,6 +362,219 @@ def cleanup_stale_worktrees(project_path: str, active_session_ids: Optional[List
 
     # Final prune
     prune_worktrees(project_path)
+
+
+def reap_foreign_worktrees(
+    project_path: str,
+    max_age_days: float = FOREIGN_WORKTREE_MAX_AGE_DAYS,
+    dry_run: bool = False,
+) -> List[str]:
+    """Remove stale worktrees registered in this project but living outside it.
+
+    Agents with a shell tool check revisions out ad hoc — `git worktree add
+    /tmp/review-<sha> <sha>` — because that is what the review skill instructs, and the
+    skill has no teardown step. Those worktrees are registered in the project's repo but
+    sit outside `<project>/.worktrees/`, so `cleanup_stale_worktrees()` (which only walks
+    `.worktrees/`) never sees them, and `prune_worktrees()` only drops registrations whose
+    directory is *already* gone. Nothing reclaims a leaked worktree whose directory still
+    exists.
+
+    On a large checkout each one costs hundreds of megabytes. On 2026-07-30 this filled a
+    50G root filesystem on the `koan` host: 14 leaked ~410M cPanel review worktrees plus 5
+    phantom registrations.
+
+    Guards, in order — each one exists because skipping it would destroy work:
+      * only worktrees *outside* project_path — anything inside is owned by
+        cleanup_stale_worktrees() or by another harness (e.g. `.claude/worktrees/`)
+      * never the main worktree
+      * never a `locked` worktree — that is someone's live workspace
+      * never one with tracked or untracked file activity within max_age_days — a review
+        that started minutes ago is still running, and removing its tree kills the job
+      * never one holding commits absent from its upstream or from every durable ref
+
+    Returns the list of paths removed (or, with dry_run, the paths that would be).
+    """
+    project_real = os.path.realpath(project_path)
+    removed: List[str] = []
+    cutoff = time.time() - (max_age_days * 86400)
+
+    # Drop registrations whose directory is already gone before looking at what remains.
+    # These accumulate whenever something deletes a worktree without telling git — the 10d
+    # systemd-tmpfiles sweep of /tmp does exactly that — and nothing else clears them. A
+    # fleet survey on 2026-07-30 found ~20 across six hosts, including 10 on one repo.
+    if not dry_run:
+        prune_worktrees(project_path)
+
+    for wt in list_worktrees(project_path):
+        if wt.is_main or not wt.path:
+            continue
+
+        # Only foreign worktrees. Anything under the project belongs to another owner.
+        wt_real = os.path.realpath(wt.path)
+        if wt_real == project_real or wt_real.startswith(project_real + os.sep):
+            continue
+
+        if wt.locked:
+            print(f"[worktree_manager] skip (locked) {wt.path}", file=sys.stderr)
+            continue
+
+        if not os.path.isdir(wt_real):
+            continue  # already gone — prune_worktrees() drops the registration
+
+        if _has_recent_worktree_activity(wt_real, cutoff):
+            continue  # possibly a live review, or activity could not be verified
+
+        if _has_unpushed_commits(wt_real):
+            print(
+                f"[worktree_manager] skip (unpushed commits) {wt.path}",
+                file=sys.stderr,
+            )
+            continue
+
+        if dry_run:
+            removed.append(wt.path)
+            continue
+
+        try:
+            # force=True: reviews routinely leave incidental edits behind (a regenerated
+            # lockfile, a touched test file), which would otherwise block removal.
+            remove_worktree(project_path, worktree_path=wt.path, force=True)
+            removed.append(wt.path)
+            print(f"[worktree_manager] reaped foreign worktree {wt.path}", file=sys.stderr)
+        except Exception as e:
+            print(
+                f"[worktree_manager] foreign worktree reap failed for {wt.path}: {e}",
+                file=sys.stderr,
+            )
+
+    return removed
+
+
+def _has_recent_worktree_activity(worktree_path: str, cutoff: float) -> bool:
+    """Return True when non-ignored worktree content changed after ``cutoff``.
+
+    Root directory mtime alone misses edits to existing files. Ask git for tracked and
+    non-ignored untracked files, then inspect those files and their parent directories
+    (the latter catches recent deletions). Ignored dependency trees stay outside the scan.
+    Any inspection failure keeps the worktree.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "ls-files", "-co", "--exclude-standard", "-z"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if result.returncode != 0:
+        return True
+
+    root = os.path.realpath(worktree_path)
+    directories = {root}
+    for relative_path in result.stdout.split("\0"):
+        if not relative_path:
+            continue
+        path = os.path.join(root, relative_path)
+        try:
+            if os.lstat(path).st_mtime > cutoff:
+                return True
+        except FileNotFoundError:
+            pass  # A tracked deletion updates its parent directory mtime.
+        except OSError:
+            return True
+
+        parent = os.path.dirname(path)
+        while parent != root:
+            directories.add(parent)
+            parent = os.path.dirname(parent)
+
+    try:
+        return any(os.lstat(path).st_mtime > cutoff for path in directories)
+    except OSError:
+        return True
+
+
+def _has_unpushed_commits(worktree_path: str) -> bool:
+    """Return True when removing the worktree could make commits unreachable.
+
+    Tracking branches are unsafe when HEAD exceeds their upstream. A detached HEAD
+    without an upstream is safe only when another durable branch, remote, or tag reaches
+    it. Local branches without upstreams remain durable after path-based removal. Any git
+    or verification failure keeps the worktree.
+    """
+    try:
+        branch = subprocess.run(
+            ["git", "symbolic-ref", "--quiet", "--short", "HEAD"],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+
+    if branch.returncode == 0:
+        branch_name = branch.stdout.strip()
+        try:
+            remote = subprocess.run(
+                ["git", "config", "--get", f"branch.{branch_name}.remote"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+            )
+            merge = subprocess.run(
+                ["git", "config", "--get", f"branch.{branch_name}.merge"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return True
+
+        if remote.returncode == 1 and merge.returncode == 1:
+            return False  # The local branch itself keeps HEAD reachable.
+        if remote.returncode != 0 or merge.returncode != 0:
+            return True
+
+        try:
+            result = subprocess.run(
+                ["git", "rev-list", "--count", "@{u}..HEAD"],
+                cwd=worktree_path,
+                capture_output=True,
+                text=True,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return True
+        if result.returncode != 0:
+            return True
+        try:
+            return int(result.stdout.strip()) > 0
+        except ValueError:
+            return True
+
+    if branch.returncode != 1:
+        return True
+
+    try:
+        result = subprocess.run(
+            [
+                "git",
+                "for-each-ref",
+                "--contains=HEAD",
+                "--format=%(refname)",
+                "refs/heads",
+                "refs/remotes",
+                "refs/tags",
+            ],
+            cwd=worktree_path,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if result.returncode != 0:
+        return True
+    return not bool(result.stdout.strip())
 
 
 def prune_worktrees(project_path: str):
@@ -475,4 +698,5 @@ def _parse_worktree_entry(entry: dict, project_path: str) -> WorktreeInfo:
         project_path=project_path,
         commit=commit,
         is_main=is_main,
+        locked=bool(entry.get("locked", False)),
     )

--- a/koan/tests/test_awake.py
+++ b/koan/tests/test_awake.py
@@ -4123,6 +4123,54 @@ def test_periodic_compaction_disabled_when_interval_zero():
         assert new_ts == 0.0
 
 
+def test_worktree_reap_fires_on_interval():
+    with patch("app.project_explorer.get_projects",
+               return_value=[("proj", "/srv/proj")]), \
+         patch("app.worktree_manager.reap_foreign_worktrees",
+               return_value=["/tmp/review-abc"]) as mock_reap, \
+         patch("app.awake.time.time", return_value=10_000.0):
+        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+        mock_reap.assert_called_once_with("/srv/proj")
+        assert new_ts == 10_000.0
+
+
+def test_worktree_reap_skips_before_interval():
+    with patch("app.worktree_manager.reap_foreign_worktrees") as mock_reap, \
+         patch("app.awake.time.time", return_value=100.0):
+        new_ts = awake._maybe_reap_worktrees(last_reap=90.0, interval=3600)
+        mock_reap.assert_not_called()
+        assert new_ts == 90.0
+
+
+def test_worktree_reap_disabled_when_interval_zero():
+    with patch("app.worktree_manager.reap_foreign_worktrees") as mock_reap:
+        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=0)
+        mock_reap.assert_not_called()
+        assert new_ts == 0.0
+
+
+def test_worktree_reap_survives_errors():
+    """A reap failure must never take the poll loop down."""
+    with patch("app.project_explorer.get_projects",
+               side_effect=RuntimeError("config gone")), \
+         patch("app.awake.time.time", return_value=10_000.0):
+        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+        # Timestamp still advances, so a persistent failure doesn't retry every cycle.
+        assert new_ts == 10_000.0
+
+
+def test_worktree_reap_continues_across_projects():
+    """One project's failure must not stop the others being swept."""
+    with patch("app.project_explorer.get_projects",
+               return_value=[("a", "/srv/a"), ("b", "/srv/b")]), \
+         patch("app.worktree_manager.reap_foreign_worktrees",
+               side_effect=[RuntimeError("bad repo"), ["/tmp/review-b"]]) as mock_reap, \
+         patch("app.awake.time.time", return_value=10_000.0):
+        new_ts = awake._maybe_reap_worktrees(last_reap=0.0, interval=3600)
+        assert [c.args[0] for c in mock_reap.call_args_list] == ["/srv/a", "/srv/b"]
+        assert new_ts == 10_000.0
+
+
 def test_read_sections_cached_serves_within_ttl():
     awake._sections_cache["ts"] = 0.0
     awake._sections_cache["value"] = None

--- a/koan/tests/test_worktree_manager.py
+++ b/koan/tests/test_worktree_manager.py
@@ -4,7 +4,9 @@ Uses real git repos in temp directories (not mocks) per the plan's testing strat
 """
 
 import os
+import shutil
 import subprocess
+import time
 import pytest
 from pathlib import Path
 from unittest.mock import patch
@@ -18,6 +20,7 @@ from app.worktree_manager import (
     git_retry,
     inject_worktree_claude_md,
     prune_worktrees,
+    reap_foreign_worktrees,
     setup_shared_deps,
     WORKTREE_DIR,
 )
@@ -378,6 +381,182 @@ class TestPruneWorktrees:
         captured = capsys.readouterr()
         # --verbose output should mention pruning
         assert "pruned" in captured.err.lower() or not Path(wt_path).exists()
+
+
+class TestReapForeignWorktrees:
+    """Reclaiming worktrees an agent checked out ad hoc outside the project.
+
+    These are the ones that filled the koan host's disk: registered in the project repo,
+    living under /tmp, invisible to both cleanup_stale_worktrees() and prune_worktrees().
+    """
+
+    @staticmethod
+    def _add_foreign(repo, path, age_days=0.0):
+        """Register a worktree outside the project, optionally backdated."""
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(path), "HEAD"],
+            cwd=repo, capture_output=True, check=True,
+        )
+        if age_days:
+            old = time.time() - (age_days * 86400)
+            for root, directories, files in os.walk(path):
+                for name in directories + files:
+                    os.utime(os.path.join(root, name), (old, old))
+            os.utime(path, (old, old))
+        return str(path)
+
+    def test_reaps_stale_foreign_worktree(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-abc", age_days=5)
+        assert Path(foreign).is_dir()
+
+        reaped = reap_foreign_worktrees(git_repo)
+
+        assert reaped == [foreign]
+        assert not Path(foreign).exists()
+        # The registration must be gone too, not just the directory — leaving it behind is
+        # exactly the phantom state that accumulated on the real host.
+        paths = [w.path for w in list_worktrees(git_repo)]
+        assert foreign not in paths
+
+    def test_spares_recent_foreign_worktree(self, git_repo, tmp_path):
+        """A review that started minutes ago is still running — never touch it."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-live", age_days=0)
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_spares_locked_foreign_worktree(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-locked", age_days=5)
+        subprocess.run(
+            ["git", "worktree", "lock", foreign],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_spares_worktree_with_unpushed_commits(self, git_repo, tmp_path):
+        """Commits that exist nowhere else must survive."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-work", age_days=5)
+        # Give it a branch that tracks main, then commit beyond the upstream.
+        subprocess.run(
+            ["git", "checkout", "-b", "wip", "--track", "main"],
+            cwd=foreign, capture_output=True, check=True,
+        )
+        (Path(foreign) / "new.txt").write_text("unpushed\n")
+        subprocess.run(["git", "add", "."], cwd=foreign, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "unpushed work"],
+            cwd=foreign, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        os.utime(Path(foreign) / "new.txt", (old, old))
+        os.utime(foreign, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_spares_detached_worktree_with_unique_commit(self, git_repo, tmp_path):
+        """A detached commit with no other ref must survive."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-detached", age_days=5)
+        (Path(foreign) / "detached.txt").write_text("unique commit\n")
+        subprocess.run(["git", "add", "."], cwd=foreign, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "commit", "-m", "detached work"],
+            cwd=foreign, capture_output=True, check=True,
+        )
+        old = time.time() - (5 * 86400)
+        os.utime(Path(foreign) / "detached.txt", (old, old))
+        os.utime(foreign, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_ignores_project_owned_worktrees(self, git_repo):
+        """`.worktrees/` belongs to cleanup_stale_worktrees(); don't poach it."""
+        wt = create_worktree(git_repo)
+        old = time.time() - (30 * 86400)
+        os.utime(wt.path, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(wt.path).is_dir()
+
+    def test_clears_phantom_registrations(self, git_repo, tmp_path):
+        """A worktree whose directory vanished must not keep its registration.
+
+        This is the state the 10d /tmp sweep leaves behind; a fleet survey found ~20 of
+        them, 10 on a single repo.
+        """
+        foreign = self._add_foreign(git_repo, tmp_path / "review-gone", age_days=5)
+        shutil.rmtree(foreign)  # simulate tmpfiles deleting it behind git's back
+        assert foreign in [w.path for w in list_worktrees(git_repo)]
+
+        reap_foreign_worktrees(git_repo)
+
+        assert foreign not in [w.path for w in list_worktrees(git_repo)]
+
+    def test_dry_run_leaves_phantom_registrations(self, git_repo, tmp_path):
+        """Dry run must not mutate anything, phantoms included."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-gone-dry", age_days=5)
+        shutil.rmtree(foreign)
+
+        reap_foreign_worktrees(git_repo, dry_run=True)
+
+        assert foreign in [w.path for w in list_worktrees(git_repo)]
+
+    def test_dry_run_reports_without_removing(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-dry", age_days=5)
+
+        assert reap_foreign_worktrees(git_repo, dry_run=True) == [foreign]
+        assert Path(foreign).is_dir()
+
+    def test_reaps_incidentally_dirty_worktree(self, git_repo, tmp_path):
+        """Reviews leave edits behind (a regenerated lockfile); that must not block reap."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-dirty", age_days=5)
+        readme = Path(foreign) / "README.md"
+        readme.write_text("touched by review\n")
+        old = time.time() - (5 * 86400)
+        os.utime(readme, (old, old))
+        os.utime(foreign, (old, old))
+
+        assert reap_foreign_worktrees(git_repo) == [foreign]
+        assert not Path(foreign).exists()
+
+    def test_spares_recent_tracked_file_edit(self, git_repo, tmp_path):
+        """Editing an existing file does not update root mtime, but remains live work."""
+        foreign = self._add_foreign(git_repo, tmp_path / "review-active", age_days=5)
+        root_mtime = os.path.getmtime(foreign)
+        (Path(foreign) / "README.md").write_text("active review edit\n")
+
+        assert os.path.getmtime(foreign) == root_mtime
+        assert reap_foreign_worktrees(git_repo) == []
+        assert Path(foreign).is_dir()
+
+    def test_age_threshold_is_configurable(self, git_repo, tmp_path):
+        foreign = self._add_foreign(git_repo, tmp_path / "review-age", age_days=1)
+
+        assert reap_foreign_worktrees(git_repo, max_age_days=2) == []
+        assert reap_foreign_worktrees(git_repo, max_age_days=0.5) == [foreign]
+
+
+class TestWorktreeLockedParsing:
+    def test_list_worktrees_reports_locked(self, git_repo, tmp_path):
+        path = tmp_path / "locked-wt"
+        subprocess.run(
+            ["git", "worktree", "add", "--detach", str(path), "HEAD"],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+        subprocess.run(
+            ["git", "worktree", "lock", str(path)],
+            cwd=git_repo, capture_output=True, check=True,
+        )
+
+        entry = next(w for w in list_worktrees(git_repo) if w.path == str(path))
+        assert entry.locked is True
+
+    def test_unlocked_worktrees_are_not_locked(self, git_repo):
+        entry = next(w for w in list_worktrees(git_repo) if w.is_main)
+        assert entry.locked is False
 
 
 class TestWorktreeErrorPaths:


### PR DESCRIPTION
… project

Agents with a shell tool check revisions out ad hoc during PR review — `git worktree add /tmp/review-<sha> <sha>`, which is what the review skill instructs — and the skill has no teardown step. Those worktrees are registered in the project's repo but live outside `<project>/.worktrees/`, so nothing reclaimed them: cleanup_stale_worktrees() only walks `.worktrees/`, and prune_worktrees() only drops registrations whose directory is already gone.

On 2026-07-30 this filled the 50G root filesystem on the `koan` host and crash-looped koan-awake.service: 14 leaked ~410M cPanel review worktrees plus 5 phantom registrations, 27 registrations in total on /usr/local/cpanel.

Add reap_foreign_worktrees(), called from recover_stale_sessions() alongside the existing prune. It removes worktrees registered in the project but living outside it, guarded so it can only ever delete throwaway state:

  * only paths outside project_path — `.worktrees/` stays owned by cleanup_stale_worktrees(), and `.claude/worktrees/` by its own harness
  * never the main worktree
  * never a `locked` worktree — that is a live agent workspace
  * never one modified within max_age_days (default 2), so a review that is still running is not stripped of its working tree
  * never one holding commits its upstream lacks

Removal goes through remove_worktree(), so the registration is dropped with the directory instead of leaving the phantom state that `rm -rf` produces.

Also parse `locked` from `git worktree list --porcelain` into WorktreeInfo, which the guard needs and which list_worktrees() previously discarded.

<!--
  Thanks for contributing to Kōan. Keep this description accurate — the
  spec-change guard (.github/workflows/spec-change-guard.yml) reads the
  "Architectural change" declaration below.
-->

## Summary

<!-- What does this PR do, and why? -->

## Testing

<!-- How was this verified? (make lint, make test, manual steps…) -->

## Declarations

- [ ] **Architectural change** — this PR modifies a durable design contract
  (`specs/components/**` or `specs/skills/**`). The new architecture needs review
  before approval. Rationale: <one line>

<!--
  CHECK the box above ONLY if this PR adds or changes a durable design contract
  under specs/components/ or specs/skills/. Doing so is an ARCHITECTURAL CHANGE:
  it must be deliberate and contract-first (change the intended contract, then make
  code conform — never edit the spec afterward to match sloppy code), and such
  changes should be rare. See docs/design/spec-changes-are-architectural.md and
  .specify/memory/constitution.md (Principle II).

  Editing an ephemeral speckit folder (specs/<NNN-slug>/…), an index.md, or the
  skill-spec template is NOT an architectural change — leave the box unchecked.
-->
